### PR TITLE
Task 155: finish dark mode auth and public parity sweep

### DIFF
--- a/frontend/src/features/auth/components/LoginForm.tsx
+++ b/frontend/src/features/auth/components/LoginForm.tsx
@@ -37,7 +37,7 @@ export function LoginForm(): React.ReactElement {
   };
 
   return (
-    <main className="flex min-h-screen flex-col items-center justify-center bg-background px-4 py-8">
+    <main className="screen-radial-backdrop flex min-h-screen flex-col items-center justify-center px-4 py-8">
       <h1 className="mb-8 font-headline text-3xl font-bold text-primary">Stima</h1>
       <section className="w-full max-w-sm rounded-xl bg-surface-container-lowest p-6 ghost-shadow">
         <h2 className="mb-6 font-headline text-2xl font-bold text-on-surface">Welcome Back</h2>

--- a/frontend/src/features/auth/components/RegisterForm.tsx
+++ b/frontend/src/features/auth/components/RegisterForm.tsx
@@ -30,7 +30,7 @@ export function RegisterForm(): React.ReactElement {
   };
 
   return (
-    <main className="flex min-h-screen flex-col items-center justify-center bg-background px-4 py-8">
+    <main className="screen-radial-backdrop flex min-h-screen flex-col items-center justify-center px-4 py-8">
       <h1 className="mb-8 font-headline text-3xl font-bold text-primary">Stima</h1>
       <section className="w-full max-w-sm rounded-xl bg-surface-container-lowest p-6 ghost-shadow">
         <h2 className="mb-6 font-headline text-2xl font-bold text-on-surface">Create your account</h2>

--- a/frontend/src/features/auth/tests/LoginForm.test.tsx
+++ b/frontend/src/features/auth/tests/LoginForm.test.tsx
@@ -50,6 +50,7 @@ describe("LoginForm", () => {
     });
 
     renderLogin();
+    expect(await screen.findByRole("main")).toHaveClass("screen-radial-backdrop");
 
     fireEvent.change(await screen.findByLabelText(/email/i), {
       target: { value: "user@example.com" },
@@ -84,6 +85,7 @@ describe("LoginForm", () => {
       pathname: "/login",
       state: { from: { pathname: "/dashboard" } },
     });
+    expect(await screen.findByRole("main")).toHaveClass("screen-radial-backdrop");
 
     fireEvent.change(await screen.findByLabelText(/email/i), {
       target: { value: "user@example.com" },
@@ -101,6 +103,7 @@ describe("LoginForm", () => {
     mockedAuthService.login.mockRejectedValueOnce(new Error("Invalid credentials"));
 
     renderLogin();
+    expect(await screen.findByRole("main")).toHaveClass("screen-radial-backdrop");
 
     fireEvent.change(await screen.findByLabelText(/email/i), {
       target: { value: "user@example.com" },

--- a/frontend/src/features/auth/tests/RegisterForm.test.tsx
+++ b/frontend/src/features/auth/tests/RegisterForm.test.tsx
@@ -50,6 +50,7 @@ describe("RegisterForm", () => {
     });
 
     renderRegister();
+    expect(await screen.findByRole("main")).toHaveClass("screen-radial-backdrop");
 
     fireEvent.change(await screen.findByLabelText(/email/i), {
       target: { value: "new@example.com" },
@@ -78,6 +79,7 @@ describe("RegisterForm", () => {
     mockedAuthService.register.mockRejectedValueOnce(new Error("Email already exists"));
 
     renderRegister();
+    expect(await screen.findByRole("main")).toHaveClass("screen-radial-backdrop");
 
     fireEvent.change(await screen.findByLabelText(/email/i), {
       target: { value: "new@example.com" },

--- a/frontend/src/features/profile/components/OnboardingForm.tsx
+++ b/frontend/src/features/profile/components/OnboardingForm.tsx
@@ -47,7 +47,7 @@ export function OnboardingForm(): React.ReactElement {
   };
 
   return (
-    <main className="flex min-h-screen flex-col items-center justify-center bg-background px-4 py-8">
+    <main className="screen-radial-backdrop flex min-h-screen flex-col items-center justify-center px-4 py-8">
       <h1 className="mb-8 font-headline text-3xl font-bold text-primary">Stima</h1>
       <section className="w-full max-w-sm rounded-xl bg-surface-container-lowest p-6 ghost-shadow">
         <h2 className="font-headline text-2xl font-bold text-on-surface">Set up your business</h2>

--- a/frontend/src/features/profile/tests/OnboardingForm.test.tsx
+++ b/frontend/src/features/profile/tests/OnboardingForm.test.tsx
@@ -76,6 +76,7 @@ describe("OnboardingForm", () => {
   it("renders required onboarding fields with default trade type", () => {
     renderForm();
 
+    expect(screen.getByRole("main")).toHaveClass("screen-radial-backdrop");
     expect(screen.getByLabelText(/business name/i)).toBeRequired();
     expect(screen.getByLabelText(/first name/i)).toBeInTheDocument();
     expect(screen.getByLabelText(/last name/i)).toBeInTheDocument();
@@ -104,6 +105,7 @@ describe("OnboardingForm", () => {
     );
 
     renderForm();
+    expect(screen.getByRole("main")).toHaveClass("screen-radial-backdrop");
 
     fireEvent.change(screen.getByLabelText(/business name/i), {
       target: { value: "Summit Exterior Care" },
@@ -134,6 +136,7 @@ describe("OnboardingForm", () => {
     mockedProfileService.updateProfile.mockRejectedValueOnce(new Error("Unable to save profile"));
 
     renderForm();
+    expect(screen.getByRole("main")).toHaveClass("screen-radial-backdrop");
 
     fireEvent.change(screen.getByLabelText(/business name/i), {
       target: { value: "Summit Exterior Care" },
@@ -160,6 +163,7 @@ describe("OnboardingForm", () => {
     );
 
     renderForm();
+    expect(screen.getByRole("main")).toHaveClass("screen-radial-backdrop");
 
     fireEvent.change(screen.getByLabelText(/business name/i), {
       target: { value: "Summit Exterior Care" },

--- a/frontend/src/features/public/components/PublicQuotePage.tsx
+++ b/frontend/src/features/public/components/PublicQuotePage.tsx
@@ -124,7 +124,7 @@ export function PublicQuotePage(): React.ReactElement {
 
   if (effectiveLoadState === "loading") {
     return (
-      <main className="min-h-screen bg-background px-4 py-10 text-on-surface">
+      <main className="screen-radial-backdrop min-h-screen px-4 py-10 text-on-surface">
         <div className="mx-auto max-w-3xl rounded-[1.75rem] border border-surface-container-high bg-surface-container-lowest p-8 ghost-shadow">
           <p role="status" className="text-sm text-on-surface-variant">
             Loading shared quote...
@@ -136,7 +136,7 @@ export function PublicQuotePage(): React.ReactElement {
 
   if (effectiveLoadState === "invalid") {
     return (
-      <main className="min-h-screen bg-[radial-gradient(circle_at_top,_#dce9ff_0%,_#f8f9ff_45%,_#eff4ff_100%)] px-4 py-10 text-on-surface">
+      <main className="screen-radial-backdrop min-h-screen px-4 py-10 text-on-surface">
         <div className="mx-auto max-w-xl rounded-[1.75rem] border border-surface-container-high bg-surface-container-lowest p-8 text-center ghost-shadow">
           <p className="text-xs font-semibold uppercase tracking-[0.3em] text-outline">Shared Quote</p>
           <h1 className="mt-4 text-3xl font-semibold">This link is not valid</h1>
@@ -150,7 +150,7 @@ export function PublicQuotePage(): React.ReactElement {
 
   if (effectiveLoadState === "error" || quote === null) {
     return (
-      <main className="min-h-screen bg-background px-4 py-10 text-on-surface">
+      <main className="screen-radial-backdrop min-h-screen px-4 py-10 text-on-surface">
         <div className="mx-auto max-w-xl rounded-[1.75rem] border border-error/15 bg-surface-container-lowest p-8 ghost-shadow">
           <h1 className="text-2xl font-semibold">We couldn&apos;t load this quote</h1>
           <p className="mt-3 text-sm text-on-surface-variant">
@@ -177,12 +177,12 @@ export function PublicQuotePage(): React.ReactElement {
   );
 
   return (
-    <main className="min-h-screen bg-[radial-gradient(circle_at_top,_#dce9ff_0%,_#f8f9ff_42%,_#eff4ff_100%)] px-4 py-6 text-on-surface sm:px-6 lg:py-10">
+    <main className="screen-radial-backdrop min-h-screen px-4 py-6 text-on-surface sm:px-6 lg:py-10">
       <div className="mx-auto max-w-4xl">
         <section className="overflow-hidden rounded-[1.75rem] border border-surface-container-high bg-surface-container-lowest ghost-shadow">
           <div className="forest-gradient px-5 py-6 text-on-primary sm:px-8 sm:py-8">
             <div className="flex items-start gap-4">
-              <div className="flex h-16 w-16 shrink-0 items-center justify-center overflow-hidden rounded-2xl bg-white/15 text-xl font-semibold uppercase text-on-primary">
+              <div className="flex h-16 w-16 shrink-0 items-center justify-center overflow-hidden rounded-2xl bg-on-primary/15 text-xl font-semibold uppercase text-on-primary">
                 {showLogo ? (
                   <img
                     src={quote.logo_url}
@@ -195,13 +195,13 @@ export function PublicQuotePage(): React.ReactElement {
                 )}
               </div>
               <div className="min-w-0">
-                <p className="text-xs font-semibold uppercase tracking-[0.3em] text-white/70">
+                <p className="text-xs font-semibold uppercase tracking-[0.3em] text-on-primary/70">
                   {getDisplayBusinessName(quote)}
                 </p>
                 <h1 className="mt-3 text-3xl font-semibold leading-tight">
                   {getDisplayTitle(quote)}
                 </h1>
-                <p className="mt-2 text-sm text-white/80">
+                <p className="mt-2 text-sm text-on-primary/80">
                   {quote.doc_number} · Issued {quote.issued_date}
                 </p>
               </div>

--- a/frontend/src/features/public/tests/PublicQuotePage.test.tsx
+++ b/frontend/src/features/public/tests/PublicQuotePage.test.tsx
@@ -83,8 +83,10 @@ describe("PublicQuotePage", () => {
     renderScreen();
 
     expect(await screen.findByRole("heading", { name: "Spring Cleanup" })).toBeInTheDocument();
+    expect(screen.getByRole("main")).toHaveClass("screen-radial-backdrop");
     expect(mockedPublicService.getQuote).toHaveBeenCalledWith("token-1");
     expect(screen.getByText("This quote has been accepted")).toBeInTheDocument();
+    expect(screen.getByText("Northline Landscaping")).toHaveClass("text-on-primary/70");
     expect(screen.getByText("Taylor Morgan")).toBeInTheDocument();
     expect(screen.getByText("$425.00")).toBeInTheDocument();
     expect(screen.getByText("Mulch refresh")).toBeInTheDocument();
@@ -106,6 +108,7 @@ describe("PublicQuotePage", () => {
     renderScreen();
 
     expect(await screen.findByRole("heading", { name: "This link is not valid" })).toBeInTheDocument();
+    expect(screen.getByRole("main")).toHaveClass("screen-radial-backdrop");
     expect(screen.queryByRole("link", { name: /download pdf/i })).not.toBeInTheDocument();
   });
 
@@ -115,6 +118,7 @@ describe("PublicQuotePage", () => {
     renderScreen();
 
     expect(await screen.findByRole("heading", { name: /we couldn't load this quote/i })).toBeInTheDocument();
+    expect(screen.getByRole("main")).toHaveClass("screen-radial-backdrop");
     expect(screen.queryByRole("link", { name: /download pdf/i })).not.toBeInTheDocument();
   });
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -223,6 +223,15 @@
   );
 }
 
+.screen-radial-backdrop {
+  background: radial-gradient(
+    circle at top,
+    var(--color-surface-container-high) 0%,
+    var(--color-background) 42%,
+    var(--color-surface-container-low) 100%
+  );
+}
+
 .ghost-shadow {
   box-shadow: var(--shadow-ghost);
 }


### PR DESCRIPTION
## Summary
- add a shared token-backed radial backdrop utility for auth/onboarding and public quote shells
- replace the public quote page's remaining hardcoded light-only gradient and white overlay classes with semantic theme tokens
- extend auth/onboarding/public route tests to lock the new token-backed shell styling

## Verification
- make frontend-verify

## Notes
- Manual theme sweep across System, Light, and Dark is still an operator check.

Closes #155