### PR TITLE
Task #77: Backend error path hardening

### DIFF
--- a/backend/app/features/customers/tests/test_customers.py
+++ b/backend/app/features/customers/tests/test_customers.py
@@ -98,6 +98,15 @@ async def test_get_customer_by_id_returns_owned_customer(client: AsyncClient) ->
     assert response.json()["id"] == created_customer["id"]
 
 
+async def test_get_customer_returns_404_for_nonexistent_id(client: AsyncClient) -> None:
+    await _register_and_login(client, _credentials())
+
+    response = await client.get(f"/api/customers/{uuid4()}")
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Not found"}
+
+
 async def test_patch_customer_updates_customer(client: AsyncClient) -> None:
     csrf_token = await _register_and_login(client, _credentials())
     created_customer = await _create_customer(
@@ -114,6 +123,46 @@ async def test_patch_customer_updates_customer(client: AsyncClient) -> None:
 
     assert response.status_code == 200
     assert response.json()["name"] == "Alice Smith"
+
+
+async def test_patch_customer_returns_404_for_nonexistent_id(client: AsyncClient) -> None:
+    csrf_token = await _register_and_login(client, _credentials())
+
+    response = await client.patch(
+        f"/api/customers/{uuid4()}",
+        json={"name": "Ghost Customer"},
+        headers={"X-CSRF-Token": csrf_token},
+    )
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Not found"}
+
+
+async def test_patch_customer_updates_only_provided_fields(client: AsyncClient) -> None:
+    csrf_token = await _register_and_login(client, _credentials())
+    created_customer = await _create_customer(
+        client,
+        csrf_token,
+        {
+            "name": "Alice Johnson",
+            "phone": "555-0102",
+            "email": "alice@example.com",
+            "address": "10 Main St",
+        },
+    )
+
+    response = await client.patch(
+        f"/api/customers/{created_customer['id']}",
+        json={"phone": "555-9999"},
+        headers={"X-CSRF-Token": csrf_token},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["name"] == "Alice Johnson"
+    assert payload["phone"] == "555-9999"
+    assert payload["email"] == "alice@example.com"
+    assert payload["address"] == "10 Main St"
 
 
 async def test_patch_customer_rejects_null_name(client: AsyncClient) -> None:

--- a/backend/app/features/profile/tests/test_profile.py
+++ b/backend/app/features/profile/tests/test_profile.py
@@ -101,6 +101,63 @@ async def test_patch_profile_rejects_empty_first_name(client: AsyncClient) -> No
     assert response.status_code == 422
 
 
+async def test_patch_profile_rejects_invalid_trade_type(client: AsyncClient) -> None:
+    await _register_and_login(client, _credentials())
+    csrf_token = client.cookies.get(CSRF_COOKIE_NAME)
+    assert csrf_token is not None
+
+    response = await client.patch(
+        "/api/profile",
+        json={
+            "business_name": "Summit Exterior Care",
+            "first_name": "Jane",
+            "last_name": "Doe",
+            "trade_type": "InvalidType",
+        },
+        headers={"X-CSRF-Token": csrf_token},
+    )
+
+    assert response.status_code == 422
+    assert any(error["loc"][-1] == "trade_type" for error in response.json()["detail"])
+
+
+async def test_patch_profile_rejects_partial_update_and_preserves_existing_values(
+    client: AsyncClient,
+) -> None:
+    credentials = _credentials()
+    await _register_and_login(client, credentials)
+    csrf_token = client.cookies.get(CSRF_COOKIE_NAME)
+    assert csrf_token is not None
+
+    initial_response = await client.patch(
+        "/api/profile",
+        json={
+            "business_name": "Summit Exterior Care",
+            "first_name": "Jane",
+            "last_name": "Doe",
+            "trade_type": "Landscaper",
+        },
+        headers={"X-CSRF-Token": csrf_token},
+    )
+    assert initial_response.status_code == 200
+
+    partial_response = await client.patch(
+        "/api/profile",
+        json={"first_name": "Janet"},
+        headers={"X-CSRF-Token": csrf_token},
+    )
+
+    assert partial_response.status_code == 422
+
+    profile_response = await client.get("/api/profile")
+    assert profile_response.status_code == 200
+    payload = profile_response.json()
+    assert payload["business_name"] == "Summit Exterior Care"
+    assert payload["first_name"] == "Jane"
+    assert payload["last_name"] == "Doe"
+    assert payload["trade_type"] == "Landscaper"
+
+
 async def test_patch_profile_requires_authentication(client: AsyncClient) -> None:
     client.cookies.clear()
     client.cookies.set(CSRF_COOKIE_NAME, "csrf", path="/")

--- a/backend/app/features/quotes/tests/test_pdf.py
+++ b/backend/app/features/quotes/tests/test_pdf.py
@@ -152,6 +152,30 @@ async def test_generate_pdf_returns_422_when_render_fails(
     assert response.json() == {"detail": "Unable to render quote PDF"}
 
 
+async def test_generate_pdf_returns_404_for_nonexistent_quote(client: AsyncClient) -> None:
+    csrf_token = await _register_and_login(client, _credentials())
+
+    response = await client.post(
+        f"/api/quotes/{uuid4()}/pdf",
+        headers={"X-CSRF-Token": csrf_token},
+    )
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Not found"}
+
+
+async def test_share_quote_returns_404_for_nonexistent_quote(client: AsyncClient) -> None:
+    csrf_token = await _register_and_login(client, _credentials())
+
+    response = await client.post(
+        f"/api/quotes/{uuid4()}/share",
+        headers={"X-CSRF-Token": csrf_token},
+    )
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Not found"}
+
+
 async def test_pdf_endpoint_requires_csrf(client: AsyncClient) -> None:
     csrf_token = await _register_and_login(client, _credentials())
     customer_id = await _create_customer(client, csrf_token)

--- a/backend/app/features/quotes/tests/test_quotes.py
+++ b/backend/app/features/quotes/tests/test_quotes.py
@@ -262,6 +262,163 @@ async def test_quote_crud_happy_path_with_ordering_and_line_item_replacement(
     assert patched["notes"] == "Updated note"
 
 
+async def test_get_quote_returns_404_for_nonexistent_id(client: AsyncClient) -> None:
+    await _register_and_login(client, _credentials())
+
+    response = await client.get(f"/api/quotes/{uuid4()}")
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Not found"}
+
+
+async def test_update_quote_returns_404_for_nonexistent_id(client: AsyncClient) -> None:
+    csrf_token = await _register_and_login(client, _credentials())
+
+    response = await client.patch(
+        f"/api/quotes/{uuid4()}",
+        json={"notes": "updated"},
+        headers={"X-CSRF-Token": csrf_token},
+    )
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Not found"}
+
+
+async def test_create_quote_returns_404_for_nonexistent_customer(client: AsyncClient) -> None:
+    csrf_token = await _register_and_login(client, _credentials())
+
+    response = await client.post(
+        "/api/quotes",
+        json={
+            "customer_id": str(uuid4()),
+            "transcript": "quote transcript",
+            "line_items": [{"description": "line item", "details": None, "price": 55}],
+            "total_amount": 55,
+            "notes": None,
+            "source_type": "text",
+        },
+        headers={"X-CSRF-Token": csrf_token},
+    )
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Not found"}
+
+
+async def test_create_quote_allows_empty_line_items_and_returns_empty_list(
+    client: AsyncClient,
+) -> None:
+    csrf_token = await _register_and_login(client, _credentials())
+    customer_id = await _create_customer(client, csrf_token)
+
+    response = await client.post(
+        "/api/quotes",
+        json={
+            "customer_id": customer_id,
+            "transcript": "quote transcript",
+            "line_items": [],
+            "total_amount": None,
+            "notes": "No line items yet",
+            "source_type": "text",
+        },
+        headers={"X-CSRF-Token": csrf_token},
+    )
+
+    assert response.status_code == 201
+    payload = response.json()
+    assert payload["line_items"] == []
+
+    list_response = await client.get("/api/quotes")
+    assert list_response.status_code == 200
+    assert list_response.json()[0]["item_count"] == 0
+
+
+async def test_update_quote_preserves_line_items_when_omitted(
+    client: AsyncClient,
+) -> None:
+    csrf_token = await _register_and_login(client, _credentials())
+    customer_id = await _create_customer(client, csrf_token)
+
+    create_response = await client.post(
+        "/api/quotes",
+        json={
+            "customer_id": customer_id,
+            "transcript": "quote transcript",
+            "line_items": [
+                {"description": "Mulch", "details": "5 yards", "price": 120},
+                {"description": "Edging", "details": None, "price": 80},
+            ],
+            "total_amount": 200,
+            "notes": "Initial note",
+            "source_type": "text",
+        },
+        headers={"X-CSRF-Token": csrf_token},
+    )
+    assert create_response.status_code == 201
+    quote_id = create_response.json()["id"]
+
+    response = await client.patch(
+        f"/api/quotes/{quote_id}",
+        json={"notes": "Updated note only"},
+        headers={"X-CSRF-Token": csrf_token},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert [item["description"] for item in payload["line_items"]] == ["Mulch", "Edging"]
+    assert [item["price"] for item in payload["line_items"]] == [120, 80]
+    assert payload["notes"] == "Updated note only"
+    assert payload["total_amount"] == 200
+
+
+async def test_update_quote_replaces_line_items_when_provided(client: AsyncClient) -> None:
+    csrf_token = await _register_and_login(client, _credentials())
+    customer_id = await _create_customer(client, csrf_token)
+
+    create_response = await client.post(
+        "/api/quotes",
+        json={
+            "customer_id": customer_id,
+            "transcript": "quote transcript",
+            "line_items": [
+                {"description": "Mulch", "details": "5 yards", "price": 120},
+                {"description": "Edging", "details": None, "price": 80},
+            ],
+            "total_amount": 200,
+            "notes": "Initial note",
+            "source_type": "text",
+        },
+        headers={"X-CSRF-Token": csrf_token},
+    )
+    assert create_response.status_code == 201
+    quote_id = create_response.json()["id"]
+
+    response = await client.patch(
+        f"/api/quotes/{quote_id}",
+        json={
+            "line_items": [
+                {
+                    "description": "Premium mulch refresh",
+                    "details": "6 yards",
+                    "price": 180,
+                }
+            ]
+        },
+        headers={"X-CSRF-Token": csrf_token},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["line_items"] == [
+        {
+            "id": payload["line_items"][0]["id"],
+            "description": "Premium mulch refresh",
+            "details": "6 yards",
+            "price": 180,
+            "sort_order": 0,
+        }
+    ]
+
+
 async def test_business_events_are_logged_for_quote_customer_and_extraction_flows(
     client: AsyncClient,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
Closes #77

## Summary
- add targeted backend tests for missing quote, PDF/share, and customer 404 paths
- document current contracts for empty quote line items and profile validation behavior
- keep the change test-only and avoid duplicating existing public share and customer empty-name coverage

## Verification
- make backend-verify