### PR TITLE
Task #167: Simplify review flow warnings and optional pricing disclosure

### DIFF
--- a/frontend/src/features/quotes/components/ReviewScreen.tsx
+++ b/frontend/src/features/quotes/components/ReviewScreen.tsx
@@ -12,6 +12,7 @@ import {
   buildCreatePayload,
   EMPTY_LINE_ITEM,
   getReviewMessages,
+  getWarningMessages,
   isInvalidLineItem,
   mapExtractedLineItems,
   normalizeLineItem,
@@ -89,6 +90,7 @@ export function ReviewScreen(): React.ReactElement | null {
   }, 0);
   const trimmedTranscript = currentDraft.transcript.trim();
   const reviewMessages = getReviewMessages(currentDraft);
+  const warningMessages = getWarningMessages(reviewMessages, hasNullPrices, documentType);
   const isInteractionLocked = isSaving || isRegenerating;
 
   function updateDraft(updater: (current: QuoteDraft) => QuoteDraft): void {
@@ -223,16 +225,13 @@ export function ReviewScreen(): React.ReactElement | null {
           <FeedbackMessage variant="error">{saveError}</FeedbackMessage>
         ) : null}
 
-        {reviewMessages.length > 0 ? (
+        {warningMessages.length > 0 ? (
           <section className="rounded-lg border border-warning-accent/30 bg-warning-container p-4 text-warning">
             <p className="text-[0.6875rem] font-bold uppercase tracking-widest">
               Review required before generating
             </p>
-            <p className="mt-2 text-sm font-medium">
-              Check these items so the quote matches the job before you continue.
-            </p>
             <ul className="mt-3 list-disc space-y-2 pl-5 text-sm">
-              {reviewMessages.map((message) => (
+              {warningMessages.map((message) => (
                 <li key={message}>{message}</li>
               ))}
             </ul>
@@ -424,7 +423,6 @@ export function ReviewScreen(): React.ReactElement | null {
       </form>
       <ReviewSubmitFooter
         documentType={documentType}
-        hasNullPrices={hasNullPrices}
         canSubmit={canSubmit}
         isInteractionLocked={isInteractionLocked}
         isSaving={isSaving}

--- a/frontend/src/features/quotes/components/ReviewSubmitFooter.tsx
+++ b/frontend/src/features/quotes/components/ReviewSubmitFooter.tsx
@@ -4,7 +4,6 @@ import { ScreenFooter } from "@/shared/components/ScreenFooter";
 
 interface ReviewSubmitFooterProps {
   documentType: ReviewDocumentType;
-  hasNullPrices: boolean;
   canSubmit: boolean;
   isInteractionLocked: boolean;
   isSaving: boolean;
@@ -12,7 +11,6 @@ interface ReviewSubmitFooterProps {
 
 export function ReviewSubmitFooter({
   documentType,
-  hasNullPrices,
   canSubmit,
   isInteractionLocked,
   isSaving,
@@ -20,13 +18,6 @@ export function ReviewSubmitFooter({
   return (
     <ScreenFooter>
       <div className="mx-auto w-full max-w-2xl">
-        {hasNullPrices ? (
-          <p className="mb-2 rounded-lg bg-warning-container px-3 py-2 text-center text-xs text-warning">
-            {documentType === "quote"
-              ? "Review missing prices before sharing. Quote generation stays enabled, and any blank prices will render as \"TBD\"."
-              : "Review missing prices before creating the invoice. Blank prices will render as \"TBD\"."}
-          </p>
-        ) : null}
         <Button
           type="submit"
           form="quote-review-form"

--- a/frontend/src/features/quotes/components/TotalAmountSection.test.tsx
+++ b/frontend/src/features/quotes/components/TotalAmountSection.test.tsx
@@ -5,13 +5,25 @@ import { describe, expect, it } from "vitest";
 import { TotalAmountSection } from "@/features/quotes/components/TotalAmountSection";
 import type { DiscountType } from "@/shared/lib/pricing";
 
-function renderSection(): void {
+function renderSection({
+  initialTaxRate = null,
+  initialDiscountType = null,
+  initialDiscountValue = null,
+  initialDepositAmount = null,
+  suggestedTaxRate = 0.0825,
+}: {
+  initialTaxRate?: number | null;
+  initialDiscountType?: DiscountType | null;
+  initialDiscountValue?: number | null;
+  initialDepositAmount?: number | null;
+  suggestedTaxRate?: number | null;
+} = {}): void {
   function Wrapper(): React.ReactElement {
     const [total, setTotal] = useState<number | null>(100);
-    const [taxRate, setTaxRate] = useState<number | null>(null);
-    const [discountType, setDiscountType] = useState<DiscountType | null>(null);
-    const [discountValue, setDiscountValue] = useState<number | null>(null);
-    const [depositAmount, setDepositAmount] = useState<number | null>(null);
+    const [taxRate, setTaxRate] = useState<number | null>(initialTaxRate);
+    const [discountType, setDiscountType] = useState<DiscountType | null>(initialDiscountType);
+    const [discountValue, setDiscountValue] = useState<number | null>(initialDiscountValue);
+    const [depositAmount, setDepositAmount] = useState<number | null>(initialDepositAmount);
 
     return (
       <TotalAmountSection
@@ -21,7 +33,7 @@ function renderSection(): void {
         discountType={discountType}
         discountValue={discountValue}
         depositAmount={depositAmount}
-        suggestedTaxRate={0.0825}
+        suggestedTaxRate={suggestedTaxRate}
         onTotalChange={setTotal}
         onTaxRateChange={setTaxRate}
         onDiscountTypeChange={setDiscountType}
@@ -43,6 +55,24 @@ describe("TotalAmountSection", () => {
     );
   });
 
+  it("keeps optional pricing discoverable while collapsed when nothing is active", () => {
+    renderSection({ suggestedTaxRate: null });
+
+    expect(screen.getByRole("button", { name: /optional pricing/i })).toHaveAttribute(
+      "aria-expanded",
+      "false",
+    );
+    expect(screen.queryByRole("checkbox", { name: "Discount" })).not.toBeInTheDocument();
+  });
+
+  it("auto-expands optional pricing when a suggested tax rate exists and shows percent units", () => {
+    renderSection();
+
+    expect(screen.getByText(/optional pricing/i)).toBeInTheDocument();
+    expect(screen.getByRole("spinbutton", { name: /suggested tax/i })).toHaveValue(8.25);
+    expect(screen.getByText("%")).toBeInTheDocument();
+  });
+
   it("shows editable inputs without seeding zero values and applies the suggested tax rate", () => {
     renderSection();
 
@@ -51,7 +81,7 @@ describe("TotalAmountSection", () => {
     expect(discountInput.value).toBe("");
 
     fireEvent.click(screen.getByRole("checkbox", { name: "Tax" }));
-    const taxInput = screen.getByPlaceholderText("8.25") as HTMLInputElement;
+    const taxInput = screen.getByRole("spinbutton", { name: /tax rate/i }) as HTMLInputElement;
     expect(taxInput.value).toBe("8.25");
 
     fireEvent.click(screen.getByRole("checkbox", { name: "Deposit" }));

--- a/frontend/src/features/quotes/components/TotalAmountSection.tsx
+++ b/frontend/src/features/quotes/components/TotalAmountSection.tsx
@@ -43,6 +43,7 @@ export function TotalAmountSection({
   const [discountToggleOverride, setDiscountToggleOverride] = useState<boolean | null>(null);
   const [taxToggleOverride, setTaxToggleOverride] = useState<boolean | null>(null);
   const [depositToggleOverride, setDepositToggleOverride] = useState<boolean | null>(null);
+  const [isOptionalPricingOpen, setIsOptionalPricingOpen] = useState(false);
   const isDiscountEnabled = discountToggleOverride ?? (
     discountType !== null || isPopulatedPricingValue(discountValue)
   );
@@ -56,13 +57,14 @@ export function TotalAmountSection({
     discountValue,
     depositAmount,
   });
-  const hasPricingControls = (
+  const shouldAutoExpandOptionalPricing = (
     isDiscountEnabled
     || isTaxEnabled
     || isDepositEnabled
     || suggestedTaxRate !== null
   );
   const hasPricingBreakdown = pricingBreakdown.hasPricingBreakdown;
+  const shouldShowOptionalPricingPanel = shouldAutoExpandOptionalPricing || isOptionalPricingOpen;
 
   return (
     <section className="rounded-lg bg-surface-container-low p-4">
@@ -102,16 +104,45 @@ export function TotalAmountSection({
         </div>
       </div>
 
-      {hasPricingControls ? (
-        <div className="mt-4 space-y-4 border-t border-outline-variant/30 pt-4">
-          <div className="flex items-center justify-between">
-            <p className="text-xs font-bold uppercase tracking-widest text-on-surface">
-              Optional Pricing
-            </p>
-            <span className="text-xs text-outline">Only appears when enabled</span>
+      <div className="mt-4 border-t border-outline-variant/30 pt-4">
+        {shouldAutoExpandOptionalPricing ? (
+          <div className="flex items-center justify-between gap-4 rounded-lg bg-surface-container-lowest px-4 py-3">
+            <div>
+              <p className="text-xs font-bold uppercase tracking-widest text-on-surface">
+                Optional Pricing
+              </p>
+              <p className="mt-1 text-sm text-outline">
+                Tax, discount, and deposit
+              </p>
+            </div>
+            <span className="text-xs font-semibold uppercase tracking-widest text-outline">
+              Shown
+            </span>
           </div>
+        ) : (
+          <button
+            type="button"
+            aria-expanded={isOptionalPricingOpen}
+            aria-controls="optional-pricing-panel"
+            className="flex w-full items-center justify-between gap-4 rounded-lg bg-surface-container-lowest px-4 py-3 text-left transition-colors hover:bg-surface-container"
+            onClick={() => setIsOptionalPricingOpen((current) => !current)}
+          >
+            <div>
+              <p className="text-xs font-bold uppercase tracking-widest text-on-surface">
+                Optional Pricing
+              </p>
+              <p className="mt-1 text-sm text-outline">
+                Tax, discount, and deposit
+              </p>
+            </div>
+            <span className="text-xs font-semibold uppercase tracking-widest text-outline">
+              {isOptionalPricingOpen ? "Hide" : "Show"}
+            </span>
+          </button>
+        )}
 
-          <div className="space-y-3">
+        {shouldShowOptionalPricingPanel ? (
+          <div id="optional-pricing-panel" className="mt-4 space-y-3">
             <label className="flex items-center gap-3 text-sm text-on-surface">
               <input
                 type="checkbox"
@@ -178,28 +209,42 @@ export function TotalAmountSection({
             </label>
             {suggestedTaxRate !== null && !isTaxEnabled ? (
               <div className="rounded-lg bg-surface-container-lowest p-3 text-sm text-on-surface-variant">
-                <p className="text-xs font-bold uppercase tracking-widest text-outline">Suggested Tax</p>
-                <input
-                  type="number"
-                  value={toTaxPercentDisplay(suggestedTaxRate)}
-                  disabled
-                  className="mt-2 w-full rounded-lg bg-surface-container-high px-4 py-3 text-sm text-on-surface-variant"
-                />
+                <p className="text-xs font-bold uppercase tracking-widest text-outline">
+                  Suggested Tax Rate
+                </p>
+                <div className="relative mt-2">
+                  <input
+                    type="number"
+                    aria-label="Suggested tax (%)"
+                    value={toTaxPercentDisplay(suggestedTaxRate)}
+                    disabled
+                    className="w-full rounded-lg bg-surface-container-high px-4 py-3 pr-10 text-sm text-on-surface-variant"
+                  />
+                  <span className="pointer-events-none absolute right-4 top-1/2 -translate-y-1/2 text-sm text-outline">
+                    %
+                  </span>
+                </div>
                 <p className="mt-2 text-xs text-outline">
                   Enable tax to apply this default rate to this document.
                 </p>
               </div>
             ) : null}
             {isTaxEnabled ? (
-              <input
-                type="number"
-                step="0.01"
-                disabled={disabled}
-                value={toTaxPercentDisplay(taxRate)}
-                onChange={(event) => onTaxRateChange(parseTaxPercentInput(event.target.value))}
-                className="w-full rounded-lg bg-surface-container-high px-4 py-3 text-sm text-on-surface transition-all focus:bg-surface-container-lowest focus:outline-none focus:ring-2 focus:ring-primary/30"
-                placeholder="8.25"
-              />
+              <div className="relative">
+                <input
+                  type="number"
+                  step="0.01"
+                  aria-label="Tax rate (%)"
+                  disabled={disabled}
+                  value={toTaxPercentDisplay(taxRate)}
+                  onChange={(event) => onTaxRateChange(parseTaxPercentInput(event.target.value))}
+                  className="w-full rounded-lg bg-surface-container-high px-4 py-3 pr-10 text-sm text-on-surface transition-all focus:bg-surface-container-lowest focus:outline-none focus:ring-2 focus:ring-primary/30"
+                  placeholder="8.25"
+                />
+                <span className="pointer-events-none absolute right-4 top-1/2 -translate-y-1/2 text-sm text-outline">
+                  %
+                </span>
+              </div>
             ) : null}
 
             <label className="flex items-center gap-3 text-sm text-on-surface">
@@ -236,8 +281,8 @@ export function TotalAmountSection({
               />
             ) : null}
           </div>
-        </div>
-      ) : null}
+        ) : null}
+      </div>
 
       {hasPricingBreakdown ? (
         <div className="mt-4 space-y-2 border-t border-outline-variant/30 pt-4 text-sm">

--- a/frontend/src/features/quotes/components/reviewScreenUtils.ts
+++ b/frontend/src/features/quotes/components/reviewScreenUtils.ts
@@ -60,6 +60,23 @@ export function getReviewMessages(draft: QuoteDraft): string[] {
   return [...new Set([...confidenceMessages, ...flaggedMessages])];
 }
 
+export function getWarningMessages(
+  reviewMessages: string[],
+  hasNullPrices: boolean,
+  documentType: "quote" | "invoice",
+): string[] {
+  if (!hasNullPrices) {
+    return reviewMessages;
+  }
+
+  return [
+    ...reviewMessages,
+    documentType === "quote"
+      ? "Line items without prices will render as \"TBD\" when the quote is shared."
+      : "Line items without prices will render as \"TBD\" when the invoice is created.",
+  ];
+}
+
 export function buildCreatePayload(draft: QuoteDraft, lineItems: LineItemDraft[]) {
   return {
     customer_id: draft.customerId,

--- a/frontend/src/features/quotes/tests/ReviewScreen.test.tsx
+++ b/frontend/src/features/quotes/tests/ReviewScreen.test.tsx
@@ -271,7 +271,11 @@ describe("ReviewScreen", () => {
   });
 
   it("hides review guidance when there are no confidence notes and no flagged items", () => {
-    renderScreen(makeDraft());
+    renderScreen(
+      makeDraft({
+        lineItems: [{ description: "Brown mulch", details: "5 yards", price: 120 }],
+      }),
+    );
 
     expect(screen.queryByText(/review required before generating/i)).not.toBeInTheDocument();
   });
@@ -279,8 +283,8 @@ describe("ReviewScreen", () => {
   it("shows a clearer null-price warning when any submitted line item has no price", () => {
     renderScreen(makeDraft());
 
-    expect(screen.getByText(/review missing prices before sharing/i)).toBeInTheDocument();
-    expect(screen.getByText(/render as "TBD"/i)).toBeInTheDocument();
+    expect(screen.getByText(/review required before generating/i)).toBeInTheDocument();
+    expect(screen.getByText(/render as "TBD" when the quote is shared/i)).toBeInTheDocument();
   });
 
   it("hides the null-price warning when all submitted line items have prices", () => {
@@ -290,13 +294,14 @@ describe("ReviewScreen", () => {
       }),
     );
 
-    expect(screen.queryByText(/review missing prices before sharing/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/render as "TBD" when the quote is shared/i)).not.toBeInTheDocument();
   });
 
-  it("keeps quote generation enabled when the null-price warning is shown", () => {
+  it("keeps quote generation enabled and removes the sticky footer warning when prices are missing", () => {
     renderScreen(makeDraft());
 
-    expect(screen.getByText(/review missing prices before sharing/i)).toBeInTheDocument();
+    expect(screen.queryByText(/review missing prices before sharing/i)).not.toBeInTheDocument();
+    expect(screen.getByText(/render as "TBD" when the quote is shared/i)).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /^generate quote$/i })).toBeEnabled();
   });
 


### PR DESCRIPTION
## Summary
- keep optional pricing visible through an always-present disclosure and show clearer tax percent units
- auto-show optional pricing when existing pricing or a suggested tax rate is present
- collapse the review warnings into a single top band and remove the sticky footer warning

## Verification
- make frontend-verify

Closes #167