### PR TITLE
UI: top-level header branding/alignment and Settings as primary tab

### DIFF
--- a/frontend/src/features/customers/components/CustomerListScreen.tsx
+++ b/frontend/src/features/customers/components/CustomerListScreen.tsx
@@ -69,7 +69,7 @@ export function CustomerListScreen(): React.ReactElement {
 
   return (
     <main className="min-h-screen bg-background pb-24">
-      <ScreenHeader title="Customers" subtitle={customerSubtitle} />
+      <ScreenHeader title="Customers" subtitle={customerSubtitle} layout="top-level" />
       <section className="mx-auto w-full max-w-3xl pb-2 pt-20">
 
         <div className="mb-4 px-4">

--- a/frontend/src/features/customers/tests/CustomerListScreen.test.tsx
+++ b/frontend/src/features/customers/tests/CustomerListScreen.test.tsx
@@ -67,6 +67,7 @@ describe("CustomerListScreen", () => {
     renderScreen();
 
     expect(await screen.findByRole("heading", { name: "Customers" })).toBeInTheDocument();
+    expect(screen.getByText("Stima")).toBeInTheDocument();
     expect(await screen.findByText("2 customers")).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Back" })).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: /alice johnson/i })).toBeInTheDocument();

--- a/frontend/src/features/quotes/components/QuoteList.tsx
+++ b/frontend/src/features/quotes/components/QuoteList.tsx
@@ -194,7 +194,7 @@ export function QuoteList(): React.ReactElement {
 
   return (
     <main className="min-h-screen bg-background pb-24">
-      <ScreenHeader title={headerTitle} subtitle={headerSubtitle} />
+      <ScreenHeader title={headerTitle} subtitle={headerSubtitle} layout="top-level" />
       <section className="mx-auto w-full max-w-3xl pb-2 pt-20">
         <div className="mb-4 px-4">
           <div

--- a/frontend/src/features/quotes/tests/QuoteList.test.tsx
+++ b/frontend/src/features/quotes/tests/QuoteList.test.tsx
@@ -141,6 +141,7 @@ describe("QuoteList", () => {
     renderScreen();
 
     expect(await screen.findByRole("heading", { name: "Quotes" })).toBeInTheDocument();
+    expect(screen.getByText("Stima")).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Back" })).not.toBeInTheDocument();
     expect(screen.queryByText("Sorted by: Most Recent")).not.toBeInTheDocument();
     expect(await screen.findByText("Q-001")).toBeInTheDocument();

--- a/frontend/src/features/settings/components/SettingsScreen.tsx
+++ b/frontend/src/features/settings/components/SettingsScreen.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useState } from "react";
-import { useNavigate } from "react-router-dom";
 
 import { useAuth } from "@/features/auth/hooks/useAuth";
 import { getTimezoneOptions } from "@/features/profile/lib/timezones";
@@ -9,24 +8,23 @@ import {
   type ProfileResponse,
   type TradeType,
 } from "@/features/profile/types/profile.types";
+import { BottomNav } from "@/shared/components/BottomNav";
 import { Button } from "@/shared/components/Button";
 import { ConfirmModal } from "@/shared/components/ConfirmModal";
 import { FeedbackMessage } from "@/shared/components/FeedbackMessage";
 import { Input } from "@/shared/components/Input";
-import { ScreenFooter } from "@/shared/components/ScreenFooter";
 import { ScreenHeader } from "@/shared/components/ScreenHeader";
 import { useTheme } from "@/shared/hooks/useTheme";
 import { parseTaxPercentInput, toTaxPercentDisplay } from "@/shared/lib/pricing";
 import type { ThemePreference } from "@/shared/lib/theme";
 
 const THEME_OPTIONS: ReadonlyArray<{ label: string; value: ThemePreference }> = [
-  { label: "System", value: "system" },
+  { label: "System default", value: "system" },
   { label: "Light", value: "light" },
   { label: "Dark", value: "dark" },
 ];
 
 export function SettingsScreen(): React.ReactElement {
-  const navigate = useNavigate();
   const { logout, refreshUser } = useAuth();
   const { preference: themePreference, setPreference: setThemePreference } = useTheme();
   const logoPreviewSrc = `${import.meta.env.VITE_API_URL ?? ""}/api/profile/logo`;
@@ -170,10 +168,10 @@ export function SettingsScreen(): React.ReactElement {
   };
 
   return (
-    <main className="min-h-screen bg-background pb-32 pt-16">
-      <ScreenHeader title="Settings" onBack={() => navigate(-1)} />
+    <main className="min-h-screen bg-background pb-24 pt-16">
+      <ScreenHeader title="Settings" layout="top-level" />
 
-      <section className="mx-auto w-full max-w-2xl space-y-4 px-4 pt-4">
+      <section className="mx-auto w-full max-w-3xl space-y-4 px-4 pt-4">
         {isLoadingProfile ? (
           <p role="status" className="text-sm text-on-surface-variant">
             Loading settings...
@@ -185,7 +183,7 @@ export function SettingsScreen(): React.ReactElement {
         ) : null}
 
         {!isLoadingProfile && !loadError ? (
-          <form className="space-y-4 pb-28" onSubmit={onSubmit}>
+          <form className="space-y-4 pb-8" onSubmit={onSubmit}>
             {saveSuccess ? (
               <p role="status" className="rounded-lg bg-success-container p-3 text-sm text-success">
                 {saveSuccess}
@@ -265,35 +263,57 @@ export function SettingsScreen(): React.ReactElement {
                   value={businessName}
                   onChange={(event) => setBusinessName(event.target.value)}
                 />
-                <Input
-                  id="settings-first-name"
-                  label="First name"
-                  value={firstName}
-                  onChange={(event) => setFirstName(event.target.value)}
-                />
-                <Input
-                  id="settings-last-name"
-                  label="Last name"
-                  value={lastName}
-                  onChange={(event) => setLastName(event.target.value)}
-                />
-                <div className="flex flex-col gap-1">
-                  <label htmlFor="settings-trade-type" className="text-sm font-medium text-on-surface">
-                    Trade type
-                  </label>
-                  <select
-                    id="settings-trade-type"
-                    value={tradeType}
-                    onChange={(event) => setTradeType(event.target.value as TradeType)}
-                    className="w-full rounded-lg bg-surface-container-high px-4 py-3 font-body text-sm text-on-surface transition-all focus:bg-surface-container-lowest focus:outline-none focus:ring-2 focus:ring-primary/30"
-                  >
-                    {TRADE_TYPES.map((tradeTypeOption) => (
-                      <option key={tradeTypeOption} value={tradeTypeOption}>
-                        {tradeTypeOption}
-                      </option>
-                    ))}
-                  </select>
+
+                <div className="grid grid-cols-2 gap-4">
+                  <Input
+                    id="settings-first-name"
+                    label="First name"
+                    value={firstName}
+                    onChange={(event) => setFirstName(event.target.value)}
+                  />
+                  <Input
+                    id="settings-last-name"
+                    label="Last name"
+                    value={lastName}
+                    onChange={(event) => setLastName(event.target.value)}
+                  />
                 </div>
+
+                <div className="grid grid-cols-2 gap-4">
+                  <div className="flex flex-col gap-1">
+                    <label htmlFor="settings-trade-type" className="text-sm font-medium text-on-surface">
+                      Trade type
+                    </label>
+                    <select
+                      id="settings-trade-type"
+                      value={tradeType}
+                      onChange={(event) => setTradeType(event.target.value as TradeType)}
+                      className="w-full rounded-lg bg-surface-container-high px-4 py-3 font-body text-sm text-on-surface transition-all focus:bg-surface-container-lowest focus:outline-none focus:ring-2 focus:ring-primary/30"
+                    >
+                      {TRADE_TYPES.map((tradeTypeOption) => (
+                        <option key={tradeTypeOption} value={tradeTypeOption}>
+                          {tradeTypeOption}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+
+                  <div className="flex flex-col gap-1">
+                    <label htmlFor="settings-default-tax-rate" className="text-sm font-medium text-on-surface">
+                      Tax rate (%)
+                    </label>
+                    <input
+                      id="settings-default-tax-rate"
+                      type="number"
+                      step="0.01"
+                      value={defaultTaxRate}
+                      onChange={(event) => setDefaultTaxRate(event.target.value)}
+                      className="w-full rounded-lg bg-surface-container-high px-4 py-3 font-body text-sm text-on-surface transition-all focus:bg-surface-container-lowest focus:outline-none focus:ring-2 focus:ring-primary/30"
+                      placeholder="8.25"
+                    />
+                  </div>
+                </div>
+
                 <div className="flex flex-col gap-1">
                   <label htmlFor="settings-timezone" className="text-sm font-medium text-on-surface">
                     Timezone
@@ -311,69 +331,23 @@ export function SettingsScreen(): React.ReactElement {
                     ))}
                   </select>
                 </div>
+
                 <div className="flex flex-col gap-1">
-                  <label htmlFor="settings-default-tax-rate" className="text-sm font-medium text-on-surface">
-                    Default tax rate (%)
-                  </label>
-                  <input
-                    id="settings-default-tax-rate"
-                    type="number"
-                    step="0.01"
-                    value={defaultTaxRate}
-                    onChange={(event) => setDefaultTaxRate(event.target.value)}
-                    className="w-full rounded-lg bg-surface-container-high px-4 py-3 font-body text-sm text-on-surface transition-all focus:bg-surface-container-lowest focus:outline-none focus:ring-2 focus:ring-primary/30"
-                    placeholder="8.25"
-                  />
-                  <p className="text-xs text-on-surface-variant">
-                    Used as the suggested tax rate for new documents. Tax stays off until you enable it.
-                  </p>
-                </div>
-              </div>
-            </section>
-
-            <section className="rounded-xl bg-surface-container-low p-4">
-              <h2 className="text-[0.6875rem] font-bold uppercase tracking-widest text-outline">
-                Appearance
-              </h2>
-              <div className="mt-3 rounded-xl bg-surface-container-lowest p-4">
-                <div className="space-y-1">
-                  <p className="text-[0.6875rem] font-bold uppercase tracking-widest text-outline">
+                  <label htmlFor="settings-theme" className="text-sm font-medium text-on-surface">
                     Theme
-                  </p>
-                  <p className="text-sm text-on-surface">
-                    Choose how Stima looks across the app.
-                  </p>
-                  <p className="text-xs text-on-surface-variant">
-                    System follows your device. Light and Dark override it immediately.
-                  </p>
-                </div>
-
-                <div role="radiogroup" aria-label="Theme" className="mt-4 grid grid-cols-3 gap-2">
-                  {THEME_OPTIONS.map((option) => {
-                    const isSelected = option.value === themePreference;
-
-                    return (
-                      <label
-                        key={option.value}
-                        className={[
-                          "cursor-pointer rounded-lg border-2 py-3 font-label text-sm transition-all",
-                          isSelected
-                            ? "border-primary bg-primary/5 font-semibold text-primary"
-                            : "border-transparent bg-surface-container-low text-on-surface-variant",
-                        ].join(" ")}
-                      >
-                        <input
-                          type="radio"
-                          name="settings-theme"
-                          value={option.value}
-                          checked={isSelected}
-                          onChange={() => setThemePreference(option.value)}
-                          className="sr-only"
-                        />
-                        <span className="block">{option.label}</span>
-                      </label>
-                    );
-                  })}
+                  </label>
+                  <select
+                    id="settings-theme"
+                    value={themePreference}
+                    onChange={(event) => setThemePreference(event.target.value as ThemePreference)}
+                    className="w-full rounded-lg bg-surface-container-high px-4 py-3 font-body text-sm text-on-surface transition-all focus:bg-surface-container-lowest focus:outline-none focus:ring-2 focus:ring-primary/30"
+                  >
+                    {THEME_OPTIONS.map((option) => (
+                      <option key={option.value} value={option.value}>
+                        {option.label}
+                      </option>
+                    ))}
+                  </select>
                 </div>
               </div>
             </section>
@@ -401,17 +375,21 @@ export function SettingsScreen(): React.ReactElement {
               </div>
             </section>
 
-            {/* Keep the footer inside the form so the fixed primary action submits natively. */}
-            <ScreenFooter>
-              <div className="mx-auto w-full max-w-2xl">
-                <Button type="submit" variant="primary" className="w-full" isLoading={isSubmitting}>
-                  Save Changes
-                </Button>
-              </div>
-            </ScreenFooter>
+            <div className="pt-2">
+              <Button
+                type="submit"
+                variant="primary"
+                className="w-full md:min-w-[13rem] md:w-auto md:px-8"
+                isLoading={isSubmitting}
+              >
+                Save Changes
+              </Button>
+            </div>
           </form>
         ) : null}
       </section>
+
+      <BottomNav active="settings" />
 
       {isRemoveLogoOpen ? (
         <ConfirmModal

--- a/frontend/src/features/settings/tests/SettingsScreen.test.tsx
+++ b/frontend/src/features/settings/tests/SettingsScreen.test.tsx
@@ -105,7 +105,7 @@ afterEach(() => {
 });
 
 describe("SettingsScreen", () => {
-  it("renders pre-filled form fields in the tightened layout with compact selects", async () => {
+  it("renders the top-level settings shell with grouped fields and inline save", async () => {
     mockedProfileService.getProfile.mockResolvedValueOnce(
       makeProfileResponse({
         email: "owner@example.com",
@@ -131,13 +131,16 @@ describe("SettingsScreen", () => {
       "tracking-widest",
       "text-outline",
     );
+    expect(screen.getByText("Stima")).toBeInTheDocument();
     expect(screen.getByText("JPEG or PNG, up to 2 MB. Appears on quote PDFs.")).toBeInTheDocument();
     expect(screen.getByLabelText(/upload logo/i)).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /save changes/i }).closest("footer")).not.toBeNull();
+    expect(screen.getByRole("button", { name: /save changes/i }).closest("footer")).toBeNull();
     expect(screen.getByText("Account").closest("section")).toHaveClass("bg-surface-container-low");
     expect(screen.queryByText("Session")).not.toBeInTheDocument();
     expect(screen.queryByLabelText(/^email$/i)).not.toBeInTheDocument();
-    expect(screen.queryByRole("navigation")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /back/i })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /settings/i })).toHaveClass("text-primary");
+    expect(screen.queryByText("Appearance")).not.toBeInTheDocument();
   });
 
   it("normalizes null profile values before binding to controlled inputs", async () => {
@@ -226,42 +229,39 @@ describe("SettingsScreen", () => {
     expect(await screen.findByText("Saved")).toHaveClass("rounded-lg");
   });
 
-  it("updates the theme preference immediately from the segmented control", async () => {
+  it("updates the theme preference immediately from the dropdown", async () => {
     mockedProfileService.getProfile.mockResolvedValueOnce(makeProfileResponse());
 
     renderScreen();
 
     await screen.findByLabelText(/business name/i);
 
-    expect(screen.getByRole("radiogroup", { name: "Theme" })).toBeInTheDocument();
+    const themeSelect = screen.getByRole("combobox", { name: "Theme" });
 
-    const systemRadio = screen.getByRole("radio", { name: "System" });
-    const lightRadio = screen.getByRole("radio", { name: "Light" });
-    const darkRadio = screen.getByRole("radio", { name: "Dark" });
+    expect(themeSelect).toHaveValue("system");
+    expect(screen.getByRole("option", { name: "System default" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "Light" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "Dark" })).toBeInTheDocument();
 
-    expect(systemRadio).toBeChecked();
-    expect(lightRadio).not.toBeChecked();
-    expect(darkRadio).not.toBeChecked();
-
-    fireEvent.click(darkRadio);
+    fireEvent.change(themeSelect, { target: { value: "dark" } });
 
     expect(window.localStorage.getItem(THEME_STORAGE_KEY)).toBe("dark");
     expect(document.documentElement.dataset.theme).toBe("dark");
     expect(document.documentElement.style.colorScheme).toBe("dark");
-    expect(darkRadio).toBeChecked();
+    expect(themeSelect).toHaveValue("dark");
 
-    fireEvent.click(lightRadio);
+    fireEvent.change(themeSelect, { target: { value: "light" } });
 
     expect(window.localStorage.getItem(THEME_STORAGE_KEY)).toBe("light");
     expect(document.documentElement.dataset.theme).toBe("light");
     expect(document.documentElement.style.colorScheme).toBe("light");
-    expect(lightRadio).toBeChecked();
+    expect(themeSelect).toHaveValue("light");
 
-    fireEvent.click(systemRadio);
+    fireEvent.change(themeSelect, { target: { value: "system" } });
 
     expect(window.localStorage.getItem(THEME_STORAGE_KEY)).toBe("system");
     expect(document.documentElement.dataset.theme).toBeUndefined();
-    expect(systemRadio).toBeChecked();
+    expect(themeSelect).toHaveValue("system");
   });
 
   it("shows the saved default tax as a percent and persists edited values as fractions", async () => {
@@ -275,7 +275,7 @@ describe("SettingsScreen", () => {
     renderScreen();
 
     expect(await screen.findByDisplayValue("8.25")).toBeInTheDocument();
-    fireEvent.change(screen.getByLabelText(/default tax rate/i), {
+    fireEvent.change(screen.getByLabelText(/tax rate/i), {
       target: { value: "7.5" },
     });
     fireEvent.click(screen.getByRole("button", { name: /save changes/i }));

--- a/frontend/src/shared/components/ScreenHeader.test.tsx
+++ b/frontend/src/shared/components/ScreenHeader.test.tsx
@@ -16,6 +16,14 @@ describe("ScreenHeader", () => {
     );
   });
 
+  it("renders the branded top-level shell layout when requested", () => {
+    const { container } = render(<ScreenHeader title="Quotes" subtitle="2 active" layout="top-level" />);
+
+    expect(screen.getByText("Stima")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Quotes" })).toBeInTheDocument();
+    expect(container.querySelector("header > div")).toHaveClass("mx-auto", "max-w-3xl");
+  });
+
   it("renders and wires the back button when onBack is provided", () => {
     const onBack = vi.fn();
     render(<ScreenHeader title="Quote Preview" onBack={onBack} />);

--- a/frontend/src/shared/components/ScreenHeader.tsx
+++ b/frontend/src/shared/components/ScreenHeader.tsx
@@ -7,6 +7,7 @@ interface ScreenHeaderProps {
   onBack?: () => void;
   trailing?: ReactNode;
   backLabel?: string;
+  layout?: "default" | "top-level";
 }
 
 export function ScreenHeader({
@@ -16,10 +17,18 @@ export function ScreenHeader({
   onBack,
   trailing,
   backLabel = "Back",
+  layout = "default",
 }: ScreenHeaderProps): React.ReactElement {
+  const isTopLevelLayout = layout === "top-level";
+
   return (
     <header className="glass-surface glass-shadow-top fixed top-0 z-50 h-16 w-full border-b border-outline-variant/20 backdrop-blur-md">
-      <div className="flex h-16 items-center gap-3 px-4">
+      <div
+        className={[
+          "flex h-16 w-full items-center gap-3 px-4",
+          isTopLevelLayout ? "mx-auto max-w-3xl" : "",
+        ].join(" ")}
+      >
         {onBack ? (
           <button
             type="button"
@@ -30,7 +39,10 @@ export function ScreenHeader({
             <span className="material-symbols-outlined">arrow_back</span>
           </button>
         ) : null}
-        <div className="min-w-0 flex-1">
+        {isTopLevelLayout ? (
+          <p className="shrink-0 font-headline text-[2rem] font-bold leading-none text-primary">Stima</p>
+        ) : null}
+        <div className={["min-w-0 flex-1", isTopLevelLayout ? "text-right" : ""].join(" ")}>
           {eyebrow ? (
             <p className="truncate text-[0.6875rem] font-bold uppercase tracking-wider text-outline">{eyebrow}</p>
           ) : null}


### PR DESCRIPTION
## Summary
- align the shared top-level header for Quotes, Customers, and Settings while adding the Stima wordmark
- make Settings a primary tab with bottom navigation and simplified form grouping
- keep save/theme/account behavior intact while updating affected tests

## Verification
- not run yet per current review request

## Notes
- Closes #186
- Logo-specific layout/enlargement work was deferred for a follow-up issue; this PR intentionally preserves the current logo behavior after reverting the exploratory logo changes.
