### PR TITLE
Task #146: add customer invoice history parity

### DIFF
--- a/frontend/src/features/customers/components/CustomerDetailScreen.tsx
+++ b/frontend/src/features/customers/components/CustomerDetailScreen.tsx
@@ -19,6 +19,8 @@ import { Button } from "@/shared/components/Button";
 import { FeedbackMessage } from "@/shared/components/FeedbackMessage";
 import { ScreenHeader } from "@/shared/components/ScreenHeader";
 
+type HistoryMode = "quotes" | "invoices";
+
 function getCustomerDraftValues(nextCustomer: Customer): {
   name: string;
   phone: string;
@@ -53,6 +55,7 @@ export function CustomerDetailScreen(): React.ReactElement {
   const [saveSuccess, setSaveSuccess] = useState<string | null>(null);
   const [isSaving, setIsSaving] = useState(false);
   const [isEditing, setIsEditing] = useState(false);
+  const [historyMode, setHistoryMode] = useState<HistoryMode>("quotes");
 
   function populateDraftFields(nextCustomer: Customer): void {
     const draftValues = getCustomerDraftValues(nextCustomer);
@@ -218,6 +221,9 @@ export function CustomerDetailScreen(): React.ReactElement {
     return trimmedValue || fallback;
   }
 
+  const activeHistoryCount = historyMode === "quotes" ? customerQuotes.length : customerInvoices.length;
+  const activeHistoryCountLabel = `${activeHistoryCount} ${activeHistoryCount === 1 ? "ITEM" : "ITEMS"}`;
+
   return (
     <main className="min-h-screen bg-background pb-24">
       <ScreenHeader
@@ -314,18 +320,60 @@ export function CustomerDetailScreen(): React.ReactElement {
               />
             )}
 
-            <QuoteHistoryList
-              quotes={customerQuotes}
-              onQuoteClick={(quoteId) => navigate(`/quotes/${quoteId}/preview`)}
-              timezone={user?.timezone}
-            />
-            <InvoiceHistoryList
-              invoices={customerInvoices}
-              isLoading={isLoadingInvoices}
-              loadError={invoiceLoadError}
-              onInvoiceClick={(invoiceId) => navigate(`/invoices/${invoiceId}`)}
-              timezone={user?.timezone}
-            />
+            <section>
+              <div className="mb-2 flex items-center justify-between gap-3">
+                <div
+                  aria-label="Customer history type filter"
+                  className="inline-flex rounded-full bg-surface-container-low p-1"
+                >
+                  <button
+                    type="button"
+                    aria-pressed={historyMode === "quotes"}
+                    className={`rounded-full px-4 py-2 text-sm font-semibold transition ${
+                      historyMode === "quotes"
+                        ? "bg-surface-container-lowest text-on-surface shadow-sm"
+                        : "text-on-surface-variant"
+                    }`}
+                    onClick={() => setHistoryMode("quotes")}
+                  >
+                    Quotes
+                  </button>
+                  <button
+                    type="button"
+                    aria-pressed={historyMode === "invoices"}
+                    className={`rounded-full px-4 py-2 text-sm font-semibold transition ${
+                      historyMode === "invoices"
+                        ? "bg-surface-container-lowest text-on-surface shadow-sm"
+                        : "text-on-surface-variant"
+                    }`}
+                    onClick={() => setHistoryMode("invoices")}
+                  >
+                    Invoices
+                  </button>
+                </div>
+                <p className="shrink-0 text-[0.6875rem] font-bold uppercase tracking-widest text-outline">
+                  {activeHistoryCountLabel}
+                </p>
+              </div>
+
+              {historyMode === "quotes" ? (
+                <QuoteHistoryList
+                  quotes={customerQuotes}
+                  onQuoteClick={(quoteId) => navigate(`/quotes/${quoteId}/preview`)}
+                  timezone={user?.timezone}
+                  showHeader={false}
+                />
+              ) : (
+                <InvoiceHistoryList
+                  invoices={customerInvoices}
+                  isLoading={isLoadingInvoices}
+                  loadError={invoiceLoadError}
+                  onInvoiceClick={(invoiceId) => navigate(`/invoices/${invoiceId}`)}
+                  timezone={user?.timezone}
+                  showHeader={false}
+                />
+              )}
+            </section>
           </>
         ) : null}
       </section>

--- a/frontend/src/features/customers/components/InvoiceHistoryList.tsx
+++ b/frontend/src/features/customers/components/InvoiceHistoryList.tsx
@@ -9,6 +9,7 @@ interface InvoiceHistoryListProps {
   loadError: string | null;
   onInvoiceClick: (invoiceId: string) => void;
   timezone?: string | null;
+  showHeader?: boolean;
 }
 
 export function InvoiceHistoryList({
@@ -17,19 +18,22 @@ export function InvoiceHistoryList({
   loadError,
   onInvoiceClick,
   timezone,
+  showHeader = true,
 }: InvoiceHistoryListProps): React.ReactElement {
   const invoiceCountLabel = `${invoices.length} ${invoices.length === 1 ? "INVOICE" : "INVOICES"}`;
 
   return (
     <section>
-      <div className="mb-2 flex items-center justify-between">
-        <p className="text-[0.6875rem] font-bold uppercase tracking-widest text-outline">
-          Invoice History
-        </p>
-        <p className="text-[0.6875rem] font-bold uppercase tracking-widest text-outline">
-          {invoiceCountLabel}
-        </p>
-      </div>
+      {showHeader ? (
+        <div className="mb-2 flex items-center justify-between">
+          <p className="text-[0.6875rem] font-bold uppercase tracking-widest text-outline">
+            Invoice History
+          </p>
+          <p className="text-[0.6875rem] font-bold uppercase tracking-widest text-outline">
+            {invoiceCountLabel}
+          </p>
+        </div>
+      ) : null}
 
       {isLoading ? (
         <p role="status" className="rounded-lg bg-surface-container-lowest p-4 text-sm text-outline ghost-shadow">

--- a/frontend/src/features/customers/components/QuoteHistoryList.tsx
+++ b/frontend/src/features/customers/components/QuoteHistoryList.tsx
@@ -6,25 +6,29 @@ interface QuoteHistoryListProps {
   quotes: QuoteListItem[];
   onQuoteClick: (quoteId: string) => void;
   timezone?: string | null;
+  showHeader?: boolean;
 }
 
 export function QuoteHistoryList({
   quotes,
   onQuoteClick,
   timezone,
+  showHeader = true,
 }: QuoteHistoryListProps): React.ReactElement {
   const quoteCountLabel = `${quotes.length} ${quotes.length === 1 ? "QUOTE" : "QUOTES"}`;
 
   return (
     <section>
-      <div className="mb-2 flex items-center justify-between">
-        <p className="text-[0.6875rem] font-bold uppercase tracking-widest text-outline">
-          Quote History
-        </p>
-        <p className="text-[0.6875rem] font-bold uppercase tracking-widest text-outline">
-          {quoteCountLabel}
-        </p>
-      </div>
+      {showHeader ? (
+        <div className="mb-2 flex items-center justify-between">
+          <p className="text-[0.6875rem] font-bold uppercase tracking-widest text-outline">
+            Quote History
+          </p>
+          <p className="text-[0.6875rem] font-bold uppercase tracking-widest text-outline">
+            {quoteCountLabel}
+          </p>
+        </div>
+      ) : null}
 
       {quotes.length > 0 ? (
         <div className="rounded-xl bg-surface-container-low p-3">

--- a/frontend/src/features/customers/tests/CustomerDetailScreen.test.tsx
+++ b/frontend/src/features/customers/tests/CustomerDetailScreen.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -88,6 +88,11 @@ async function openEditForm(): Promise<void> {
   await screen.findByLabelText(/^name$/i);
 }
 
+async function switchToInvoicesTab(): Promise<void> {
+  await screen.findByRole("heading", { level: 1, name: "Alice Johnson" });
+  fireEvent.click(screen.getByRole("button", { name: "Invoices" }));
+}
+
 beforeEach(() => {
   mockedCustomerService.getCustomer.mockResolvedValue({
     id: "cust-1",
@@ -163,6 +168,9 @@ describe("CustomerDetailScreen", () => {
     expect(screen.getByText("555-0101")).toBeInTheDocument();
     expect(screen.getByText("alice@example.com")).toBeInTheDocument();
     expect(screen.getByText("1 Main St")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Quotes" })).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByRole("button", { name: "Invoices" })).toHaveAttribute("aria-pressed", "false");
+    expect(screen.getByText("1 ITEM")).toBeInTheDocument();
     expect(screen.queryByLabelText(/^name$/i)).not.toBeInTheDocument();
   });
 
@@ -288,6 +296,7 @@ describe("CustomerDetailScreen", () => {
     expect(await screen.findByText("Q-001")).toBeInTheDocument();
     expect(screen.getByText(/Mar 24, 2026\s*·\s*1 item/)).toBeInTheDocument();
     expect(screen.queryByText("Q-002")).not.toBeInTheDocument();
+    expect(screen.queryByText("I-001")).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: /q-001/i }));
     expect(navigateMock).toHaveBeenCalledWith("/quotes/quote-1/preview");
@@ -295,14 +304,16 @@ describe("CustomerDetailScreen", () => {
 
   it("renders invoice history filtered to this customer and opens detail on click", async () => {
     renderScreen();
+    await switchToInvoicesTab();
 
     expect(await screen.findByText("I-001")).toBeInTheDocument();
-    const invoiceHistorySection = screen.getByText("Invoice History").closest("section");
-    expect(invoiceHistorySection).not.toBeNull();
-    expect(within(invoiceHistorySection as HTMLElement).getByText("2 INVOICES")).toBeInTheDocument();
-    expect(within(invoiceHistorySection as HTMLElement).getByText("Mar 24, 2026")).toBeInTheDocument();
-    expect(within(invoiceHistorySection as HTMLElement).getByText(/I-002\s*·\s*Mar 25, 2026/)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Invoices" })).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByRole("button", { name: "Quotes" })).toHaveAttribute("aria-pressed", "false");
+    expect(screen.getByText("2 ITEMS")).toBeInTheDocument();
+    expect(screen.getByText("Mar 24, 2026")).toBeInTheDocument();
+    expect(screen.getByText(/I-002\s*·\s*Mar 25, 2026/)).toBeInTheDocument();
     expect(screen.getByText("Final walkthrough")).toBeInTheDocument();
+    expect(screen.queryByText("Q-001")).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: /i-001/i }));
     expect(navigateMock).toHaveBeenCalledWith("/invoices/invoice-1");
@@ -312,6 +323,7 @@ describe("CustomerDetailScreen", () => {
     mockedInvoiceService.listInvoices.mockResolvedValueOnce([]);
 
     renderScreen();
+    await switchToInvoicesTab();
 
     expect(await screen.findByText("No invoices yet.")).toBeInTheDocument();
   });
@@ -320,19 +332,20 @@ describe("CustomerDetailScreen", () => {
     mockedInvoiceService.listInvoices.mockRejectedValueOnce(new Error("Unable to load invoices"));
 
     renderScreen();
+    await switchToInvoicesTab();
 
     expect(await screen.findByRole("alert")).toHaveTextContent("Unable to load invoices");
     expect(screen.getByRole("heading", { level: 1, name: "Alice Johnson" })).toBeInTheDocument();
-    expect(screen.getByText("Q-001")).toBeInTheDocument();
+    expect(screen.queryByText("Q-001")).not.toBeInTheDocument();
   });
 
   it("renders invoice history loading state while invoices are in flight", async () => {
     mockedInvoiceService.listInvoices.mockImplementationOnce(() => new Promise<InvoiceListItem[]>(() => {}));
 
     renderScreen();
+    await switchToInvoicesTab();
 
     expect(await screen.findByRole("heading", { level: 1, name: "Alice Johnson" })).toBeInTheDocument();
-    expect(screen.getByText("Q-001")).toBeInTheDocument();
     expect(screen.getByRole("status")).toHaveTextContent("Loading invoices...");
   });
 

--- a/plans/2026-03-31/task-m8-customer-scoped-invoice-filtering-parity.md
+++ b/plans/2026-03-31/task-m8-customer-scoped-invoice-filtering-parity.md
@@ -14,9 +14,12 @@ quotes, which means invoices do not yet benefit from that parity on the customer
 - Non-goals: account-wide invoice IA redesign, invoice payments/AR workflows, invoice public
   landing pages, or changes to invoice edit/share semantics.
 - Constraints:
+  - Scope this work to the existing customer detail screen.
   - Reuse the existing `GET /api/invoices?customer_id=<id>` contract.
   - Preserve the current quote-scoped customer history behavior.
   - Keep the UI lightweight and customer-contextual rather than adding a new standalone invoice hub.
+  - Add invoice history within the existing customer history area using a lightweight quote/invoice
+    switcher rather than inventing a new customer-context surface.
   - Direct invoices and quote-derived invoices must both appear correctly when filtered to one
     customer.
   - Empty/loading/error states should be explicit, not implied.
@@ -26,7 +29,7 @@ quotes, which means invoices do not yet benefit from that parity on the customer
 2. Reuse `invoiceService.listInvoices({ customer_id })` rather than introducing a new transport
    shape.
 3. Add the smallest UI needed to expose invoice history in customer context, keeping quote and
-   invoice concerns readable.
+   invoice concerns readable through a simple history toggle.
 4. Add backend/frontend tests covering customer-filtered invoice data, including direct and
    quote-derived invoices.
 5. Update docs only if the customer-detail/history contract or UX expectations materially change.
@@ -41,12 +44,17 @@ quotes, which means invoices do not yet benefit from that parity on the customer
 ## Acceptance Criteria
 - [ ] A contractor can view invoices filtered to a single customer on the intended customer-scoped
       surface.
+- [ ] The intended surface is the existing customer detail screen.
+- [ ] The customer detail screen exposes a lightweight history switcher so contractors can toggle
+      between customer-scoped quotes and invoices on the same surface.
 - [ ] The feature uses existing `GET /api/invoices?customer_id=<id>` filtering rather than a new
       backend contract.
 - [ ] Both direct invoices and quote-derived invoices appear when they belong to the selected
       customer.
-- [ ] Quotes remain available on the existing customer-scoped surface without regression.
-- [ ] Empty, loading, and error states are explicit for customer-scoped invoice history.
+- [ ] Quotes remain available on the same customer-scoped surface without regression when switching
+      history modes.
+- [ ] Empty, loading, and error states are explicit for customer-scoped invoice history when the
+      invoice history mode is active.
 - [ ] No new standalone invoice dashboard or navigation surface is introduced.
 - [ ] `make backend-verify` passes if backend tests change.
 - [ ] `make frontend-verify` passes.


### PR DESCRIPTION
## Summary
- add a customer-history toggle on the customer detail screen so contractors can switch between quote history and invoice history
- reuse the existing `customer_id` invoice list filter while keeping invoice loading, empty, and error states scoped to invoice mode
- extend customer detail tests to cover default quote mode, switching to invoices, item counts, navigation, and invoice tab states

## Test plan
- [x] `make frontend-verify`
- [ ] Manual check: open a customer with direct and quote-derived invoices, switch to `Invoices`, and confirm both appear in customer context
- [ ] Manual check: switch between `Quotes` and `Invoices` and confirm the visible list and count match the active history mode
- [ ] Manual check: open a customer with no invoices, switch to `Invoices`, and confirm the empty state is intentional
- [ ] Manual check: confirm quote history remains available by default on the same customer detail screen and still navigates as before

Closes #146