### PR TITLE
Task #56: split quote extraction service boundary

### DIFF
--- a/backend/app/features/quotes/api.py
+++ b/backend/app/features/quotes/api.py
@@ -9,6 +9,7 @@ from fastapi import APIRouter, Depends, File, Form, HTTPException, Request, Uplo
 from fastapi.responses import StreamingResponse
 
 from app.features.auth.models import User
+from app.features.quotes.extraction_service import CaptureAudioClip, ExtractionService
 from app.features.quotes.schemas import (
     ConvertNotesRequest,
     ExtractionResult,
@@ -18,13 +19,43 @@ from app.features.quotes.schemas import (
     QuoteResponse,
     QuoteUpdateRequest,
 )
-from app.features.quotes.service import CaptureAudioClip, QuoteService, QuoteServiceError
-from app.shared.dependencies import get_current_user, get_quote_service, require_csrf
+from app.features.quotes.service import QuoteService, QuoteServiceError
+from app.shared.dependencies import (
+    get_current_user,
+    get_extraction_service,
+    get_quote_service,
+    require_csrf,
+)
 from app.shared.rate_limit import get_ip_key, limiter
 
 router = APIRouter(prefix="/quotes", tags=["quotes"])
 public_router = APIRouter(tags=["quotes"])
 MAX_AUDIO_CLIP_BYTES = 10 * 1024 * 1024
+
+
+async def _parse_upload_clips(clips: list[UploadFile]) -> list[CaptureAudioClip]:
+    """Read uploaded clips into service payloads while enforcing size limits."""
+    parsed_clips: list[CaptureAudioClip] = []
+    for clip in clips:
+        try:
+            if clip.size is not None and clip.size > MAX_AUDIO_CLIP_BYTES:
+                raise HTTPException(status_code=400, detail="Clip too large")
+
+            content = await clip.read()
+            if len(content) > MAX_AUDIO_CLIP_BYTES:
+                raise HTTPException(status_code=400, detail="Clip too large")
+
+            parsed_clips.append(
+                CaptureAudioClip(
+                    filename=clip.filename,
+                    content_type=clip.content_type,
+                    content=content,
+                )
+            )
+        finally:
+            await clip.close()
+
+    return parsed_clips
 
 
 @router.post(
@@ -35,12 +66,12 @@ MAX_AUDIO_CLIP_BYTES = 10 * 1024 * 1024
 async def convert_notes(
     payload: ConvertNotesRequest,
     user: Annotated[User, Depends(get_current_user)],
-    quote_service: Annotated[QuoteService, Depends(get_quote_service)],
+    extraction_service: Annotated[ExtractionService, Depends(get_extraction_service)],
 ) -> ExtractionResult:
     """Convert freeform notes into structured quote extraction output."""
     del user
     try:
-        return await quote_service.convert_notes(payload.notes)
+        return await extraction_service.convert_notes(payload.notes)
     except QuoteServiceError as exc:
         raise HTTPException(status_code=exc.status_code, detail=exc.detail) from exc
 
@@ -74,33 +105,15 @@ async def capture_audio(
     request: Request,
     clips: Annotated[list[UploadFile], File(...)],
     user: Annotated[User, Depends(get_current_user)],
-    quote_service: Annotated[QuoteService, Depends(get_quote_service)],
+    extraction_service: Annotated[ExtractionService, Depends(get_extraction_service)],
 ) -> ExtractionResult:
     """Convert uploaded audio clips into structured quote extraction output."""
     del request
     del user
-    clip_inputs: list[CaptureAudioClip] = []
-    for clip in clips:
-        try:
-            if clip.size is not None and clip.size > MAX_AUDIO_CLIP_BYTES:
-                raise HTTPException(status_code=400, detail="Clip too large")
-
-            content = await clip.read()
-            if len(content) > MAX_AUDIO_CLIP_BYTES:
-                raise HTTPException(status_code=400, detail="Clip too large")
-
-            clip_inputs.append(
-                CaptureAudioClip(
-                    filename=clip.filename,
-                    content_type=clip.content_type,
-                    content=content,
-                )
-            )
-        finally:
-            await clip.close()
+    clip_inputs = await _parse_upload_clips(clips)
 
     try:
-        return await quote_service.capture_audio(clip_inputs)
+        return await extraction_service.capture_audio(clip_inputs)
     except QuoteServiceError as exc:
         raise HTTPException(status_code=exc.status_code, detail=exc.detail) from exc
 
@@ -114,35 +127,17 @@ async def capture_audio(
 async def extract_combined(
     request: Request,
     user: Annotated[User, Depends(get_current_user)],
-    quote_service: Annotated[QuoteService, Depends(get_quote_service)],
+    extraction_service: Annotated[ExtractionService, Depends(get_extraction_service)],
     clips: Annotated[list[UploadFile] | None, File()] = None,
     notes: Annotated[str, Form()] = "",
 ) -> ExtractionResult:
     """Extract structured quote data from optional audio clips and optional notes."""
     del request
     del user
-    clip_inputs: list[CaptureAudioClip] = []
-    for clip in clips or []:
-        try:
-            if clip.size is not None and clip.size > MAX_AUDIO_CLIP_BYTES:
-                raise HTTPException(status_code=400, detail="Clip too large")
-
-            content = await clip.read()
-            if len(content) > MAX_AUDIO_CLIP_BYTES:
-                raise HTTPException(status_code=400, detail="Clip too large")
-
-            clip_inputs.append(
-                CaptureAudioClip(
-                    filename=clip.filename,
-                    content_type=clip.content_type,
-                    content=content,
-                )
-            )
-        finally:
-            await clip.close()
+    clip_inputs = await _parse_upload_clips(clips or [])
 
     try:
-        return await quote_service.extract_combined(clip_inputs, notes)
+        return await extraction_service.extract_combined(clip_inputs, notes)
     except QuoteServiceError as exc:
         raise HTTPException(status_code=exc.status_code, detail=exc.detail) from exc
 

--- a/backend/app/features/quotes/extraction_service.py
+++ b/backend/app/features/quotes/extraction_service.py
@@ -1,0 +1,119 @@
+"""Quote extraction orchestration."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Protocol
+
+from app.features.quotes.schemas import ExtractionResult
+from app.features.quotes.service import QuoteServiceError
+from app.integrations.audio import AudioClip, AudioError
+from app.integrations.extraction import ExtractionError
+from app.integrations.transcription import TranscriptionError
+
+
+class ExtractionIntegrationProtocol(Protocol):
+    """Structural protocol for extraction integration dependency."""
+
+    async def extract(self, notes: str) -> ExtractionResult: ...
+
+
+class AudioIntegrationProtocol(Protocol):
+    """Structural protocol for audio normalization integration dependency."""
+
+    def normalize_and_stitch(self, clips: Sequence[AudioClip]) -> bytes: ...
+
+
+class TranscriptionIntegrationProtocol(Protocol):
+    """Structural protocol for speech-to-text integration dependency."""
+
+    async def transcribe(self, audio_wav: bytes) -> str: ...
+
+
+@dataclass(slots=True)
+class CaptureAudioClip:
+    """Internal clip payload used by service orchestration."""
+
+    filename: str | None
+    content_type: str | None
+    content: bytes
+
+
+class ExtractionService:
+    """Coordinate audio/transcription/extraction integrations for quote intake."""
+
+    def __init__(
+        self,
+        *,
+        extraction_integration: ExtractionIntegrationProtocol,
+        audio_integration: AudioIntegrationProtocol,
+        transcription_integration: TranscriptionIntegrationProtocol,
+    ) -> None:
+        self._extraction = extraction_integration
+        self._audio = audio_integration
+        self._transcription = transcription_integration
+
+    async def convert_notes(self, notes: str) -> ExtractionResult:
+        """Extract structured line items from freeform notes."""
+        try:
+            return await self._extraction.extract(notes)
+        except ExtractionError as exc:
+            raise QuoteServiceError(
+                detail=f"Extraction failed: {exc}",
+                status_code=422,
+            ) from exc
+
+    async def capture_audio(self, clips: Sequence[CaptureAudioClip]) -> ExtractionResult:
+        """Normalize uploaded clips, transcribe audio, and extract quote line items."""
+        transcript = await self._transcribe_clips(clips)
+        return await self.convert_notes(transcript)
+
+    async def extract_combined(
+        self,
+        clips: Sequence[CaptureAudioClip] | None,
+        notes: str | None,
+    ) -> ExtractionResult:
+        """Extract quote line items from optional clips plus optional typed notes."""
+        normalized_notes = (notes or "").strip()
+        combined_text = normalized_notes
+
+        if clips:
+            transcript = await self._transcribe_clips(clips)
+            combined_text = transcript
+            if normalized_notes:
+                combined_text = f"{transcript}\n\n{normalized_notes}"
+
+        if not combined_text:
+            raise QuoteServiceError(
+                detail="Provide at least one audio clip or typed notes.",
+                status_code=400,
+            )
+
+        return await self.convert_notes(combined_text)
+
+    async def _transcribe_clips(self, clips: Sequence[CaptureAudioClip]) -> str:
+        """Normalize clip uploads and return the resulting transcript."""
+        try:
+            stitched_wav = await asyncio.to_thread(
+                self._audio.normalize_and_stitch,
+                [
+                    AudioClip(
+                        filename=clip.filename,
+                        content_type=clip.content_type,
+                        content=clip.content,
+                    )
+                    for clip in clips
+                ],
+            )
+        except AudioError as exc:
+            raise QuoteServiceError(detail=str(exc), status_code=400) from exc
+
+        try:
+            return await self._transcription.transcribe(stitched_wav)
+        except TranscriptionError as exc:
+            raise QuoteServiceError(
+                detail=f"Transcription failed: {exc}",
+                status_code=502,
+            ) from exc

--- a/backend/app/features/quotes/service.py
+++ b/backend/app/features/quotes/service.py
@@ -3,8 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Sequence
-from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Protocol, cast
 from uuid import UUID, uuid4
@@ -20,15 +18,11 @@ from app.features.quotes.repository import (
     QuoteRenderContext,
 )
 from app.features.quotes.schemas import (
-    ExtractionResult,
     LineItemDraft,
     QuoteCreateRequest,
     QuoteUpdateRequest,
 )
-from app.integrations.audio import AudioClip, AudioError
-from app.integrations.extraction import ExtractionError
 from app.integrations.pdf import PdfRenderError
-from app.integrations.transcription import TranscriptionError
 
 
 class QuoteServiceError(Exception):
@@ -92,138 +86,23 @@ class QuoteRepositoryProtocol(Protocol):
     async def rollback(self) -> None: ...
 
 
-class ExtractionIntegrationProtocol(Protocol):
-    """Structural protocol for extraction integration dependency."""
-
-    async def extract(self, notes: str) -> ExtractionResult: ...
-
-
 class PdfIntegrationProtocol(Protocol):
     """Structural protocol for PDF rendering integration dependency."""
 
     def render(self, context: QuoteRenderContext) -> bytes: ...
 
 
-class AudioIntegrationProtocol(Protocol):
-    """Structural protocol for audio normalization integration dependency."""
-
-    def normalize_and_stitch(self, clips: Sequence[AudioClip]) -> bytes: ...
-
-
-class TranscriptionIntegrationProtocol(Protocol):
-    """Structural protocol for speech-to-text integration dependency."""
-
-    async def transcribe(self, audio_wav: bytes) -> str: ...
-
-
-@dataclass(slots=True)
-class CaptureAudioClip:
-    """Internal clip payload used by service orchestration."""
-
-    filename: str | None
-    content_type: str | None
-    content: bytes
-
-
 class QuoteService:
-    """Coordinate quote domain rules with persistence and extraction."""
+    """Coordinate quote domain rules with persistence and PDF rendering."""
 
     def __init__(
         self,
         *,
         repository: QuoteRepositoryProtocol,
-        extraction_integration: ExtractionIntegrationProtocol,
-        audio_integration: AudioIntegrationProtocol,
-        transcription_integration: TranscriptionIntegrationProtocol,
         pdf_integration: PdfIntegrationProtocol,
     ) -> None:
         self._repository = repository
-        self._extraction = extraction_integration
-        self._audio = audio_integration
-        self._transcription = transcription_integration
         self._pdf = pdf_integration
-
-    async def convert_notes(self, notes: str) -> ExtractionResult:
-        """Extract structured line items from freeform notes."""
-        try:
-            return await self._extraction.extract(notes)
-        except ExtractionError as exc:
-            raise QuoteServiceError(
-                detail=f"Extraction failed: {exc}",
-                status_code=422,
-            ) from exc
-
-    async def capture_audio(self, clips: Sequence[CaptureAudioClip]) -> ExtractionResult:
-        """Normalize uploaded clips, transcribe audio, and extract quote line items."""
-        try:
-            stitched_wav = await asyncio.to_thread(
-                self._audio.normalize_and_stitch,
-                [
-                    AudioClip(
-                        filename=clip.filename,
-                        content_type=clip.content_type,
-                        content=clip.content,
-                    )
-                    for clip in clips
-                ],
-            )
-        except AudioError as exc:
-            raise QuoteServiceError(detail=str(exc), status_code=400) from exc
-
-        try:
-            transcript = await self._transcription.transcribe(stitched_wav)
-        except TranscriptionError as exc:
-            raise QuoteServiceError(
-                detail=f"Transcription failed: {exc}",
-                status_code=502,
-            ) from exc
-
-        return await self.convert_notes(transcript)
-
-    async def extract_combined(
-        self,
-        clips: Sequence[CaptureAudioClip],
-        notes: str,
-    ) -> ExtractionResult:
-        """Extract quote line items from optional clips plus optional typed notes."""
-        normalized_notes = notes.strip()
-        combined_text = normalized_notes
-
-        if clips:
-            try:
-                stitched_wav = await asyncio.to_thread(
-                    self._audio.normalize_and_stitch,
-                    [
-                        AudioClip(
-                            filename=clip.filename,
-                            content_type=clip.content_type,
-                            content=clip.content,
-                        )
-                        for clip in clips
-                    ],
-                )
-            except AudioError as exc:
-                raise QuoteServiceError(detail=str(exc), status_code=400) from exc
-
-            try:
-                transcript = await self._transcription.transcribe(stitched_wav)
-            except TranscriptionError as exc:
-                raise QuoteServiceError(
-                    detail=f"Transcription failed: {exc}",
-                    status_code=502,
-                ) from exc
-
-            combined_text = transcript
-            if normalized_notes:
-                combined_text = f"{transcript}\n\n{normalized_notes}"
-
-        if not combined_text:
-            raise QuoteServiceError(
-                detail="Provide at least one audio clip or typed notes.",
-                status_code=400,
-            )
-
-        return await self.convert_notes(combined_text)
 
     async def create_quote(self, user: User, data: QuoteCreateRequest) -> Document:
         """Create a user-owned quote and retry once on sequence collisions."""

--- a/backend/app/features/quotes/tests/test_pdf.py
+++ b/backend/app/features/quotes/tests/test_pdf.py
@@ -15,19 +15,12 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.database import get_db
 from app.features.auth.service import CSRF_COOKIE_NAME
 from app.features.quotes.repository import QuoteRenderContext, QuoteRepository
-from app.features.quotes.schemas import ExtractionResult
 from app.features.quotes.service import QuoteService
 from app.integrations.pdf import PdfRenderError
 from app.main import app
 from app.shared.dependencies import get_quote_service
 
 pytestmark = pytest.mark.asyncio
-
-
-class _NoopExtractionIntegration:
-    async def extract(self, notes: str) -> ExtractionResult:
-        del notes
-        raise AssertionError("Extraction is not expected in PDF/share endpoint tests")
 
 
 class _ConfigurablePdfIntegration:
@@ -40,18 +33,6 @@ class _ConfigurablePdfIntegration:
         return f"PDF for {context.doc_number}".encode()
 
 
-class _NoopAudioIntegration:
-    def normalize_and_stitch(self, clips: object) -> bytes:
-        del clips
-        raise AssertionError("Audio normalization is not expected in PDF/share endpoint tests")
-
-
-class _NoopTranscriptionIntegration:
-    async def transcribe(self, audio_wav: bytes) -> str:
-        del audio_wav
-        raise AssertionError("Transcription is not expected in PDF/share endpoint tests")
-
-
 @pytest.fixture(autouse=True)
 def _override_quote_service_dependency() -> Iterator[_ConfigurablePdfIntegration]:
     pdf_integration = _ConfigurablePdfIntegration()
@@ -61,9 +42,6 @@ def _override_quote_service_dependency() -> Iterator[_ConfigurablePdfIntegration
     ) -> QuoteService:
         return QuoteService(
             repository=QuoteRepository(db),
-            extraction_integration=_NoopExtractionIntegration(),
-            audio_integration=_NoopAudioIntegration(),
-            transcription_integration=_NoopTranscriptionIntegration(),
             pdf_integration=pdf_integration,
         )
 

--- a/backend/app/features/quotes/tests/test_quotes.py
+++ b/backend/app/features/quotes/tests/test_quotes.py
@@ -14,6 +14,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.database import get_db
 from app.features.auth.service import CSRF_COOKIE_NAME
 from app.features.quotes import api as quote_api
+from app.features.quotes.extraction_service import ExtractionService
 from app.features.quotes.repository import QuoteRenderContext, QuoteRepository
 from app.features.quotes.schemas import ExtractionResult, LineItemExtracted
 from app.features.quotes.service import QuoteService
@@ -21,7 +22,7 @@ from app.integrations.audio import AudioClip, AudioError
 from app.integrations.extraction import ExtractionError
 from app.integrations.transcription import TranscriptionError
 from app.main import app
-from app.shared.dependencies import get_quote_service
+from app.shared.dependencies import get_extraction_service, get_quote_service
 
 pytestmark = pytest.mark.asyncio
 
@@ -100,15 +101,26 @@ def _override_quote_service_dependency() -> Iterator[None]:
     ) -> QuoteService:
         return QuoteService(
             repository=QuoteRepository(db),
-            extraction_integration=_MockExtractionIntegration(),
-            audio_integration=_MockAudioIntegration(),
-            transcription_integration=_MockTranscriptionIntegration(),
             pdf_integration=_MockPdfIntegration(),
         )
 
     app.dependency_overrides[get_quote_service] = _override_get_quote_service
     yield
     app.dependency_overrides.pop(get_quote_service, None)
+
+
+@pytest.fixture(autouse=True)
+def _override_extraction_service_dependency() -> Iterator[None]:
+    async def _override_get_extraction_service() -> ExtractionService:
+        return ExtractionService(
+            extraction_integration=_MockExtractionIntegration(),
+            audio_integration=_MockAudioIntegration(),
+            transcription_integration=_MockTranscriptionIntegration(),
+        )
+
+    app.dependency_overrides[get_extraction_service] = _override_get_extraction_service
+    yield
+    app.dependency_overrides.pop(get_extraction_service, None)
 
 
 @pytest.fixture(autouse=True)

--- a/backend/app/shared/dependencies.py
+++ b/backend/app/shared/dependencies.py
@@ -23,6 +23,7 @@ from app.features.customers.repository import CustomerRepository
 from app.features.customers.service import CustomerService
 from app.features.profile.repository import ProfileRepository
 from app.features.profile.service import ProfileService
+from app.features.quotes.extraction_service import ExtractionService
 from app.features.quotes.repository import QuoteRepository
 from app.features.quotes.service import QuoteService
 from app.integrations.audio import AudioIntegration
@@ -61,10 +62,17 @@ def get_customer_service(
 def get_quote_service(
     db: Annotated[AsyncSession, Depends(get_db)],
 ) -> QuoteService:
-    """Build a request-scoped quote service wired to DB and extraction integration."""
-    settings = get_settings()
+    """Build a request-scoped quote service wired to DB and PDF integration."""
     return QuoteService(
         repository=QuoteRepository(db),
+        pdf_integration=get_pdf_integration(),
+    )
+
+
+def get_extraction_service() -> ExtractionService:
+    """Build a request-scoped extraction service wired to external integrations."""
+    settings = get_settings()
+    return ExtractionService(
         extraction_integration=ExtractionIntegration(
             api_key=settings.anthropic_api_key,
             model=settings.extraction_model,
@@ -74,7 +82,6 @@ def get_quote_service(
             api_key=settings.openai_api_key,
             model=settings.transcription_model,
         ),
-        pdf_integration=get_pdf_integration(),
     )
 
 


### PR DESCRIPTION
## Summary
- extract audio/transcription/notes conversion orchestration into a dedicated ExtractionService
- wire extraction endpoints to get_extraction_service and deduplicate upload clip parsing in the quotes API
- update quote and PDF tests for the new dependency boundary while preserving endpoint contracts

## Verification
- make backend-verify

Closes #56