### PR TITLE
Fix quote email fallback contact copy

### DIFF
--- a/backend/app/features/quotes/email_delivery_service.py
+++ b/backend/app/features/quotes/email_delivery_service.py
@@ -67,8 +67,8 @@ class QuoteEmailTemplateContext:
 
     business_name: str
     contractor_name: str
-    contractor_phone: str
     contractor_email: str | None
+    contact_line: str
     customer_name: str
     doc_number: str
     title: str | None
@@ -283,15 +283,16 @@ def _build_template_context(
 ) -> QuoteEmailTemplateContext:
     business_name = _resolve_business_name(context)
     contractor_name = _resolve_contractor_name(context, business_name)
-    contractor_phone = _resolve_contractor_phone(context)
-    contractor_email = (
-        context.contractor_email.strip() if context.contractor_email.strip() else None
-    )
+    contractor_phone = _normalize_optional_text(context.contractor_phone)
+    contractor_email = _normalize_optional_text(context.contractor_email)
     return QuoteEmailTemplateContext(
         business_name=business_name,
         contractor_name=contractor_name,
-        contractor_phone=contractor_phone,
         contractor_email=contractor_email,
+        contact_line=_build_contact_line(
+            contractor_phone=contractor_phone,
+            contractor_email=contractor_email,
+        ),
         customer_name=context.customer_name,
         doc_number=context.doc_number,
         title=_normalize_optional_text(context.title),
@@ -322,11 +323,16 @@ def _resolve_contractor_name(context: QuoteEmailContext, fallback: str) -> str:
     return fallback
 
 
-def _resolve_contractor_phone(context: QuoteEmailContext) -> str:
-    phone_number = _normalize_optional_text(context.contractor_phone)
-    if phone_number is not None:
-        return phone_number
-    return "your contractor"
+def _build_contact_line(
+    *,
+    contractor_phone: str | None,
+    contractor_email: str | None,
+) -> str:
+    if contractor_phone is not None:
+        return f"Questions? Call or text {contractor_phone}."
+    if contractor_email is not None:
+        return "Questions? Reply to this email."
+    return "Questions? Contact your contractor for help."
 
 
 def _normalize_optional_text(value: str | None) -> str | None:
@@ -361,7 +367,7 @@ def _render_text(context: QuoteEmailTemplateContext) -> str:
             f"View quote: {context.landing_page_url}",
             f"Download PDF: {context.pdf_download_url}",
             "",
-            f"Questions? Call or text {context.contractor_phone}.",
+            context.contact_line,
         ]
     )
     if context.contractor_email:

