### PR TITLE
Task 62: add server-side customer quote filter

### DIFF
--- a/backend/app/features/quotes/api.py
+++ b/backend/app/features/quotes/api.py
@@ -5,7 +5,17 @@ from __future__ import annotations
 from typing import Annotated
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, File, Form, HTTPException, Request, UploadFile, status
+from fastapi import (
+    APIRouter,
+    Depends,
+    File,
+    Form,
+    HTTPException,
+    Query,
+    Request,
+    UploadFile,
+    status,
+)
 from fastapi.responses import StreamingResponse
 
 from app.features.auth.models import User
@@ -146,9 +156,10 @@ async def extract_combined(
 async def list_quotes(
     user: Annotated[User, Depends(get_current_user)],
     quote_service: Annotated[QuoteService, Depends(get_quote_service)],
+    customer_id: Annotated[UUID | None, Query()] = None,
 ) -> list[QuoteListItemResponse]:
     """List quotes for the authenticated user."""
-    quotes = await quote_service.list_quotes(user)
+    quotes = await quote_service.list_quotes(user, customer_id=customer_id)
     return [QuoteListItemResponse.model_validate(quote) for quote in quotes]
 
 

--- a/backend/app/features/quotes/repository.py
+++ b/backend/app/features/quotes/repository.py
@@ -103,7 +103,11 @@ class QuoteRepository:
         )
         return customer is not None
 
-    async def list_by_user(self, user_id: UUID) -> list[QuoteListItemSummary]:
+    async def list_by_user(
+        self,
+        user_id: UUID,
+        customer_id: UUID | None = None,
+    ) -> list[QuoteListItemSummary]:
         """Return quote summaries for a user ordered newest-first."""
         line_item_count = (
             select(func.count(LineItem.id))
@@ -111,7 +115,7 @@ class QuoteRepository:
             .correlate(Document)
             .scalar_subquery()
         )
