### PR TITLE
Task #60: sweep remaining frontend hardcoded colors into design tokens

### DIFF
--- a/frontend/src/features/customers/components/CustomerCreateScreen.tsx
+++ b/frontend/src/features/customers/components/CustomerCreateScreen.tsx
@@ -88,7 +88,7 @@ export function CustomerCreateScreen(): React.ReactElement {
             />
 
             <div className="flex flex-col gap-1">
-              <label htmlFor="customer-address" className="text-sm font-medium text-slate-700">
+              <label htmlFor="customer-address" className="text-sm font-medium text-on-surface">
                 Address
               </label>
               <textarea

--- a/frontend/src/features/customers/components/CustomerInfoForm.tsx
+++ b/frontend/src/features/customers/components/CustomerInfoForm.tsx
@@ -40,7 +40,7 @@ export function CustomerInfoForm({
       </h2>
 
       {saveSuccess ? (
-        <p role="status" className="mb-4 rounded-lg bg-emerald-50 p-3 text-sm text-emerald-700">
+        <p role="status" className="mb-4 rounded-lg bg-success-container p-3 text-sm text-success">
           {saveSuccess}
         </p>
       ) : null}
@@ -63,7 +63,7 @@ export function CustomerInfoForm({
         />
 
         <div className="flex flex-col gap-1">
-          <label htmlFor="customer-detail-address" className="text-sm font-medium text-slate-700">
+          <label htmlFor="customer-detail-address" className="text-sm font-medium text-on-surface">
             Address
           </label>
           <textarea

--- a/frontend/src/features/quotes/components/CaptureScreen.tsx
+++ b/frontend/src/features/quotes/components/CaptureScreen.tsx
@@ -105,7 +105,7 @@ export function CaptureScreen(): React.ReactElement {
         ) : null}
 
         {!isSupported ? (
-          <p className="mb-4 rounded-lg border border-amber-200 bg-amber-50 p-3 text-sm text-amber-900">
+          <p className="mb-4 rounded-lg border border-warning-accent/40 bg-warning-container p-3 text-sm text-warning">
             Voice capture is not supported in this browser. You can still type notes and extract line items.
           </p>
         ) : null}

--- a/frontend/src/features/quotes/components/LineItemCard.tsx
+++ b/frontend/src/features/quotes/components/LineItemCard.tsx
@@ -17,7 +17,7 @@ export function LineItemCard({
     <button
       type="button"
       className={`w-full bg-surface-container-lowest rounded-lg p-4 ghost-shadow text-left flex items-start justify-between gap-3 active:scale-[0.99] transition-all ${
-        flagged ? "border border-amber-500/20" : ""
+        flagged ? "border border-warning-accent/20" : ""
       }`}
       onClick={onClick}
     >
@@ -25,7 +25,7 @@ export function LineItemCard({
         <div className="flex items-center gap-2">
           <p className="font-bold text-on-surface">{description}</p>
           {flagged ? (
-            <span className="rounded bg-amber-100 px-2 py-0.5 text-[0.6875rem] font-bold uppercase tracking-wide text-amber-700">
+            <span className="rounded bg-warning-container px-2 py-0.5 text-[0.6875rem] font-bold uppercase tracking-wide text-warning">
               REVIEW
             </span>
           ) : null}

--- a/frontend/src/features/quotes/components/LineItemRow.tsx
+++ b/frontend/src/features/quotes/components/LineItemRow.tsx
@@ -18,17 +18,19 @@ export function LineItemRow({
   const descriptionInputId = `${rowId}-description`;
   const detailsInputId = `${rowId}-details`;
   const priceInputId = `${rowId}-price`;
+  const inputClassName =
+    "rounded-md border border-outline-variant px-3 py-2 text-sm text-on-surface outline-none focus:border-primary focus:ring-2 focus:ring-primary/30";
 
   return (
-    <div className="rounded-md border border-slate-200 p-4">
+    <div className="rounded-md border border-outline-variant p-4">
       {item.flagged ? (
-        <p className="mb-3 rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-900">
+        <p className="mb-3 rounded-md border border-warning-accent/40 bg-warning-container px-3 py-2 text-sm text-warning">
           {item.flagReason ?? "This item may need review"}
         </p>
       ) : null}
       <div className="grid gap-3 md:grid-cols-[1.3fr_1.3fr_0.8fr_auto] md:items-end">
         <div className="flex flex-col gap-1">
-          <label className="text-sm font-medium text-slate-700" htmlFor={descriptionInputId}>
+          <label className="text-sm font-medium text-on-surface" htmlFor={descriptionInputId}>
             Description
           </label>
           <input
@@ -36,13 +38,13 @@ export function LineItemRow({
             type="text"
             value={item.description}
             onChange={(event) => onChange({ ...item, description: event.target.value })}
-            className="rounded-md border border-slate-300 px-3 py-2 text-sm text-slate-900 outline-none focus:border-slate-500 focus:ring-2 focus:ring-slate-200"
+            className={inputClassName}
           />
-          {descriptionError ? <p className="text-xs text-red-600">{descriptionError}</p> : null}
+          {descriptionError ? <p className="text-xs text-error">{descriptionError}</p> : null}
         </div>
 
         <div className="flex flex-col gap-1">
-          <label className="text-sm font-medium text-slate-700" htmlFor={detailsInputId}>
+          <label className="text-sm font-medium text-on-surface" htmlFor={detailsInputId}>
             Details
           </label>
           <input
@@ -55,12 +57,12 @@ export function LineItemRow({
                 details: event.target.value.trim().length > 0 ? event.target.value : null,
               })
             }
-            className="rounded-md border border-slate-300 px-3 py-2 text-sm text-slate-900 outline-none focus:border-slate-500 focus:ring-2 focus:ring-slate-200"
+            className={inputClassName}
           />
         </div>
 
         <div className="flex flex-col gap-1">
-          <label className="text-sm font-medium text-slate-700" htmlFor={priceInputId}>
+          <label className="text-sm font-medium text-on-surface" htmlFor={priceInputId}>
             Price
           </label>
           <input
@@ -80,14 +82,14 @@ export function LineItemRow({
                 price: Number.isFinite(parsedValue) ? parsedValue : null,
               });
             }}
-            className="rounded-md border border-slate-300 px-3 py-2 text-sm text-slate-900 outline-none focus:border-slate-500 focus:ring-2 focus:ring-slate-200"
+            className={inputClassName}
           />
         </div>
 
         <button
           type="button"
           onClick={onDelete}
-          className="rounded-md border border-slate-300 px-3 py-2 text-sm font-medium text-slate-700 transition hover:bg-slate-100"
+          className="rounded-md border border-outline-variant px-3 py-2 text-sm font-medium text-on-surface transition hover:bg-surface-container-low"
         >
           Delete
         </button>

--- a/frontend/src/features/quotes/components/QuoteDetailsCard.tsx
+++ b/frontend/src/features/quotes/components/QuoteDetailsCard.tsx
@@ -22,7 +22,7 @@ export function QuoteDetailsCard({
         </p>
       </section>
 
-      <section className="ghost-shadow rounded-lg border-l-4 border-teal-500 bg-surface-container-lowest p-4">
+      <section className="ghost-shadow rounded-lg border-l-4 border-surface-tint bg-surface-container-lowest p-4">
         <h2 className="text-[0.6875rem] font-bold uppercase tracking-widest text-outline">CLIENT</h2>
         <p className="mt-2 font-bold text-on-surface">{clientName}</p>
         <p className="mt-1 text-sm text-on-surface-variant">{clientContact}</p>

--- a/frontend/src/features/quotes/components/QuoteList.tsx
+++ b/frontend/src/features/quotes/components/QuoteList.tsx
@@ -90,7 +90,7 @@ export function QuoteList(): React.ReactElement {
               {activeQuoteCount}
             </p>
           </div>
-          <div className="rounded-lg border-l-4 border-amber-500 bg-surface-container-lowest p-4 ghost-shadow">
+          <div className="rounded-lg border-l-4 border-warning-accent bg-surface-container-lowest p-4 ghost-shadow">
             <p className="text-[0.6875rem] font-bold uppercase tracking-widest text-outline">
               PENDING REVIEW
             </p>

--- a/frontend/src/features/quotes/components/QuotePreviewActions.tsx
+++ b/frontend/src/features/quotes/components/QuotePreviewActions.tsx
@@ -69,7 +69,7 @@ export function QuotePreviewActions({
       ) : null}
 
       {shareMessage ? (
-        <p className="mx-4 mt-3 rounded-md bg-emerald-50 p-3 text-sm text-emerald-800">{shareMessage}</p>
+        <p className="mx-4 mt-3 rounded-md bg-success-container p-3 text-sm text-success">{shareMessage}</p>
       ) : null}
     </>
   );

--- a/frontend/src/features/quotes/tests/LineItemCard.test.tsx
+++ b/frontend/src/features/quotes/tests/LineItemCard.test.tsx
@@ -30,7 +30,7 @@ describe("LineItemCard", () => {
       />,
     );
 
-    expect(screen.getByRole("button", { name: /brown mulch/i })).toHaveClass("border-amber-500/20");
+    expect(screen.getByRole("button", { name: /brown mulch/i })).toHaveClass("border-warning-accent/20");
     expect(screen.getByText("REVIEW")).toBeInTheDocument();
   });
 

--- a/frontend/src/features/settings/components/SettingsScreen.tsx
+++ b/frontend/src/features/settings/components/SettingsScreen.tsx
@@ -108,7 +108,7 @@ export function SettingsScreen(): React.ReactElement {
         {!isLoadingProfile && !loadError ? (
           <form className="space-y-4" onSubmit={onSubmit}>
             {saveSuccess ? (
-              <p role="status" className="rounded-md bg-emerald-50 p-3 text-sm text-emerald-700">
+              <p role="status" className="rounded-md bg-success-container p-3 text-sm text-success">
                 {saveSuccess}
               </p>
             ) : null}
@@ -141,7 +141,7 @@ export function SettingsScreen(): React.ReactElement {
                   onChange={(event) => setLastName(event.target.value)}
                 />
                 <fieldset className="flex flex-col gap-2">
-                  <legend className="mb-1 text-sm font-medium text-slate-700">Trade type</legend>
+                  <legend className="mb-1 text-sm font-medium text-on-surface">Trade type</legend>
                   <TradeTypeSelector
                     options={TRADE_TYPES}
                     value={tradeType}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -6,6 +6,14 @@
   --color-on-primary: #ffffff;
   --color-secondary: #904a45;
   --color-on-secondary: #ffffff;
+  --color-success: #166534;
+  --color-success-container: #dcfce7;
+  --color-warning: #92400e;
+  --color-warning-accent: #f59e0b;
+  --color-warning-container: #fef3c7;
+  --color-info: #075985;
+  --color-info-container: #e0f2fe;
+  --color-neutral-container: #f1f5f9;
   --color-error: #ba1a1a;
   --color-on-error: #ffffff;
   --color-error-container: #ffdad6;

--- a/frontend/src/shared/components/AIConfidenceBanner.test.tsx
+++ b/frontend/src/shared/components/AIConfidenceBanner.test.tsx
@@ -11,7 +11,7 @@ describe("AIConfidenceBanner", () => {
     expect(screen.getByText("Please verify line item quantities before sharing.")).toBeInTheDocument();
 
     const icon = screen.getByText("info");
-    expect(icon).toHaveClass("material-symbols-outlined", "text-amber-600");
+    expect(icon).toHaveClass("material-symbols-outlined", "text-warning-accent");
     expect((icon as HTMLElement).style.fontVariationSettings).toBe('"FILL" 1, "wght" 400, "GRAD" 0, "opsz" 24');
   });
 });

--- a/frontend/src/shared/components/AIConfidenceBanner.tsx
+++ b/frontend/src/shared/components/AIConfidenceBanner.tsx
@@ -4,17 +4,17 @@ interface AIConfidenceBannerProps {
 
 export function AIConfidenceBanner({ message }: AIConfidenceBannerProps): React.ReactElement {
   return (
-    <div className="bg-amber-500/10 border-l-4 border-amber-500 rounded-lg p-4 backdrop-blur-md shadow-[0_0_24px_rgba(0,0,0,0.04)]">
+    <div className="rounded-lg border-l-4 border-warning-accent bg-warning-container p-4 backdrop-blur-md shadow-[0_0_24px_rgba(0,0,0,0.04)]">
       <div className="flex gap-3">
         <span
-          className="material-symbols-outlined text-amber-600"
+          className="material-symbols-outlined text-warning-accent"
           style={{ fontVariationSettings: '"FILL" 1, "wght" 400, "GRAD" 0, "opsz" 24' }}
         >
           info
         </span>
         <div>
-          <p className="text-[0.6875rem] font-bold text-amber-800 uppercase tracking-wider">AI Confidence Note</p>
-          <p className="text-sm font-medium text-amber-900 leading-snug">{message}</p>
+          <p className="text-[0.6875rem] font-bold uppercase tracking-wider text-warning">AI Confidence Note</p>
+          <p className="text-sm font-medium leading-snug text-warning">{message}</p>
         </div>
       </div>
     </div>

--- a/frontend/src/shared/components/Button.tsx
+++ b/frontend/src/shared/components/Button.tsx
@@ -14,7 +14,7 @@ interface ButtonProps {
 const variantClasses = {
   primary: "forest-gradient text-white font-semibold py-4 rounded-lg active:scale-[0.98] transition-all",
   destructive: "border border-secondary text-secondary font-semibold py-4 rounded-lg active:scale-[0.98] transition-all",
-  ghost: "p-2 rounded-full hover:bg-slate-50 active:scale-95 transition-all",
+  ghost: "p-2 rounded-full hover:bg-surface-container-low active:scale-95 transition-all",
 } as const;
 
 export function Button({

--- a/frontend/src/shared/components/Input.tsx
+++ b/frontend/src/shared/components/Input.tsx
@@ -34,7 +34,7 @@ export function Input({
   return (
     <div className="flex flex-col gap-1">
       {label ? (
-        <label htmlFor={id} className="text-sm font-medium text-slate-700">
+        <label htmlFor={id} className="text-sm font-medium text-on-surface">
           {label}
         </label>
       ) : null}
@@ -48,7 +48,7 @@ export function Input({
         placeholder={placeholder}
         className={inputClassName}
       />
-      {error ? <p className="text-xs text-red-600">{error}</p> : null}
+      {error ? <p className="text-xs text-error">{error}</p> : null}
     </div>
   );
 }

--- a/frontend/src/shared/components/ScreenHeader.tsx
+++ b/frontend/src/shared/components/ScreenHeader.tsx
@@ -24,7 +24,7 @@ export function ScreenHeader({
           type="button"
           onClick={onBack}
           aria-label={backLabel}
-          className="rounded-full p-2 text-emerald-900 transition-all hover:bg-slate-50 active:scale-95"
+          className="rounded-full p-2 text-primary transition-all hover:bg-surface-container-low active:scale-95"
         >
           <span className="material-symbols-outlined">arrow_back</span>
         </button>

--- a/frontend/src/shared/components/StatusBadge.test.tsx
+++ b/frontend/src/shared/components/StatusBadge.test.tsx
@@ -7,18 +7,18 @@ describe("StatusBadge", () => {
   it("renders draft variant styles", () => {
     render(<StatusBadge variant="draft" />);
 
-    expect(screen.getByText("Draft")).toHaveClass("bg-slate-100", "text-slate-600");
+    expect(screen.getByText("Draft")).toHaveClass("bg-neutral-container", "text-on-surface-variant");
   });
 
   it("renders ready variant styles", () => {
     render(<StatusBadge variant="ready" />);
 
-    expect(screen.getByText("Ready")).toHaveClass("bg-emerald-100", "text-emerald-800");
+    expect(screen.getByText("Ready")).toHaveClass("bg-success-container", "text-success");
   });
 
   it("renders shared variant styles", () => {
     render(<StatusBadge variant="shared" />);
 
-    expect(screen.getByText("Shared")).toHaveClass("bg-sky-100", "text-sky-800");
+    expect(screen.getByText("Shared")).toHaveClass("bg-info-container", "text-info");
   });
 });

--- a/frontend/src/shared/components/StatusBadge.tsx
+++ b/frontend/src/shared/components/StatusBadge.tsx
@@ -3,9 +3,9 @@ interface StatusBadgeProps {
 }
 
 const styles = {
-  draft: "bg-slate-100 text-slate-600",
-  ready: "bg-emerald-100 text-emerald-800",
-  shared: "bg-sky-100 text-sky-800",
+  draft: "bg-neutral-container text-on-surface-variant",
+  ready: "bg-success-container text-success",
+  shared: "bg-info-container text-info",
 } as const;
 
 const labels = {


### PR DESCRIPTION
## Summary
- add success, warning, info, and neutral container tokens to complete the frontend design-token set
- replace the remaining hardcoded Tailwind color utilities in the scoped shared, quote, customer, and settings components
- update the small set of class-based tests that intentionally asserted the old utility names

## Verification
- `make frontend-verify`
- `grep -rn "text-slate\|bg-slate\|border-slate\|text-red-\|bg-red-\|text-emerald\|bg-emerald\|text-amber\|bg-amber\|border-amber\|text-sky\|bg-sky\|border-teal" frontend/src/features/ frontend/src/shared/components/ --include="*.tsx" | grep -v "\.test\."` returned zero results

## Notes
- `border-teal-500` was intentionally aligned to `border-surface-tint` per the Task parity lock

Closes #60