### PR TITLE
Task #70: add backend event logging foundation

### DIFF
--- a/backend/app/features/customers/service.py
+++ b/backend/app/features/customers/service.py
@@ -8,6 +8,7 @@ from uuid import UUID
 from app.features.auth.models import User
 from app.features.customers.models import Customer
 from app.features.customers.schemas import CustomerCreateRequest, CustomerUpdateRequest
+from app.shared.event_logger import log_event
 
 
 class CustomerServiceError(Exception):
@@ -72,6 +73,7 @@ class CustomerService:
             address=data.address,
         )
         await self._repository.commit()
+        log_event("customer.created", user_id=user.id, customer_id=customer.id)
         return customer
 
     async def update_customer(

--- a/backend/app/features/quotes/api.py
+++ b/backend/app/features/quotes/api.py
@@ -143,11 +143,10 @@ async def extract_combined(
 ) -> ExtractionResult:
     """Extract structured quote data from optional audio clips and optional notes."""
     del request
-    del user
     clip_inputs = await _parse_upload_clips(clips or [])
 
     try:
-        return await extraction_service.extract_combined(clip_inputs, notes)
+        return await extraction_service.extract_combined(clip_inputs, notes, user_id=user.id)
     except QuoteServiceError as exc:
         raise HTTPException(status_code=exc.status_code, detail=exc.detail) from exc
 

--- a/backend/app/features/quotes/extraction_service.py
+++ b/backend/app/features/quotes/extraction_service.py
@@ -6,12 +6,14 @@ import asyncio
 from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Protocol
+from uuid import UUID
 
 from app.features.quotes.schemas import ExtractionResult
 from app.features.quotes.service import QuoteServiceError
 from app.integrations.audio import AudioClip, AudioError
 from app.integrations.extraction import ExtractionError
 from app.integrations.transcription import TranscriptionError
+from app.shared.event_logger import log_event
 
 
 class ExtractionIntegrationProtocol(Protocol):
@@ -74,15 +76,20 @@ class ExtractionService:
         self,
         clips: Sequence[CaptureAudioClip] | None,
         notes: str | None,
+        *,
+        user_id: UUID | None = None,
     ) -> ExtractionResult:
         """Extract quote line items from optional clips plus optional typed notes."""
         normalized_notes = (notes or "").strip()
         combined_text = normalized_notes
+        source_type = "notes"
 
         if clips:
+            source_type = "audio"
             transcript = await self._transcribe_clips(clips)
             combined_text = transcript
             if normalized_notes:
+                source_type = "audio+notes"
                 combined_text = f"{transcript}\n\n{normalized_notes}"
 
         if not combined_text:
@@ -91,7 +98,9 @@ class ExtractionService:
                 status_code=400,
             )
 
-        return await self.convert_notes(combined_text)
+        extraction = await self.convert_notes(combined_text)
+        log_event("extraction.completed", user_id=user_id, detail=source_type)
+        return extraction
 
     async def _transcribe_clips(self, clips: Sequence[CaptureAudioClip]) -> str:
         """Normalize clip uploads and return the resulting transcript."""

--- a/backend/app/features/quotes/service.py
+++ b/backend/app/features/quotes/service.py
@@ -23,6 +23,7 @@ from app.features.quotes.schemas import (
     QuoteUpdateRequest,
 )
 from app.integrations.pdf import PdfRenderError
+from app.shared.event_logger import log_event
 
 
 class QuoteServiceError(Exception):
@@ -132,6 +133,12 @@ class QuoteService:
                     source_type=data.source_type,
                 )
                 await self._repository.commit()
+                log_event(
+                    "quote.created",
+                    user_id=user_id,
+                    quote_id=quote.id,
+                    customer_id=quote.customer_id,
+                )
                 return quote
             except IntegrityError as exc:
                 await self._repository.rollback()
@@ -173,7 +180,8 @@ class QuoteService:
         data: QuoteUpdateRequest,
     ) -> Document:
         """Patch editable quote fields and optionally replace line items."""
