### PR TITLE
test(auth): MSW infrastructure + integration regression coverage

### DIFF
--- a/frontend/src/features/auth/services/authService.ts
+++ b/frontend/src/features/auth/services/authService.ts
@@ -11,6 +11,7 @@ async function login(credentials: LoginRequest): Promise<void> {
   const response = await request<AuthResponse>("/api/auth/login", {
     method: "POST",
     body: credentials,
+    skipRefresh: true,
   });
   setCsrfToken(response.csrf_token);
 }
@@ -19,6 +20,7 @@ async function register(credentials: RegisterRequest): Promise<void> {
   await request<RegisterResponse>("/api/auth/register", {
     method: "POST",
     body: credentials,
+    skipRefresh: true,
   });
 }
 

--- a/frontend/src/features/auth/tests/authService.integration.test.ts
+++ b/frontend/src/features/auth/tests/authService.integration.test.ts
@@ -1,0 +1,148 @@
+import { http, HttpResponse } from "msw";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { authService } from "@/features/auth/services/authService";
+import { clearCsrfToken, request } from "@/shared/lib/http";
+import { server } from "@/shared/tests/mocks/server";
+
+describe("authService integration (MSW)", () => {
+  afterEach(() => {
+    clearCsrfToken();
+  });
+
+  it("login sets CSRF token that propagates to subsequent mutating requests", async () => {
+    await authService.login({ email: "a@b.com", password: "pass" });
+
+    // Logout is a mutating POST — MSW handler requires X-CSRF-Token.
+    // If the token from login didn't propagate, MSW returns 403 and
+    // request() would throw.
+    await authService.logout();
+  });
+
+  it("register sends correct payload and returns user", async () => {
+    // Override register to capture and echo the request body for assertion
+    let capturedBody: { email: string; password: string } | null = null;
+
+    server.use(
+      http.post("/api/auth/register", async ({ request: req }) => {
+        capturedBody = (await req.json()) as { email: string; password: string };
+        return HttpResponse.json(
+          {
+            user: {
+              id: "user-42",
+              email: capturedBody.email,
+              is_active: true,
+            },
+          },
+          { status: 201 },
+        );
+      }),
+    );
+
+    await authService.register({ email: "new@example.com", password: "s3cret" });
+
+    expect(capturedBody).toEqual({ email: "new@example.com", password: "s3cret" });
+  });
+
+  it("logout clears CSRF so next mutating request has no token", async () => {
+    await authService.login({ email: "a@b.com", password: "pass" });
+    await authService.logout();
+
+    // After logout, CSRF should be cleared.
+    // Set up a handler that captures headers on a mutating endpoint.
+    let csrfHeader: string | null = "NOT_CHECKED";
+
+    server.use(
+      http.post("/api/test/mutating", ({ request: req }) => {
+        csrfHeader = req.headers.get("X-CSRF-Token");
+        return HttpResponse.json({ ok: true });
+      }),
+    );
+
+    await request("/api/test/mutating", {
+      method: "POST",
+      body: { x: 1 },
+      skipRefresh: true,
+    });
+
+    expect(csrfHeader).toBeNull();
+  });
+
+  it("auto-refreshes on 401 and retries successfully (end-to-end)", async () => {
+    // Login first to establish CSRF token (needed for refresh's CSRF validation)
+    await authService.login({ email: "a@b.com", password: "pass" });
+
+    let meCallCount = 0;
+
+    server.use(
+      http.get("/api/auth/me", () => {
+        meCallCount++;
+        if (meCallCount === 1) {
+          return HttpResponse.json({ detail: "Unauthorized" }, { status: 401 });
+        }
+        return HttpResponse.json(
+          { id: "user-1", email: "test@example.com", is_active: true },
+          { status: 200 },
+        );
+      }),
+    );
+
+    const user = await authService.me();
+
+    expect(user).toEqual({
+      id: "user-1",
+      email: "test@example.com",
+      is_active: true,
+    });
+    expect(meCallCount).toBe(2);
+  });
+
+  it("preserves error message from failed login", async () => {
+    server.use(
+      http.post("/api/auth/login", () => {
+        return HttpResponse.json(
+          { detail: "Invalid credentials" },
+          { status: 401 },
+        );
+      }),
+    );
+
+    await expect(
+      authService.login({ email: "bad@example.com", password: "wrong" }),
+    ).rejects.toThrow("Invalid credentials");
+  });
+
+  it("clears CSRF and propagates error when refresh also fails", async () => {
+    // Login to get a CSRF token
+    await authService.login({ email: "a@b.com", password: "pass" });
+
+    server.use(
+      http.get("/api/auth/me", () => {
+        return HttpResponse.json({ detail: "Unauthorized" }, { status: 401 });
+      }),
+      http.post("/api/auth/refresh", () => {
+        return HttpResponse.json({ detail: "Unauthorized" }, { status: 401 });
+      }),
+    );
+
+    await expect(authService.me()).rejects.toThrow("Unauthorized");
+
+    // CSRF should be cleared — verify via a captured header
+    let csrfHeader: string | null = "NOT_CHECKED";
+
+    server.use(
+      http.post("/api/test/probe", ({ request: req }) => {
+        csrfHeader = req.headers.get("X-CSRF-Token");
+        return HttpResponse.json({ ok: true });
+      }),
+    );
+
+    await request("/api/test/probe", {
+      method: "POST",
+      body: { x: 1 },
+      skipRefresh: true,
+    });
+
+    expect(csrfHeader).toBeNull();
+  });
+});

