### PR TITLE
test: add frontend error and loading state coverage

### DIFF
--- a/frontend/src/features/customers/tests/CustomerDetailScreen.test.tsx
+++ b/frontend/src/features/customers/tests/CustomerDetailScreen.test.tsx
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { CustomerDetailScreen } from "@/features/customers/components/CustomerDetailScreen";
 import { customerService } from "@/features/customers/services/customerService";
+import type { Customer } from "@/features/customers/types/customer.types";
 import { quoteService } from "@/features/quotes/services/quoteService";
 
 const navigateMock = vi.fn();
@@ -100,6 +101,22 @@ describe("CustomerDetailScreen", () => {
     expect(screen.getByLabelText(/^address$/i)).toHaveValue("1 Main St");
   });
 
+  it("shows loading state while fetching", () => {
+    mockedCustomerService.getCustomer.mockImplementationOnce(() => new Promise<Customer>(() => {}));
+
+    renderScreen();
+
+    expect(screen.getByRole("status")).toHaveTextContent("Loading customer...");
+  });
+
+  it("shows error when customer fetch fails", async () => {
+    mockedCustomerService.getCustomer.mockRejectedValueOnce(new Error("Unable to load customer"));
+
+    renderScreen();
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("Unable to load customer");
+  });
+
   it("calls updateCustomer with edited values and shows success feedback", async () => {
     renderScreen();
     await screen.findByLabelText(/^name$/i);
@@ -129,6 +146,17 @@ describe("CustomerDetailScreen", () => {
     });
 
     expect(await screen.findByRole("status")).toHaveTextContent("Saved");
+  });
+
+  it("shows save error when update fails", async () => {
+    mockedCustomerService.updateCustomer.mockRejectedValueOnce(new Error("Unable to save customer"));
+
+    renderScreen();
+    await screen.findByLabelText(/^name$/i);
+
+    fireEvent.click(screen.getByRole("button", { name: /save changes/i }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("Unable to save customer");
   });
 
   it("sends null for optional fields when user clears them", async () => {

--- a/frontend/src/features/customers/tests/CustomerSelectScreen.test.tsx
+++ b/frontend/src/features/customers/tests/CustomerSelectScreen.test.tsx
@@ -96,6 +96,14 @@ describe("CustomerSelectScreen", () => {
     expect(await screen.findByText("Alice Johnson")).toBeInTheDocument();
   });
 
+  it("shows error when customer list fails", async () => {
+    mockedCustomerService.listCustomers.mockRejectedValueOnce(new Error("Unable to load customers"));
+
+    renderScreen();
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("Unable to load customers");
+  });
+
   it("filters list when user types in search input", async () => {
     renderScreen();
     await screen.findByText("Alice Johnson");

--- a/frontend/src/features/quotes/tests/CaptureScreen.test.tsx
+++ b/frontend/src/features/quotes/tests/CaptureScreen.test.tsx
@@ -157,6 +157,17 @@ describe("CaptureScreen", () => {
     expect(screen.getByRole("button", { name: /stop/i })).toBeInTheDocument();
   });
 
+  it("shows browser unsupported warning", () => {
+    mockVoiceCapture({ isSupported: false });
+    renderScreen();
+
+    expect(
+      screen.getByText(
+        "Voice capture is not supported in this browser. You can still type notes and extract line items.",
+      ),
+    ).toBeInTheDocument();
+  });
+
   it("shows a leave confirmation when navigating back with unsaved clips", () => {
     mockVoiceCapture({ clips: [clipFixture] });
     renderScreen();

--- a/frontend/src/features/quotes/tests/QuotePreview.test.tsx
+++ b/frontend/src/features/quotes/tests/QuotePreview.test.tsx
@@ -191,6 +191,15 @@ describe("QuotePreview", () => {
     expect(screen.queryByRole("button", { name: /generate pdf/i })).not.toBeInTheDocument();
   });
 
+  it("shows loading state while fetching quote", () => {
+    mockedQuoteService.getQuote.mockImplementationOnce(() => new Promise<QuoteDetail>(() => {}));
+
+    renderScreen();
+
+    expect(screen.getByRole("status")).toHaveTextContent("Loading quote...");
+    expect(screen.queryByRole("button", { name: /generate pdf/i })).not.toBeInTheDocument();
+  });
+
   it("renders amount and falls back to customer_id when customer details are unavailable", async () => {
     mockedQuoteService.getQuote.mockResolvedValueOnce(
       makeQuoteDetail({

--- a/frontend/src/features/quotes/tests/ReviewScreen.test.tsx
+++ b/frontend/src/features/quotes/tests/ReviewScreen.test.tsx
@@ -224,6 +224,15 @@ describe("ReviewScreen", () => {
     expect(navigateMock).toHaveBeenCalledWith("/quotes/quote-1/preview");
   });
 
+  it("shows save error when create fails", async () => {
+    mockedQuoteService.createQuote.mockRejectedValueOnce(new Error("Unable to create quote"));
+    renderScreen(makeDraft());
+
+    fireEvent.click(screen.getByRole("button", { name: /generate quote >/i }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("Unable to create quote");
+  });
+
   it("filters blank rows before submit and only sends described line items", async () => {
     renderScreen(
       makeDraft({
@@ -292,5 +301,24 @@ describe("ReviewScreen", () => {
     );
 
     expect(screen.getByRole("button", { name: /generate quote >/i })).toBeDisabled();
+  });
+
+  it("disables submit when there are no line items", () => {
+    renderScreen(
+      makeDraft({
+        lineItems: [],
+      }),
+    );
+
+    expect(screen.getByText("No line items extracted yet.")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /generate quote >/i })).toBeDisabled();
+  });
+
+  it("redirects to home when no draft is available", async () => {
+    renderScreen(null);
+
+    await waitFor(() => {
+      expect(navigateMock).toHaveBeenCalledWith("/", { replace: true });
+    });
   });
 });


### PR DESCRIPTION
## Summary
- add missing QuotePreview, ReviewScreen, and CaptureScreen error/loading coverage
- add missing CustomerDetailScreen and CustomerSelectScreen error/loading coverage
- keep the task test-only with no behavior changes

## Verification
- make frontend-verify

Closes #78