-        quote = await self._repository.get_by_id(quote_id, _resolve_user_id(user))
+        user_id = _resolve_user_id(user)
+        quote = await self._repository.get_by_id(quote_id, user_id)
         if quote is None:
             raise QuoteServiceError(detail="Not found", status_code=404)
         if quote.status == QuoteStatus.SHARED:
@@ -194,11 +202,18 @@ class QuoteService:
         if updated_quote.status == QuoteStatus.READY:
             updated_quote.status = QuoteStatus.DRAFT
         await self._repository.commit()
+        log_event(
+            "quote.updated",
+            user_id=user_id,
+            quote_id=updated_quote.id,
+            customer_id=updated_quote.customer_id,
+        )
         return await self._repository.refresh(updated_quote)
 
     async def delete_quote(self, user: User, quote_id: UUID) -> None:
         """Delete a user-owned quote unless it has already been shared."""
-        quote = await self._repository.get_by_id(quote_id, _resolve_user_id(user))
+        user_id = _resolve_user_id(user)
+        quote = await self._repository.get_by_id(quote_id, user_id)
         if quote is None:
             raise QuoteServiceError(detail="Not found", status_code=404)
         if quote.status == QuoteStatus.SHARED:
@@ -209,6 +224,12 @@ class QuoteService:
 
         await self._repository.delete(quote_id)
         await self._repository.commit()
+        log_event(
+            "quote.deleted",
+            user_id=user_id,
+            quote_id=quote.id,
+            customer_id=quote.customer_id,
+        )
 
     async def generate_pdf(self, user: User, quote_id: UUID) -> tuple[str, bytes]:
         """Render and return quote PDF bytes while applying ready transition rules."""
@@ -224,6 +245,7 @@ class QuoteService:
 
         await self._repository.mark_ready_if_not_shared(quote_id=quote_id, user_id=user_id)
         await self._repository.commit()
+        log_event("quote.pdf_generated", user_id=user_id, quote_id=quote_id)
         return context.doc_number, pdf_bytes
 
     async def generate_shared_pdf(self, share_token: str) -> tuple[str, bytes]:
@@ -241,7 +263,8 @@ class QuoteService:
 
     async def share_quote(self, user: User, quote_id: UUID) -> Document:
         """Set share token/timestamp and transition quote status to shared."""
-        quote = await self._repository.get_by_id(quote_id, _resolve_user_id(user))
+        user_id = _resolve_user_id(user)
+        quote = await self._repository.get_by_id(quote_id, user_id)
         if quote is None:
             raise QuoteServiceError(detail="Not found", status_code=404)
 
@@ -251,6 +274,12 @@ class QuoteService:
         quote.shared_at = _utcnow()
         quote.status = QuoteStatus.SHARED
         await self._repository.commit()
+        log_event(
+            "quote.shared",
+            user_id=user_id,
+            quote_id=quote.id,
+            customer_id=quote.customer_id,
+        )
         return await self._repository.refresh(quote)
 
 

--- a/backend/app/features/quotes/tests/test_quotes.py
+++ b/backend/app/features/quotes/tests/test_quotes.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from collections.abc import Iterator, Sequence
 from typing import Annotated
 from uuid import UUID, uuid4
@@ -24,6 +25,7 @@ from app.integrations.audio import AudioClip, AudioError
 from app.integrations.extraction import ExtractionError
 from app.integrations.transcription import TranscriptionError
 from app.main import app
+from app.shared import event_logger
 from app.shared.dependencies import get_extraction_service, get_quote_service
 
 pytestmark = pytest.mark.asyncio