--- a/frontend/src/shared/lib/http.test.ts
+++ b/frontend/src/shared/lib/http.test.ts
@@ -72,4 +72,72 @@ describe("http request helper", () => {
     const refreshInit = fetchMock.mock.calls[1]?.[1] as RequestInit;
     expect(new Headers(refreshInit.headers).get("X-CSRF-Token")).toBe("boot-token");
   });
+
+  it("clears CSRF and throws when refresh itself fails with 401", async () => {
+    const fetchMock = vi.mocked(fetch);
+
+    document.cookie = "stima_csrf_token=boot-token; path=/";
+
+    // original → 401, refresh → 401
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse({ detail: "Unauthorized" }, 401))
+      .mockResolvedValueOnce(jsonResponse({ detail: "Unauthorized" }, 401));
+
+    await expect(request("/api/auth/me")).rejects.toThrow("Unauthorized");
+
+    // CSRF should be cleared — clear cookie too so hydrate doesn't re-read it
+    clearCsrfCookie();
+    fetchMock.mockResolvedValueOnce(jsonResponse({ ok: true }));
+    await request("/api/quotes", { method: "POST", body: { a: 1 }, skipRefresh: true });
+
+    const postInit = fetchMock.mock.calls[2]?.[1] as RequestInit;
+    expect(new Headers(postInit.headers).get("X-CSRF-Token")).toBeNull();
+  });
+
+  it("deduplicates concurrent 401 refreshes into a single flight", async () => {
+    const fetchMock = vi.mocked(fetch);
+
+    document.cookie = "stima_csrf_token=boot-token; path=/";
+
+    // Two original requests both get 401, then one refresh succeeds,
+    // then both replays succeed.
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse({ detail: "Unauthorized" }, 401)) // req A original
+      .mockResolvedValueOnce(jsonResponse({ detail: "Unauthorized" }, 401)) // req B original
+      .mockResolvedValueOnce(jsonResponse({ csrf_token: "new-token" }))     // single refresh
+      .mockResolvedValueOnce(jsonResponse({ id: "a" }))                     // req A replay
+      .mockResolvedValueOnce(jsonResponse({ id: "b" }));                    // req B replay
+
+    const [resultA, resultB] = await Promise.all([
+      request<{ id: string }>("/api/auth/me"),
+      request<{ id: string }>("/api/auth/me"),
+    ]);
+
+    expect(resultA).toEqual({ id: "a" });
+    expect(resultB).toEqual({ id: "b" });
+
+    // Exactly one call to /api/auth/refresh
+    const refreshCalls = fetchMock.mock.calls.filter(
+      (call) => call[0] === "/api/auth/refresh",
+    );
+    expect(refreshCalls).toHaveLength(1);
+  });
+
+  it("uses the rotated CSRF token from refresh on the replayed request", async () => {
+    const fetchMock = vi.mocked(fetch);
+
+    document.cookie = "stima_csrf_token=boot-token; path=/";
+
+    // original → 401, refresh returns rotated token, replay
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse({ detail: "Unauthorized" }, 401))
+      .mockResolvedValueOnce(jsonResponse({ csrf_token: "rotated-token" }))
+      .mockResolvedValueOnce(jsonResponse({ ok: true }));
+
+    await request("/api/quotes", { method: "POST", body: { x: 1 } });
+
+    // The replayed request (call index 2) must carry the rotated token
+    const replayInit = fetchMock.mock.calls[2]?.[1] as RequestInit;
+    expect(new Headers(replayInit.headers).get("X-CSRF-Token")).toBe("rotated-token");
+  });
 });