--- a/backend/app/features/quotes/tests/test_quotes.py
+++ b/backend/app/features/quotes/tests/test_quotes.py
@@ -661,12 +661,90 @@ async def test_send_quote_email_shares_quote_delivers_email_and_logs_success(
     assert f"/share/{payload['share_token']}" in message.html_content
     assert "Questions? Call or text +1-555-111-2222." in message.html_content
     assert credentials["email"] in message.html_content
+    assert "Questions? Call or text +1-555-111-2222." in message.text_content
+    assert f"Reply to: {credentials['email']}" in message.text_content
     assert message.reply_to_email == credentials["email"]
 
     quote_event_names = [
         payload["event"] for payload in emitted_events if payload.get("quote_id") == quote["id"]
     ]
     assert quote_event_names[-2:] == ["quote_shared", "email_sent"]
+
+
+async def test_send_quote_email_uses_reply_copy_when_phone_is_missing(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    mock_email_service: _MockEmailService,
+) -> None:
+    credentials = _credentials()
+    csrf_token = await _register_and_login(client, credentials)
+    await _set_profile_for_email_delivery(client, csrf_token)
+    customer_id = await _create_customer(
+        client,
+        csrf_token,
+        name="Alice Johnson",
+        email="alice@example.com",
+    )
+    quote = await _create_quote(client, csrf_token, customer_id)
+    await _set_quote_status(db_session, quote["id"], QuoteStatus.READY)
+
+    response = await client.post(
+        f"/api/quotes/{quote['id']}/send-email",
+        headers={"X-CSRF-Token": csrf_token},
+    )
+
+    assert response.status_code == 200
+    assert len(mock_email_service.messages) == 1
+    message = mock_email_service.messages[0]
+    assert "Questions? Reply to this email." in message.html_content
+    assert "Questions? Reply to this email." in message.text_content
+    assert "Questions? Call or text" not in message.html_content
+    assert "Questions? Call or text" not in message.text_content
+    assert credentials["email"] in message.html_content
+    assert f"Reply to: {credentials['email']}" in message.text_content
+    assert message.reply_to_email == credentials["email"]
+
+
+async def test_send_quote_email_uses_neutral_contact_copy_when_phone_and_email_are_missing(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    mock_email_service: _MockEmailService,
+) -> None:
+    credentials = _credentials()
+    csrf_token = await _register_and_login(client, credentials)
+    await _set_profile_for_email_delivery(client, csrf_token)
+    await _set_user_email_and_phone_number(
+        db_session,
+        email=credentials["email"],
+        updated_email="",
+        phone_number=None,
+    )
+    customer_id = await _create_customer(
+        client,
+        csrf_token,
+        name="Alice Johnson",
+        email="alice@example.com",
+    )
+    quote = await _create_quote(client, csrf_token, customer_id)
+    await _set_quote_status(db_session, quote["id"], QuoteStatus.READY)
+
+    response = await client.post(
+        f"/api/quotes/{quote['id']}/send-email",
+        headers={"X-CSRF-Token": csrf_token},
+    )
+
+    assert response.status_code == 200
+    assert len(mock_email_service.messages) == 1
+    message = mock_email_service.messages[0]
+    assert "Questions? Contact your contractor for help." in message.html_content
+    assert "Questions? Contact your contractor for help." in message.text_content
+    assert "Questions? Call or text" not in message.html_content
+    assert "Questions? Call or text" not in message.text_content
+    assert "Reply to this email." not in message.html_content
+    assert "Reply to this email." not in message.text_content
+    assert "Reply to " not in message.html_content
+    assert "Reply to:" not in message.text_content
+    assert message.reply_to_email is None
 
 
 @pytest.mark.parametrize(
@@ -2360,6 +2438,19 @@ async def _set_user_phone_number(
     phone_number: str,
 ) -> None:
     user = await _get_user_by_email(db_session, email)
+    user.phone_number = phone_number
+    await db_session.commit()
+
+
+async def _set_user_email_and_phone_number(
+    db_session: AsyncSession,
+    *,
+    email: str,
+    updated_email: str,
+    phone_number: str | None,
+) -> None:
+    user = await _get_user_by_email(db_session, email)
+    user.email = updated_email
     user.phone_number = phone_number
     await db_session.commit()
 

--- a/backend/app/templates/quote_email.html
+++ b/backend/app/templates/quote_email.html
@@ -52,7 +52,7 @@
                   Need the PDF instead? <a href="{{ pdf_download_url }}" style="color:#1f4d3a; font-weight:700;">Download PDF</a>
                 </p>
                 <p style="margin:0 0 8px; font-size:16px; line-height:1.6;">
-                  Questions? Call or text {{ contractor_phone }}.
+                  {{ contact_line }}
                 </p>
                 {% if contractor_email %}
                 <p style="margin:0; font-size:14px; line-height:1.6; color:#52606d;">

--- a/docs/V1_ROADMAP.md
+++ b/docs/V1_ROADMAP.md
@@ -269,7 +269,10 @@ paths in V1.
   - quote number, optional title, and total in the email body
   - a clear link to the public landing page
   - the PDF attached or linked as a secondary option
-  - a contact line: "Questions? Call or text [contractor phone number]."
+  - conditional contact copy based on available contractor details:
+    - "Questions? Call or text [contractor phone number]." when phone exists
+    - "Questions? Reply to this email." when phone is missing and contractor email exists
+    - neutral fallback copy when both phone and contractor email are missing
   - contractor email address if present (optional footer field)
 - Email is only available if the customer record has an email address
 - If no customer email exists, Copy Link / manual sharing remains fully functional;

--- a/plans/2026-03-29/task-milestone-3-email-delivery.md
+++ b/plans/2026-03-29/task-milestone-3-email-delivery.md
@@ -124,7 +124,10 @@ On resend, `share_quote()` is a no-op for already-shared statuses, so `quote_sha
   - business name and contractor name
   - quote number and total
   - optional quote title (if present)
-  - contact line "Questions? Call or text [contractor phone number]."
+  - conditional contact copy:
+    - `Questions? Call or text [contractor phone number].` when phone exists
+    - `Questions? Reply to this email.` when phone is missing and contractor email exists
+    - neutral fallback copy when both phone and contractor email are missing
   - contractor email footer if present
 - [ ] If customer has no email, "Send by Email" is disabled with a help prompt; Copy Link remains functional.
 - [ ] If customer email is invalid, send returns 422 with a user-friendly message (no provider call).


### PR DESCRIPTION
## Summary
- add conditional quote email contact copy for phone, email, and neutral fallback cases
- cover HTML and text bodies for each contact branch without changing send-email status semantics
- update planning and roadmap wording to describe conditional contact copy

## Verification
- make backend-verify

Closes #131