### PR TITLE
Task #23: Harden PDF/share coverage gaps

### DIFF
--- a/backend/app/features/quotes/tests/test_pdf.py
+++ b/backend/app/features/quotes/tests/test_pdf.py
@@ -211,6 +211,29 @@ async def test_public_share_endpoint_returns_404_for_unknown_token(client: Async
     assert response.json() == {"detail": "Not found"}
 
 
+async def test_public_share_endpoint_returns_422_when_render_fails(
+    client: AsyncClient,
+    _override_quote_service_dependency: _ConfigurablePdfIntegration,
+) -> None:
+    _override_quote_service_dependency.should_fail = True
+    csrf_token = await _register_and_login(client, _credentials())
+    customer_id = await _create_customer(client, csrf_token)
+    quote = await _create_quote(client, csrf_token, customer_id)
+
+    share_response = await client.post(
+        f"/api/quotes/{quote['id']}/share",
+        headers={"X-CSRF-Token": csrf_token},
+    )
+    assert share_response.status_code == 200
+    share_token = share_response.json()["share_token"]
+
+    client.cookies.clear()
+    response = await client.get(f"/share/{share_token}")
+
+    assert response.status_code == 422
+    assert response.json() == {"detail": "Unable to render quote PDF"}
+
+
 async def _register_and_login(client: AsyncClient, credentials: dict[str, str]) -> str:
     register_response = await client.post("/api/auth/register", json=credentials)
     assert register_response.status_code == 201

--- a/backend/app/features/quotes/tests/test_pdf_template.py
+++ b/backend/app/features/quotes/tests/test_pdf_template.py
@@ -1,0 +1,130 @@
+"""Quote PDF template rendering behavior tests."""
+
+from __future__ import annotations
+
+import re
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+
+from app.features.quotes.repository import QuoteRenderContext, QuoteRenderLineItem
+from app.integrations.pdf import PdfIntegration
+
+
+def _make_context(
+    *,
+    updated_at: datetime,
+    line_item_price: Decimal | None,
+    total: Decimal | None,
+) -> QuoteRenderContext:
+    created_at = datetime(2026, 3, 1, 12, 0, tzinfo=UTC)
+    return QuoteRenderContext(
+        business_name="Acme Landscaping",
+        first_name="Taylor",
+        last_name="Owner",
+        customer_name="Jamie Customer",
+        customer_phone=None,
+        customer_email=None,
+        customer_address=None,
+        doc_number="Q-201",
+        status="ready",
+        total_amount=total,
+        notes=None,
+        line_items=[
+            QuoteRenderLineItem(
+                description="Leaf cleanup",
+                details=None,
+                price=line_item_price,
+            )
+        ],
+        created_at=created_at,
+        updated_at=updated_at,
+    )
+
+
+@pytest.mark.parametrize(
+    ("delta_seconds", "should_show_updated"),
+    [
+        (300, False),
+        (301, True),
+    ],
+)
+def test_render_shows_updated_date_only_when_delta_exceeds_threshold(
+    monkeypatch: pytest.MonkeyPatch,
+    delta_seconds: int,
+    should_show_updated: bool,
+) -> None:
+    captured_html: list[str] = []
+
+    class _FakeHTML:
+        def __init__(self, *, string: str, base_url: str) -> None:
+            del base_url
+            captured_html.append(string)
+
+        def write_pdf(self) -> bytes:
+            return b"fake-pdf"
+
+    monkeypatch.setattr("app.integrations.pdf.HTML", _FakeHTML)
+    template_dir = Path(__file__).resolve().parents[3] / "templates"
+    integration = PdfIntegration(template_dir=template_dir)
+    updated_at = datetime(2026, 3, 1, 12, 0, tzinfo=UTC) + timedelta(seconds=delta_seconds)
+
+    result = integration.render(
+        _make_context(
+            updated_at=updated_at,
+            line_item_price=Decimal("120.00"),
+            total=Decimal("120.00"),
+        )
+    )
+
+    assert result == b"fake-pdf"
+    assert len(captured_html) == 1
+    assert ("Updated" in captured_html[0]) is should_show_updated
+
+
+def test_render_blanks_null_line_item_and_total_prices(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured_html: list[str] = []
+
+    class _FakeHTML:
+        def __init__(self, *, string: str, base_url: str) -> None:
+            del base_url
+            captured_html.append(string)
+
+        def write_pdf(self) -> bytes:
+            return b"fake-pdf"
+
+    monkeypatch.setattr("app.integrations.pdf.HTML", _FakeHTML)
+    template_dir = Path(__file__).resolve().parents[3] / "templates"
+    integration = PdfIntegration(template_dir=template_dir)
+    updated_at = datetime(2026, 3, 1, 12, 6, tzinfo=UTC)
+
+    result = integration.render(
+        _make_context(
+            updated_at=updated_at,
+            line_item_price=None,
+            total=None,
+        )
+    )
+
+    assert result == b"fake-pdf"
+    assert len(captured_html) == 1
+    rendered_html = captured_html[0]
+    assert "$0.00" not in rendered_html
+    assert "$None" not in rendered_html
+    assert re.search(
+        r"<td>Leaf cleanup</td>\s*<td class=\"details\"></td>\s*<td class=\"price-col\">\s*</td>",
+        rendered_html,
+        re.DOTALL,
+    )
+    assert re.search(
+        (
+            r"<tr class=\"total-row\">\s*<td colspan=\"2\">Total</td>\s*"
+            r"<td class=\"price-col\">\s*</td>"
+        ),
+        rendered_html,
+        re.DOTALL,
+    )

--- a/frontend/src/features/quotes/tests/QuotePreview.test.tsx
+++ b/frontend/src/features/quotes/tests/QuotePreview.test.tsx
@@ -99,6 +99,16 @@ describe("QuotePreview", () => {
     expect(screen.getByText(/Status:/i)).toHaveTextContent("draft");
   });
 
+  it("shows an error when quote fetch fails", async () => {
+    mockedQuoteService.getQuote.mockRejectedValueOnce(new Error("Unable to load quote"));
+
+    renderScreen();
+
+    expect(await screen.findByText("Unable to load quote")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /generate pdf/i })).toBeDisabled();
+    expect(screen.getByRole("button", { name: /^share$/i })).toBeDisabled();
+  });
+
   it("generates PDF and renders iframe preview", async () => {
     renderScreen();
 
@@ -112,6 +122,23 @@ describe("QuotePreview", () => {
 
     const frame = screen.getByTitle("Quote PDF Preview") as HTMLIFrameElement;
     expect(frame.src).toContain("blob:quote-preview");
+  });
+
+  it("shows an error when PDF generation fails", async () => {
+    mockedQuoteService.generatePdf.mockRejectedValueOnce(
+      new Error("Unable to render quote PDF"),
+    );
+
+    renderScreen();
+
+    await screen.findByText(/Q-001/i);
+    fireEvent.click(screen.getByRole("button", { name: /generate pdf/i }));
+
+    await waitFor(() => {
+      expect(mockedQuoteService.generatePdf).toHaveBeenCalledWith("quote-1");
+    });
+    expect(await screen.findByText("Unable to render quote PDF")).toBeInTheDocument();
+    expect(screen.queryByTitle("Quote PDF Preview")).not.toBeInTheDocument();
   });
 
   it("uses navigator.share when available", async () => {
@@ -186,5 +213,21 @@ describe("QuotePreview", () => {
     });
     expect(screen.queryByText("Share canceled")).not.toBeInTheDocument();
     expect(await screen.findByText(/share\/share-token-1/i)).toBeInTheDocument();
+  });
+
+  it("shows an error when share request fails", async () => {
+    mockedQuoteService.getQuote.mockResolvedValueOnce(makeQuote({ status: "ready" }));
+    mockedQuoteService.shareQuote.mockRejectedValueOnce(new Error("Unable to share quote"));
+
+    renderScreen();
+
+    await screen.findByText(/Q-001/i);
+    fireEvent.click(screen.getByRole("button", { name: /^share$/i }));
+
+    await waitFor(() => {
+      expect(mockedQuoteService.shareQuote).toHaveBeenCalledWith("quote-1");
+    });
+    expect(await screen.findByText("Unable to share quote")).toBeInTheDocument();
+    expect(screen.queryByText(/Share URL:/i)).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- add backend API contract coverage for public share render failures (422 path)
- add direct PDF template behavior tests for conditional Updated row visibility and null-price blank rendering
- add QuotePreview negative-path tests for quote fetch, PDF generation, and share request failures

## Verification
- make backend-verify
- make frontend-verify

Closes #23
