### PR TITLE
Task #140: invoice discoverability and quote clone flow

### DIFF
--- a/backend/app/features/invoices/api.py
+++ b/backend/app/features/invoices/api.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Annotated
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 from fastapi.responses import StreamingResponse
 
 from app.features.auth.models import User
@@ -13,6 +13,7 @@ from app.features.invoices.schemas import (
     InvoiceCreateRequest,
     InvoiceCustomerResponse,
     InvoiceDetailResponse,
+    InvoiceListItemResponse,
     InvoiceResponse,
     InvoiceUpdateRequest,
 )
@@ -41,6 +42,17 @@ async def create_invoice(
     except QuoteServiceError as exc:
         raise HTTPException(status_code=exc.status_code, detail=exc.detail) from exc
     return InvoiceResponse.model_validate(invoice)
+
+
+@router.get("", response_model=list[InvoiceListItemResponse])
+async def list_invoices(
+    user: Annotated[User, Depends(get_current_user)],
+    invoice_service: Annotated[InvoiceService, Depends(get_invoice_service)],
+    customer_id: Annotated[UUID | None, Query()] = None,
+) -> list[InvoiceListItemResponse]:
+    """List invoices for the authenticated user."""
+    invoices = await invoice_service.list_invoices(user, customer_id=customer_id)
+    return [InvoiceListItemResponse.model_validate(invoice) for invoice in invoices]
 
 
 @router.get("/{invoice_id}", response_model=InvoiceDetailResponse)

--- a/backend/app/features/invoices/repository.py
+++ b/backend/app/features/invoices/repository.py
@@ -1,4 +1,9 @@
-"""Invoice repository operations."""
+"""Invoice repository operations.
+
+This module owns invoice persistence and read models for authenticated users.
+It returns detail/list summaries plus PDF render context, but leaves HTTP errors
+and higher-level workflow rules to the service layer.
+"""
 
 from __future__ import annotations
 
@@ -46,6 +51,22 @@ class InvoiceDetailRow:
     updated_at: datetime
 
 
+@dataclass(slots=True)
+class InvoiceListItemSummary:
+    """Summary row returned by the invoice list query."""
+
+    id: UUID
+    customer_id: UUID
+    customer_name: str
+    doc_number: str
+    title: str | None
+    status: str
+    total_amount: Decimal | None
+    due_date: date | None
+    created_at: datetime
+    source_document_id: UUID | None
+
+
 class InvoiceRepository:
     """Persist and query invoice documents using SQLAlchemy async sessions."""
 
@@ -61,6 +82,54 @@ class InvoiceRepository:
             )
         )
         return customer is not None
+
+    async def list_by_user(
+        self,
+        user_id: UUID,
+        customer_id: UUID | None = None,
+    ) -> list[InvoiceListItemSummary]:
+        """Return invoice summaries for a user ordered newest-first."""
+        statement = (
+            select(
+                Document.id,
+                Document.customer_id,
+                Customer.name.label("customer_name"),
+                Document.doc_number,
+                Document.title,
+                Document.status,
+                Document.total_amount,
+                Document.due_date,
+                Document.created_at,
+                Document.source_document_id,
+            )
+            .join(Customer, Customer.id == Document.customer_id)
+            .where(
+                Document.user_id == user_id,
+                Document.doc_type == _INVOICE_DOC_TYPE,
+            )
+            .order_by(Document.created_at.desc(), Document.doc_sequence.desc())
+        )
+        if customer_id is not None:
+            statement = statement.where(Document.customer_id == customer_id)
+
+        result = await self._session.execute(statement)
+        return [
+            InvoiceListItemSummary(
+                id=row.id,
+                customer_id=row.customer_id,
+                customer_name=row.customer_name,
+                doc_number=row.doc_number,
+                title=row.title,
+                status=(
+                    row.status.value if isinstance(row.status, QuoteStatus) else str(row.status)
+                ),
+                total_amount=row.total_amount,
+                due_date=row.due_date,
+                created_at=row.created_at,
+                source_document_id=row.source_document_id,
+            )
+            for row in result.all()
+        ]
 
     async def get_by_id(self, invoice_id: UUID, user_id: UUID) -> Document | None:
         """Return one invoice owned by a user, including line items."""

--- a/backend/app/features/invoices/schemas.py
+++ b/backend/app/features/invoices/schemas.py
@@ -54,6 +54,23 @@ class InvoiceResponse(BaseModel):
     updated_at: datetime
 
 