-        result = await self._session.execute(
+        statement = (
             select(
                 Document.id,
                 Document.customer_id,
@@ -126,6 +130,10 @@ class QuoteRepository:
             .where(Document.user_id == user_id)
             .order_by(Document.created_at.desc(), Document.doc_sequence.desc())
         )
+        if customer_id is not None:
+            statement = statement.where(Document.customer_id == customer_id)
+
+        result = await self._session.execute(statement)
         return [
             QuoteListItemSummary(
                 id=row.id,

--- a/backend/app/features/quotes/service.py
+++ b/backend/app/features/quotes/service.py
@@ -39,7 +39,11 @@ class QuoteRepositoryProtocol(Protocol):
 
     async def customer_exists_for_user(self, *, user_id: UUID, customer_id: UUID) -> bool: ...
 
-    async def list_by_user(self, user_id: UUID) -> list[QuoteListItemSummary]: ...
+    async def list_by_user(
+        self,
+        user_id: UUID,
+        customer_id: UUID | None = None,
+    ) -> list[QuoteListItemSummary]: ...
 
     async def get_by_id(self, quote_id: UUID, user_id: UUID) -> Document | None: ...
 
@@ -135,9 +139,16 @@ class QuoteService:
 
         raise QuoteServiceError(detail="Unable to create quote", status_code=409)
 
-    async def list_quotes(self, user: User) -> list[QuoteListItemSummary]:
+    async def list_quotes(
+        self,
+        user: User,
+        customer_id: UUID | None = None,
+    ) -> list[QuoteListItemSummary]:
         """List quotes for the authenticated user."""
-        return await self._repository.list_by_user(_resolve_user_id(user))
+        return await self._repository.list_by_user(
+            _resolve_user_id(user),
+            customer_id=customer_id,
+        )
 
     async def get_quote(self, user: User, quote_id: UUID) -> Document:
         """Return one user-owned quote or raise not found."""

--- a/backend/app/features/quotes/tests/test_quotes.py
+++ b/backend/app/features/quotes/tests/test_quotes.py
@@ -306,6 +306,84 @@ async def test_get_quote_detail_includes_nullable_customer_contact_fields(
     assert detail_payload["customer_phone"] is None
 
 
+async def test_list_quotes_can_filter_by_customer_id(client: AsyncClient) -> None:
+    csrf_token = await _register_and_login(client, _credentials())
+    customer_id_a = await _create_customer(client, csrf_token, name="Customer A")
+    customer_id_b = await _create_customer(client, csrf_token, name="Customer B")
+
+    create_response_a = await client.post(
+        "/api/quotes",
+        json={
+            "customer_id": customer_id_a,
+            "transcript": "Quote for customer A",
+            "line_items": [{"description": "Mulch", "details": None, "price": 120}],
+            "total_amount": 120,
+            "notes": None,
+            "source_type": "text",
+        },
+        headers={"X-CSRF-Token": csrf_token},
+    )
+    assert create_response_a.status_code == 201
+
+    create_response_b = await client.post(
+        "/api/quotes",
+        json={
+            "customer_id": customer_id_b,
+            "transcript": "Quote for customer B",
+            "line_items": [{"description": "Stone", "details": None, "price": 220}],
+            "total_amount": 220,
+            "notes": None,
+            "source_type": "text",
+        },
+        headers={"X-CSRF-Token": csrf_token},
+    )
+    assert create_response_b.status_code == 201
+    quote_b = create_response_b.json()
+
+    response = await client.get(f"/api/quotes?customer_id={customer_id_b}")
+
+    assert response.status_code == 200
+    assert response.json() == [
+        {
+            "id": quote_b["id"],
+            "customer_id": customer_id_b,
+            "customer_name": "Customer B",
+            "doc_number": "Q-002",
+            "status": "draft",
+            "total_amount": 220,
+            "item_count": 1,
+            "created_at": quote_b["created_at"],
+        }
+    ]
+
+
+async def test_list_quotes_returns_empty_when_customer_filter_has_no_matches(
+    client: AsyncClient,
+) -> None:
+    csrf_token = await _register_and_login(client, _credentials())
+    existing_customer_id = await _create_customer(client, csrf_token, name="Customer A")
+    missing_customer_id = await _create_customer(client, csrf_token, name="Customer B")
+
+    create_response = await client.post(
+        "/api/quotes",
+        json={
+            "customer_id": existing_customer_id,
+            "transcript": "Quote for customer A",
+            "line_items": [{"description": "Mulch", "details": None, "price": 120}],
+            "total_amount": 120,
+            "notes": None,
+            "source_type": "text",
+        },
+        headers={"X-CSRF-Token": csrf_token},
+    )
+    assert create_response.status_code == 201
+
+    response = await client.get(f"/api/quotes?customer_id={missing_customer_id}")
+
+    assert response.status_code == 200
+    assert response.json() == []
+
+
 async def test_convert_notes_can_return_flagged_line_items(client: AsyncClient) -> None:
     csrf_token = await _register_and_login(client, _credentials())
 

--- a/frontend/src/features/customers/components/CustomerDetailScreen.tsx
+++ b/frontend/src/features/customers/components/CustomerDetailScreen.tsx
@@ -48,7 +48,7 @@ export function CustomerDetailScreen(): React.ReactElement {
       try {
         const [nextCustomer, nextQuotes] = await Promise.all([
           customerService.getCustomer(customerId),
-          quoteService.listQuotes(),
+          quoteService.listQuotes({ customer_id: customerId }),
         ]);
 
         if (!isActive) {
@@ -61,10 +61,7 @@ export function CustomerDetailScreen(): React.ReactElement {
         setEmail(nextCustomer.email ?? "");
         setAddress(nextCustomer.address ?? "");
 
-        const filteredQuotes = nextQuotes
-          .filter((quote) => quote.customer_id === customerId)
-          .sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime());
-        setCustomerQuotes(filteredQuotes);
+        setCustomerQuotes(nextQuotes);
       } catch (error) {
         const message = error instanceof Error ? error.message : "Unable to load customer";
         if (isActive) {

--- a/frontend/src/features/customers/tests/CustomerDetailScreen.test.tsx
+++ b/frontend/src/features/customers/tests/CustomerDetailScreen.test.tsx
@@ -72,16 +72,6 @@ beforeEach(() => {
       item_count: 1,
       created_at: "2026-03-20T00:00:00.000Z",
     },
-    {
-      id: "quote-2",
-      customer_id: "cust-2",
-      customer_name: "Bob Brown",
-      doc_number: "Q-002",
-      status: "ready",
-      total_amount: 240,
-      item_count: 2,
-      created_at: "2026-03-21T00:00:00.000Z",
-    },
   ]);
   mockedCustomerService.updateCustomer.mockResolvedValue({
     id: "cust-1",
@@ -103,6 +93,7 @@ describe("CustomerDetailScreen", () => {
     renderScreen();
 
     expect(await screen.findByRole("heading", { name: "Alice Johnson" })).toBeInTheDocument();
+    expect(mockedQuoteService.listQuotes).toHaveBeenCalledWith({ customer_id: "cust-1" });
     expect(screen.getByLabelText(/^name$/i)).toHaveValue("Alice Johnson");
     expect(screen.getByLabelText(/^phone$/i)).toHaveValue("555-0101");
     expect(screen.getByLabelText(/^email$/i)).toHaveValue("alice@example.com");
@@ -189,18 +180,7 @@ describe("CustomerDetailScreen", () => {
   });
 
   it("renders quote history empty state when customer has no quotes", async () => {
-    mockedQuoteService.listQuotes.mockResolvedValueOnce([
-      {
-        id: "quote-2",
-        customer_id: "cust-2",
-        customer_name: "Bob Brown",
-        doc_number: "Q-002",
-        status: "ready",
-        total_amount: 240,
-        item_count: 2,
-        created_at: "2026-03-21T00:00:00.000Z",
-      },
-    ]);
+    mockedQuoteService.listQuotes.mockResolvedValueOnce([]);
 
     renderScreen();
 

--- a/frontend/src/features/quotes/services/quoteService.ts
+++ b/frontend/src/features/quotes/services/quoteService.ts
@@ -77,8 +77,9 @@ function createQuote(data: QuoteCreateRequest): Promise<Quote> {
   });
 }
 
-function listQuotes(): Promise<QuoteListItem[]> {
-  return request<QuoteListItem[]>("/api/quotes");
+function listQuotes(params?: { customer_id?: string }): Promise<QuoteListItem[]> {
+  const query = params?.customer_id ? `?customer_id=${params.customer_id}` : "";
+  return request<QuoteListItem[]>(`/api/quotes${query}`);
 }
 
 function getQuote(id: string): Promise<QuoteDetail> {

--- a/frontend/src/features/quotes/tests/quoteService.integration.test.ts
+++ b/frontend/src/features/quotes/tests/quoteService.integration.test.ts
@@ -196,6 +196,21 @@ describe("quoteService integration (MSW)", () => {
     expect(quotes[0]).not.toHaveProperty("line_items");
   });
 
+  it("listQuotes sends customer_id query param when provided", async () => {
+    let capturedCustomerId: string | null = null;
+
+    server.use(
+      http.get("/api/quotes", ({ request }) => {
+        capturedCustomerId = new URL(request.url).searchParams.get("customer_id");
+        return HttpResponse.json([], { status: 200 });
+      }),
+    );
+
+    await quoteService.listQuotes({ customer_id: "cust-1" });
+
+    expect(capturedCustomerId).toBe("cust-1");
+  });
+
   it("captureAudio sends multipart clips and returns ExtractionResult", async () => {
     setCsrfToken("integration-csrf-token");
     let capturedCsrfHeader: string | null = null;


### PR DESCRIPTION
## Summary
- add optional `customer_id` filtering to `GET /api/quotes`
- route customer detail quote history through the server-side filter instead of client-side filtering
- cover backend filtering and frontend query-param behavior with tests

## Verification
- make backend-verify
- make frontend-verify

Closes #62