### PR TITLE
Task #83: Redesign quote list cards

### DIFF
--- a/frontend/src/features/quotes/components/QuoteList.tsx
+++ b/frontend/src/features/quotes/components/QuoteList.tsx
@@ -79,32 +79,17 @@ export function QuoteList(): React.ReactElement {
           <h1 className="font-headline text-2xl font-bold tracking-tight text-primary">
             Stima Quotes
           </h1>
+          <p className="mt-1 text-sm text-on-surface-variant">
+            {activeQuoteCount} active {"\u00b7"} {pendingReviewCount} pending review
+          </p>
         </div>
-
-        <section className="mb-4 grid grid-cols-2 gap-3 px-4">
-          <div className="rounded-lg border-l-4 border-primary bg-surface-container-lowest p-4 ghost-shadow">
-            <p className="text-[0.6875rem] font-bold uppercase tracking-widest text-outline">
-              ACTIVE QUOTES
-            </p>
-            <p className="mt-2 font-headline text-3xl font-bold text-on-surface">
-              {activeQuoteCount}
-            </p>
-          </div>
-          <div className="rounded-lg border-l-4 border-warning-accent bg-surface-container-lowest p-4 ghost-shadow">
-            <p className="text-[0.6875rem] font-bold uppercase tracking-widest text-outline">
-              PENDING REVIEW
-            </p>
-            <p className="mt-2 font-headline text-3xl font-bold text-on-surface">
-              {pendingReviewCount}
-            </p>
-          </div>
-        </section>
 
         <div className="mb-4 px-4">
           <Input
             label="Search quotes"
             id="quote-search"
             placeholder="Search customer or quote ID..."
+            hideLabel
             value={searchQuery}
             onChange={(event) => setSearchQuery(event.target.value)}
           />
@@ -143,33 +128,36 @@ export function QuoteList(): React.ReactElement {
                 Sorted by: Most Recent
               </p>
             </div>
-            <ul className="px-4 pb-2">
-              {filteredQuotes.map((quote) => (
-                <li key={quote.id} className="mb-2">
-                  <button
-                    type="button"
-                    onClick={() => navigate(`/quotes/${quote.id}/preview`)}
-                    className="w-full rounded-lg bg-surface-container-lowest p-4 text-left ghost-shadow transition active:scale-[0.99]"
-                  >
-                    <div className="flex items-start justify-between gap-3">
-                      <div>
+            <div className="mx-4 rounded-xl bg-surface-container-low p-3">
+              <ul className="flex flex-col gap-3">
+                {filteredQuotes.map((quote) => (
+                  <li key={quote.id}>
+                    <button
+                      type="button"
+                      onClick={() => navigate(`/quotes/${quote.id}/preview`)}
+                      className="w-full rounded-xl bg-surface-container-lowest p-4 text-left ghost-shadow transition active:scale-[0.98] active:bg-surface-container-low"
+                    >
+                      <div className="flex items-baseline justify-between gap-3">
                         <p className="font-headline font-bold text-on-surface">
                           {quote.customer_name}
                         </p>
-                        <p className="mt-1 text-sm text-on-surface-variant">
-                          {quote.doc_number} {" \u00b7 "} {formatDate(quote.created_at)}
+                        <p className="font-headline font-bold text-on-surface">
+                          {formatCurrency(quote.total_amount)}
                         </p>
                       </div>
-                      <StatusBadge variant={quote.status} />
-                    </div>
-                    <p className="mt-2 text-xs text-outline">{quote.item_count} items</p>
-                    <p className="mt-3 text-right font-bold text-on-surface">
-                      {formatCurrency(quote.total_amount)}
-                    </p>
-                  </button>
-                </li>
-              ))}
-            </ul>
+                      <div className="mt-1 flex items-center justify-between gap-3">
+                        <p className="text-sm text-on-surface-variant">
+                          {quote.doc_number} {" \u00b7 "} {formatDate(quote.created_at)} {" \u00b7 "}
+                          {" "}
+                          {quote.item_count} {quote.item_count === 1 ? "item" : "items"}
+                        </p>
+                        <StatusBadge variant={quote.status} />
+                      </div>
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            </div>
           </>
         ) : null}
       </section>

--- a/frontend/src/features/quotes/tests/QuoteList.test.tsx
+++ b/frontend/src/features/quotes/tests/QuoteList.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
@@ -75,9 +75,9 @@ describe("QuoteList", () => {
 
     expect(await screen.findByText("Stima Quotes")).toBeInTheDocument();
     expect(await screen.findByText("Alice Johnson")).toBeInTheDocument();
-    expect(screen.getByText(/Q-002/)).toBeInTheDocument();
+    expect(screen.getByText(/Q-002\s*·\s*Mar 20, 2026\s*·\s*3 items/)).toBeInTheDocument();
     expect(screen.getByText("Ready")).toBeInTheDocument();
-    expect(screen.getByText("3 items")).toBeInTheDocument();
+    expect(screen.getAllByText("$120.00")).toHaveLength(2);
   });
 
   it("renders empty state when no quotes are returned", async () => {
@@ -156,7 +156,7 @@ describe("QuoteList", () => {
     expect(navigateMock).toHaveBeenCalledWith("/quotes/quote-1/preview");
   });
 
-  it("renders stats bar counts for active and pending quotes", async () => {
+  it("renders compact stats text for active and pending quotes", async () => {
     mockedQuoteService.listQuotes.mockResolvedValueOnce([
       makeQuoteListItem({ status: "ready" }),
       makeQuoteListItem({
@@ -171,13 +171,9 @@ describe("QuoteList", () => {
     renderScreen();
     await screen.findByText("Alice Johnson");
 
-    const activeTile = screen.getByText("ACTIVE QUOTES").closest("div");
-    const pendingTile = screen.getByText("PENDING REVIEW").closest("div");
-
-    expect(activeTile).not.toBeNull();
-    expect(pendingTile).not.toBeNull();
-    expect(within(activeTile as HTMLDivElement).getByText("1")).toBeInTheDocument();
-    expect(within(pendingTile as HTMLDivElement).getByText("1")).toBeInTheDocument();
+    expect(screen.getByText(/1 active\s*·\s*1 pending review/i)).toBeInTheDocument();
+    expect(screen.queryByText("ACTIVE QUOTES")).not.toBeInTheDocument();
+    expect(screen.queryByText("PENDING REVIEW")).not.toBeInTheDocument();
   });
 
   it("renders BottomNav with quotes tab active", async () => {
@@ -228,6 +224,33 @@ describe("QuoteList", () => {
     renderScreen();
 
     expect(await screen.findByText(/Q-001\s*·\s*Mar 21, 2026/)).toBeInTheDocument();
+  });
+
+  it("renders an em dash when total_amount is null", async () => {
+    mockedQuoteService.listQuotes.mockResolvedValueOnce([
+      makeQuoteListItem({
+        id: "quote-null-total",
+        total_amount: null,
+      }),
+    ]);
+
+    renderScreen();
+
+    expect(await screen.findByText("—")).toBeInTheDocument();
+  });
+
+  it("keeps the search label accessible while visually hiding it", async () => {
+    mockedQuoteService.listQuotes.mockResolvedValueOnce([makeQuoteListItem()]);
+
+    renderScreen();
+    await screen.findByText("Alice Johnson");
+
+    const searchInput = screen.getByLabelText("Search quotes");
+    const searchLabel = document.querySelector('label[for="quote-search"]');
+
+    expect(searchInput).toBeInTheDocument();
+    expect(searchLabel).not.toBeNull();
+    expect(searchLabel).toHaveClass("sr-only");
   });
 
   it("shows error state when list request fails", async () => {

--- a/frontend/src/shared/components/Input.tsx
+++ b/frontend/src/shared/components/Input.tsx
@@ -7,6 +7,7 @@ interface InputProps {
   className?: string;
   type?: string;
   required?: boolean;
+  hideLabel?: boolean;
   value: string;
   onChange: (event: ChangeEvent<HTMLInputElement>) => void;
   error?: string;
@@ -19,6 +20,7 @@ export function Input({
   className,
   type = "text",
   required = false,
+  hideLabel = false,
   value,
   onChange,
   error,
@@ -34,7 +36,10 @@ export function Input({
   return (
     <div className="flex flex-col gap-1">
       {label ? (
-        <label htmlFor={id} className="text-sm font-medium text-on-surface">
+        <label
+          htmlFor={id}
+          className={hideLabel ? "sr-only" : "text-sm font-medium text-on-surface"}
+        >
           {label}
         </label>
       ) : null}


### PR DESCRIPTION
## Summary
- redesign the quote list cards into a compact two-row layout with a tonal list container and inline stats text
- add an optional visually-hidden label path to shared Input and use it for the quote search field
- refresh QuoteList tests for the new layout plus null-total and sr-only label coverage

## Verification
- `make frontend-verify`

Closes #83