@@ -258,6 +260,115 @@ async def test_quote_crud_happy_path_with_ordering_and_line_item_replacement(
     assert patched["line_items"][0]["price"] is None
     assert patched["total_amount"] == 150
     assert patched["notes"] == "Updated note"
+
+
+async def test_business_events_are_logged_for_quote_customer_and_extraction_flows(
+    client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    emitted_events: list[dict[str, str]] = []
+
+    def _capture(message: str) -> None:
+        emitted_events.append(json.loads(message))
+
+    monkeypatch.setattr(event_logger._EVENT_LOGGER, "info", _capture)  # noqa: SLF001
+
+    csrf_token = await _register_and_login(client, _credentials())
+
+    customer_response = await client.post(
+        "/api/customers",
+        json={"name": "Event Test Customer", "email": "customer@example.com"},
+        headers={"X-CSRF-Token": csrf_token},
+    )
+    assert customer_response.status_code == 201
+    customer_payload = customer_response.json()
+
+    create_response = await client.post(
+        "/api/quotes",
+        json={
+            "customer_id": customer_payload["id"],
+            "transcript": "Spring cleanup quote",
+            "line_items": [{"description": "Cleanup", "details": None, "price": 200}],
+            "total_amount": 200,
+            "notes": "Initial draft",
+            "source_type": "text",
+        },
+        headers={"X-CSRF-Token": csrf_token},
+    )
+    assert create_response.status_code == 201
+    quote_payload = create_response.json()
+
+    extract_response = await client.post(
+        "/api/quotes/extract",
+        data={"notes": "Refresh beds and edge walkway"},
+        headers={"X-CSRF-Token": csrf_token},
+    )
+    assert extract_response.status_code == 200
+
+    update_response = await client.patch(
+        f"/api/quotes/{quote_payload['id']}",
+        json={"notes": "Revised draft"},
+        headers={"X-CSRF-Token": csrf_token},
+    )
+    assert update_response.status_code == 200
+
+    pdf_response = await client.post(
+        f"/api/quotes/{quote_payload['id']}/pdf",
+        headers={"X-CSRF-Token": csrf_token},
+    )
+    assert pdf_response.status_code == 200
+
+    share_response = await client.post(
+        f"/api/quotes/{quote_payload['id']}/share",
+        headers={"X-CSRF-Token": csrf_token},
+    )
+    assert share_response.status_code == 200
+
+    delete_create_response = await client.post(
+        "/api/quotes",
+        json={
+            "customer_id": customer_payload["id"],
+            "transcript": "Delete me",
+            "line_items": [{"description": "Mulch", "details": None, "price": 80}],
+            "total_amount": 80,
+            "notes": None,
+            "source_type": "text",
+        },
+        headers={"X-CSRF-Token": csrf_token},
+    )
+    assert delete_create_response.status_code == 201
+    delete_quote_payload = delete_create_response.json()
+
+    delete_response = await client.delete(
+        f"/api/quotes/{delete_quote_payload['id']}",
+        headers={"X-CSRF-Token": csrf_token},
+    )
+    assert delete_response.status_code == 204
+
+    event_names = [payload["event"] for payload in emitted_events]
+    assert event_names == [
+        "customer.created",
+        "quote.created",
+        "extraction.completed",
+        "quote.updated",
+        "quote.pdf_generated",
+        "quote.shared",
+        "quote.created",
+        "quote.deleted",
+    ]
+    assert emitted_events[0]["customer_id"] == customer_payload["id"]
+    assert emitted_events[1]["quote_id"] == quote_payload["id"]
+    assert emitted_events[2]["detail"] == "notes"
+    assert emitted_events[4]["quote_id"] == quote_payload["id"]
+    assert emitted_events[7]["quote_id"] == delete_quote_payload["id"]
+    assert all(
+        "Event Test Customer" not in payload_text
+        for payload_text in map(json.dumps, emitted_events)
+    )
+    assert all(
+        "customer@example.com" not in payload_text
+        for payload_text in map(json.dumps, emitted_events)
+    )
 
 
 async def test_convert_notes_returns_422_for_extraction_errors(client: AsyncClient) -> None:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -13,12 +13,14 @@ from app.features.customers.api import router as customer_router
 from app.features.profile.api import router as profile_router
 from app.features.quotes.api import public_router as quote_public_router
 from app.features.quotes.api import router as quote_router
+from app.shared.event_logger import configure_event_logging
 from app.shared.rate_limit import limiter
 
 
 def create_app() -> FastAPI:
     """Create and configure the FastAPI application."""
     settings = get_settings()
+    configure_event_logging()
 
     app = FastAPI(title="Stima API")
     app.state.limiter = limiter

--- a/backend/app/shared/event_logger.py
+++ b/backend/app/shared/event_logger.py
@@ -1,0 +1,48 @@
+"""Structured business event logging helpers."""
+
+from __future__ import annotations
+
+import json
+import logging
+import sys
+from datetime import UTC, datetime
+from uuid import UUID
+
+EVENT_LOGGER_NAME = "stima.events"
+_HANDLER_SENTINEL = "_stima_event_handler"
+_EVENT_LOGGER = logging.getLogger(EVENT_LOGGER_NAME)
+
+
+def configure_event_logging() -> None:
+    """Attach a stdout handler for structured event messages exactly once."""
+    _EVENT_LOGGER.setLevel(logging.INFO)
+    _EVENT_LOGGER.propagate = False
+    if any(getattr(handler, _HANDLER_SENTINEL, False) for handler in _EVENT_LOGGER.handlers):
+        return
+
+    handler = logging.StreamHandler(stream=sys.stdout)
+    handler.setFormatter(logging.Formatter("%(message)s"))
+    setattr(handler, _HANDLER_SENTINEL, True)
+    _EVENT_LOGGER.addHandler(handler)
+
+
+def log_event(
+    event: str,
+    *,
+    user_id: UUID | None = None,
+    quote_id: UUID | None = None,
+    customer_id: UUID | None = None,
+    detail: str | None = None,
+) -> None:
+    """Emit a structured JSON log record for one business event."""
+    payload = {
+        "event": event,
+        "timestamp": datetime.now(UTC).isoformat(),
+        "user_id": str(user_id) if user_id else None,
+        "quote_id": str(quote_id) if quote_id else None,
+        "customer_id": str(customer_id) if customer_id else None,
+        "detail": detail,
+    }
+    _EVENT_LOGGER.info(
+        json.dumps({key: value for key, value in payload.items() if value is not None})
+    )

--- a/backend/app/shared/tests/test_event_logger.py
+++ b/backend/app/shared/tests/test_event_logger.py
@@ -1,0 +1,64 @@
+"""Structured event logger tests."""
+
+from __future__ import annotations
+
+import json
+import logging
+import sys
+from datetime import datetime
+from uuid import uuid4
+
+from app.shared import event_logger
+
+
+def test_configure_event_logging_uses_stdout_and_does_not_duplicate_handlers() -> None:
+    logger = logging.getLogger(event_logger.EVENT_LOGGER_NAME)
+    original_handlers = list(logger.handlers)
+    original_level = logger.level
+    original_propagate = logger.propagate
+
+    try:
+        for handler in list(logger.handlers):
+            logger.removeHandler(handler)
+
+        event_logger.configure_event_logging()
+        event_logger.configure_event_logging()
+
+        assert logger.level == logging.INFO
+        assert logger.propagate is False
+        assert len(logger.handlers) == 1
+        handler = logger.handlers[0]
+        assert isinstance(handler, logging.StreamHandler)
+        assert handler.stream is sys.stdout
+        assert handler.formatter is not None
+        assert handler.formatter._fmt == "%(message)s"  # noqa: SLF001
+    finally:
+        for handler in list(logger.handlers):
+            logger.removeHandler(handler)
+        for handler in original_handlers:
+            logger.addHandler(handler)
+        logger.setLevel(original_level)
+        logger.propagate = original_propagate
+
+
+def test_log_event_emits_json_payload_without_none_fields(monkeypatch) -> None:
+    calls: list[str] = []
+    user_id = uuid4()
+    quote_id = uuid4()
+
+    monkeypatch.setattr(event_logger._EVENT_LOGGER, "info", calls.append)  # noqa: SLF001
+
+    event_logger.log_event(
+        "quote.created",
+        user_id=user_id,
+        quote_id=quote_id,
+    )
+
+    assert len(calls) == 1
+    payload = json.loads(calls[0])
+    assert payload["event"] == "quote.created"
+    assert payload["user_id"] == str(user_id)
+    assert payload["quote_id"] == str(quote_id)
+    assert "customer_id" not in payload
+    assert "detail" not in payload
+    datetime.fromisoformat(payload["timestamp"])


### PR DESCRIPTION
## Summary
- add a shared structured event logger configured at FastAPI startup
- instrument quote, customer, and extraction success paths with UUID-only event payloads
- add focused backend tests covering event emission and logger configuration

## Verification
- make backend-verify

Closes #70