### PR TITLE
Polish quote PDF presentation follow-up

### DIFF
--- a/backend/app/features/quotes/tests/test_pdf_template.py
+++ b/backend/app/features/quotes/tests/test_pdf_template.py
@@ -341,7 +341,7 @@ def test_render_includes_logo_image_only_when_logo_data_uri_is_present(
     assert "max-height: 56px" in captured_html[0]
 
 
-def test_render_uses_a4_page_size_and_refined_total_and_notes_styles(
+def test_render_uses_a4_page_size_and_polished_quote_layout_styles(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     captured_html: list[str] = []
@@ -372,11 +372,47 @@ def test_render_uses_a4_page_size_and_refined_total_and_notes_styles(
     assert "@page" in rendered_html
     assert "size: A4;" in rendered_html
     assert "margin: 18mm;" in rendered_html
+    assert "@bottom-center" in rendered_html
+    assert 'content: "Page " counter(page) " of " counter(pages);' in rendered_html
+    assert "page-break-inside: avoid;" in rendered_html
+    assert "overflow-wrap: break-word;" in rendered_html
+    assert re.search(r"\.meta-right\s*\{[^}]*text-align:\s*right;", rendered_html, re.DOTALL)
+    assert 'class="meta-right"' in rendered_html
+    assert re.search(
+        (
+            r"<table class=\"meta-grid\">.*?<tr>\s*<td>.*?</td>\s*"
+            r"<td class=\"meta-right\">"
+        ),
+        rendered_html,
+        re.DOTALL,
+    )
+    assert re.search(
+        r"\.header-doc-type\s*\{[^}]*font-size:\s*28px;[^}]*text-transform:\s*uppercase;",
+        rendered_html,
+        re.DOTALL,
+    )
+    assert re.search(
+        (
+            r"<td class=\"header-logo-cell\">\s*"
+            r"(?:<img class=\"company-logo\"[^>]*>\s*)?"
+            r"<p class=\"header-doc-type\">Quote</p>\s*</td>"
+        ),
+        rendered_html,
+        re.DOTALL,
+    )
+    assert "table.line-items thead th.price-col" in rendered_html
+    assert re.search(
+        r"table\.line-items thead th\.price-col\s*\{[^}]*text-align:\s*right;",
+        rendered_html,
+        re.DOTALL,
+    )
+    assert re.search(r"<th class=\"price-col\">Price</th>", rendered_html)
     assert ".total-amount" in rendered_html
     assert "font-weight: 700;" in rendered_html
     assert "font-size: 16px;" in rendered_html
     assert re.search(r"\.total-block\s*\{[^}]*border-top:", rendered_html, re.DOTALL)
     assert re.search(r"\.notes\s*\{[^}]*border-left:", rendered_html, re.DOTALL)
+    assert "#9ca3af" in rendered_html
     assert not re.search(r"\.notes\s*\{[^}]*\bborder:", rendered_html, re.DOTALL)
     assert not re.search(r"\.notes\s*\{[^}]*background(?:-color)?:", rendered_html, re.DOTALL)
     line_items_table, total_block = rendered_html.split('<section class="total-block">', maxsplit=1)
@@ -418,6 +454,7 @@ def test_render_handles_sparse_quote_without_blank_placeholders(
 
     assert result == b"fake-pdf"
     rendered_html = captured_html[0]
+    assert 'class="header-doc-type"' in rendered_html
     assert 'class="quote-title"' not in rendered_html
     assert 'class="company-logo"' not in rendered_html
     assert 'class="notes"' not in rendered_html

--- a/backend/app/templates/quote.html
+++ b/backend/app/templates/quote.html
@@ -8,6 +8,12 @@
       @page {
         size: A4;
         margin: 18mm;
+        @bottom-center {
+          content: "Page " counter(page) " of " counter(pages);
+          font-family: "Inter", sans-serif;
+          font-size: 11px;
+          color: #6b7280;
+        }
       }
 
       @font-face {
@@ -55,10 +61,20 @@
         white-space: nowrap;
       }
 
+      .header-doc-type {
+        margin: 12px 0 0;
+        font-size: 28px;
+        font-weight: 700;
+        letter-spacing: 0.06em;
+        text-transform: uppercase;
+        color: #111827;
+      }
+
       .company-name {
         margin: 0;
         font-size: 30px;
         font-weight: 700;
+        overflow-wrap: break-word;
       }
 
       .owner-name {
@@ -101,6 +117,11 @@
         padding: 0 24px 12px 0;
       }
 
+      .meta-right {
+        text-align: right;
+        padding-right: 0;
+      }
+
       .label {
         margin: 0 0 4px;
         font-size: 11px;
@@ -131,11 +152,20 @@
         padding: 10px 8px;
       }
 
+      table.line-items thead th.price-col {
+        text-align: right;
+      }
+
+      table.line-items tbody tr {
+        page-break-inside: avoid;
+      }
+
       table.line-items tbody td {
         border-bottom: 1px solid #e5e7eb;
         padding: 14px 8px;
         font-size: 13px;
         vertical-align: top;
+        overflow-wrap: break-word;
       }
 
       .price-col {
@@ -183,7 +213,7 @@
       .notes {
         margin-top: 24px;
         padding-left: 16px;
-        border-left: 3px solid #d1d5db;
+        border-left: 3px solid #9ca3af;
       }
 
       .notes p {
@@ -212,11 +242,12 @@
                 <p class="header-contact">{{ contractor_email }}</p>
                 {% endif %}
               </td>
-              {% if logo_data_uri %}
               <td class="header-logo-cell">
+                {% if logo_data_uri %}
                 <img class="company-logo" src="{{ logo_data_uri }}" alt="Company logo" />
+                {% endif %}
+                <p class="header-doc-type">Quote</p>
               </td>
-              {% endif %}
             </tr>
           </tbody>
         </table>
@@ -242,7 +273,7 @@
               <p class="value">{{ customer_address }}</p>
               {% endif %}
             </td>
-            <td>
+            <td class="meta-right">
               <p class="label">Quote Number</p>
               <p class="value">{{ doc_number }}</p>
               <p class="label" style="margin-top: 10px">Issued</p>


### PR DESCRIPTION
## Summary
- add the remaining quote PDF presentation polish for page numbering, row wrapping protection, right-aligned metadata, and notes/overflow styling
- move the `QUOTE` document type into the header area on the right and render it larger in uppercase to match the requested presentation update
- extend the PDF template rendering assertions to cover the new CSS and sparse-quote header behavior

## Verification
- `make backend-verify`

Closes #134