+class InvoiceListItemResponse(BaseModel):
+    """Serializable invoice summary payload returned by the invoice list endpoint."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+    customer_id: UUID
+    customer_name: str
+    doc_number: str
+    title: str | None
+    status: Literal["draft", "ready", "sent"]
+    total_amount: float | None
+    due_date: date | None
+    created_at: datetime
+    source_document_id: UUID | None
+
+
 class InvoiceCustomerResponse(BaseModel):
     """Customer summary embedded in invoice detail responses."""
 

--- a/backend/app/features/invoices/service.py
+++ b/backend/app/features/invoices/service.py
@@ -1,4 +1,9 @@
-"""Invoice service orchestration."""
+"""Invoice service orchestration.
+
+This module applies invoice domain rules on top of repository reads/writes.
+It owns creation, quote conversion, list/detail access, and invoice PDF/share
+side effects while preserving quote-service error semantics for the API layer.
+"""
 
 from __future__ import annotations
 
@@ -15,6 +20,7 @@ from sqlalchemy.exc import IntegrityError
 from app.features.auth.models import User
 from app.features.invoices.repository import (
     InvoiceDetailRow,
+    InvoiceListItemSummary,
     InvoiceRepository,
     build_default_due_date,
 )
@@ -38,6 +44,12 @@ class InvoiceRepositoryProtocol(Protocol):
     async def customer_exists_for_user(self, *, user_id: UUID, customer_id: UUID) -> bool: ...
 
     async def get_by_id(self, invoice_id: UUID, user_id: UUID) -> Document | None: ...
+
+    async def list_by_user(
+        self,
+        user_id: UUID,
+        customer_id: UUID | None = None,
+    ) -> list[InvoiceListItemSummary]: ...
 
     async def get_by_source_document_id(
         self,
@@ -159,6 +171,17 @@ class InvoiceService:
                 raise
 
         raise QuoteServiceError(detail="Unable to create invoice", status_code=409)
+
+    async def list_invoices(
+        self,
+        user: User,
+        customer_id: UUID | None = None,
+    ) -> list[InvoiceListItemSummary]:
+        """List invoices for the authenticated user."""
+        return await self._invoice_repository.list_by_user(
+            _resolve_user_id(user),
+            customer_id=customer_id,
+        )
 
     async def convert_quote_to_invoice(self, user: User, quote_id: UUID) -> Document:
         """Create one invoice from an approved quote."""

--- a/backend/app/features/invoices/tests/test_service.py
+++ b/backend/app/features/invoices/tests/test_service.py
@@ -37,6 +37,11 @@ class _RetryingInvoiceRepository:
         del customer_id
         return False
 
+    async def list_by_user(self, user_id, customer_id=None):  # noqa: ANN001
+        del user_id
+        del customer_id
+        return []
+
     async def get_by_source_document_id(self, *, source_document_id, user_id):  # noqa: ANN001
         if str(source_document_id) == self._quote_id and str(user_id) == self._user_id:
             return None
@@ -128,6 +133,11 @@ class _DirectInvoiceCollisionRepository:
         del user_id
         del customer_id
         return True
+
+    async def list_by_user(self, user_id, customer_id=None):  # noqa: ANN001
+        del user_id
+        del customer_id
+        return []
 
     async def get_by_id(self, invoice_id, user_id):  # noqa: ANN001
         del invoice_id

--- a/backend/app/features/quotes/tests/test_quotes.py
+++ b/backend/app/features/quotes/tests/test_quotes.py
@@ -2619,6 +2619,104 @@ async def test_create_direct_invoice_sets_default_due_date_and_keeps_quote_list_
     assert invoice_count == 1
 
 
+async def test_list_invoices_returns_direct_and_quote_derived_summaries_newest_first(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    csrf_token = await _register_and_login(client, _credentials())
+    quote_customer_id = await _create_customer(client, csrf_token, name="Quote Customer")
+    direct_customer_id = await _create_customer(client, csrf_token, name="Direct Customer")
+
+    quote = await _create_quote(client, csrf_token, quote_customer_id)
+    await _set_quote_status(db_session, quote["id"], QuoteStatus.APPROVED)
+    linked_invoice_response = await client.post(
+        f"/api/quotes/{quote['id']}/convert-to-invoice",
+        headers={"X-CSRF-Token": csrf_token},
+    )
+    assert linked_invoice_response.status_code == 201
+    linked_invoice = linked_invoice_response.json()
+
+    direct_invoice = await _create_direct_invoice(
+        client,
+        csrf_token,
+        direct_customer_id,
+        title="Direct invoice",
+        transcript="direct invoice transcript",
+        total_amount=220,
+    )
+
+    response = await client.get("/api/invoices")
+
+    assert response.status_code == 200
+    assert response.json() == [
+        {
+            "id": direct_invoice["id"],
+            "customer_id": direct_customer_id,
+            "customer_name": "Direct Customer",
+            "doc_number": "I-002",
+            "title": "Direct invoice",
+            "status": "draft",
+            "total_amount": 220,
+            "due_date": direct_invoice["due_date"],
+            "created_at": direct_invoice["created_at"],
+            "source_document_id": None,
+        },
+        {
+            "id": linked_invoice["id"],
+            "customer_id": quote_customer_id,
+            "customer_name": "Quote Customer",
+            "doc_number": "I-001",
+            "title": None,
+            "status": "draft",
+            "total_amount": 55,
+            "due_date": linked_invoice["due_date"],
+            "created_at": linked_invoice["created_at"],
+            "source_document_id": quote["id"],
+        },
+    ]
+
+
+async def test_list_invoices_can_filter_by_customer_id(client: AsyncClient) -> None:
+    csrf_token = await _register_and_login(client, _credentials())
+    customer_id_a = await _create_customer(client, csrf_token, name="Customer A")
+    customer_id_b = await _create_customer(client, csrf_token, name="Customer B")
+
+    await _create_direct_invoice(
+        client,
+        csrf_token,
+        customer_id_a,
+        title="Invoice for A",
+        transcript="invoice for customer a",
+        total_amount=120,
+    )
+    invoice_b = await _create_direct_invoice(
+        client,
+        csrf_token,
+        customer_id_b,
+        title="Invoice for B",
+        transcript="invoice for customer b",
+        total_amount=220,
+    )
+
+    response = await client.get(f"/api/invoices?customer_id={customer_id_b}")
+
+    assert response.status_code == 200
+    assert response.json() == [
+        {
+            "id": invoice_b["id"],
+            "customer_id": customer_id_b,
+            "customer_name": "Customer B",
+            "doc_number": "I-002",
+            "title": "Invoice for B",
+            "status": "draft",
+            "total_amount": 220,
+            "due_date": invoice_b["due_date"],
+            "created_at": invoice_b["created_at"],
+            "source_document_id": None,
+        }
+    ]
+
+
 async def test_convert_quote_to_invoice_rejects_duplicates_and_patch_preserves_sent_invoice_status(
     client: AsyncClient,
     db_session: AsyncSession,
@@ -2743,6 +2841,32 @@ async def _create_quote(client: AsyncClient, csrf_token: str, customer_id: str) 
             "transcript": "quote transcript",
             "line_items": [{"description": "line item", "details": None, "price": 55}],
             "total_amount": 55,
+            "notes": "Original note",
+            "source_type": "text",
+        },
+        headers={"X-CSRF-Token": csrf_token},
+    )
+    assert response.status_code == 201
+    return response.json()
+
+
+async def _create_direct_invoice(
+    client: AsyncClient,
+    csrf_token: str,
+    customer_id: str,
+    *,
+    title: str | None,
+    transcript: str,
+    total_amount: int,
+) -> dict[str, object]:
+    response = await client.post(
+        "/api/invoices",
+        json={
+            "customer_id": customer_id,
+            "title": title,
+            "transcript": transcript,
+            "line_items": [{"description": "line item", "details": None, "price": total_amount}],
+            "total_amount": total_amount,
             "notes": "Original note",
             "source_type": "text",
         },

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -228,6 +228,7 @@ Rules:
 | Endpoint | Method | CSRF | Auth | Request | Response |
 |---|---|---|---|---|---|
 | `/invoices` | POST | yes | cookie | `{ customer_id, title?, transcript, line_items, total_amount, notes, source_type }` | `201 Invoice` with `doc_number` (`I-001`), `status: "draft"`, server-default `due_date`, and nullable `source_document_id` |
+| `/invoices` | GET | no | cookie | `customer_id?` (UUID query param) | `200 InvoiceListItem[]` ordered `created_at DESC, doc_sequence DESC` (owned by current user; filtered to customer when `customer_id` provided; includes both direct invoices and quote-derived invoices) |
 | `/invoices/{id}` | GET | no | cookie | — | `200 InvoiceDetail`, `404 { detail: "Not found" }` |
 | `/invoices/{id}` | PATCH | yes | cookie | `{ due_date }` | `200 Invoice` for `draft`, `ready`, and `sent` invoices, or `404 { detail: "Not found" }` |
 | `/invoices/{id}/pdf` | POST | yes | cookie | — | `200` raw PDF bytes; preview transitions `draft -> ready` |
@@ -272,6 +273,18 @@ Public landing-page rules:
 - `item_count`
 - `created_at`
 
+`InvoiceListItem` fields:
+- `id`
+- `customer_id`
+- `customer_name`
+- `doc_number`
+- `title`
+- `status`
+- `total_amount`
+- `due_date`
+- `created_at`
+- `source_document_id`
+
 `QuoteDetailResponse` fields:
 - Standard `Quote` fields, including `id`, `customer_id`, `doc_number`, `title`, `status`, `source_type`, `transcript`, `total_amount`, `notes`, `shared_at`, `share_token`, `line_items`, `created_at`, and `updated_at`
 - Customer display fields: `customer_name`, `customer_email`, `customer_phone`
@@ -284,6 +297,9 @@ Public landing-page rules:
 
 Invoice rules:
 - direct invoices can be created from the shared builder via `POST /api/invoices` without a source quote
+- the authenticated `/` route remains the main document list, defaulting to `Quotes` with an `Invoices` secondary filter
+- list search stays parallel in both modes (`customer_name`, `title`, `doc_number`)
+- quote rows continue to route to `/quotes/{id}/preview`; invoice rows route to `/invoices/{id}`
 - direct invoices receive the server-side default due date on create
 - direct invoices use `source_document_id = null` and `source_quote_number = null`
 - only `approved` quotes can convert to invoices

--- a/frontend/src/features/invoices/services/invoiceService.ts
+++ b/frontend/src/features/invoices/services/invoiceService.ts
@@ -2,6 +2,7 @@ import type {
   InvoiceCreateRequest,
   Invoice,
   InvoiceDetail,
+  InvoiceListItem,
   InvoiceUpdateRequest,
 } from "@/features/invoices/types/invoice.types";
 import { request, requestBlob } from "@/shared/lib/http";
@@ -15,6 +16,11 @@ function createInvoice(data: InvoiceCreateRequest): Promise<Invoice> {
 
 function getInvoice(id: string): Promise<InvoiceDetail> {
   return request<InvoiceDetail>(`/api/invoices/${id}`);
+}
+
+function listInvoices(params?: { customer_id?: string }): Promise<InvoiceListItem[]> {
+  const query = params?.customer_id ? `?customer_id=${params.customer_id}` : "";
+  return request<InvoiceListItem[]>(`/api/invoices${query}`);
 }
 
 function updateInvoice(id: string, data: InvoiceUpdateRequest): Promise<Invoice> {
@@ -39,6 +45,7 @@ function shareInvoice(id: string): Promise<Invoice> {
 export const invoiceService = {
   createInvoice,
   getInvoice,
+  listInvoices,
   updateInvoice,
   generatePdf,
   shareInvoice,

--- a/frontend/src/features/invoices/tests/invoiceService.integration.test.ts
+++ b/frontend/src/features/invoices/tests/invoiceService.integration.test.ts
@@ -78,6 +78,52 @@ describe("invoiceService integration (MSW)", () => {
     expect(invoice.customer.name).toBe("Alice Johnson");
   });
 
+  it("listInvoices returns the invoice summary contract", async () => {
+    const invoices = await invoiceService.listInvoices();
+
+    expect(invoices).toEqual([
+      {
+        id: "invoice-2",
+        customer_id: "cust-2",
+        customer_name: "Bob Brown",
+        doc_number: "I-002",
+        title: "Front bed refresh",
+        status: "ready",
+        total_amount: 220,
+        due_date: "2026-04-22",
+        created_at: "2026-03-21T00:00:00.000Z",
+        source_document_id: null,
+      },
+      {
+        id: "invoice-1",
+        customer_id: "cust-1",
+        customer_name: "Alice Johnson",
+        doc_number: "I-001",
+        title: "Spring cleanup",
+        status: "draft",
+        total_amount: 120,
+        due_date: "2026-04-19",
+        created_at: "2026-03-20T00:00:00.000Z",
+        source_document_id: "quote-1",
+      },
+    ]);
+  });
+
+  it("listInvoices sends customer_id query param when provided", async () => {
+    let capturedCustomerId: string | null = null;
+
+    server.use(
+      http.get("/api/invoices", ({ request }) => {
+        capturedCustomerId = new URL(request.url).searchParams.get("customer_id");
+        return HttpResponse.json([], { status: 200 });
+      }),
+    );
+
+    await invoiceService.listInvoices({ customer_id: "cust-1" });
+
+    expect(capturedCustomerId).toBe("cust-1");
+  });
+
   it("updateInvoice sends CSRF and persists the due date payload", async () => {
     setCsrfToken("invoice-csrf-token");
     let capturedCsrfHeader: string | null = null;

--- a/frontend/src/features/invoices/types/invoice.types.ts
+++ b/frontend/src/features/invoices/types/invoice.types.ts
@@ -32,6 +32,19 @@ export interface Invoice {
   updated_at: string;
 }
 
+export interface InvoiceListItem {
+  id: string;
+  customer_id: string;
+  customer_name: string;
+  doc_number: string;
+  title: string | null;
+  status: InvoiceStatus;
+  total_amount: number | null;
+  due_date: string | null;
+  created_at: string;
+  source_document_id: string | null;
+}
+
 export interface InvoiceDetail extends Invoice {
   source_quote_number: string | null;
   customer: {

--- a/frontend/src/features/quotes/components/QuoteList.tsx
+++ b/frontend/src/features/quotes/components/QuoteList.tsx
@@ -2,6 +2,8 @@ import { useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 
 import { useAuth } from "@/features/auth/hooks/useAuth";
+import { invoiceService } from "@/features/invoices/services/invoiceService";
+import type { InvoiceListItem } from "@/features/invoices/types/invoice.types";
 import { quoteService } from "@/features/quotes/services/quoteService";
 import type { QuoteListItem } from "@/features/quotes/types/quote.types";
 import { BottomNav } from "@/shared/components/BottomNav";
@@ -11,85 +13,223 @@ import { ScreenHeader } from "@/shared/components/ScreenHeader";
 import { StatusBadge } from "@/shared/components/StatusBadge";
 import { formatCurrency, formatDate } from "@/shared/lib/formatters";
 
+type DocumentMode = "quotes" | "invoices";
+type DocumentStatus = QuoteListItem["status"] | InvoiceListItem["status"];
+
+interface DocumentRow {
+  id: string;
+  primaryLabel: string;
+  supportingDetails: string;
+  totalAmount: number | null;
+  status: DocumentStatus;
+  destination: string;
+}
+
+function matchesSearch(
+  item: Pick<QuoteListItem, "customer_name" | "doc_number" | "title">,
+  normalizedSearchQuery: string,
+): boolean {
+  if (!normalizedSearchQuery) {
+    return true;
+  }
+
+  return (
+    item.customer_name.toLowerCase().includes(normalizedSearchQuery)
+    || item.doc_number.toLowerCase().includes(normalizedSearchQuery)
+    || (item.title?.toLowerCase() ?? "").includes(normalizedSearchQuery)
+  );
+}
+
+function buildQuoteSubtitle(quotes: QuoteListItem[], isLoading: boolean, loadError: string | null): string | undefined {
+  if (isLoading || loadError) {
+    return undefined;
+  }
+
+  const activeQuoteCount = quotes.filter((quote) => quote.status === "ready" || quote.status === "shared").length;
+  const pendingReviewCount = quotes.filter((quote) => quote.status === "draft").length;
+  return `${activeQuoteCount} active · ${pendingReviewCount} pending`;
+}
+
+function buildInvoiceSubtitle(
+  invoices: InvoiceListItem[],
+  isLoading: boolean,
+  loadError: string | null,
+): string | undefined {
+  if (isLoading || loadError) {
+    return undefined;
+  }
+
+  const activeInvoiceCount = invoices.filter((invoice) => invoice.status === "ready" || invoice.status === "sent").length;
+  const pendingInvoiceCount = invoices.filter((invoice) => invoice.status === "draft").length;
+  return `${activeInvoiceCount} active · ${pendingInvoiceCount} pending`;
+}
+
 export function QuoteList(): React.ReactElement {
   const navigate = useNavigate();
   const { user } = useAuth();
+  const [documentMode, setDocumentMode] = useState<DocumentMode>("quotes");
   const [quotes, setQuotes] = useState<QuoteListItem[]>([]);
+  const [invoices, setInvoices] = useState<InvoiceListItem[]>([]);
   const [searchQuery, setSearchQuery] = useState("");
-  const [isLoading, setIsLoading] = useState(true);
-  const [loadError, setLoadError] = useState<string | null>(null);
+  const [isLoadingQuotes, setIsLoadingQuotes] = useState(true);
+  const [isLoadingInvoices, setIsLoadingInvoices] = useState(false);
+  const [quoteLoadError, setQuoteLoadError] = useState<string | null>(null);
+  const [invoiceLoadError, setInvoiceLoadError] = useState<string | null>(null);
 
   useEffect(() => {
     let isActive = true;
 
-    async function fetchQuotes(): Promise<void> {
-      setIsLoading(true);
-      setLoadError(null);
+    async function fetchDocuments(): Promise<void> {
+      if (documentMode === "quotes") {
+        setIsLoadingQuotes(true);
+        setQuoteLoadError(null);
+        try {
+          const nextQuotes = await quoteService.listQuotes();
+          if (isActive) {
+            setQuotes(nextQuotes);
+          }
+        } catch (error) {
+          const message = error instanceof Error ? error.message : "Unable to load quotes";
+          if (isActive) {
+            setQuoteLoadError(message);
+          }
+        } finally {
+          if (isActive) {
+            setIsLoadingQuotes(false);
+          }
+        }
+        return;
+      }
+
+      setIsLoadingInvoices(true);
+      setInvoiceLoadError(null);
       try {
-        const nextQuotes = await quoteService.listQuotes();
+        const nextInvoices = await invoiceService.listInvoices();
         if (isActive) {
-          setQuotes(nextQuotes);
+          setInvoices(nextInvoices);
         }
       } catch (error) {
-        const message = error instanceof Error ? error.message : "Unable to load quotes";
+        const message = error instanceof Error ? error.message : "Unable to load invoices";
         if (isActive) {
-          setLoadError(message);
+          setInvoiceLoadError(message);
         }
       } finally {
         if (isActive) {
-          setIsLoading(false);
+          setIsLoadingInvoices(false);
         }
       }
     }
 
-    void fetchQuotes();
+    void fetchDocuments();
 
     return () => {
       isActive = false;
     };
-  }, []);
+  }, [documentMode]);
 
   const normalizedSearchQuery = searchQuery.trim().toLowerCase();
   const filteredQuotes = useMemo(() => {
-    if (!normalizedSearchQuery) {
-      return quotes;
-    }
-
-    return quotes.filter((quote) => {
-      const customerName = quote.customer_name.toLowerCase();
-      const docNumber = quote.doc_number.toLowerCase();
-      const title = quote.title?.toLowerCase() ?? "";
-      return (
-        customerName.includes(normalizedSearchQuery) ||
-        docNumber.includes(normalizedSearchQuery) ||
-        title.includes(normalizedSearchQuery)
-      );
-    });
+    return quotes.filter((quote) => matchesSearch(quote, normalizedSearchQuery));
   }, [normalizedSearchQuery, quotes]);
 
-  // Active: ready/shared quotes. Pending: draft quotes.
-  const activeQuoteCount = useMemo(
-    () => quotes.filter((quote) => quote.status === "ready" || quote.status === "shared").length,
-    [quotes],
+  const filteredInvoices = useMemo(
+    () => invoices.filter((invoice) => matchesSearch(invoice, normalizedSearchQuery)),
+    [invoices, normalizedSearchQuery],
   );
-  const pendingReviewCount = useMemo(
-    () => quotes.filter((quote) => quote.status === "draft").length,
-    [quotes],
-  );
+
   const timezone = user?.timezone ?? null;
-  const quoteSubtitle =
-    !isLoading && !loadError ? `${activeQuoteCount} active · ${pendingReviewCount} pending` : undefined;
+  const quoteSubtitle = useMemo(
+    () => buildQuoteSubtitle(quotes, isLoadingQuotes, quoteLoadError),
+    [isLoadingQuotes, quoteLoadError, quotes],
+  );
+  const invoiceSubtitle = useMemo(
+    () => buildInvoiceSubtitle(invoices, isLoadingInvoices, invoiceLoadError),
+    [invoiceLoadError, invoices, isLoadingInvoices],
+  );
+  const isLoading = documentMode === "quotes" ? isLoadingQuotes : isLoadingInvoices;
+  const loadError = documentMode === "quotes" ? quoteLoadError : invoiceLoadError;
+  const filteredRows = documentMode === "quotes" ? filteredQuotes : filteredInvoices;
+  const totalRows = documentMode === "quotes" ? quotes.length : invoices.length;
+  const headerTitle = documentMode === "quotes" ? "Quotes" : "Invoices";
+  const headerSubtitle = documentMode === "quotes" ? quoteSubtitle : invoiceSubtitle;
+  const searchLabel = documentMode === "quotes" ? "Search quotes" : "Search invoices";
+  const searchPlaceholder = documentMode === "quotes"
+    ? "Search customer, title, or quote ID..."
+    : "Search customer, title, or invoice ID...";
+  const emptyStateMessage = totalRows === 0
+    ? `No ${documentMode} yet. Tap Create Document to create your first.`
+    : `No ${documentMode} match your search.`;
+  const sectionLabel = documentMode === "quotes" ? "PAST QUOTES" : "PAST INVOICES";
+
+  const documentRows = useMemo<DocumentRow[]>(() => {
+    if (documentMode === "quotes") {
+      return filteredQuotes.map((quote) => ({
+        id: quote.id,
+        primaryLabel: quote.title ?? quote.doc_number,
+        supportingDetails: [
+          quote.customer_name,
+          ...(quote.title ? [quote.doc_number] : []),
+          formatDate(quote.created_at, timezone),
+          `${quote.item_count} ${quote.item_count === 1 ? "item" : "items"}`,
+        ].join(" · "),
+        totalAmount: quote.total_amount,
+        status: quote.status,
+        destination: `/quotes/${quote.id}/preview`,
+      }));
+    }
+
+    return filteredInvoices.map((invoice) => ({
+      id: invoice.id,
+      primaryLabel: invoice.title ?? invoice.doc_number,
+      supportingDetails: [
+        invoice.customer_name,
+        ...(invoice.title ? [invoice.doc_number] : []),
+        formatDate(invoice.created_at, timezone),
+      ].join(" · "),
+      totalAmount: invoice.total_amount,
+      status: invoice.status,
+      destination: `/invoices/${invoice.id}`,
+    }));
+  }, [documentMode, filteredInvoices, filteredQuotes, timezone]);
 
   return (
     <main className="min-h-screen bg-background pb-24">
-      <ScreenHeader title="Quotes" subtitle={quoteSubtitle} />
+      <ScreenHeader title={headerTitle} subtitle={headerSubtitle} />
       <section className="mx-auto w-full max-w-3xl pb-2 pt-20">
-
         <div className="mb-4 px-4">
+          <div
+            aria-label="Document type filter"
+            className="mb-4 inline-flex rounded-full bg-surface-container-low p-1"
+          >
+            <button
+              type="button"
+              aria-pressed={documentMode === "quotes"}
+              className={`rounded-full px-4 py-2 text-sm font-semibold transition ${
+                documentMode === "quotes"
+                  ? "bg-surface-container-lowest text-on-surface shadow-sm"
+                  : "text-on-surface-variant"
+              }`}
+              onClick={() => setDocumentMode("quotes")}
+            >
+              Quotes
+            </button>
+            <button
+              type="button"
+              aria-pressed={documentMode === "invoices"}
+              className={`rounded-full px-4 py-2 text-sm font-semibold transition ${
+                documentMode === "invoices"
+                  ? "bg-surface-container-lowest text-on-surface shadow-sm"
+                  : "text-on-surface-variant"
+              }`}
+              onClick={() => setDocumentMode("invoices")}
+            >
+              Invoices
+            </button>
+          </div>
           <Input
-            label="Search quotes"
-            id="quote-search"
-            placeholder="Search customer, title, or quote ID..."
+            label={searchLabel}
+            id="document-search"
+            placeholder={searchPlaceholder}
             hideLabel
             value={searchQuery}
             onChange={(event) => setSearchQuery(event.target.value)}
@@ -98,7 +238,7 @@ export function QuoteList(): React.ReactElement {
 
         {isLoading ? (
           <p role="status" className="px-4 text-sm text-on-surface-variant">
-            Loading quotes...
+            {documentMode === "quotes" ? "Loading quotes..." : "Loading invoices..."}
           </p>
         ) : null}
 
@@ -108,60 +248,46 @@ export function QuoteList(): React.ReactElement {
           </div>
         ) : null}
 
-        {!isLoading && !loadError && filteredQuotes.length === 0 ? (
+        {!isLoading && !loadError && filteredRows.length === 0 ? (
           <section className="mx-4 mt-8 flex flex-col items-center rounded-lg bg-surface-container-lowest p-8 text-center ghost-shadow">
             <span className="material-symbols-outlined mb-2 text-3xl text-outline">description</span>
-            <p className="text-sm text-outline">
-              {quotes.length === 0
-                ? "No quotes yet. Tap + to create your first."
-                : "No quotes match your search."}
-            </p>
+            <p className="text-sm text-outline">{emptyStateMessage}</p>
           </section>
         ) : null}
 
-        {!isLoading && !loadError && filteredQuotes.length > 0 ? (
+        {!isLoading && !loadError && filteredRows.length > 0 ? (
           <>
             <div className="mb-2 px-4">
               <p className="text-[0.6875rem] font-bold uppercase tracking-widest text-outline">
-                PAST QUOTES
+                {sectionLabel}
               </p>
             </div>
             <div className="mx-4 rounded-xl bg-surface-container-low p-3">
               <ul className="flex flex-col gap-3">
-                {filteredQuotes.map((quote) => {
-                  const primaryLabel = quote.title ?? quote.doc_number;
-                  const supportingDetails = [
-                    quote.customer_name,
-                    ...(quote.title ? [quote.doc_number] : []),
-                    formatDate(quote.created_at, timezone),
-                    `${quote.item_count} ${quote.item_count === 1 ? "item" : "items"}`,
-                  ].join(" · ");
-
-                  return (
-                    <li key={quote.id}>
-                      <button
-                        type="button"
-                        onClick={() => navigate(`/quotes/${quote.id}/preview`)}
-                        className="w-full rounded-xl bg-surface-container-lowest p-4 text-left ghost-shadow transition active:scale-[0.98] active:bg-surface-container-low"
-                      >
-                        <div className="flex items-baseline justify-between gap-3">
-                          <p className="font-headline font-bold text-on-surface">
-                            {primaryLabel}
-                          </p>
-                          <p className="font-headline font-bold text-on-surface">
-                            {formatCurrency(quote.total_amount)}
-                          </p>
-                        </div>
-                        <div className="mt-1 flex items-center justify-between gap-3">
-                          <p className="text-sm text-on-surface-variant">
-                            {supportingDetails}
-                          </p>
-                          <StatusBadge variant={quote.status} />
-                        </div>
-                      </button>
-                    </li>
-                  );
-                })}
+                {documentRows.map((row) => (
+                  <li key={row.id}>
+                    <button
+                      type="button"
+                      onClick={() => navigate(row.destination)}
+                      className="w-full rounded-xl bg-surface-container-lowest p-4 text-left ghost-shadow transition active:scale-[0.98] active:bg-surface-container-low"
+                    >
+                      <div className="flex items-baseline justify-between gap-3">
+                        <p className="font-headline font-bold text-on-surface">
+                          {row.primaryLabel}
+                        </p>
+                        <p className="font-headline font-bold text-on-surface">
+                          {formatCurrency(row.totalAmount)}
+                        </p>
+                      </div>
+                      <div className="mt-1 flex items-center justify-between gap-3">
+                        <p className="text-sm text-on-surface-variant">
+                          {row.supportingDetails}
+                        </p>
+                        <StatusBadge variant={row.status} />
+                      </div>
+                    </button>
+                  </li>
+                ))}
               </ul>
             </div>
           </>
@@ -170,7 +296,7 @@ export function QuoteList(): React.ReactElement {
 
       <button
         type="button"
-        aria-label="Create quote"
+        aria-label="Create document"
         className="fixed bottom-20 right-4 z-50 flex h-14 w-14 items-center justify-center rounded-full forest-gradient text-white shadow-[0_0_24px_rgba(0,0,0,0.12)] transition-all active:scale-95"
         onClick={() => navigate("/quotes/new")}
       >

--- a/frontend/src/features/quotes/tests/QuoteList.test.tsx
+++ b/frontend/src/features/quotes/tests/QuoteList.test.tsx
@@ -1,8 +1,10 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { useAuth } from "@/features/auth/hooks/useAuth";
+import { invoiceService } from "@/features/invoices/services/invoiceService";
+import type { InvoiceListItem } from "@/features/invoices/types/invoice.types";
 import { QuoteList } from "@/features/quotes/components/QuoteList";
 import { quoteService } from "@/features/quotes/services/quoteService";
 import type { QuoteListItem } from "@/features/quotes/types/quote.types";
@@ -30,11 +32,18 @@ vi.mock("@/features/quotes/services/quoteService", () => ({
   },
 }));
 
+vi.mock("@/features/invoices/services/invoiceService", () => ({
+  invoiceService: {
+    listInvoices: vi.fn(),
+  },
+}));
+
 vi.mock("@/features/auth/hooks/useAuth", () => ({
   useAuth: vi.fn(),
 }));
 
 const mockedQuoteService = vi.mocked(quoteService);
+const mockedInvoiceService = vi.mocked(invoiceService);
 const mockedUseAuth = vi.mocked(useAuth);
 
 function makeQuoteListItem(overrides: Partial<QuoteListItem> = {}): QuoteListItem {
@@ -48,6 +57,22 @@ function makeQuoteListItem(overrides: Partial<QuoteListItem> = {}): QuoteListIte
     total_amount: 120,
     item_count: 1,
     created_at: "2026-03-20T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function makeInvoiceListItem(overrides: Partial<InvoiceListItem> = {}): InvoiceListItem {
+  return {
+    id: "invoice-1",
+    customer_id: "cust-1",
+    customer_name: "Alice Johnson",
+    doc_number: "I-001",
+    title: null,
+    status: "draft",
+    total_amount: 120,
+    due_date: "2026-04-19",
+    created_at: "2026-03-20T00:00:00.000Z",
+    source_document_id: null,
     ...overrides,
   };
 }
@@ -120,8 +145,38 @@ describe("QuoteList", () => {
     renderScreen();
 
     expect(
-      await screen.findByText("No quotes yet. Tap + to create your first."),
+      await screen.findByText("No quotes yet. Tap Create Document to create your first."),
     ).toBeInTheDocument();
+  });
+
+  it("switches to invoices mode and renders invoice cards", async () => {
+    mockedQuoteService.listQuotes.mockResolvedValueOnce([makeQuoteListItem()]);
+    mockedInvoiceService.listInvoices.mockResolvedValueOnce([
+      makeInvoiceListItem(),
+      makeInvoiceListItem({
+        id: "invoice-2",
+        customer_id: "cust-2",
+        customer_name: "Bob Brown",
+        doc_number: "I-002",
+        title: "Front Bed Refresh",
+        status: "ready",
+        total_amount: 220,
+        created_at: "2026-03-21T00:00:00.000Z",
+        source_document_id: "quote-2",
+      }),
+    ]);
+
+    renderScreen();
+    await screen.findByText("Q-001");
+
+    fireEvent.click(screen.getByRole("button", { name: "Invoices" }));
+
+    expect(await screen.findByRole("heading", { name: "Invoices" })).toBeInTheDocument();
+    expect(screen.getByText("1 active · 1 pending")).toBeInTheDocument();
+    expect(screen.getByText("Front Bed Refresh")).toBeInTheDocument();
+    expect(screen.getByText(/Bob Brown\s*·\s*I-002\s*·\s*Mar 21, 2026/)).toBeInTheDocument();
+    expect(screen.getByText("Ready")).toBeInTheDocument();
+    expect(screen.getAllByText("$220.00")).toHaveLength(1);
   });
 
   it("filters rows by customer name", async () => {
@@ -191,6 +246,19 @@ describe("QuoteList", () => {
     expect(navigateMock).toHaveBeenCalledWith("/quotes/quote-1/preview");
   });
 
+  it("navigates to invoice detail when an invoice row is clicked", async () => {
+    mockedQuoteService.listQuotes.mockResolvedValueOnce([makeQuoteListItem()]);
+    mockedInvoiceService.listInvoices.mockResolvedValueOnce([makeInvoiceListItem()]);
+
+    renderScreen();
+    await screen.findByText("Q-001");
+
+    fireEvent.click(screen.getByRole("button", { name: "Invoices" }));
+    fireEvent.click(await screen.findByRole("button", { name: /i-001/i }));
+
+    expect(navigateMock).toHaveBeenCalledWith("/invoices/invoice-1");
+  });
+
   it("renders compact stats text for active and pending quotes", async () => {
     mockedQuoteService.listQuotes.mockResolvedValueOnce([
       makeQuoteListItem({ status: "ready" }),
@@ -217,7 +285,7 @@ describe("QuoteList", () => {
     renderScreen();
     await screen.findByText("Q-001");
 
-    expect(screen.getByRole("button", { name: /quotes/i })).toHaveClass("text-primary");
+    expect(within(screen.getByRole("navigation")).getByRole("button", { name: /quotes/i })).toHaveClass("text-primary");
   });
 
   it("navigates to new quote when FAB is clicked", async () => {
@@ -226,9 +294,23 @@ describe("QuoteList", () => {
     renderScreen();
     await screen.findByText("Q-001");
 
-    fireEvent.click(screen.getByRole("button", { name: "Create quote" }));
+    fireEvent.click(screen.getByRole("button", { name: "Create document" }));
 
     expect(navigateMock).toHaveBeenCalledWith("/quotes/new");
+  });
+
+  it("renders invoice empty state when no invoices are returned", async () => {
+    mockedQuoteService.listQuotes.mockResolvedValueOnce([makeQuoteListItem()]);
+    mockedInvoiceService.listInvoices.mockResolvedValueOnce([]);
+
+    renderScreen();
+    await screen.findByText("Q-001");
+
+    fireEvent.click(screen.getByRole("button", { name: "Invoices" }));
+
+    expect(
+      await screen.findByText("No invoices yet. Tap Create Document to create your first."),
+    ).toBeInTheDocument();
   });
 
   it("shows loading state while list request is in flight", async () => {
@@ -284,7 +366,7 @@ describe("QuoteList", () => {
     await screen.findByText("Q-001");
 
     const searchInput = screen.getByLabelText("Search quotes");
-    const searchLabel = document.querySelector('label[for="quote-search"]');
+    const searchLabel = document.querySelector('label[for="document-search"]');
 
     expect(searchInput).toBeInTheDocument();
     expect(searchLabel).not.toBeNull();

--- a/frontend/src/shared/tests/mocks/handlers.ts
+++ b/frontend/src/shared/tests/mocks/handlers.ts
@@ -483,6 +483,42 @@ export const handlers = [
     );
   }),
 
+  http.get("/api/invoices", ({ request }) => {
+    const customerId = new URL(request.url).searchParams.get("customer_id");
+    const invoices = [
+      {
+        id: "invoice-2",
+        customer_id: "cust-2",
+        customer_name: "Bob Brown",
+        doc_number: "I-002",
+        title: "Front bed refresh",
+        status: "ready",
+        total_amount: 220,
+        due_date: "2026-04-22",
+        created_at: "2026-03-21T00:00:00.000Z",
+        source_document_id: null,
+      },
+      {
+        id: "invoice-1",
+        customer_id: "cust-1",
+        customer_name: "Alice Johnson",
+        doc_number: "I-001",
+        title: "Spring cleanup",
+        status: "draft",
+        total_amount: 120,
+        due_date: "2026-04-19",
+        created_at: "2026-03-20T00:00:00.000Z",
+        source_document_id: "quote-1",
+      },
+    ];
+
+    const filteredInvoices = customerId
+      ? invoices.filter((invoice) => invoice.customer_id === customerId)
+      : invoices;
+
+    return HttpResponse.json(filteredInvoices, { status: 200 });
+  }),
+
   http.get("/api/invoices/:id", ({ params }) => {
     const invoiceId = String(params.id);
 


### PR DESCRIPTION
## Summary
- add authenticated `GET /api/invoices` summaries with customer filtering for both direct and quote-derived invoices
- turn `/` into a quote-first `Quotes` / `Invoices` switch with parallel search, loading, empty-state, and row-routing behavior
- preserve the approved-only, one-to-one quote conversion flow while adding backend/frontend/docs coverage for the new discoverability path

## Test plan
- [x] `make backend-verify`
- [x] `make frontend-verify`

Closes #140