### PR TITLE
Fix optional pricing collapse behavior on review/edit

### DIFF
--- a/frontend/src/features/quotes/components/TotalAmountSection.test.tsx
+++ b/frontend/src/features/quotes/components/TotalAmountSection.test.tsx
@@ -65,16 +65,23 @@ describe("TotalAmountSection", () => {
     expect(screen.queryByRole("checkbox", { name: "Discount" })).not.toBeInTheDocument();
   });
 
-  it("auto-expands optional pricing when a suggested tax rate exists and shows percent units", () => {
+  it("keeps optional pricing collapsed by default when only a suggested tax rate exists", () => {
     renderSection();
 
-    expect(screen.getByText(/optional pricing/i)).toBeInTheDocument();
-    expect(screen.getByRole("spinbutton", { name: /suggested tax/i })).toHaveValue(8.25);
-    expect(screen.getByText("%")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /optional pricing/i })).toHaveAttribute(
+      "aria-expanded",
+      "false",
+    );
+    expect(screen.queryByRole("checkbox", { name: "Tax" })).not.toBeInTheDocument();
   });
 
-  it("shows editable inputs without seeding zero values and applies the suggested tax rate", () => {
+  it("shows the suggested tax hint after manually opening the panel and applies the default when tax is enabled", () => {
     renderSection();
+
+    fireEvent.click(screen.getByRole("button", { name: /optional pricing/i }));
+
+    expect(screen.getByRole("spinbutton", { name: /suggested tax/i })).toHaveValue(8.25);
+    expect(screen.getByText("%")).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("checkbox", { name: "Discount" }));
     const discountInput = screen.getByPlaceholderText("25") as HTMLInputElement;
@@ -87,5 +94,27 @@ describe("TotalAmountSection", () => {
     fireEvent.click(screen.getByRole("checkbox", { name: "Deposit" }));
     const depositInput = screen.getByPlaceholderText("50") as HTMLInputElement;
     expect(depositInput.value).toBe("");
+  });
+
+  it("forces optional pricing open only when an option is active and returns to collapsible state after clearing the last active option", () => {
+    renderSection({ initialDiscountType: "fixed" });
+
+    expect(screen.queryByRole("button", { name: /optional pricing/i })).not.toBeInTheDocument();
+    expect(screen.getByRole("checkbox", { name: "Discount" })).toBeChecked();
+
+    fireEvent.click(screen.getByRole("checkbox", { name: "Discount" }));
+
+    expect(screen.getByRole("button", { name: /optional pricing/i })).toHaveAttribute(
+      "aria-expanded",
+      "false",
+    );
+    expect(screen.queryByRole("checkbox", { name: "Discount" })).not.toBeInTheDocument();
+  });
+
+  it("treats zero-valued pricing as active so the panel stays forced open", () => {
+    renderSection({ initialDepositAmount: 0 });
+
+    expect(screen.queryByRole("button", { name: /optional pricing/i })).not.toBeInTheDocument();
+    expect(screen.getByRole("checkbox", { name: "Deposit" })).toBeChecked();
   });
 });

--- a/frontend/src/features/quotes/components/TotalAmountSection.tsx
+++ b/frontend/src/features/quotes/components/TotalAmountSection.tsx
@@ -45,10 +45,10 @@ export function TotalAmountSection({
   const [depositToggleOverride, setDepositToggleOverride] = useState<boolean | null>(null);
   const [isOptionalPricingOpen, setIsOptionalPricingOpen] = useState(false);
   const isDiscountEnabled = discountToggleOverride ?? (
-    discountType !== null || isPopulatedPricingValue(discountValue)
+    discountType !== null || hasActivePricingValue(discountValue)
   );
-  const isTaxEnabled = taxToggleOverride ?? isPopulatedPricingValue(taxRate);
-  const isDepositEnabled = depositToggleOverride ?? isPopulatedPricingValue(depositAmount);
+  const isTaxEnabled = taxToggleOverride ?? hasActivePricingValue(taxRate);
+  const isDepositEnabled = depositToggleOverride ?? hasActivePricingValue(depositAmount);
 
   const pricingBreakdown = calculatePricingFromSubtotal({
     totalAmount: total,
@@ -57,14 +57,9 @@ export function TotalAmountSection({
     discountValue,
     depositAmount,
   });
-  const shouldAutoExpandOptionalPricing = (
-    isDiscountEnabled
-    || isTaxEnabled
-    || isDepositEnabled
-    || suggestedTaxRate !== null
-  );
+  const hasActiveOptionalPricing = isDiscountEnabled || isTaxEnabled || isDepositEnabled;
   const hasPricingBreakdown = pricingBreakdown.hasPricingBreakdown;
-  const shouldShowOptionalPricingPanel = shouldAutoExpandOptionalPricing || isOptionalPricingOpen;
+  const shouldShowOptionalPricingPanel = hasActiveOptionalPricing || isOptionalPricingOpen;
 
   return (
     <section className="rounded-lg bg-surface-container-low p-4">
@@ -105,7 +100,7 @@ export function TotalAmountSection({
       </div>
 
       <div className="mt-4 border-t border-outline-variant/30 pt-4">
-        {shouldAutoExpandOptionalPricing ? (
+        {hasActiveOptionalPricing ? (
           <div className="flex items-center justify-between gap-4 rounded-lg bg-surface-container-lowest px-4 py-3">
             <div>
               <p className="text-xs font-bold uppercase tracking-widest text-on-surface">
@@ -306,6 +301,6 @@ export function TotalAmountSection({
   );
 }
 
-function isPopulatedPricingValue(value: number | null): boolean {
-  return value !== null && value !== 0;
+function hasActivePricingValue(value: number | null): boolean {
+  return value !== null;
 }

--- a/frontend/src/features/quotes/tests/QuoteEditScreen.test.tsx
+++ b/frontend/src/features/quotes/tests/QuoteEditScreen.test.tsx
@@ -204,6 +204,49 @@ describe("QuoteEditScreen", () => {
     });
   });
 
+  it("keeps optional pricing collapsed by default when no pricing option is active", async () => {
+    window.sessionStorage.setItem(EDIT_STORAGE_KEY, JSON.stringify(makeDraft()));
+
+    renderScreen();
+
+    expect(await screen.findByRole("heading", { name: "Q-001" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /optional pricing/i })).toHaveAttribute(
+      "aria-expanded",
+      "false",
+    );
+    expect(screen.queryByRole("checkbox", { name: "Tax" })).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /optional pricing/i }));
+
+    expect(screen.getByRole("checkbox", { name: "Tax" })).toBeInTheDocument();
+  });
+
+  it("returns optional pricing to a collapsible state after clearing the last active edit option", async () => {
+    mockedQuoteService.getQuote.mockResolvedValueOnce(
+      makeQuoteDetail({
+        deposit_amount: 0,
+      }),
+    );
+
+    renderScreen();
+
+    expect(await screen.findByRole("heading", { name: "Q-001" })).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.queryByRole("button", { name: /optional pricing/i })).not.toBeInTheDocument();
+      expect(screen.getByRole("checkbox", { name: "Deposit" })).toBeChecked();
+    });
+
+    fireEvent.click(screen.getByRole("checkbox", { name: "Deposit" }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /optional pricing/i })).toHaveAttribute(
+        "aria-expanded",
+        "false",
+      );
+      expect(screen.queryByRole("checkbox", { name: "Deposit" })).not.toBeInTheDocument();
+    });
+  });
+
   it("shows a load error when the quote fetch fails", async () => {
     mockedQuoteService.getQuote.mockRejectedValueOnce(new Error("Unable to load quote"));
 

--- a/frontend/src/features/quotes/tests/ReviewScreen.test.tsx
+++ b/frontend/src/features/quotes/tests/ReviewScreen.test.tsx
@@ -258,6 +258,38 @@ describe("ReviewScreen", () => {
     expect(screen.getByText(/price for edging is uncertain/i)).toBeInTheDocument();
   });
 
+  it("keeps optional pricing collapsed until manually opened when only a suggested tax rate exists", async () => {
+    mockedProfileService.getProfile.mockResolvedValueOnce({
+      id: "user-1",
+      email: "owner@example.com",
+      first_name: "Jamie",
+      last_name: "Owner",
+      business_name: "North Star Lawn",
+      trade_type: "Landscaper",
+      timezone: "UTC",
+      default_tax_rate: 0.0825,
+      has_logo: false,
+      is_active: true,
+      is_onboarded: true,
+    });
+
+    renderScreen(makeDraft());
+
+    await waitFor(() => {
+      expect(mockedProfileService.getProfile).toHaveBeenCalled();
+      expect(screen.getByRole("button", { name: /optional pricing/i })).toHaveAttribute(
+        "aria-expanded",
+        "false",
+      );
+    });
+    expect(screen.queryByRole("checkbox", { name: "Tax" })).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /optional pricing/i }));
+
+    expect(screen.getByRole("spinbutton", { name: /suggested tax/i })).toHaveValue(8.25);
+    expect(screen.getByText(/enable tax to apply this default rate/i)).toBeInTheDocument();
+  });
+
   it("shows review-required guidance when a line item is flagged", () => {
     renderScreen(
       makeDraft({


### PR DESCRIPTION
## Summary
- keep optional pricing collapsed by default when only a suggested tax rate exists
- force the panel open only when a real optional pricing value is active, including zero values
- add focused Review/Edit tests for manual open, forced-open, and clear-last-active behavior

## Verification
- cd frontend && npx vitest run src/features/quotes/components/TotalAmountSection.test.tsx src/features/quotes/tests/ReviewScreen.test.tsx src/features/quotes/tests/QuoteEditScreen.test.tsx

Closes #192