### PR TITLE
Task 154: finish dark mode token cleanup on authenticated surfaces

### DIFF
--- a/frontend/src/features/customers/components/CustomerListScreen.tsx
+++ b/frontend/src/features/customers/components/CustomerListScreen.tsx
@@ -135,7 +135,7 @@ export function CustomerListScreen(): React.ReactElement {
       <button
         type="button"
         aria-label="New customer"
-        className="fixed right-4 bottom-20 z-50 flex h-14 w-14 items-center justify-center rounded-full forest-gradient text-white shadow-[0_0_24px_rgba(0,0,0,0.12)] transition-all active:scale-95"
+        className="fixed right-4 bottom-20 z-50 flex h-14 w-14 items-center justify-center rounded-full forest-gradient text-on-primary ghost-shadow transition-all active:scale-95"
         onClick={() => navigate("/customers/new")}
       >
         <span className="material-symbols-outlined">person_add</span>

--- a/frontend/src/features/customers/tests/CustomerListScreen.test.tsx
+++ b/frontend/src/features/customers/tests/CustomerListScreen.test.tsx
@@ -143,7 +143,10 @@ describe("CustomerListScreen", () => {
     renderScreen();
     await screen.findByText("Alice Johnson");
 
-    fireEvent.click(screen.getByRole("button", { name: "New customer" }));
+    const newCustomerButton = screen.getByRole("button", { name: "New customer" });
+    expect(newCustomerButton).toHaveClass("forest-gradient", "text-on-primary", "ghost-shadow");
+
+    fireEvent.click(newCustomerButton);
 
     expect(navigateMock).toHaveBeenCalledWith("/customers/new");
   });

--- a/frontend/src/features/invoices/components/InvoiceEditScreen.tsx
+++ b/frontend/src/features/invoices/components/InvoiceEditScreen.tsx
@@ -398,7 +398,7 @@ export function InvoiceEditScreen(): React.ReactElement {
                       ...nextDraft,
                       notes: event.target.value,
                     }))}
-                  className="w-full rounded-lg border border-outline-variant/30 bg-white p-4 text-sm text-on-surface-variant placeholder:text-outline/70 outline-none transition-all focus:border-primary focus:ring-2 focus:ring-primary/20"
+                  className="w-full rounded-lg border border-outline-variant/30 bg-surface-container-high p-4 text-sm text-on-surface placeholder:text-outline/70 outline-none transition-all focus:bg-surface-container-lowest focus:border-primary focus:ring-2 focus:ring-primary/20"
                   placeholder="Any notes to include for the customer."
                 />
               </section>

--- a/frontend/src/features/invoices/tests/InvoiceEditScreen.test.tsx
+++ b/frontend/src/features/invoices/tests/InvoiceEditScreen.test.tsx
@@ -345,6 +345,19 @@ describe("InvoiceEditScreen", () => {
     });
   });
 
+  it("uses token-backed styling for the customer notes textarea", async () => {
+    renderScreen();
+
+    const customerNotes = await screen.findByLabelText(/customer notes/i);
+
+    expect(customerNotes).toHaveClass(
+      "bg-surface-container-high",
+      "text-on-surface",
+      "focus:bg-surface-container-lowest",
+    );
+    expect(customerNotes).not.toHaveClass("bg-white");
+  });
+
   it("blocks save when a line item has details or price but no description", async () => {
     window.sessionStorage.setItem(
       EDIT_STORAGE_KEY,

--- a/frontend/src/features/settings/components/SettingsScreen.tsx
+++ b/frontend/src/features/settings/components/SettingsScreen.tsx
@@ -393,7 +393,7 @@ export function SettingsScreen(): React.ReactElement {
                 {/* Sign out is a compact filled terracotta button per Stitch, not the shared outlined destructive variant. */}
                 <button
                   type="button"
-                  className="shrink-0 rounded-lg bg-secondary px-4 py-2 text-sm font-semibold text-white transition-all active:scale-[0.98]"
+                  className="shrink-0 rounded-lg bg-secondary px-4 py-2 text-sm font-semibold text-on-secondary transition-all active:scale-[0.98]"
                   onClick={() => setIsSignOutConfirmOpen(true)}
                 >
                   Sign Out

--- a/frontend/src/features/settings/tests/SettingsScreen.test.tsx
+++ b/frontend/src/features/settings/tests/SettingsScreen.test.tsx
@@ -381,7 +381,7 @@ describe("SettingsScreen", () => {
     renderScreen();
 
     const signOutButton = await screen.findByRole("button", { name: /sign out/i });
-    expect(signOutButton).toHaveClass("bg-secondary", "text-white");
+    expect(signOutButton).toHaveClass("bg-secondary", "text-on-secondary");
     expect(signOutButton).not.toHaveClass("border");
 
     fireEvent.click(signOutButton);


### PR DESCRIPTION
## Summary
- replace remaining task-owned light-only classes on the customer FAB, invoice editor notes field, and Settings sign-out action with semantic token-backed styling
- align the invoice customer-notes textarea with the existing quote editor/review dark-mode pattern
- add targeted frontend assertions so these dark-mode regressions stay covered

## Verification
- `make frontend-verify`

Closes #154