### PR TITLE
Task #101: Canonicalize quote-flow event names before pilot

### DIFF
--- a/backend/app/features/quotes/service.py
+++ b/backend/app/features/quotes/service.py
@@ -245,7 +245,6 @@ class QuoteService:
 
         await self._repository.mark_ready_if_not_shared(quote_id=quote_id, user_id=user_id)
         await self._repository.commit()
-        log_event("quote.pdf_generated", user_id=user_id, quote_id=quote_id)
         log_event("quote_pdf_generated", user_id=user_id, quote_id=quote_id)
         return context.doc_number, pdf_bytes
 
@@ -276,12 +275,6 @@ class QuoteService:
         quote.status = QuoteStatus.SHARED
         await self._repository.commit()
         refreshed_quote = await self._repository.refresh(quote)
-        log_event(
-            "quote.shared",
-            user_id=user_id,
-            quote_id=refreshed_quote.id,
-            customer_id=refreshed_quote.customer_id,
-        )
         log_event(
             "quote_shared",
             user_id=user_id,

--- a/backend/app/features/quotes/tests/test_quotes.py
+++ b/backend/app/features/quotes/tests/test_quotes.py
@@ -509,9 +509,7 @@ async def test_business_events_are_logged_for_quote_customer_and_extraction_flow
         "quote_started",
         "draft_generated",
         "quote.updated",
-        "quote.pdf_generated",
         "quote_pdf_generated",
-        "quote.shared",
         "quote_shared",
         "quote.created",
         "quote.deleted",
@@ -521,7 +519,7 @@ async def test_business_events_are_logged_for_quote_customer_and_extraction_flow
     assert emitted_events[2]["detail"] == "notes"
     assert emitted_events[3]["detail"] == "notes"
     assert emitted_events[5]["quote_id"] == quote_payload["id"]
-    assert emitted_events[9]["quote_id"] == delete_quote_payload["id"]
+    assert emitted_events[7]["quote_id"] == delete_quote_payload["id"]
     assert all(
         "Event Test Customer" not in payload_text
         for payload_text in map(json.dumps, emitted_events)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -127,6 +127,8 @@ Pilot event set:
 - `quote_pdf_generated`
 - `quote_shared`
 
+These underscore names are the canonical quote-flow vocabulary for pilot instrumentation; dot-notation events such as `quote.created`, `quote.updated`, `quote.deleted`, and `customer.created` remain separate operational logs outside the pilot analytics scope.
+
 ## API Contracts
 
 ### Auth endpoints (`/api/auth/`)


### PR DESCRIPTION
## Summary
- remove duplicate dot-notation PDF/share emits from QuoteService
- update quote-flow event assertions to the canonical underscore sequence
- clarify in architecture docs that underscore quote-flow names are the pilot analytics vocabulary

## Verification
- make backend-verify

Closes #101