### PR TITLE
Task 91: transcript correction and review guardrails

### DIFF
--- a/frontend/src/features/quotes/components/LineItemCard.tsx
+++ b/frontend/src/features/quotes/components/LineItemCard.tsx
@@ -3,6 +3,7 @@ interface LineItemCardProps {
   details: string | null;
   price: number | null;
   flagged?: boolean;
+  disabled?: boolean;
   onClick: () => void;
 }
 
@@ -11,11 +12,13 @@ export function LineItemCard({
   details,
   price,
   flagged = false,
+  disabled = false,
   onClick,
 }: LineItemCardProps): React.ReactElement {
   return (
     <button
       type="button"
+      disabled={disabled}
       className={`flex w-full items-start justify-between gap-3 rounded-xl bg-surface-container-lowest p-4 text-left ghost-shadow transition-all active:scale-[0.98] active:bg-surface-container-low ${
         flagged ? "border border-warning-accent/20" : ""
       }`}

--- a/frontend/src/features/quotes/components/ReviewScreen.tsx
+++ b/frontend/src/features/quotes/components/ReviewScreen.tsx
@@ -110,6 +110,7 @@ export function ReviewScreen(): React.ReactElement | null {
   }, 0);
   const trimmedTranscript = currentDraft.transcript.trim();
   const reviewMessages = getReviewMessages(currentDraft);
+  const isInteractionLocked = isSaving || isRegenerating;
 
   function updateDraft(updater: (current: QuoteDraft) => QuoteDraft): void {
     setDraft(updater(currentDraft));
@@ -202,7 +203,12 @@ export function ReviewScreen(): React.ReactElement | null {
       <ScreenHeader
         title="Review & Edit"
         backLabel="Back to capture"
-        onBack={() => navigate(`/quotes/capture/${currentDraft.customerId}`)}
+        onBack={() => {
+          if (isInteractionLocked) {
+            return;
+          }
+          navigate(`/quotes/capture/${currentDraft.customerId}`);
+        }}
       />
 
       <form
@@ -246,6 +252,7 @@ export function ReviewScreen(): React.ReactElement | null {
             <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
               <button
                 type="button"
+                disabled={isInteractionLocked}
                 className="text-left text-sm font-semibold text-primary underline-offset-4 hover:underline"
                 onClick={() => setIsTranscriptEditorVisible((isVisible) => !isVisible)}
               >
@@ -257,7 +264,7 @@ export function ReviewScreen(): React.ReactElement | null {
                   type="button"
                   className="w-full px-4 py-3 sm:w-auto"
                   onClick={onRegenerateRequest}
-                  disabled={trimmedTranscript.length === 0 || isSaving}
+                  disabled={trimmedTranscript.length === 0 || isInteractionLocked}
                   isLoading={isRegenerating}
                 >
                   Regenerate From Transcript
@@ -276,6 +283,7 @@ export function ReviewScreen(): React.ReactElement | null {
                 <textarea
                   id="transcript-notes"
                   rows={6}
+                  disabled={isInteractionLocked}
                   value={currentDraft.transcript}
                   onChange={(event) =>
                     updateDraft((nextDraft) => ({
@@ -311,6 +319,7 @@ export function ReviewScreen(): React.ReactElement | null {
                 details={lineItem.details}
                 price={lineItem.price}
                 flagged={lineItem.flagged}
+                disabled={isInteractionLocked}
                 onClick={() => navigate(`/quotes/review/line-items/${index}/edit`)}
               />
             ))
@@ -323,6 +332,7 @@ export function ReviewScreen(): React.ReactElement | null {
 
         <button
           type="button"
+          disabled={isInteractionLocked}
           className="flex w-full items-center justify-center gap-2 rounded-lg border-2 border-dashed border-outline-variant/30 py-3 text-sm text-on-surface-variant transition-colors hover:bg-surface-container-low"
           onClick={onLineItemAdd}
         >
@@ -333,6 +343,7 @@ export function ReviewScreen(): React.ReactElement | null {
         <TotalAmountSection
           lineItemSum={lineItemSum}
           total={currentDraft.total}
+          disabled={isInteractionLocked}
           onTotalChange={(total) => {
             updateDraft((nextDraft) => ({ ...nextDraft, total }));
           }}
@@ -348,6 +359,7 @@ export function ReviewScreen(): React.ReactElement | null {
           <textarea
             id="quote-notes"
             rows={3}
+            disabled={isInteractionLocked}
             value={currentDraft.notes}
             onChange={(event) =>
               updateDraft((nextDraft) => ({
@@ -374,7 +386,7 @@ export function ReviewScreen(): React.ReactElement | null {
             form="quote-review-form"
             variant="primary"
             className="w-full"
-            disabled={!canSubmit}
+            disabled={!canSubmit || isInteractionLocked}
             isLoading={isSaving}
           >
             Generate Quote {">"}

--- a/frontend/src/features/quotes/components/TotalAmountSection.tsx
+++ b/frontend/src/features/quotes/components/TotalAmountSection.tsx
@@ -3,12 +3,14 @@ import { formatCurrency } from "@/shared/lib/formatters";
 interface TotalAmountSectionProps {
   lineItemSum: number;
   total: number | null;
+  disabled?: boolean;
   onTotalChange: (value: number | null) => void;
 }
 
 export function TotalAmountSection({
   lineItemSum,
   total,
+  disabled = false,
   onTotalChange,
 }: TotalAmountSectionProps): React.ReactElement {
   return (
@@ -32,6 +34,7 @@ export function TotalAmountSection({
             id="quote-total"
             type="number"
             step="0.01"
+            disabled={disabled}
             value={total ?? ""}
             onChange={(event) => {
               const rawValue = event.target.value.trim();

--- a/frontend/src/features/quotes/tests/ReviewScreen.test.tsx
+++ b/frontend/src/features/quotes/tests/ReviewScreen.test.tsx
@@ -41,6 +41,21 @@ vi.mock("@/features/quotes/services/quoteService", () => ({
 const mockedUseQuoteDraft = vi.mocked(useQuoteDraft);
 const mockedQuoteService = vi.mocked(quoteService);
 
+function createDeferredPromise<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (reason?: unknown) => void;
+} {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((innerResolve, innerReject) => {
+    resolve = innerResolve;
+    reject = innerReject;
+  });
+
+  return { promise, resolve, reject };
+}
+
 function makeDraft(overrides: Partial<QuoteDraft> = {}): QuoteDraft {
   return {
     customerId: "cust-1",
@@ -272,6 +287,35 @@ describe("ReviewScreen", () => {
     });
   });
 
+  it("blocks quote submission while regeneration is pending", async () => {
+    const user = userEvent.setup();
+    const regeneration = createDeferredPromise<Awaited<ReturnType<typeof quoteService.convertNotes>>>();
+    mockedQuoteService.convertNotes.mockReturnValueOnce(regeneration.promise);
+    renderScreen(makeDraft());
+
+    await user.click(screen.getByRole("button", { name: /edit transcript notes/i }));
+    await user.click(screen.getByRole("button", { name: /regenerate from transcript/i }));
+    await user.click(screen.getByRole("button", { name: /replace draft/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /generate quote >/i })).toBeDisabled();
+    });
+
+    await user.click(screen.getByRole("button", { name: /generate quote >/i }));
+    expect(mockedQuoteService.createQuote).not.toHaveBeenCalled();
+
+    regeneration.resolve({
+      transcript: "Corrected transcript",
+      line_items: [{ description: "Brown mulch", details: "6 yards", price: 275 }],
+      total: 275,
+      confidence_notes: [],
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /generate quote >/i })).toBeEnabled();
+    });
+  });
+
   it("replaces transcript, line items, total, and confidence notes after successful regeneration", async () => {
     const user = userEvent.setup();
     mockedQuoteService.convertNotes.mockResolvedValueOnce({
@@ -306,6 +350,34 @@ describe("ReviewScreen", () => {
     expect(screen.getByText(/verify soil depth before sending/i)).toBeInTheDocument();
     expect(screen.getByRole("textbox", { name: /customer notes/i })).toHaveValue("Keep customer note");
     expect(screen.queryByRole("textbox", { name: /transcript notes/i })).not.toBeInTheDocument();
+  });
+
+  it("locks customer notes during regeneration and preserves them after success", async () => {
+    const user = userEvent.setup();
+    const regeneration = createDeferredPromise<Awaited<ReturnType<typeof quoteService.convertNotes>>>();
+    mockedQuoteService.convertNotes.mockReturnValueOnce(regeneration.promise);
+    renderScreen(makeDraft({ notes: "Keep customer note" }));
+
+    await user.click(screen.getByRole("button", { name: /edit transcript notes/i }));
+    await user.click(screen.getByRole("button", { name: /regenerate from transcript/i }));
+    await user.click(screen.getByRole("button", { name: /replace draft/i }));
+
+    const customerNotes = screen.getByRole("textbox", { name: /customer notes/i });
+    await waitFor(() => {
+      expect(customerNotes).toBeDisabled();
+    });
+
+    regeneration.resolve({
+      transcript: "Corrected transcript",
+      line_items: [{ description: "Brown mulch", details: "6 yards", price: 275 }],
+      total: 275,
+      confidence_notes: [],
+    });
+
+    await waitFor(() => {
+      expect(customerNotes).toBeEnabled();
+    });
+    expect(customerNotes).toHaveValue("Keep customer note");
   });
 
   it("preserves the edited transcript and current draft when regeneration fails", async () => {


### PR DESCRIPTION
## Summary
- add an explicit transcript edit/regenerate path to the quote review screen
- require confirmation before regeneration replaces existing extracted draft details
- surface clearer review-required and null-pricing guidance with focused regression coverage

## Verification
- make frontend-verify

Closes #91