### PR TITLE
Task #271: customer pulse and shared toast polish

### DIFF
--- a/frontend/src/features/customers/components/CustomerDetailScreen.tsx
+++ b/frontend/src/features/customers/components/CustomerDetailScreen.tsx
@@ -19,6 +19,7 @@ import { BottomNav } from "@/shared/components/BottomNav";
 import { Button } from "@/shared/components/Button";
 import { FeedbackMessage } from "@/shared/components/FeedbackMessage";
 import { ScreenHeader } from "@/shared/components/ScreenHeader";
+import { Toast } from "@/shared/components/Toast";
 
 type HistoryMode = "quotes" | "invoices";
 
@@ -249,15 +250,6 @@ export function CustomerDetailScreen(): React.ReactElement {
             {!isEditing ? (
               <section className="rounded-xl bg-surface-container-lowest p-4 ghost-shadow">
                 <div className="flex flex-col gap-3">
-                  {saveSuccess ? (
-                    <p
-                      role="status"
-                      className="rounded-lg bg-success-container px-3 py-2 text-sm text-success"
-                    >
-                      {saveSuccess}
-                    </p>
-                  ) : null}
-
                   <dl className="flex flex-col gap-1.5">
                     <div className="flex items-center gap-3">
                       <dt className="w-16 shrink-0 text-[0.6875rem] font-bold uppercase tracking-widest text-outline">
@@ -382,6 +374,7 @@ export function CustomerDetailScreen(): React.ReactElement {
       </section>
 
       <BottomNav active="customers" />
+      <Toast message={saveSuccess} onDismiss={() => setSaveSuccess(null)} />
     </main>
   );
 }

--- a/frontend/src/features/customers/tests/CustomerDetailScreen.test.tsx
+++ b/frontend/src/features/customers/tests/CustomerDetailScreen.test.tsx
@@ -248,7 +248,10 @@ describe("CustomerDetailScreen", () => {
       );
     });
 
-    expect(await screen.findByRole("status")).toHaveTextContent("Saved");
+    const savedToast = await screen.findByRole("status");
+    expect(savedToast).toHaveTextContent("Saved");
+    expect(savedToast).toHaveClass("bg-on-surface");
+    expect(savedToast).not.toHaveClass("bg-success-container");
     expect(screen.queryByLabelText(/^name$/i)).not.toBeInTheDocument();
     expect(
       screen.getByRole("heading", { level: 1, name: "Alice A. Johnson" }),

--- a/frontend/src/features/quotes/components/CaptureScreen.tsx
+++ b/frontend/src/features/quotes/components/CaptureScreen.tsx
@@ -28,8 +28,8 @@ import type {
 } from "@/features/quotes/types/quote.types";
 import { Button } from "@/shared/components/Button";
 import { ConfirmModal } from "@/shared/components/ConfirmModal";
-import { FeedbackMessage } from "@/shared/components/FeedbackMessage";
 import { ScreenFooter } from "@/shared/components/ScreenFooter";
+import { Toast } from "@/shared/components/Toast";
 import { WorkflowScreenHeader } from "@/shared/components/WorkflowScreenHeader";
 import { jobService } from "@/shared/lib/jobService";
 import { formatByteLimit } from "@/shared/lib/formatters";
@@ -89,9 +89,19 @@ export function CaptureScreen(): React.ReactElement {
     extractionStageTimerRefs.current = [];
   }
 
-  function clearSubmissionErrors(): void {
+  function clearActionErrors(): void {
     setError(null);
     clearError();
+  }
+
+  function dismissActiveError(): void {
+    if (error) {
+      setError(null);
+      return;
+    }
+    if (voiceError) {
+      clearError();
+    }
   }
 
   useEffect(() => {
@@ -158,7 +168,7 @@ export function CaptureScreen(): React.ReactElement {
   }
 
   async function onExtract(): Promise<void> {
-    clearSubmissionErrors();
+    clearActionErrors();
     if (clips.length > MAX_AUDIO_CLIPS_PER_REQUEST) {
       setError(
         `You can upload up to ${MAX_AUDIO_CLIPS_PER_REQUEST} clips at a time.`,
@@ -331,17 +341,6 @@ export function CaptureScreen(): React.ReactElement {
       />
 
       <section className="mx-auto h-full w-full max-w-2xl overflow-hidden px-4 pb-24 pt-20">
-        {displayedError ? (
-          <div className="mb-4 space-y-3">
-            <FeedbackMessage variant="error">{displayedError}</FeedbackMessage>
-            {error ? (
-              <Button type="button" onClick={clearSubmissionErrors}>
-                Try again
-              </Button>
-            ) : null}
-          </div>
-        ) : null}
-
         {!isSupported ? (
           <p className="mb-4 rounded-lg border border-warning-accent/40 bg-warning-container p-3 text-sm text-warning">
             Voice capture is not supported in this browser. You can still type
@@ -391,6 +390,13 @@ export function CaptureScreen(): React.ReactElement {
           </Button>
         </div>
       </ScreenFooter>
+
+      <Toast
+        message={displayedError}
+        variant="error"
+        durationMs={null}
+        onDismiss={dismissActiveError}
+      />
 
       {pendingExitTarget ? (
         <ConfirmModal

--- a/frontend/src/features/quotes/components/ReviewCustomerRow.test.tsx
+++ b/frontend/src/features/quotes/components/ReviewCustomerRow.test.tsx
@@ -22,7 +22,6 @@ describe("ReviewCustomerRow", () => {
       "animate-pulse",
       "[animation-iteration-count:3]",
     );
-    expect((assignmentButton as HTMLButtonElement).style.animationIterationCount).toBe("3");
   });
 
   it("does not apply warning pulse classes when a customer is already assigned", () => {
@@ -43,6 +42,5 @@ describe("ReviewCustomerRow", () => {
       "animate-pulse",
       "[animation-iteration-count:3]",
     );
-    expect((assignmentButton as HTMLButtonElement).style.animationIterationCount).toBe("");
   });
 });

--- a/frontend/src/features/quotes/components/ReviewCustomerRow.test.tsx
+++ b/frontend/src/features/quotes/components/ReviewCustomerRow.test.tsx
@@ -22,6 +22,7 @@ describe("ReviewCustomerRow", () => {
       "animate-pulse",
       "[animation-iteration-count:3]",
     );
+    expect((assignmentButton as HTMLButtonElement).style.animationIterationCount).toBe("3");
   });
 
   it("does not apply warning pulse classes when a customer is already assigned", () => {
@@ -42,5 +43,6 @@ describe("ReviewCustomerRow", () => {
       "animate-pulse",
       "[animation-iteration-count:3]",
     );
+    expect((assignmentButton as HTMLButtonElement).style.animationIterationCount).toBe("");
   });
 });

--- a/frontend/src/features/quotes/components/ReviewCustomerRow.test.tsx
+++ b/frontend/src/features/quotes/components/ReviewCustomerRow.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { ReviewCustomerRow } from "@/features/quotes/components/ReviewCustomerRow";
+
+describe("ReviewCustomerRow", () => {
+  it("applies warning pulse classes when customer assignment is required", () => {
+    render(
+      <ReviewCustomerRow
+        customerName={null}
+        requiresCustomerAssignment
+        canReassignCustomer
+        isInteractionLocked={false}
+        onRequestAssignment={vi.fn()}
+      />,
+    );
+
+    const assignmentButton = screen.getByRole("button", { name: /customer: unassigned/i });
+    expect(assignmentButton).toHaveClass(
+      "ring-2",
+      "ring-warning-accent/60",
+      "animate-pulse",
+      "[animation-iteration-count:3]",
+    );
+  });
+
+  it("does not apply warning pulse classes when a customer is already assigned", () => {
+    render(
+      <ReviewCustomerRow
+        customerName="Alice Johnson"
+        requiresCustomerAssignment={false}
+        canReassignCustomer
+        isInteractionLocked={false}
+        onRequestAssignment={vi.fn()}
+      />,
+    );
+
+    const assignmentButton = screen.getByRole("button", { name: /alice johnson/i });
+    expect(assignmentButton).not.toHaveClass(
+      "ring-2",
+      "ring-warning-accent/60",
+      "animate-pulse",
+      "[animation-iteration-count:3]",
+    );
+  });
+});

--- a/frontend/src/features/quotes/components/ReviewCustomerRow.tsx
+++ b/frontend/src/features/quotes/components/ReviewCustomerRow.tsx
@@ -29,7 +29,11 @@ export function ReviewCustomerRow({
 
       <button
         type="button"
-        className="flex w-full cursor-pointer items-center justify-between rounded-lg border border-outline-variant/30 bg-surface-container-high px-4 py-3 text-left transition-all hover:bg-surface-container-lowest disabled:cursor-not-allowed disabled:opacity-70"
+        className={`flex w-full cursor-pointer items-center justify-between rounded-lg border border-outline-variant/30 bg-surface-container-high px-4 py-3 text-left transition-all hover:bg-surface-container-lowest disabled:cursor-not-allowed disabled:opacity-70 ${
+          requiresCustomerAssignment
+            ? "ring-2 ring-warning-accent/60 animate-pulse [animation-iteration-count:3]"
+            : ""
+        }`}
         onClick={onRequestAssignment}
         disabled={!canOpenSheet}
       >

--- a/frontend/src/features/quotes/components/ReviewCustomerRow.tsx
+++ b/frontend/src/features/quotes/components/ReviewCustomerRow.tsx
@@ -34,6 +34,7 @@ export function ReviewCustomerRow({
             ? "ring-2 ring-warning-accent/60 animate-pulse [animation-iteration-count:3]"
             : ""
         }`}
+        style={requiresCustomerAssignment ? { animationIterationCount: 3 } : undefined}
         onClick={onRequestAssignment}
         disabled={!canOpenSheet}
       >

--- a/frontend/src/features/quotes/components/ReviewCustomerRow.tsx
+++ b/frontend/src/features/quotes/components/ReviewCustomerRow.tsx
@@ -34,7 +34,6 @@ export function ReviewCustomerRow({
             ? "ring-2 ring-warning-accent/60 animate-pulse [animation-iteration-count:3]"
             : ""
         }`}
-        style={requiresCustomerAssignment ? { animationIterationCount: 3 } : undefined}
         onClick={onRequestAssignment}
         disabled={!canOpenSheet}
       >

--- a/frontend/src/features/quotes/components/ReviewFormContent.tsx
+++ b/frontend/src/features/quotes/components/ReviewFormContent.tsx
@@ -18,7 +18,6 @@ interface ReviewFormContentProps {
   locationNotice?: string;
   loadError: string | null;
   saveError: string | null;
-  saveNotice: string | null;
   requiresCustomerAssignment: boolean;
   canReassignCustomer: boolean;
   isInteractionLocked: boolean;
@@ -47,7 +46,6 @@ export function ReviewFormContent({
   locationNotice,
   loadError,
   saveError,
-  saveNotice,
   requiresCustomerAssignment,
   canReassignCustomer,
   isInteractionLocked,
@@ -88,12 +86,6 @@ export function ReviewFormContent({
 
       {saveError ? (
         <FeedbackMessage variant="error">{saveError}</FeedbackMessage>
-      ) : null}
-
-      {saveNotice ? (
-        <section className="rounded-lg border border-success/30 bg-success-container px-4 py-3 text-sm text-success">
-          {saveNotice}
-        </section>
       ) : null}
 
       <section className="space-y-2">

--- a/frontend/src/features/quotes/components/ReviewScreen.tsx
+++ b/frontend/src/features/quotes/components/ReviewScreen.tsx
@@ -17,6 +17,7 @@ import { readQuoteConfidenceNotes, writeQuoteConfidenceNotes } from "@/features/
 import { normalizeOptionalTitle } from "@/features/quotes/utils/normalizeOptionalTitle";
 import { ConfirmModal } from "@/shared/components/ConfirmModal";
 import { FeedbackMessage } from "@/shared/components/FeedbackMessage";
+import { Toast } from "@/shared/components/Toast";
 import { DOCUMENT_LINE_ITEMS_MAX_ITEMS } from "@/shared/lib/inputLimits";
 import { WorkflowScreenHeader } from "@/shared/components/WorkflowScreenHeader";
 import { getPricingValidationMessage } from "@/shared/lib/pricing";
@@ -41,7 +42,7 @@ export function ReviewScreen(): React.ReactElement {
   } = usePersistedReview(id);
 
   const [saveError, setSaveError] = useState<string | null>(null);
-  const [saveNotice, setSaveNotice] = useState<string | null>(null);
+  const [toastMessage, setToastMessage] = useState<string | null>(null);
   const [submitAction, setSubmitAction] = useState<"save" | "continue" | null>(null);
   const [isAssignmentSheetOpen, setIsAssignmentSheetOpen] = useState(false);
   const [showLeaveWarning, setShowLeaveWarning] = useState(false);
@@ -233,7 +234,7 @@ export function ReviewScreen(): React.ReactElement {
 
   async function saveDraft(nextAction: "save" | "continue"): Promise<void> {
     setSaveError(null);
-    setSaveNotice(null);
+    setToastMessage(null);
 
     if (lineItemsForSubmit.length === 0) {
       setSaveError("Add at least one line item description before saving the quote.");
@@ -280,7 +281,7 @@ export function ReviewScreen(): React.ReactElement {
         return;
       }
 
-      setSaveNotice("Draft saved.");
+      setToastMessage("Draft saved.");
     } catch (error) {
       const message = error instanceof Error ? error.message : "Unable to save quote";
       setSaveError(message);
@@ -320,7 +321,6 @@ export function ReviewScreen(): React.ReactElement {
         locationNotice={locationState.notice}
         loadError={loadError}
         saveError={saveError}
-        saveNotice={saveNotice}
         requiresCustomerAssignment={requiresCustomerAssignment}
         canReassignCustomer={canReassignCustomer}
         isInteractionLocked={isInteractionLocked}
@@ -340,7 +340,7 @@ export function ReviewScreen(): React.ReactElement {
           setConfidenceNotes(nextNotes);
         }}
         onTitleChange={(nextTitle) => {
-          setSaveNotice(null);
+          setToastMessage(null);
           setDraft((currentDraft) => ({ ...currentDraft, title: nextTitle }));
         }}
         onEditLineItem={(lineItemIndex) => {
@@ -356,27 +356,27 @@ export function ReviewScreen(): React.ReactElement {
           setLineItemSheetState({ mode: "add" });
         }}
         onTotalChange={(nextTotal) => {
-          setSaveNotice(null);
+          setToastMessage(null);
           setDraft((currentDraft) => ({ ...currentDraft, total: nextTotal }));
         }}
         onTaxRateChange={(nextTaxRate) => {
-          setSaveNotice(null);
+          setToastMessage(null);
           setDraft((currentDraft) => ({ ...currentDraft, taxRate: nextTaxRate }));
         }}
         onDiscountTypeChange={(nextDiscountType) => {
-          setSaveNotice(null);
+          setToastMessage(null);
           setDraft((currentDraft) => ({ ...currentDraft, discountType: nextDiscountType }));
         }}
         onDiscountValueChange={(nextDiscountValue) => {
-          setSaveNotice(null);
+          setToastMessage(null);
           setDraft((currentDraft) => ({ ...currentDraft, discountValue: nextDiscountValue }));
         }}
         onDepositAmountChange={(nextDepositAmount) => {
-          setSaveNotice(null);
+          setToastMessage(null);
           setDraft((currentDraft) => ({ ...currentDraft, depositAmount: nextDepositAmount }));
         }}
         onNotesChange={(nextNotes) => {
-          setSaveNotice(null);
+          setToastMessage(null);
           setDraft((currentDraft) => ({ ...currentDraft, notes: nextNotes }));
         }}
       />
@@ -407,20 +407,22 @@ export function ReviewScreen(): React.ReactElement {
           onClose={() => setLineItemSheetState(null)}
           onSave={(nextLineItem) => {
             const nextSheetState = lineItemSheetState;
-            setSaveNotice(null);
+            setToastMessage(null);
             setDraft((currentDraft) => applyLineItemSheetSave(currentDraft, nextSheetState, nextLineItem));
             setLineItemSheetState(null);
           }}
           onDelete={lineItemSheetState.mode === "edit"
             ? () => {
                 const nextSheetState = lineItemSheetState;
-                setSaveNotice(null);
+                setToastMessage(null);
                 setDraft((currentDraft) => applyLineItemSheetDelete(currentDraft, nextSheetState));
                 setLineItemSheetState(null);
               }
             : undefined}
         />
       ) : null}
+
+      <Toast message={toastMessage} onDismiss={() => setToastMessage(null)} />
 
       {showLeaveWarning ? (
         <ConfirmModal

--- a/frontend/src/features/quotes/tests/CaptureScreen.test.tsx
+++ b/frontend/src/features/quotes/tests/CaptureScreen.test.tsx
@@ -478,7 +478,7 @@ describe("CaptureScreen", () => {
     );
   });
 
-  it("shows inline error and does not navigate when extraction fails", async () => {
+  it("shows persistent error toast and does not navigate when extraction fails", async () => {
     mockedQuoteService.extract.mockRejectedValueOnce(new Error("Extraction failed"));
     renderScreen();
 
@@ -489,6 +489,35 @@ describe("CaptureScreen", () => {
 
     expect(await screen.findByRole("alert")).toHaveTextContent("Extraction failed");
     expect(navigateMock).not.toHaveBeenCalledWith("/quotes/quote-1/review");
+  });
+
+  it("dismisses submission errors via local error state without clearing voice capture", async () => {
+    mockedQuoteService.extract.mockRejectedValueOnce(new Error("Extraction failed"));
+    renderScreen();
+
+    fireEvent.change(screen.getByLabelText(/written description/i), {
+      target: { value: "Install sod in backyard" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /extract line items/i }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("Extraction failed");
+    clearVoiceErrorMock.mockClear();
+    fireEvent.click(screen.getByRole("button", { name: /dismiss/i }));
+
+    await waitFor(() => {
+      expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    });
+    expect(clearVoiceErrorMock).not.toHaveBeenCalled();
+  });
+
+  it("dismisses recoverable voice-capture runtime errors via clearError", async () => {
+    mockVoiceCapture({ error: "Microphone permission denied" });
+    renderScreen();
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("Microphone permission denied");
+    fireEvent.click(screen.getByRole("button", { name: /dismiss/i }));
+
+    expect(clearVoiceErrorMock).toHaveBeenCalledTimes(1);
   });
 
   it("derives the total audio limit error from the shared byte ceiling", async () => {
@@ -713,7 +742,7 @@ describe("CaptureScreen", () => {
     expect(navigateMock).not.toHaveBeenCalledWith("/quotes/quote-1/review");
   });
 
-  it("shows a retry affordance when an async extraction job reaches terminal failure", async () => {
+  it("shows a dismissable error toast when an async extraction job reaches terminal failure", async () => {
     mockedQuoteService.extract.mockResolvedValueOnce({ type: "async", jobId: "job-1" });
     mockedJobService.getJobStatus.mockResolvedValueOnce(
       makeJobStatusResponse({
@@ -732,9 +761,10 @@ describe("CaptureScreen", () => {
     fireEvent.click(screen.getByRole("button", { name: /extract line items/i }));
 
     expect(await screen.findByRole("alert")).toHaveTextContent("Extraction failed. Please try again.");
-    expect(screen.getByRole("button", { name: "Try again" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Dismiss" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /extract line items/i })).toBeEnabled();
 
-    fireEvent.click(screen.getByRole("button", { name: "Try again" }));
+    fireEvent.click(screen.getByRole("button", { name: "Dismiss" }));
 
     expect(screen.queryByRole("alert")).not.toBeInTheDocument();
   });

--- a/frontend/src/features/settings/components/SettingsScreen.tsx
+++ b/frontend/src/features/settings/components/SettingsScreen.tsx
@@ -14,6 +14,7 @@ import { ConfirmModal } from "@/shared/components/ConfirmModal";
 import { FeedbackMessage } from "@/shared/components/FeedbackMessage";
 import { Input } from "@/shared/components/Input";
 import { ScreenHeader } from "@/shared/components/ScreenHeader";
+import { Toast } from "@/shared/components/Toast";
 import { useTheme } from "@/shared/hooks/useTheme";
 import { formatByteLimit } from "@/shared/lib/formatters";
 import { MAX_LOGO_SIZE_BYTES } from "@/shared/lib/inputLimits";
@@ -192,12 +193,6 @@ export function SettingsScreen(): React.ReactElement {
 
         {!isLoadingProfile && !loadError ? (
           <form className="space-y-4 pb-8" onSubmit={onSubmit}>
-            {saveSuccess ? (
-              <p role="status" className="rounded-lg bg-success-container p-3 text-sm text-success">
-                {saveSuccess}
-              </p>
-            ) : null}
-
             {saveError ? (
               <FeedbackMessage variant="error">{saveError}</FeedbackMessage>
             ) : null}
@@ -416,6 +411,7 @@ export function SettingsScreen(): React.ReactElement {
       </section>
 
       <BottomNav active="settings" />
+      <Toast message={saveSuccess} onDismiss={() => setSaveSuccess(null)} />
 
       {isRemoveLogoOpen ? (
         <ConfirmModal

--- a/frontend/src/features/settings/tests/SettingsScreen.test.tsx
+++ b/frontend/src/features/settings/tests/SettingsScreen.test.tsx
@@ -190,7 +190,7 @@ describe("SettingsScreen", () => {
     consoleErrorSpy.mockRestore();
   });
 
-  it("submits profile updates, refreshes auth user, and shows inline success feedback", async () => {
+  it("submits profile updates, refreshes auth user, and shows toast success feedback", async () => {
     const refreshUser = vi.fn(async () => undefined);
     mockedUseAuth.mockReturnValue({
       user: {
@@ -244,7 +244,10 @@ describe("SettingsScreen", () => {
       });
     });
     expect(refreshUser).toHaveBeenCalledTimes(1);
-    expect(await screen.findByText("Saved")).toHaveClass("rounded-lg");
+    const savedToast = await screen.findByRole("status");
+    expect(savedToast).toHaveTextContent("Saved");
+    expect(savedToast).toHaveClass("bg-on-surface");
+    expect(savedToast).not.toHaveClass("bg-success-container");
   });
 
   it("updates the theme preference immediately from the dropdown", async () => {
@@ -339,7 +342,9 @@ describe("SettingsScreen", () => {
 
     await waitFor(() => expect(mockedProfileService.updateProfile).toHaveBeenCalledTimes(1));
     expect(refreshUser).toHaveBeenCalledTimes(1);
-    expect(await screen.findByText("Saved")).toBeInTheDocument();
+    const savedToast = await screen.findByRole("status");
+    expect(savedToast).toHaveTextContent("Saved");
+    expect(savedToast).toHaveClass("bg-on-surface");
     expect(screen.queryByText("Unable to save settings")).not.toBeInTheDocument();
   });
 

--- a/frontend/src/shared/components/Toast.test.tsx
+++ b/frontend/src/shared/components/Toast.test.tsx
@@ -1,0 +1,65 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { Toast } from "@/shared/components/Toast";
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("Toast", () => {
+  it("does not render when message is null", () => {
+    render(<Toast message={null} onDismiss={vi.fn()} />);
+
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
+  it("renders success variant and auto-dismisses after the default timeout", () => {
+    vi.useFakeTimers();
+    const onDismiss = vi.fn();
+
+    render(<Toast message="Saved" onDismiss={onDismiss} />);
+
+    const toast = screen.getByRole("status");
+    expect(toast).toHaveClass(
+      "fixed",
+      "bottom-20",
+      "left-1/2",
+      "-translate-x-1/2",
+      "rounded-xl",
+      "px-4",
+      "py-2.5",
+      "text-sm",
+      "ghost-shadow",
+      "bg-on-surface",
+      "text-background",
+    );
+    expect(screen.getByText("Saved")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /dismiss/i })).not.toBeInTheDocument();
+
+    act(() => {
+      vi.advanceTimersByTime(2500);
+    });
+
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders persistent error variant with manual dismiss only", () => {
+    vi.useFakeTimers();
+    const onDismiss = vi.fn();
+
+    render(<Toast message="Extraction failed" variant="error" durationMs={null} onDismiss={onDismiss} />);
+
+    const toast = screen.getByRole("alert");
+    expect(toast).toHaveClass("bg-error-container", "border", "border-error/40", "text-error");
+
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
+    expect(onDismiss).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole("button", { name: /dismiss/i }));
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/shared/components/Toast.test.tsx
+++ b/frontend/src/shared/components/Toast.test.tsx
@@ -62,4 +62,25 @@ describe("Toast", () => {
     fireEvent.click(screen.getByRole("button", { name: /dismiss/i }));
     expect(onDismiss).toHaveBeenCalledTimes(1);
   });
+
+  it("keeps the original auto-dismiss schedule when onDismiss callback identity changes", () => {
+    vi.useFakeTimers();
+    const firstDismiss = vi.fn();
+    const secondDismiss = vi.fn();
+
+    const { rerender } = render(<Toast message="Saved" onDismiss={firstDismiss} />);
+
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+
+    rerender(<Toast message="Saved" onDismiss={secondDismiss} />);
+
+    act(() => {
+      vi.advanceTimersByTime(600);
+    });
+
+    expect(firstDismiss).not.toHaveBeenCalled();
+    expect(secondDismiss).toHaveBeenCalledTimes(1);
+  });
 });

--- a/frontend/src/shared/components/Toast.tsx
+++ b/frontend/src/shared/components/Toast.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 
 interface ToastProps {
   message: string | null;
@@ -13,19 +13,25 @@ export function Toast({
   onDismiss,
   durationMs = 2500,
 }: ToastProps): React.ReactElement | null {
+  const onDismissRef = useRef(onDismiss);
+
+  useEffect(() => {
+    onDismissRef.current = onDismiss;
+  }, [onDismiss]);
+
   useEffect(() => {
     if (!message || durationMs === null) {
       return;
     }
 
     const timeoutId = window.setTimeout(() => {
-      onDismiss();
+      onDismissRef.current();
     }, durationMs);
 
     return () => {
       window.clearTimeout(timeoutId);
     };
-  }, [durationMs, message, onDismiss]);
+  }, [durationMs, message]);
 
   if (!message) {
     return null;

--- a/frontend/src/shared/components/Toast.tsx
+++ b/frontend/src/shared/components/Toast.tsx
@@ -1,0 +1,58 @@
+import { useEffect } from "react";
+
+interface ToastProps {
+  message: string | null;
+  variant?: "success" | "error";
+  onDismiss: () => void;
+  durationMs?: number | null;
+}
+
+export function Toast({
+  message,
+  variant = "success",
+  onDismiss,
+  durationMs = 2500,
+}: ToastProps): React.ReactElement | null {
+  useEffect(() => {
+    if (!message || durationMs === null) {
+      return;
+    }
+
+    const timeoutId = window.setTimeout(() => {
+      onDismiss();
+    }, durationMs);
+
+    return () => {
+      window.clearTimeout(timeoutId);
+    };
+  }, [durationMs, message, onDismiss]);
+
+  if (!message) {
+    return null;
+  }
+
+  const isError = variant === "error";
+
+  return (
+    <div
+      role={isError ? "alert" : "status"}
+      className={`fixed bottom-20 left-1/2 z-50 flex w-fit max-w-[calc(100%-2rem)] -translate-x-1/2 items-center gap-3 rounded-xl px-4 py-2.5 text-sm ghost-shadow ${
+        isError
+          ? "border border-error/40 bg-error-container text-error"
+          : "bg-on-surface text-background"
+      }`}
+    >
+      <p className="min-w-0 truncate">{message}</p>
+      {isError ? (
+        <button
+          type="button"
+          aria-label="Dismiss"
+          className="inline-flex h-6 w-6 shrink-0 cursor-pointer items-center justify-center rounded-full text-base leading-none transition-colors hover:bg-error/15"
+          onClick={onDismiss}
+        >
+          ×
+        </button>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/src/shared/components/Toast.tsx
+++ b/frontend/src/shared/components/Toast.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useLayoutEffect, useRef } from "react";
 
 interface ToastProps {
   message: string | null;
@@ -15,7 +15,7 @@ export function Toast({
 }: ToastProps): React.ReactElement | null {
   const onDismissRef = useRef(onDismiss);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     onDismissRef.current = onDismiss;
   }, [onDismiss]);
 


### PR DESCRIPTION
## Summary
- add a shared `Toast` component with success/error variants, auto-dismiss support, and persistent error mode
- apply CSS-only assignment pulse styling to `ReviewCustomerRow` when customer assignment is required
- replace inline save/error action-result notices with toast usage in `ReviewScreen`, `SettingsScreen`, `CustomerDetailScreen`, and `CaptureScreen`
- add and update tests for toast behavior, review pulse classes, and capture dismissal semantics

Closes #271

## Verification
- make frontend-verify
- cd frontend && npx vitest run src/shared/components/Toast.test.tsx src/features/quotes/components/ReviewCustomerRow.test.tsx src/features/quotes/tests/ReviewScreen.test.tsx src/features/settings/tests/SettingsScreen.test.tsx src/features/customers/tests/CustomerDetailScreen.test.tsx src/features/quotes/tests/CaptureScreen.test.tsx