### PR TITLE
Task 240: post-Redis hardening follow-up

### DIFF
--- a/backend/app/core/tests/test_main.py
+++ b/backend/app/core/tests/test_main.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import AsyncGenerator, Iterator
+from unittest.mock import AsyncMock
 
 import pytest
 import pytest_asyncio
@@ -109,3 +110,18 @@ async def test_https_redirect_ignores_untrusted_forwarded_proto(
 
     assert response.status_code == 307
     assert response.headers["location"] == "https://api.stima.dev/health"
+
+
+@pytest.mark.asyncio
+async def test_app_lifespan_closes_extraction_controls(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    aclose = AsyncMock()
+    monkeypatch.setattr("app.main.extraction_controls.aclose", aclose)
+
+    app = create_app()
+
+    async with app.router.lifespan_context(app):
+        pass
+
+    aclose.assert_awaited_once()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
@@ -24,7 +27,7 @@ from app.features.quotes.api import public_router as quote_public_router
 from app.features.quotes.api import router as quote_router
 from app.shared.event_logger import configure_event_logging
 from app.shared.proxy_headers import TrustedProxyHeadersMiddleware
-from app.shared.rate_limit import limiter
+from app.shared.rate_limit import extraction_controls, limiter
 
 
 class SecurityHeadersMiddleware:
@@ -61,13 +64,19 @@ def _resolve_allowed_hosts(allowed_hosts: list[str]) -> list[str]:
     return allowed_hosts
 
 
+@asynccontextmanager
+async def _lifespan(_: FastAPI) -> AsyncIterator[None]:
+    yield
+    await extraction_controls.aclose()
+
+
 def create_app() -> FastAPI:
     """Create and configure the FastAPI application."""
     settings = get_settings()
     init_sentry(dsn=settings.sentry_dsn, environment=settings.environment)
     configure_event_logging(session_factory=get_session_maker())
 
-    app = FastAPI(title="Stima API")
+    app = FastAPI(title="Stima API", lifespan=_lifespan)
     app.state.limiter = limiter
     app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)  # type: ignore[arg-type]
     app.add_middleware(

--- a/backend/app/shared/input_limits.py
+++ b/backend/app/shared/input_limits.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 NOTE_INPUT_MAX_CHARS = 50_000
 AUDIO_TRANSCRIPT_MAX_CHARS = 100_000
+# +2 accounts for the newline separator inserted when transcript and notes are combined.
 EXTRACTION_TRANSCRIPT_MAX_CHARS = AUDIO_TRANSCRIPT_MAX_CHARS + NOTE_INPUT_MAX_CHARS + 2
 DOCUMENT_TRANSCRIPT_MAX_CHARS = 100_000
 CUSTOMER_ADDRESS_MAX_CHARS = 500

--- a/backend/app/shared/rate_limit.py
+++ b/backend/app/shared/rate_limit.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import abc
 import asyncio
 import logging
 import time
@@ -87,23 +88,28 @@ class ConcurrencyLease:
         await self.manager.release_concurrency(self.concurrency_key)
 
 
-class ExtractionStateStore:
-    """Protocol-like base for extraction quota and concurrency state backends."""
+class ExtractionStateStore(abc.ABC):
+    """Backend interface for extraction quota and concurrency state."""
 
+    @abc.abstractmethod
     async def reserve_daily_quota(self, key: str, *, limit: int, expiry_seconds: int) -> bool:
-        raise NotImplementedError
+        """Reserve one daily extraction quota slot."""
 
+    @abc.abstractmethod
     async def acquire_concurrency(self, key: str, *, limit: int, expiry_seconds: int) -> bool:
-        raise NotImplementedError
+        """Acquire one provider-concurrency slot."""
 
+    @abc.abstractmethod
     async def release_concurrency(self, key: str) -> None:
-        raise NotImplementedError
+        """Release one provider-concurrency slot."""
 
     def reset_local_state(self) -> None:
         """Reset state for in-memory test fixtures when available."""
+        return None
 
     async def aclose(self) -> None:
         """Release backend resources when the store keeps external clients."""
+        return None
 
 
 class InMemoryExtractionStateStore(ExtractionStateStore):
@@ -395,7 +401,18 @@ def reset_local_rate_limit_state() -> None:
 
 @asynccontextmanager
 async def reserve_extraction_capacity(user_id: UUID) -> AsyncIterator[bool]:
-    """Acquire extraction concurrency and daily quota before provider-backed work starts."""
+    """Acquire extraction concurrency and daily quota before provider-backed work starts.
+
+    Ordering: concurrency is acquired first so a provider slot is confirmed before
+    consuming daily quota. Quota is a non-reversible per-UTC-day counter and is
+    not rolled back if the caller raises inside the ``async with`` block. That is
+    intentional: failed provider calls still count against the daily limit to
+    prevent abuse via rapid retry loops against a failing provider.
+
+    Task #200 note: if retries re-enter this guard, each retry consumes another
+    quota slot. Decide there whether retries should bypass this guard or consume
+    quota per attempt.
+    """
     lease = await extraction_controls.acquire_concurrency(user_id)
     if lease is None:
         yield False

--- a/backend/app/shared/tests/test_rate_limit.py
+++ b/backend/app/shared/tests/test_rate_limit.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import os
 from collections.abc import Iterator
 from uuid import uuid4
 
@@ -14,6 +15,7 @@ from app.shared.rate_limit import (
     ExtractionStateStore,
     RedisExtractionStateStore,
     build_limiter,
+    configure_active_limiter_key_prefix,
     get_ip_key,
     get_user_key,
     resolve_limiter_backend,
@@ -22,6 +24,8 @@ from limits.storage.memory import MemoryStorage
 from limits.storage.redis import RedisStorage
 from pydantic import ValidationError
 from starlette.requests import Request
+
+_SKIP_REDIS_LIMITER_CONSTRUCTION = os.getenv("STIMA_SKIP_EAGER_REDIS_LIMITER_TESTS") == "1"
 
 
 @pytest.fixture(autouse=True)
@@ -177,6 +181,45 @@ def test_build_limiter_applies_configured_redis_key_prefix(
 
     assert isinstance(limiter._storage, RedisStorage)  # type: ignore[attr-defined]
     assert limiter._storage.key_prefix == "custom"  # type: ignore[attr-defined]
+
+
+def test_configure_active_limiter_key_prefix_is_no_op_for_memory_backend(
+    monkeypatch: pytest.MonkeyPatch,
+    request: pytest.FixtureRequest,
+) -> None:
+    monkeypatch.setenv("REDIS_URL", "")
+    get_settings.cache_clear()
+    request.addfinalizer(get_settings.cache_clear)
+    memory_limiter = build_limiter(get_settings())
+    monkeypatch.setattr("app.shared.rate_limit.limiter", memory_limiter)
+
+    configure_active_limiter_key_prefix("any-prefix")
+
+    assert isinstance(memory_limiter._storage, MemoryStorage)  # type: ignore[attr-defined]
+    assert not hasattr(memory_limiter._storage, "key_prefix")  # type: ignore[attr-defined]
+
+
+@pytest.mark.skipif(
+    _SKIP_REDIS_LIMITER_CONSTRUCTION,
+    reason=(
+        "Set STIMA_SKIP_EAGER_REDIS_LIMITER_TESTS=1 for environments whose Redis limiter "
+        "construction eagerly connects."
+    ),
+)
+def test_configure_active_limiter_key_prefix_updates_redis_storage(
+    monkeypatch: pytest.MonkeyPatch,
+    request: pytest.FixtureRequest,
+) -> None:
+    monkeypatch.setenv("REDIS_URL", "redis://localhost:6379/0")
+    get_settings.cache_clear()
+    request.addfinalizer(get_settings.cache_clear)
+    redis_limiter = build_limiter(get_settings())
+    monkeypatch.setattr("app.shared.rate_limit.limiter", redis_limiter)
+
+    configure_active_limiter_key_prefix("custom-test-prefix")
+
+    assert isinstance(redis_limiter._storage, RedisStorage)  # type: ignore[attr-defined]
+    assert redis_limiter._storage.key_prefix == "custom-test-prefix"  # type: ignore[attr-defined]
 
 
 def test_build_limiter_logs_redacted_redis_url(

--- a/frontend/src/shared/lib/inputLimits.ts
+++ b/frontend/src/shared/lib/inputLimits.ts
@@ -1,3 +1,6 @@
+// These values mirror backend/app/shared/input_limits.py.
+// They are duplicated intentionally because frontend and backend do not share a build artifact.
+// If a backend limit changes, update the corresponding constant here as a manual contract sync.
 export const NOTE_INPUT_MAX_CHARS = 50_000;
 export const AUDIO_TRANSCRIPT_MAX_CHARS = 100_000;
 export const EXTRACTION_TRANSCRIPT_MAX_CHARS = AUDIO_TRANSCRIPT_MAX_CHARS + NOTE_INPUT_MAX_CHARS + 2;


### PR DESCRIPTION
## Summary
- add a FastAPI lifespan hook that closes extraction-controls Redis state on shutdown and cover it with a boundary test
- document the quota-on-failure contract, harden `ExtractionStateStore` into an ABC, and add explicit limiter key-prefix path tests
- add the scoped backend/frontend input-limit comments and close #238 as completed

## Verification
- make backend-verify
- make frontend-verify

Closes #240