### PR TITLE
Add execution brief template and analog docs

### DIFF
--- a/docs/PATTERNS.md
+++ b/docs/PATTERNS.md
@@ -100,6 +100,13 @@ Record conventions that already exist in code.
   - A LOC warning is a review flag, not an automatic split mandate.
   - Split only when the two candidate halves have different collaborators/dependencies or different reasons to change.
 
+## Implementation Analogs (Reference)
+- `docs/analogs/*` is the home for repeatable implementation shapes that point at real repo examples without redefining repo-wide conventions.
+- Start with:
+  - `docs/analogs/transactional-email-flow.md`
+  - `docs/analogs/stateful-action-matrix.md`
+- Keep this file conventions-first. Add new analogs there only when a pattern is already repeated in code and worth reusing.
+
 ## Verification Reference
 Canonical targets:
 ```bash

--- a/docs/analogs/stateful-action-matrix.md
+++ b/docs/analogs/stateful-action-matrix.md
@@ -1,0 +1,99 @@
+# Stateful Action Matrix
+
+Use this analog when one screen exposes different actions, labels, or side effects based on document status, local transient state, or cross-layer contract rules.
+
+## When To Use
+
+- Adding or changing status-driven action visibility
+- Changing which actions are enabled, disabled, or hidden during async mutations
+- Introducing new document outcomes or status transitions
+- Refactoring a stateful screen while preserving action parity
+
+## Canonical Examples
+
+- `frontend/src/features/quotes/components/QuotePreview.tsx`
+- `frontend/src/features/quotes/components/QuotePreviewActions.tsx`
+- `frontend/src/features/quotes/components/quotePreview.helpers.ts`
+- `frontend/src/features/quotes/components/QuotePreviewDialogs.tsx`
+- `frontend/src/features/quotes/utils/quoteStatus.ts`
+- `backend/app/features/quotes/service.py`
+- `frontend/src/features/invoices/components/InvoiceDetailScreen.tsx`
+- `frontend/src/features/invoices/utils/invoiceStatus.ts`
+- `backend/app/features/invoices/service.py`
+- `docs/ARCHITECTURE.md`
+- `frontend/src/features/quotes/tests/QuotePreview.test.tsx`
+- `frontend/src/features/quotes/tests/QuotePreviewActions.test.tsx`
+- `frontend/src/features/invoices/tests/InvoiceDetailScreen.test.tsx`
+
+## Invariants
+
+- Derive action availability from a small, explicit state model instead of scattering status checks across unrelated components.
+- Keep backend status rules authoritative; frontend state may smooth UX but must not invent impossible transitions.
+- Preserve documented non-regression behavior, such as quote share not regressing `viewed`, `approved`, or `declined`.
+- Keep editability rules centralized in helpers such as `quoteStatus.ts` and `invoiceStatus.ts`.
+- Disable sibling actions while an async mutation is in flight.
+- Require confirmation for destructive or external side-effect actions.
+- When a mutation returns partial data, preserve existing detail fields that the screen still needs.
+
+## Canonical Matrix Shapes
+
+Quote preview:
+
+- `draft`
+  - Primary action: generate PDF
+  - Utility actions: email hidden, copy link hidden
+  - Overflow actions: delete, mark as won, mark as lost
+- `ready`
+  - Primary action: open PDF if available, otherwise generate PDF
+  - Utility actions: send by email, copy link
+  - Overflow actions: delete, mark as won, mark as lost
+- `shared`, `viewed`, `approved`, `declined`
+  - Primary action: open PDF
+  - Utility actions: resend email, copy link
+  - Overflow actions: mark as won, mark as lost
+
+Invoice detail:
+
+- `draft`
+  - Primary action: generate PDF
+  - Utility actions: copy link
+  - Email action: hidden
+  - Edit action: available
+- `ready`
+  - Primary action: open PDF if available, otherwise generate PDF
+  - Utility actions: send by email, copy link, optional source-quote back link
+  - Edit action: available
+- `sent`
+  - Primary action: open PDF
+  - Utility actions: resend by email, copy link, optional source-quote back link
+  - Edit action: still available
+
+## Allowed Deltas
+
+- Local derived state is acceptable when it mirrors a server-backed transition already in flight or a temporary device-only artifact, such as a generated Blob URL.
+- Button labels and layout can change if the action matrix and side effects remain intentional and covered by tests.
+- New statuses are acceptable if backend rules, frontend helpers, docs, and tests are updated together.
+
+## What Not To Assume
+
+- Do not assume hidden and disabled are interchangeable; the quote and invoice flows intentionally use both.
+- Do not assume all document types share the same editability or resend rules.
+- Do not assume local UI state is enough for source of truth after a mutation; refetch or merge carefully.
+- Do not assume a status change always implies the same side effects on every surface.
+
+## Minimal Checklist
+
+- Identify the authoritative statuses and any derived local action state.
+- Write down visible actions per state before changing code.
+- Verify async busy states disable conflicting actions.
+- Verify confirmation dialogs still gate send, delete, or outcome mutations.
+- Check partial-response merge behavior after state-changing actions.
+- Update docs if externally visible action or error semantics changed.
+
+## Verification Guidance
+
+- `make frontend-verify`
+- `make backend-verify` when frontend changes depend on backend status or side-effect rules
+- For quote action parity, start with `frontend/src/features/quotes/tests/QuotePreview.test.tsx` and `frontend/src/features/quotes/tests/QuotePreviewActions.test.tsx`
+- For invoice action parity, start with `frontend/src/features/invoices/tests/InvoiceDetailScreen.test.tsx`
+- For backend status and side-effect parity, inspect `backend/app/features/quotes/service.py` and the send/outcome coverage in `backend/app/features/quotes/tests/test_quotes.py`

--- a/docs/analogs/transactional-email-flow.md
+++ b/docs/analogs/transactional-email-flow.md
@@ -1,0 +1,88 @@
+# Transactional Email Flow
+
+Use this analog when a user-triggered action validates a document, prepares a reusable public link, calls an email provider, and preserves resend/error contracts across backend and frontend.
+
+## When To Use
+
+- Adding a new document email-delivery path
+- Changing send or resend rules for an existing document
+- Updating provider error semantics, duplicate-send throttling, or share-token reuse
+- Wiring a frontend action that confirms, sends, and reflects updated document state
+
+## Canonical Examples
+
+- `backend/app/features/quotes/email_delivery_service.py`
+- `backend/app/features/quotes/api.py`
+- `frontend/src/features/quotes/components/QuotePreview.tsx`
+- `frontend/src/features/quotes/components/quotePreview.helpers.ts`
+- `backend/app/features/invoices/email_delivery_service.py`
+- `backend/app/features/invoices/service.py`
+- `frontend/src/features/invoices/components/InvoiceDetailScreen.tsx`
+- `docs/ARCHITECTURE.md`
+- `backend/app/features/quotes/tests/test_quotes.py`
+- `frontend/src/features/quotes/tests/QuotePreview.test.tsx`
+- `frontend/src/features/invoices/tests/InvoiceDetailScreen.test.tsx`
+
+## Invariants
+
+- Validate ownership and load email context before any provider call.
+- Reject draft documents before send.
+- Validate customer email before send.
+- Enforce duplicate-send throttling before the provider call.
+- Share the document before the provider call so the returned document can include a reusable public token.
+- Do not rotate an existing share token on resend.
+- Provider failure does not roll back the newly shared state.
+- Successful provider sends should record the `email_sent` event.
+- If event persistence fails after a successful send, preserve throttle behavior with the fallback timestamp path instead of failing the user request.
+- Frontend send actions require explicit confirmation before the API call.
+
+## Current Repo Shape
+
+Quotes:
+
+- API entrypoint: `backend/app/features/quotes/api.py`
+- Orchestration: `backend/app/features/quotes/email_delivery_service.py`
+- Reused share contract: `backend/app/features/quotes/service.py`
+- Frontend action surface: `frontend/src/features/quotes/components/QuotePreview.tsx`
+- Frontend error mapping: `frontend/src/features/quotes/components/quotePreview.helpers.ts`
+- Public CTA shape: landing page `/doc/{share_token}` plus PDF `/share/{share_token}`
+
+Invoices:
+
+- API entrypoint: `backend/app/features/invoices/api.py`
+- Orchestration: `backend/app/features/invoices/email_delivery_service.py`
+- Reused share contract: `backend/app/features/invoices/service.py`
+- Frontend action surface: `frontend/src/features/invoices/components/InvoiceDetailScreen.tsx`
+- Public CTA shape: PDF-only `/share/{share_token}`
+
+## Allowed Deltas
+
+- Email copy, subject, and template fields may vary by document type.
+- CTA routes may differ when the public surface differs, as long as docs and tests stay aligned.
+- Duplicate-send window or fallback behavior can change only if backend tests and `docs/ARCHITECTURE.md` are updated together.
+- Frontend success and error copy can be tailored per surface, but backend status codes and externally visible semantics must stay intentional.
+
+## What Not To Assume
+
+- Do not assume all document types use the same public route. Quotes currently use `/doc/{share_token}` plus `/share/{share_token}`; invoices use `/share/{share_token}` only.
+- Do not assume provider failure leaves the document unchanged. Share state may already be persisted.
+- Do not assume resend should mint a new token.
+- Do not assume a successful provider call guarantees event persistence.
+- Do not assume frontend copy can drift from backend error semantics without a deliberate contract change.
+
+## Minimal Checklist
+
+- Add or update the backend API entrypoint and orchestration service.
+- Confirm share-before-send ordering and resend token reuse.
+- Verify duplicate-send, provider-failure, and missing-email paths.
+- Wire the frontend action with confirmation, busy state, and user-facing success/error handling.
+- Update `docs/ARCHITECTURE.md` if externally visible behavior changes.
+- Add or update backend and frontend tests for happy path, resend, and failure paths.
+
+## Verification Guidance
+
+- `make backend-verify`
+- `make frontend-verify`
+- For targeted backend coverage, start with `backend/app/features/quotes/tests/test_quotes.py`
+- For targeted quote UI coverage, start with `frontend/src/features/quotes/tests/QuotePreview.test.tsx`
+- For targeted invoice UI coverage, start with `frontend/src/features/invoices/tests/InvoiceDetailScreen.test.tsx`

--- a/docs/template/EXECUTION_BRIEF.md
+++ b/docs/template/EXECUTION_BRIEF.md
@@ -1,0 +1,110 @@
+# Execution Brief Template
+
+Use this brief only when a GitHub Task issue already exists.
+
+- The GitHub Task issue is the source of truth.
+- This brief is task-local only.
+- Keep it compressed: capture deltas, concrete file scope, and task-specific decisions without reprinting stable repo rules.
+
+## Task
+
+- Task issue: `#<task-id>`
+- Task title: `<copy issue title>`
+- Source of truth link: `<GitHub issue URL>`
+
+## Goal
+
+`<What this task should accomplish in 1-3 sentences.>`
+
+## Non-goals
+
+- `<Explicitly out-of-scope behavior or files>`
+- `<Anything this brief should not silently expand into>`
+
+## Files In Scope
+
+- `<path>` - `<why this file matters>`
+- `<path>` - `<why this file matters>`
+
+## Analog Files / Docs
+
+- `<path>` - `<how this analog applies>`
+- `<path>` - `<which contract or pattern to follow>`
+
+## Locked Decisions
+
+- `<Decision that should not be reopened during implementation>`
+- `<Decision or constraint inherited from the issue/spec>`
+
+## Acceptance Criteria Delta
+
+- Issue acceptance criteria live in the Task. Only list task-specific deltas, clarifications, or parity checks here.
+- `<Delta or added assertion>`
+- `<Delta or added assertion>`
+
+## Verification
+
+- `<exact command>`
+- `<exact command>`
+- `<manual check if needed>`
+
+## Open Product Decisions / Blockers
+
+- `<Decision the implementation should not silently lock in>`
+- `<Missing dependency, approval, or runtime detail>`
+
+## Do Not Include
+
+- Large pasted excerpts from `AGENTS.md`, `docs/WORKFLOW.md`, `docs/ISSUES_WORKFLOW.md`, or `docs/template/KICKOFF.md`
+- Full control-plane essays unless this task introduces a task-specific exception
+- Long pasted acceptance-criteria lists or full issue bodies; link the issue and capture delta only
+- Reviewer prompt, PR boilerplate, or learning handoff text unless this task is explicitly changing that workflow
+- Broad repo summaries unrelated to the files and behavior in scope
+
+## Example (Sanitized, Non-Authoritative)
+
+Use this only as a shape reference. Do not treat it as issue truth.
+
+- Task issue: `#123`
+- Task title: `Task: Optional CC on invoice send`
+- Source of truth link: `https://github.com/example/repo/issues/123`
+
+### Goal
+
+Allow invoice send flows to accept an optional CC list without changing SMTP providers or the existing primary recipient contract.
+
+### Non-goals
+
+- No provider swap
+- No inbox threading changes
+- No quote email changes
+
+### Files In Scope
+
+- `backend/app/features/invoices/email_delivery_service.py` - extend send orchestration and validation
+- `frontend/src/features/invoices/components/InvoiceDetailScreen.tsx` - pass CC data from the send flow
+
+### Analog Files / Docs
+
+- `docs/analogs/transactional-email-flow.md` - reuse share-before-send and error/ retry rules
+- `docs/ARCHITECTURE.md` - keep response and error semantics aligned
+
+### Locked Decisions
+
+- Maximum 5 CC addresses
+- Empty CC input is omitted from the payload
+- No SMTP or provider configuration change
+
+### Acceptance Criteria Delta
+
+- Preserve existing primary recipient behavior
+- Invalid CC addresses return the documented validation error
+
+### Verification
+
+- `make backend-verify`
+- `make frontend-verify`
+
+### Open Product Decisions / Blockers
+
+- None


### PR DESCRIPTION
## Summary
- add a compact `docs/template/EXECUTION_BRIEF.md` template that keeps the Task issue authoritative and includes a do-not-include boundary plus a sanitized example
- add first-pass analog docs for transactional email flows and stateful action matrices, grounded in current Stima repo paths
- add a small `docs/PATTERNS.md` pointer so analogs are discoverable without turning the conventions doc into a pattern dump

## Why
Task #181 calls for the reusable artifacts that later workflow updates can reference directly. This keeps the new guidance high-signal while leaving `KICKOFF.md`, `AGENTS.md`, and `docs/WORKFLOW.md` untouched in this PR.

## Verification
- manual markdown / consistency review
- `rg "Execution Brief" docs/template/`

Closes #181