### PR TITLE
Task #120: Sweep design-system compliance fixes

### DIFF
--- a/frontend/src/features/customers/components/CustomerDetailScreen.tsx
+++ b/frontend/src/features/customers/components/CustomerDetailScreen.tsx
@@ -239,7 +239,7 @@ export function CustomerDetailScreen(): React.ReactElement {
                       className="flex-1"
                       onClick={() => navigate(`/quotes/capture/${customer.id}`)}
                     >
-                      Create Quote {"->"}
+                      Create Quote
                     </Button>
                     <button
                       type="button"

--- a/frontend/src/features/quotes/components/CaptureScreen.tsx
+++ b/frontend/src/features/quotes/components/CaptureScreen.tsx
@@ -290,7 +290,7 @@ export function CaptureScreen(): React.ReactElement {
           {extractionStage ? (
             <p className="mb-2 text-center text-sm text-on-surface-variant">{extractionStage}</p>
           ) : null}
-          {extractionHelperCopy ? (
+          {extractionStage && extractionHelperCopy ? (
             <p className="mb-3 text-center text-xs text-on-surface-variant">{extractionHelperCopy}</p>
           ) : null}
           <Button
@@ -300,7 +300,7 @@ export function CaptureScreen(): React.ReactElement {
             isLoading={isExtracting}
             onClick={() => void onExtract()}
           >
-            Extract Line Items ✦
+            Extract Line Items
           </Button>
         </div>
       </ScreenFooter>

--- a/frontend/src/features/quotes/components/ReviewScreen.tsx
+++ b/frontend/src/features/quotes/components/ReviewScreen.tsx
@@ -330,14 +330,14 @@ export function ReviewScreen(): React.ReactElement | null {
           />
         </section>
 
-        <div className="flex items-end justify-between border-b border-outline-variant/20 pb-2">
+        <div className="flex items-end justify-between">
           <h2 className="font-headline text-xl font-bold tracking-tight text-primary">Line Items</h2>
           <span className="text-[0.6875rem] uppercase tracking-widest text-outline">
             {currentDraft.lineItems.length} ITEMS EXTRACTED
           </span>
         </div>
 
-        <div className="space-y-3">
+        <div className="mt-3 space-y-3">
           {currentDraft.lineItems.length > 0 ? (
             currentDraft.lineItems.map((lineItem, index) => (
               <LineItemCard
@@ -364,7 +364,7 @@ export function ReviewScreen(): React.ReactElement | null {
           onClick={onLineItemAdd}
         >
           <span className="material-symbols-outlined text-base">add</span>
-          + Add Manual Line Item
+          Add Line Item
         </button>
 
         <TotalAmountSection
@@ -416,7 +416,7 @@ export function ReviewScreen(): React.ReactElement | null {
             disabled={!canSubmit || isInteractionLocked}
             isLoading={isSaving}
           >
-            Generate Quote {">"}
+            Generate Quote
           </Button>
         </div>
       </ScreenFooter>

--- a/frontend/src/features/quotes/tests/CaptureScreen.test.tsx
+++ b/frontend/src/features/quotes/tests/CaptureScreen.test.tsx
@@ -149,6 +149,25 @@ describe("CaptureScreen", () => {
     expect(screen.getByRole("button", { name: /extract line items/i })).toBeEnabled();
   });
 
+  it("shows extraction helper copy only while extraction is active", async () => {
+    const extractDeferred = new Promise<ExtractionResult>(() => {});
+    mockedQuoteService.extract.mockReturnValueOnce(extractDeferred);
+    renderScreen();
+
+    fireEvent.change(screen.getByLabelText(/written description/i), {
+      target: { value: "Install sod in backyard" },
+    });
+
+    expect(
+      screen.queryByText(/we will turn your notes into draft line items/i),
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /extract line items/i }));
+
+    expect(await screen.findByText("Analyzing notes...")).toBeInTheDocument();
+    expect(screen.getByText(/we will turn your notes into draft line items/i)).toBeInTheDocument();
+  });
+
   it("shows recording state with stop button and elapsed time", () => {
     mockVoiceCapture({ isRecording: true, elapsedSeconds: 3 });
     renderScreen();

--- a/frontend/src/features/quotes/tests/ReviewScreen.test.tsx
+++ b/frontend/src/features/quotes/tests/ReviewScreen.test.tsx
@@ -233,7 +233,7 @@ describe("ReviewScreen", () => {
     renderScreen(makeDraft());
 
     expect(screen.getByText(/review missing prices before sharing/i)).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /generate quote >/i })).toBeEnabled();
+    expect(screen.getByRole("button", { name: /^generate quote$/i })).toBeEnabled();
   });
 
   it("lets users edit transcript notes locally", async () => {
@@ -300,10 +300,10 @@ describe("ReviewScreen", () => {
     await user.click(screen.getByRole("button", { name: /replace draft/i }));
 
     await waitFor(() => {
-      expect(screen.getByRole("button", { name: /generate quote >/i })).toBeDisabled();
+      expect(screen.getByRole("button", { name: /^generate quote$/i })).toBeDisabled();
     });
 
-    await user.click(screen.getByRole("button", { name: /generate quote >/i }));
+    await user.click(screen.getByRole("button", { name: /^generate quote$/i }));
     expect(mockedQuoteService.createQuote).not.toHaveBeenCalled();
 
     regeneration.resolve({
@@ -314,7 +314,7 @@ describe("ReviewScreen", () => {
     });
 
     await waitFor(() => {
-      expect(screen.getByRole("button", { name: /generate quote >/i })).toBeEnabled();
+      expect(screen.getByRole("button", { name: /^generate quote$/i })).toBeEnabled();
     });
   });
 
@@ -406,7 +406,7 @@ describe("ReviewScreen", () => {
   it("adds a blank manual line item", () => {
     renderScreen(makeDraft());
 
-    fireEvent.click(screen.getByRole("button", { name: /\+ add manual line item/i }));
+    fireEvent.click(screen.getByRole("button", { name: /add line item/i }));
 
     expect(setDraftMock).toHaveBeenCalledWith({
       customerId: "cust-1",
@@ -426,7 +426,7 @@ describe("ReviewScreen", () => {
   it("creates quote, clears draft, and navigates to preview", async () => {
     renderScreen(makeDraft({ title: "  Front Yard Refresh  ", notes: "Thanks for your business" }));
 
-    fireEvent.click(screen.getByRole("button", { name: /generate quote >/i }));
+    fireEvent.click(screen.getByRole("button", { name: /^generate quote$/i }));
 
     await waitFor(() => {
       expect(mockedQuoteService.createQuote).toHaveBeenCalledWith({
@@ -447,7 +447,7 @@ describe("ReviewScreen", () => {
     mockedQuoteService.createQuote.mockRejectedValueOnce(new Error("Unable to create quote"));
     renderScreen(makeDraft());
 
-    fireEvent.click(screen.getByRole("button", { name: /generate quote >/i }));
+    fireEvent.click(screen.getByRole("button", { name: /^generate quote$/i }));
 
     expect(await screen.findByRole("alert")).toHaveTextContent("Unable to create quote");
   });
@@ -462,7 +462,7 @@ describe("ReviewScreen", () => {
       }),
     );
 
-    fireEvent.click(screen.getByRole("button", { name: /generate quote >/i }));
+    fireEvent.click(screen.getByRole("button", { name: /^generate quote$/i }));
 
     await waitFor(() => {
       expect(mockedQuoteService.createQuote).toHaveBeenCalledWith(
@@ -488,7 +488,7 @@ describe("ReviewScreen", () => {
       }),
     );
 
-    fireEvent.click(screen.getByRole("button", { name: /generate quote >/i }));
+    fireEvent.click(screen.getByRole("button", { name: /^generate quote$/i }));
 
     await waitFor(() => {
       expect(mockedQuoteService.createQuote).toHaveBeenCalledWith(
@@ -506,7 +506,7 @@ describe("ReviewScreen", () => {
       }),
     );
 
-    const submitButton = screen.getByRole("button", { name: /generate quote >/i });
+    const submitButton = screen.getByRole("button", { name: /^generate quote$/i });
     expect(submitButton).toBeDisabled();
     fireEvent.click(submitButton);
     expect(mockedQuoteService.createQuote).not.toHaveBeenCalled();
@@ -519,7 +519,7 @@ describe("ReviewScreen", () => {
       }),
     );
 
-    expect(screen.getByRole("button", { name: /generate quote >/i })).toBeDisabled();
+    expect(screen.getByRole("button", { name: /^generate quote$/i })).toBeDisabled();
   });
 
   it("disables submit when there are no line items", () => {
@@ -530,7 +530,7 @@ describe("ReviewScreen", () => {
     );
 
     expect(screen.getByText("No line items extracted yet.")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /generate quote >/i })).toBeDisabled();
+    expect(screen.getByRole("button", { name: /^generate quote$/i })).toBeDisabled();
   });
 
   it("redirects to home when no draft is available", async () => {


### PR DESCRIPTION
## Summary
- remove small design-system copy violations across review, capture, and customer detail screens
- replace the ReviewScreen section divider with spacing and update button labels to match the design rules
- show CaptureScreen extraction helper copy only while extraction is active and cover the behavior with tests

## Verification
- make frontend-verify

Closes #120