### PR TITLE
Fix logo upload MIME preflight regression

### DIFF
--- a/frontend/src/features/settings/components/SettingsScreen.tsx
+++ b/frontend/src/features/settings/components/SettingsScreen.tsx
@@ -24,7 +24,6 @@ const THEME_OPTIONS: ReadonlyArray<{ label: string; value: ThemePreference }> = 
   { label: "Dark", value: "dark" },
 ];
 
-const ALLOWED_LOGO_TYPES = new Set(["image/jpeg", "image/png"]);
 const MAX_LOGO_SIZE_BYTES = 2 * 1024 * 1024;
 
 export function SettingsScreen(): React.ReactElement {
@@ -97,11 +96,6 @@ export function SettingsScreen(): React.ReactElement {
     const file = event.target.files?.[0];
     event.target.value = "";
     if (!file) {
-      return;
-    }
-
-    if (!ALLOWED_LOGO_TYPES.has(file.type)) {
-      setLogoError("Upload a JPEG or PNG logo.");
       return;
     }
 

--- a/frontend/src/features/settings/tests/SettingsScreen.test.tsx
+++ b/frontend/src/features/settings/tests/SettingsScreen.test.tsx
@@ -515,17 +515,36 @@ describe("SettingsScreen", () => {
     expect(await screen.findByAltText(/business logo preview/i)).toBeInTheDocument();
   });
 
-  it("shows an inline error for unsupported logo file types without uploading", async () => {
+  it("submits logo uploads when the browser omits file mime metadata", async () => {
     mockedProfileService.getProfile.mockResolvedValueOnce(makeProfileResponse());
+    mockedProfileService.uploadLogo.mockResolvedValueOnce(
+      makeProfileResponse({ has_logo: true }),
+    );
 
     renderScreen();
 
     const input = (await screen.findByLabelText(/upload logo/i)) as HTMLInputElement;
-    const file = new File(["not-an-image"], "logo.gif", { type: "image/gif" });
+    const file = new File(["fake-logo"], "logo.png");
     fireEvent.change(input, { target: { files: [file] } });
 
-    expect(await screen.findByRole("alert")).toHaveTextContent("Upload a JPEG or PNG logo.");
-    expect(mockedProfileService.uploadLogo).not.toHaveBeenCalled();
+    await waitFor(() => expect(mockedProfileService.uploadLogo).toHaveBeenCalledWith(file));
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
+  it("submits logo uploads when the browser reports a generic mime type", async () => {
+    mockedProfileService.getProfile.mockResolvedValueOnce(makeProfileResponse());
+    mockedProfileService.uploadLogo.mockResolvedValueOnce(
+      makeProfileResponse({ has_logo: true }),
+    );
+
+    renderScreen();
+
+    const input = (await screen.findByLabelText(/upload logo/i)) as HTMLInputElement;
+    const file = new File(["fake-logo"], "logo.txt", { type: "text/plain" });
+    fireEvent.change(input, { target: { files: [file] } });
+
+    await waitFor(() => expect(mockedProfileService.uploadLogo).toHaveBeenCalledWith(file));
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
   });
 
   it("shows an inline error for oversized logo uploads without uploading", async () => {


### PR DESCRIPTION
## Summary
- stop rejecting logo uploads based on File.type alone before upload
- keep the 2 MB client-side size guard in place
- add frontend coverage for empty and generic MIME metadata uploads

## Validation
- make frontend-verify
- git diff --check

## Why
Backend logo validation is byte-based and already accepts valid JPEG/PNG payloads even when browser MIME metadata is empty or generic. This PR restores frontend/backend contract parity.