### PR TITLE
UI: polish quote and invoice detail actions

### DIFF
--- a/frontend/src/features/invoices/components/InvoiceDetailScreen.tsx
+++ b/frontend/src/features/invoices/components/InvoiceDetailScreen.tsx
@@ -12,6 +12,7 @@ import { ConfirmModal } from "@/shared/components/ConfirmModal";
 import {
   DocumentActionError,
   DocumentActionHint,
+  DocumentActionManualCopyField,
   DocumentActionSuccessMessage,
   DocumentActionSurface,
   documentActionPrimaryButtonClassName,
@@ -22,6 +23,7 @@ import { FeedbackMessage } from "@/shared/components/FeedbackMessage";
 import { ScreenHeader } from "@/shared/components/ScreenHeader";
 import { StatusBadge } from "@/shared/components/StatusBadge";
 import { formatDate } from "@/shared/lib/formatters";
+import { canNavigateBack } from "@/shared/lib/navigation";
 
 export function InvoiceDetailScreen(): React.ReactElement {
   const navigate = useNavigate();
@@ -35,6 +37,7 @@ export function InvoiceDetailScreen(): React.ReactElement {
   const [isSharing, setIsSharing] = useState(false);
   const [shareError, setShareError] = useState<string | null>(null);
   const [shareMessage, setShareMessage] = useState<string | null>(null);
+  const [manualCopyUrl, setManualCopyUrl] = useState<string | null>(null);
   const [showSendEmailConfirm, setShowSendEmailConfirm] = useState(false);
   const [isSendingEmail, setIsSendingEmail] = useState(false);
   const [emailError, setEmailError] = useState<string | null>(null);
@@ -88,18 +91,22 @@ export function InvoiceDetailScreen(): React.ReactElement {
   const openPdfUrl = pdfUrl ?? rawShareUrl;
   const hasSourceQuote = Boolean(invoice?.source_document_id && invoice.source_quote_number);
   const hasCustomerEmail = Boolean(invoice?.customer.email?.trim());
+  const customerEmail = invoice?.customer.email?.trim() || null;
   const canEdit = Boolean(invoice && id && isInvoiceEditableStatus(invoice.status));
-  const emailActionLabel = (
-    invoice?.status === "ready" ? "Send Email"
-      : invoice?.status === "sent" ? "Resend Email"
-        : null
-  );
+  const emailActionLabel = invoice?.status === "ready"
+    ? "Send Email"
+    : invoice?.status === "sent" ? "Resend Email" : null;
   const shouldRenderNotes = Boolean(invoice?.notes?.trim());
   const clientContact = invoice?.customer.phone?.trim()
     || invoice?.customer.email?.trim()
     || "No contact details";
   function invalidateLocalPdf(): void {
     setPdfUrl(null);
+  }
+
+  function handleBack(): void {
+    if (canNavigateBack()) return void navigate(-1);
+    navigate("/", { replace: true });
   }
 
   function applyInvoiceUpdate(updatedInvoice: Invoice): void {
@@ -134,6 +141,7 @@ export function InvoiceDetailScreen(): React.ReactElement {
     setEmailMessage(null);
     setShareError(null);
     setShareMessage(null);
+    setManualCopyUrl(null);
     setIsGeneratingPdf(true);
     try {
       const blob = await invoiceService.generatePdf(id);
@@ -166,6 +174,7 @@ export function InvoiceDetailScreen(): React.ReactElement {
     setEmailMessage(null);
     setShareError(null);
     setShareMessage(null);
+    setManualCopyUrl(null);
     setIsSharing(true);
     try {
       const updatedInvoice = invoice?.share_token ? invoice : await invoiceService.shareInvoice(id);
@@ -178,13 +187,16 @@ export function InvoiceDetailScreen(): React.ReactElement {
 
       const nextShareUrl = `${apiBase}/share/${updatedInvoice.share_token}`;
       if (!navigator.clipboard || typeof navigator.clipboard.writeText !== "function") {
+        setManualCopyUrl(nextShareUrl);
         setShareMessage("Copy this share link manually.");
         return;
       }
 
       await navigator.clipboard.writeText(nextShareUrl);
+      setManualCopyUrl(null);
       setShareMessage("Invoice link copied to clipboard.");
     } catch (error) {
+      setManualCopyUrl(null);
       const message = error instanceof Error ? error.message : "Unable to copy invoice link";
       setShareError(message);
     } finally {
@@ -212,6 +224,7 @@ export function InvoiceDetailScreen(): React.ReactElement {
     setEmailMessage(null);
     setShareError(null);
     setShareMessage(null);
+    setManualCopyUrl(null);
     setIsSendingEmail(true);
 
     try {
@@ -231,7 +244,7 @@ export function InvoiceDetailScreen(): React.ReactElement {
       <ScreenHeader
         title={invoice?.title ?? invoice?.doc_number ?? "Invoice"}
         subtitle={invoice?.title ? invoice.doc_number : undefined}
-        onBack={() => navigate(-1)}
+        onBack={handleBack}
         trailing={invoice ? (
           <div className="flex items-center gap-2">
             <StatusBadge variant={invoice.status} />
@@ -393,6 +406,9 @@ export function InvoiceDetailScreen(): React.ReactElement {
                   {pdfError ? <DocumentActionError>{pdfError}</DocumentActionError> : null}
                   {emailError ? <DocumentActionError>{emailError}</DocumentActionError> : null}
                   {shareError ? <DocumentActionError>{shareError}</DocumentActionError> : null}
+                  {manualCopyUrl ? (
+                    <DocumentActionManualCopyField url={manualCopyUrl} />
+                  ) : null}
                   {emailMessage ? (
                     <DocumentActionSuccessMessage>{emailMessage}</DocumentActionSuccessMessage>
                   ) : null}
@@ -409,7 +425,12 @@ export function InvoiceDetailScreen(): React.ReactElement {
       {showSendEmailConfirm && emailActionLabel ? (
         <ConfirmModal
           title={`${emailActionLabel}?`}
-          body="This sends the latest invoice to the customer email on file."
+          body={customerEmail ? (
+            <>
+              This sends the latest invoice to{" "}
+              <span className="break-all font-medium text-on-surface">{customerEmail}</span>.
+            </>
+          ) : "This sends the latest invoice to the customer email on file."}
           confirmLabel={emailActionLabel}
           cancelLabel="Cancel"
           onConfirm={() => {

--- a/frontend/src/features/invoices/tests/InvoiceDetailScreen.test.tsx
+++ b/frontend/src/features/invoices/tests/InvoiceDetailScreen.test.tsx
@@ -98,6 +98,7 @@ function renderScreen(path = "/invoices/invoice-1"): void {
         <Route path="/invoices/:id" element={<InvoiceDetailScreen />} />
         <Route path="/invoices/:id/edit" element={<div>Invoice Edit Screen</div>} />
         <Route path="/quotes/:id/preview" element={<div>Quote Preview Screen</div>} />
+        <Route path="/" element={<div>Quote List Screen</div>} />
       </Routes>
     </MemoryRouter>,
   );
@@ -329,6 +330,30 @@ describe("InvoiceDetailScreen", () => {
     expect(await screen.findByText("Invoice link copied to clipboard.")).toBeInTheDocument();
   });
 
+  it("shows the manual-copy URL when the clipboard API is unavailable", async () => {
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      writable: true,
+      value: undefined,
+    });
+    mockedInvoiceService.getInvoice.mockResolvedValueOnce(
+      makeInvoiceDetail({
+        status: "sent",
+        share_token: "invoice-share-token-1",
+        shared_at: "2026-03-20T00:15:00.000Z",
+      }),
+    );
+
+    renderScreen();
+
+    fireEvent.click(await screen.findByRole("button", { name: /copy link/i }));
+
+    expect(await screen.findByLabelText("Share URL")).toHaveValue(
+      "http://localhost:3000/share/invoice-share-token-1",
+    );
+    expect(await screen.findByText("Copy this share link manually.")).toBeInTheDocument();
+  });
+
   it("clears a generated local PDF after sharing the invoice", async () => {
     renderScreen();
 
@@ -359,13 +384,11 @@ describe("InvoiceDetailScreen", () => {
 
     fireEvent.click(await screen.findByRole("button", { name: /send email/i }));
 
-    expect(screen.getByText("This sends the latest invoice to the customer email on file.")).toBeInTheDocument();
+    expect(screen.getByText(/alice@example\.com/i)).toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
 
     await waitFor(() => {
-      expect(
-        screen.queryByText("This sends the latest invoice to the customer email on file."),
-      ).not.toBeInTheDocument();
+      expect(screen.queryByText(/alice@example\.com/i)).not.toBeInTheDocument();
     });
     expect(mockedInvoiceService.sendInvoiceEmail).not.toHaveBeenCalled();
   });
@@ -391,7 +414,7 @@ describe("InvoiceDetailScreen", () => {
     expect(
       await screen.findByRole("button", { name: /sending/i }),
     ).toBeDisabled();
-    expect(screen.queryByText("This sends the latest invoice to the customer email on file.")).not.toBeInTheDocument();
+    expect(screen.queryByText(/alice@example\.com/i)).not.toBeInTheDocument();
 
     resolveSend(
       makeInvoice({
@@ -425,6 +448,16 @@ describe("InvoiceDetailScreen", () => {
     fireEvent.click(screen.getByRole("button", { name: /^Send Email$/i }));
 
     expect(await screen.findByText("Email delivery failed. Please try again.")).toBeInTheDocument();
-    expect(screen.queryByText("This sends the latest invoice to the customer email on file.")).not.toBeInTheDocument();
+    expect(screen.queryByText(/alice@example\.com/i)).not.toBeInTheDocument();
+  });
+
+  it("falls back to the quote list when back navigation is unsafe", async () => {
+    window.history.replaceState({ idx: 0 }, "");
+
+    renderScreen();
+
+    fireEvent.click(await screen.findByRole("button", { name: /back/i }));
+
+    expect(await screen.findByText("Quote List Screen")).toBeInTheDocument();
   });
 });

--- a/frontend/src/features/quotes/components/QuotePreview.tsx
+++ b/frontend/src/features/quotes/components/QuotePreview.tsx
@@ -9,7 +9,6 @@ import { QuotePreviewActions } from "@/features/quotes/components/QuotePreviewAc
 import { QuotePreviewDialogs } from "@/features/quotes/components/QuotePreviewDialogs";
 import {
   buildOverflowItems,
-  canNavigateBack,
   getEmailActionLabel,
   getSendEmailErrorMessage,
   isShareAbortError,
@@ -24,6 +23,7 @@ import { isQuoteEditableStatus } from "@/features/quotes/utils/quoteStatus";
 import { BottomNav } from "@/shared/components/BottomNav";
 import { FeedbackMessage } from "@/shared/components/FeedbackMessage";
 import { ScreenHeader } from "@/shared/components/ScreenHeader";
+import { canNavigateBack } from "@/shared/lib/navigation";
 
 export function QuotePreview(): React.ReactElement {
   const navigate = useNavigate();
@@ -42,6 +42,7 @@ export function QuotePreview(): React.ReactElement {
   const [isSendingEmail, setIsSendingEmail] = useState(false);
   const [shareMessage, setShareMessage] = useState<string | null>(null);
   const [shareError, setShareError] = useState<string | null>(null);
+  const [manualCopyUrl, setManualCopyUrl] = useState<string | null>(null);
   const [isMarkingWon, setIsMarkingWon] = useState(false);
   const [isMarkingLost, setIsMarkingLost] = useState(false);
   const [outcomeError, setOutcomeError] = useState<string | null>(null);
@@ -64,17 +65,14 @@ export function QuotePreview(): React.ReactElement {
   const actionState = resolveActionState(quote, hasLocalPdf);
   const emailActionLabel = getEmailActionLabel(actionState);
   const hasCustomerEmail = Boolean(readOptionalQuoteText(quote, "customer_email"));
+  const customerEmail = readOptionalQuoteText(quote, "customer_email");
   const openPdfUrl = pdfUrl ?? (quote?.share_token ? `${apiBase}/share/${quote.share_token}` : null);
   const quoteTitle = readOptionalQuoteText(quote, "title");
   const customerNameForHeader = readOptionalQuoteText(quote, "customer_name");
   const clientName = readOptionalQuoteText(quote, "customer_name") ?? quote?.customer_id ?? "Unknown customer";
-  const clientContact = readOptionalQuoteText(quote, "customer_phone")
-    ?? readOptionalQuoteText(quote, "customer_email")
-    ?? "No contact details";
+  const clientContact = readOptionalQuoteText(quote, "customer_phone") ?? readOptionalQuoteText(quote, "customer_email") ?? "No contact details";
   const canEdit = Boolean(quote && id && isQuoteEditableStatus(actionState));
-  const showDraftInvoicePromptBelowActions = Boolean(
-    quote && actionState === "draft" && !quote.linked_invoice,
-  );
+  const showDraftInvoicePromptBelowActions = Boolean(quote && actionState === "draft" && !quote.linked_invoice);
   const {
     invoiceError,
     isConvertingInvoice,
@@ -85,21 +83,10 @@ export function QuotePreview(): React.ReactElement {
     navigate,
     setQuote,
   });
-  const isBusy =
-    isGeneratingPdf
-    || isSharing
-    || isSendingEmail
-    || isMarkingWon
-    || isMarkingLost
-    || isDeleting
-    || isConvertingInvoice;
+  const isBusy = isGeneratingPdf || isSharing || isSendingEmail || isMarkingWon || isMarkingLost || isDeleting || isConvertingInvoice;
 
   function handleBack(): void {
-    if (canNavigateBack()) {
-      navigate(-1);
-      return;
-    }
-
+    if (canNavigateBack()) return void navigate(-1);
     navigate("/", { replace: true });
   }
 
@@ -111,6 +98,7 @@ export function QuotePreview(): React.ReactElement {
     setPdfError(null);
     setShareError(null);
     setShareMessage(null);
+    setManualCopyUrl(null);
     setIsGeneratingPdf(true);
     try {
       const blob = await quoteService.generatePdf(id);
@@ -185,6 +173,7 @@ export function QuotePreview(): React.ReactElement {
   async function onCopyLink(): Promise<void> {
     setShareError(null);
     setShareMessage(null);
+    setManualCopyUrl(null);
     setIsSharing(true);
 
     try {
@@ -198,6 +187,7 @@ export function QuotePreview(): React.ReactElement {
             url: nextSharedUrl,
           });
           setShareMessage("Quote link shared.");
+          setManualCopyUrl(null);
           return;
         } catch (error) {
           if (isShareAbortError(error)) {
@@ -208,13 +198,16 @@ export function QuotePreview(): React.ReactElement {
       }
 
       if (!navigator.clipboard || typeof navigator.clipboard.writeText !== "function") {
+        setManualCopyUrl(nextSharedUrl);
         setShareMessage("Copy this share link manually.");
         return;
       }
 
       await navigator.clipboard.writeText(nextSharedUrl);
+      setManualCopyUrl(null);
       setShareMessage("Share link copied to clipboard.");
     } catch (error) {
+      setManualCopyUrl(null);
       const message = error instanceof Error ? error.message : "Unable to copy share link";
       setShareError(message);
     } finally {
@@ -238,6 +231,7 @@ export function QuotePreview(): React.ReactElement {
     setShowSendEmailConfirm(false);
     setShareError(null);
     setShareMessage(null);
+    setManualCopyUrl(null);
     setIsSendingEmail(true);
 
     try {
@@ -381,6 +375,7 @@ export function QuotePreview(): React.ReactElement {
               onCopyLink={onCopyLink}
               openPdfUrl={openPdfUrl}
               shareUrl={shareUrl}
+              manualCopyUrl={manualCopyUrl}
               isGeneratingPdf={isGeneratingPdf}
               isSendingEmail={isSendingEmail}
               isCopyingLink={isSharing}
@@ -422,6 +417,7 @@ export function QuotePreview(): React.ReactElement {
         <QuotePreviewDialogs
           quoteLabel={quote.title ?? quote.doc_number}
           emailActionLabel={emailActionLabel}
+          customerEmail={customerEmail}
           showDeleteConfirm={showDeleteConfirm}
           showMarkWonConfirm={showMarkWonConfirm}
           showMarkLostConfirm={showMarkLostConfirm}

--- a/frontend/src/features/quotes/components/QuotePreviewActions.tsx
+++ b/frontend/src/features/quotes/components/QuotePreviewActions.tsx
@@ -2,6 +2,7 @@ import { Button } from "@/shared/components/Button";
 import {
   DocumentActionError,
   DocumentActionHint,
+  DocumentActionManualCopyField,
   DocumentActionStatus,
   DocumentActionSuccessMessage,
   DocumentActionSurface,
@@ -18,6 +19,7 @@ interface QuotePreviewActionsProps {
   onCopyLink: () => Promise<void>;
   openPdfUrl: string | null;
   shareUrl: string | null;
+  manualCopyUrl: string | null;
   isGeneratingPdf: boolean;
   isSendingEmail: boolean;
   isCopyingLink: boolean;
@@ -38,6 +40,7 @@ export function QuotePreviewActions({
   onCopyLink,
   openPdfUrl,
   shareUrl,
+  manualCopyUrl,
   isGeneratingPdf,
   isSendingEmail,
   isCopyingLink,
@@ -161,6 +164,12 @@ export function QuotePreviewActions({
           {pdfError ? <DocumentActionError>{pdfError}</DocumentActionError> : null}
           {shareError ? <DocumentActionError>{shareError}</DocumentActionError> : null}
           {outcomeError ? <DocumentActionError>{outcomeError}</DocumentActionError> : null}
+          {manualCopyUrl ? (
+            <DocumentActionManualCopyField
+              url={manualCopyUrl}
+              label={shareUrl ? "Share URL" : "Generated share URL"}
+            />
+          ) : null}
           {shareMessage ? (
             <DocumentActionSuccessMessage>{shareMessage}</DocumentActionSuccessMessage>
           ) : null}

--- a/frontend/src/features/quotes/components/QuotePreviewDialogs.tsx
+++ b/frontend/src/features/quotes/components/QuotePreviewDialogs.tsx
@@ -1,8 +1,11 @@
+import type { ReactNode } from "react";
+
 import { ConfirmModal } from "@/shared/components/ConfirmModal";
 
 interface QuotePreviewDialogsProps {
   quoteLabel: string;
   emailActionLabel: string | null;
+  customerEmail: string | null;
   showDeleteConfirm: boolean;
   showMarkWonConfirm: boolean;
   showMarkLostConfirm: boolean;
@@ -20,6 +23,7 @@ interface QuotePreviewDialogsProps {
 export function QuotePreviewDialogs({
   quoteLabel,
   emailActionLabel,
+  customerEmail,
   showDeleteConfirm,
   showMarkWonConfirm,
   showMarkLostConfirm,
@@ -33,6 +37,13 @@ export function QuotePreviewDialogs({
   onSendEmailConfirm,
   onSendEmailCancel,
 }: QuotePreviewDialogsProps): React.ReactElement {
+  const sendEmailBody: ReactNode = customerEmail ? (
+    <>
+      This sends the latest quote to{" "}
+      <span className="break-all font-medium text-on-surface">{customerEmail}</span>.
+    </>
+  ) : "This sends the latest quote to the customer email on file.";
+
   return (
     <>
       {showDeleteConfirm ? (
@@ -73,7 +84,7 @@ export function QuotePreviewDialogs({
       {showSendEmailConfirm && emailActionLabel ? (
         <ConfirmModal
           title={`${emailActionLabel}?`}
-          body="This sends the latest quote to the customer email on file."
+          body={sendEmailBody}
           confirmLabel={emailActionLabel}
           cancelLabel="Cancel"
           onConfirm={onSendEmailConfirm}

--- a/frontend/src/features/quotes/components/quotePreview.helpers.ts
+++ b/frontend/src/features/quotes/components/quotePreview.helpers.ts
@@ -23,17 +23,6 @@ export function readOptionalQuoteText(
   return trimmedValue.length > 0 ? trimmedValue : null;
 }
 
-export function canNavigateBack(): boolean {
-  const historyState = window.history.state as { idx?: number } | null;
-  if (typeof historyState?.idx === "number") {
-    return historyState.idx > 0;
-  }
-  // This can step outside the app in rare direct-entry cases where the browser has
-  // prior history but React Router did not set idx. We accept that tradeoff here to
-  // preserve a sensible back behavior for older/non-router history state entries.
-  return window.history.length > 1;
-}
-
 export function resolveActionState(
   quote: QuoteDetail | null,
   hasLocalPdf: boolean,
@@ -53,8 +42,6 @@ export function resolveActionState(
 
   return "draft";
 }
-
-
 export function getEmailActionLabel(actionState: QuotePreviewActionState): string | null {
   if (actionState === "ready") {
     return "Send Email";
@@ -69,8 +56,6 @@ export function getEmailActionLabel(actionState: QuotePreviewActionState): strin
   }
   return null;
 }
-
-
 export function getSendEmailErrorMessage(error: unknown): string {
   if (isHttpRequestError(error)) {
     switch (error.status) {

--- a/frontend/src/features/quotes/tests/QuotePreview.test.tsx
+++ b/frontend/src/features/quotes/tests/QuotePreview.test.tsx
@@ -955,6 +955,9 @@ describe("QuotePreview", () => {
     await screen.findByRole("heading", { name: "Test Customer" });
     fireEvent.click(screen.getByRole("button", { name: /copy link/i }));
 
+    expect(await screen.findByLabelText("Share URL")).toHaveValue(
+      "http://localhost:3000/doc/already-shared-token",
+    );
     expect(await screen.findByText("Copy this share link manually.")).toBeInTheDocument();
   });
 
@@ -993,6 +996,7 @@ describe("QuotePreview", () => {
     );
 
     const dialog = screen.getByRole("dialog", { name: /send email\?/i });
+    expect(within(dialog).getByText(/customer@example\.com/i)).toBeInTheDocument();
     expect(mockedQuoteService.sendQuoteEmail).not.toHaveBeenCalled();
 
     fireEvent.click(within(dialog).getByRole("button", { name: /send email/i }));

--- a/frontend/src/features/quotes/tests/QuotePreviewActions.test.tsx
+++ b/frontend/src/features/quotes/tests/QuotePreviewActions.test.tsx
@@ -13,6 +13,7 @@ function makeProps(overrides: Partial<ComponentProps<typeof QuotePreviewActions>
     onCopyLink: vi.fn().mockResolvedValue(undefined),
     openPdfUrl: "blob:quote-preview",
     shareUrl: "http://localhost:3000/doc/share-token-1",
+    manualCopyUrl: null,
     isGeneratingPdf: false,
     isSendingEmail: false,
     isCopyingLink: false,
@@ -178,5 +179,19 @@ describe("QuotePreviewActions", () => {
     fireEvent.click(screen.getByRole("button", { name: /copy link/i }));
 
     expect(onCopyLink).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders the manual-copy field when a share URL must be copied inline", () => {
+    render(
+      <QuotePreviewActions
+        {...makeProps({
+          manualCopyUrl: "http://localhost:3000/doc/share-token-1",
+        })}
+      />,
+    );
+
+    expect(screen.getByLabelText("Share URL")).toHaveValue(
+      "http://localhost:3000/doc/share-token-1",
+    );
   });
 });

--- a/frontend/src/shared/components/ConfirmModal.tsx
+++ b/frontend/src/shared/components/ConfirmModal.tsx
@@ -1,9 +1,10 @@
+import type { ReactNode } from "react";
 import { useRef } from "react";
 import * as Dialog from "@radix-ui/react-dialog";
 
 interface ConfirmModalProps {
   title: string;
-  body?: string;
+  body?: ReactNode;
   confirmLabel: string;
   cancelLabel: string;
   onConfirm: () => void;
@@ -69,7 +70,7 @@ export function ConfirmModal({
           >
             <Dialog.Title className="font-headline text-xl font-bold tracking-tight text-on-surface">{title}</Dialog.Title>
             {body ? (
-              <Dialog.Description className="mt-2 text-sm leading-6 text-on-surface-variant">
+              <Dialog.Description className="mt-2 break-words text-sm leading-6 text-on-surface-variant">
                 {body}
               </Dialog.Description>
             ) : null}

--- a/frontend/src/shared/components/DocumentActionSurface.tsx
+++ b/frontend/src/shared/components/DocumentActionSurface.tsx
@@ -26,6 +26,11 @@ interface MessageProps {
   children: ReactNode;
 }
 
+interface ManualCopyFieldProps {
+  url: string;
+  label?: string;
+}
+
 export function DocumentActionSurface({
   sectionLabel,
   primaryAction,
@@ -89,5 +94,26 @@ export function DocumentActionSuccessMessage({ children }: MessageProps): React.
     <p className="mx-4 mt-3 rounded-md bg-success-container p-3 text-sm text-success">
       {children}
     </p>
+  );
+}
+
+export function DocumentActionManualCopyField({
+  url,
+  label = "Share URL",
+}: ManualCopyFieldProps): React.ReactElement {
+  return (
+    <div className="mx-4 mt-3">
+      <label className="block text-sm font-medium text-on-surface" htmlFor="manual-share-url">
+        {label}
+      </label>
+      <input
+        id="manual-share-url"
+        type="text"
+        readOnly
+        value={url}
+        onFocus={(event) => event.currentTarget.select()}
+        className="mt-2 w-full rounded-lg border border-outline-variant/30 bg-surface-container-low px-4 py-3 text-sm text-on-surface focus:outline-none focus:ring-2 focus:ring-primary/30"
+      />
+    </div>
   );
 }

--- a/frontend/src/shared/lib/navigation.ts
+++ b/frontend/src/shared/lib/navigation.ts
@@ -1,0 +1,11 @@
+export function canNavigateBack(): boolean {
+  const historyState = window.history.state as { idx?: number } | null;
+  if (typeof historyState?.idx === "number") {
+    return historyState.idx > 0;
+  }
+
+  // This can step outside the app in rare direct-entry cases where the browser has
+  // prior history but React Router did not set idx. We accept that tradeoff here to
+  // preserve a sensible back behavior for older/non-router history state entries.
+  return window.history.length > 1;
+}


### PR DESCRIPTION
## Summary
- show the generated share URL inline on quote preview and invoice detail when native share/clipboard APIs are unavailable
- reuse the quote safe-back pattern on invoice detail with `/` as the deterministic in-app fallback route when history back is unsafe
- include the destination email in quote and invoice send-email confirmations, and keep the existing send/resend flows intact
- keep the shared action-surface affordances aligned by reusing shared helpers instead of a broader refactor

## Verification
- `make frontend-verify`

## Notes
- Safe back fallback route for invoice detail: `/`

## Manual parity checklist
- [ ] Share / link / copy affordances match on quote preview and invoice detail
- [ ] Email entry controls match on quote preview and invoice detail
- [ ] Customer navigation controls match where both screens expose them
- [ ] Utility-row links match where both screens expose them

Closes #188