--- a/frontend/src/shared/tests/mocks/handlers.ts
+++ b/frontend/src/shared/tests/mocks/handlers.ts
@@ -1,2 +1,56 @@
-// TODO: Add MSW handlers.
-export {};
+import { http, HttpResponse } from "msw";
+
+function requireCsrf(request: Request): Response | null {
+  if (!request.headers.get("X-CSRF-Token")) {
+    return HttpResponse.json({ detail: "CSRF token missing" }, { status: 403 }) as unknown as Response;
+  }
+  return null;
+}
+
+export const handlers = [
+  http.post("/api/auth/login", async ({ request }) => {
+    const body = (await request.json()) as { email: string; password: string };
+    return HttpResponse.json(
+      { csrf_token: "test-csrf-token", email: body.email },
+      { status: 200 },
+    );
+  }),
+
+  http.post("/api/auth/register", async ({ request }) => {
+    const body = (await request.json()) as { email: string; password: string };
+    return HttpResponse.json(
+      {
+        user: {
+          id: "user-1",
+          email: body.email,
+          is_active: true,
+        },
+      },
+      { status: 201 },
+    );
+  }),
+
+  http.post("/api/auth/refresh", ({ request }) => {
+    const csrfError = requireCsrf(request);
+    if (csrfError) return csrfError;
+
+    return HttpResponse.json(
+      { csrf_token: "refreshed-csrf-token" },
+      { status: 200 },
+    );
+  }),
+
+  http.post("/api/auth/logout", ({ request }) => {
+    const csrfError = requireCsrf(request);
+    if (csrfError) return csrfError;
+
+    return new HttpResponse(null, { status: 204 });
+  }),
+
+  http.get("/api/auth/me", () => {
+    return HttpResponse.json(
+      { id: "user-1", email: "test@example.com", is_active: true },
+      { status: 200 },
+    );
+  }),
+];

--- a/frontend/src/shared/tests/mocks/server.ts
+++ b/frontend/src/shared/tests/mocks/server.ts
@@ -1,2 +1,5 @@
-// TODO: Add MSW server setup.
-export {};
+import { setupServer } from "msw/node";
+
+import { handlers } from "./handlers";
+
+export const server = setupServer(...handlers);

--- a/frontend/src/shared/tests/setup.ts
+++ b/frontend/src/shared/tests/setup.ts
@@ -1,1 +1,8 @@
 import "@testing-library/jest-dom";
+import { afterAll, afterEach, beforeAll } from "vitest";
+
+import { server } from "./mocks/server";
+
+beforeAll(() => server.listen({ onUnhandledRequest: "error" }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());


### PR DESCRIPTION
## Summary
- Wire shared MSW server (`handlers.ts`, `server.ts`, `setup.ts`) with CSRF-enforcing auth handlers and `onUnhandledRequest: 'error'`
- Extend `http.test.ts` with 3 transport-level cases: refresh failure → CSRF cleared, concurrent 401 single-flight dedup, rotated CSRF token on replay
- Add `authService.integration.test.ts` with 6 end-to-end cases: login→CSRF propagation, register payload/response, logout→CSRF cleared, session-expired→auto-refresh→success, bad credentials error, refresh failure cascade
- Fix: `login`/`register` now pass `skipRefresh: true` since token refresh is nonsensical on initial auth endpoints

## Test plan
- [x] All 23 tests pass: `cd frontend && npx vitest run`
- [x] TypeScript compiles: `npx tsc --noEmit`
- [x] Lint passes: `npx eslint src/`
- [x] Build succeeds: `npm run build`
- [x] Existing component/hook tests unbroken by MSW wiring
- [x] No duplication with existing `http.test.ts` cases or Task 03 component tests

Closes #5