### PR TITLE
Task #273: Home list search toggle

### DIFF
--- a/frontend/src/features/quotes/components/QuoteList.tsx
+++ b/frontend/src/features/quotes/components/QuoteList.tsx
@@ -139,6 +139,7 @@ export function QuoteList(): React.ReactElement {
   const [documentMode, setDocumentMode] = useState<DocumentMode>("quotes");
   const [quotes, setQuotes] = useState<QuoteListItem[]>([]);
   const [invoices, setInvoices] = useState<InvoiceListItem[]>([]);
+  const [isSearchOpen, setIsSearchOpen] = useState(false);
   const [searchQuery, setSearchQuery] = useState("");
   const [isLoadingQuotes, setIsLoadingQuotes] = useState(true);
   const [isLoadingInvoices, setIsLoadingInvoices] = useState(false);
@@ -195,6 +196,17 @@ export function QuoteList(): React.ReactElement {
       isActive = false;
     };
   }, [documentMode]);
+
+  useEffect(() => {
+    if (!isSearchOpen) {
+      return;
+    }
+
+    const inputElement = document.getElementById("document-search");
+    if (inputElement instanceof HTMLInputElement) {
+      inputElement.focus();
+    }
+  }, [isSearchOpen]);
 
   const normalizedSearchQuery = searchQuery.trim().toLowerCase();
   const filteredQuotes = useMemo(() => {
@@ -294,43 +306,71 @@ export function QuoteList(): React.ReactElement {
       <ScreenHeader title={headerTitle} subtitle={headerSubtitle} layout="top-level" />
       <section className="mx-auto w-full max-w-3xl pb-2 pt-20">
         <div className="mb-4 px-4">
-          <div
-            aria-label="Document type filter"
-            className="mb-4 inline-flex rounded-full bg-surface-container-low p-1"
-          >
-            <button
-              type="button"
-              aria-pressed={documentMode === "quotes"}
-              className={`cursor-pointer rounded-full px-4 py-2 text-sm font-semibold transition ${
-                documentMode === "quotes"
-                  ? "ghost-shadow bg-surface-container-lowest text-primary"
-                  : "text-on-surface-variant"
-              }`}
-              onClick={() => setDocumentMode("quotes")}
+          <div className="mb-4 flex items-center justify-between gap-3">
+            <div
+              aria-label="Document type filter"
+              className="inline-flex rounded-full bg-surface-container-low p-1"
             >
-              Quotes
-            </button>
-            <button
-              type="button"
-              aria-pressed={documentMode === "invoices"}
-              className={`cursor-pointer rounded-full px-4 py-2 text-sm font-semibold transition ${
-                documentMode === "invoices"
-                  ? "ghost-shadow bg-surface-container-lowest text-primary"
-                  : "text-on-surface-variant"
-              }`}
-              onClick={() => setDocumentMode("invoices")}
-            >
-              Invoices
-            </button>
+              <button
+                type="button"
+                aria-pressed={documentMode === "quotes"}
+                className={`cursor-pointer rounded-full px-4 py-2 text-sm font-semibold transition ${
+                  documentMode === "quotes"
+                    ? "ghost-shadow bg-surface-container-lowest text-primary"
+                    : "text-on-surface-variant"
+                }`}
+                onClick={() => setDocumentMode("quotes")}
+              >
+                Quotes
+              </button>
+              <button
+                type="button"
+                aria-pressed={documentMode === "invoices"}
+                className={`cursor-pointer rounded-full px-4 py-2 text-sm font-semibold transition ${
+                  documentMode === "invoices"
+                    ? "ghost-shadow bg-surface-container-lowest text-primary"
+                    : "text-on-surface-variant"
+                }`}
+                onClick={() => setDocumentMode("invoices")}
+              >
+                Invoices
+              </button>
+            </div>
+            {!isSearchOpen ? (
+              <button
+                type="button"
+                aria-label="Open search"
+                className="cursor-pointer rounded-full p-2 text-outline transition-all hover:bg-surface-container-low active:scale-95"
+                onClick={() => setIsSearchOpen(true)}
+              >
+                <span className="material-symbols-outlined">search</span>
+              </button>
+            ) : null}
           </div>
-          <Input
-            label={searchLabel}
-            id="document-search"
-            placeholder={searchPlaceholder}
-            hideLabel
-            value={searchQuery}
-            onChange={(event) => setSearchQuery(event.target.value)}
-          />
+          {isSearchOpen ? (
+            <div className="relative">
+              <Input
+                label={searchLabel}
+                id="document-search"
+                placeholder={searchPlaceholder}
+                hideLabel
+                value={searchQuery}
+                onChange={(event) => setSearchQuery(event.target.value)}
+                className="pr-10"
+              />
+              <button
+                type="button"
+                aria-label="Close search"
+                className="absolute right-3 top-1/2 -translate-y-1/2 cursor-pointer rounded-full p-1 text-outline transition-all hover:bg-surface-container-low active:scale-95"
+                onClick={() => {
+                  setSearchQuery("");
+                  setIsSearchOpen(false);
+                }}
+              >
+                <span className="material-symbols-outlined text-base">close</span>
+              </button>
+            </div>
+          ) : null}
         </div>
 
         {isLoading ? (

--- a/frontend/src/features/quotes/components/QuoteList.tsx
+++ b/frontend/src/features/quotes/components/QuoteList.tsx
@@ -40,6 +40,7 @@ interface DocumentRowsSectionProps {
 const baseRowClasses = "w-full cursor-pointer rounded-xl bg-surface-container-lowest px-4 py-3 text-left ghost-shadow transition active:scale-[0.98] active:bg-surface-container-low";
 const draftRowClasses = "glass-surface w-full cursor-pointer rounded-xl border-l-4 border-warning-accent px-4 py-3 text-left backdrop-blur-md ghost-shadow transition active:scale-[0.98] active:bg-surface-container-low";
 const needsCustomerBadgeClasses = `${statusBadgeBaseClasses} shrink-0 whitespace-nowrap bg-warning-container text-warning`;
+const headerIconButtonClasses = "inline-flex h-10 w-10 cursor-pointer shrink-0 items-center justify-center rounded-full border border-outline-variant/30 bg-surface-container-lowest text-on-surface ghost-shadow transition-all hover:bg-surface-container-low active:scale-95";
 
 function DocumentRowsSection({ label, rows, onRowClick }: DocumentRowsSectionProps): React.ReactElement {
   return (
@@ -340,10 +341,10 @@ export function QuoteList(): React.ReactElement {
               <button
                 type="button"
                 aria-label="Open search"
-                className="cursor-pointer rounded-full p-2 text-outline transition-all hover:bg-surface-container-low active:scale-95"
+                className={headerIconButtonClasses}
                 onClick={() => setIsSearchOpen(true)}
               >
-                <span className="material-symbols-outlined">search</span>
+                <span className="material-symbols-outlined block text-[1.125rem] leading-none">search</span>
               </button>
             ) : null}
           </div>
@@ -356,18 +357,18 @@ export function QuoteList(): React.ReactElement {
                 hideLabel
                 value={searchQuery}
                 onChange={(event) => setSearchQuery(event.target.value)}
-                className="pr-10"
+                className="pr-14"
               />
               <button
                 type="button"
                 aria-label="Close search"
-                className="absolute right-3 top-1/2 -translate-y-1/2 cursor-pointer rounded-full p-1 text-outline transition-all hover:bg-surface-container-low active:scale-95"
+                className={`absolute right-1.5 top-1/2 -translate-y-1/2 ${headerIconButtonClasses}`}
                 onClick={() => {
                   setSearchQuery("");
                   setIsSearchOpen(false);
                 }}
               >
-                <span className="material-symbols-outlined text-base">close</span>
+                <span className="material-symbols-outlined block text-[1.125rem] leading-none">close</span>
               </button>
             </div>
           ) : null}

--- a/frontend/src/features/quotes/components/QuoteList.tsx
+++ b/frontend/src/features/quotes/components/QuoteList.tsx
@@ -362,13 +362,13 @@ export function QuoteList(): React.ReactElement {
               <button
                 type="button"
                 aria-label="Close search"
-                className="absolute right-3 top-1/2 -translate-y-1/2 cursor-pointer rounded-full p-1 text-outline transition-all hover:bg-surface-container-low active:scale-95"
+                className="absolute right-3 top-1/2 inline-flex h-6 w-6 -translate-y-1/2 cursor-pointer items-center justify-center rounded-full text-outline transition-all hover:bg-surface-container-low active:scale-95"
                 onClick={() => {
                   setSearchQuery("");
                   setIsSearchOpen(false);
                 }}
               >
-                <span className="material-symbols-outlined text-base">close</span>
+                <span className="material-symbols-outlined block text-base leading-none">close</span>
               </button>
             </div>
           ) : null}

--- a/frontend/src/features/quotes/components/QuoteList.tsx
+++ b/frontend/src/features/quotes/components/QuoteList.tsx
@@ -362,13 +362,13 @@ export function QuoteList(): React.ReactElement {
               <button
                 type="button"
                 aria-label="Close search"
-                className={`absolute right-1.5 top-1/2 -translate-y-1/2 ${headerIconButtonClasses}`}
+                className="absolute right-3 top-1/2 -translate-y-1/2 cursor-pointer rounded-full p-1 text-outline transition-all hover:bg-surface-container-low active:scale-95"
                 onClick={() => {
                   setSearchQuery("");
                   setIsSearchOpen(false);
                 }}
               >
-                <span className="material-symbols-outlined block text-[1.125rem] leading-none">close</span>
+                <span className="material-symbols-outlined text-base">close</span>
               </button>
             </div>
           ) : null}

--- a/frontend/src/features/quotes/tests/QuoteList.test.tsx
+++ b/frontend/src/features/quotes/tests/QuoteList.test.tsx
@@ -104,6 +104,11 @@ function renderScreen(): void {
   );
 }
 
+async function openSearch(label: "Search quotes" | "Search invoices" = "Search quotes"): Promise<HTMLInputElement> {
+  fireEvent.click(screen.getByRole("button", { name: "Open search" }));
+  return await screen.findByLabelText(label) as HTMLInputElement;
+}
+
 beforeEach(() => {
   mockProfile();
 });
@@ -113,6 +118,76 @@ afterEach(() => {
 });
 
 describe("QuoteList", () => {
+  it("hides search input by default and shows the open-search button", async () => {
+    mockedQuoteService.listQuotes.mockResolvedValueOnce([makeQuoteListItem()]);
+
+    renderScreen();
+    await screen.findByText(/Q-001/);
+
+    expect(screen.queryByLabelText("Search quotes")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Open search" })).toBeInTheDocument();
+  });
+
+  it("opens search, focuses the input, and hides the open-search button", async () => {
+    mockedQuoteService.listQuotes.mockResolvedValueOnce([makeQuoteListItem()]);
+
+    renderScreen();
+    await screen.findByText(/Q-001/);
+
+    const searchInput = await openSearch();
+    await waitFor(() => {
+      expect(searchInput).toHaveFocus();
+    });
+    expect(screen.queryByRole("button", { name: "Open search" })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Close search" })).toBeInTheDocument();
+  });
+
+  it("closes search and clears the query, and reopening starts empty", async () => {
+    mockedQuoteService.listQuotes.mockResolvedValueOnce([makeQuoteListItem()]);
+
+    renderScreen();
+    await screen.findByText(/Q-001/);
+
+    const searchInput = await openSearch();
+    fireEvent.change(searchInput, { target: { value: "alice" } });
+    expect(searchInput).toHaveValue("alice");
+
+    fireEvent.click(screen.getByRole("button", { name: "Close search" }));
+    expect(screen.queryByLabelText("Search quotes")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Open search" })).toBeInTheDocument();
+
+    const reopenedSearchInput = await openSearch();
+    expect(reopenedSearchInput).toHaveValue("");
+  });
+
+  it("preserves open search state and query when switching tabs", async () => {
+    mockedQuoteService.listQuotes.mockResolvedValueOnce([makeQuoteListItem()]);
+    mockedInvoiceService.listInvoices.mockResolvedValueOnce([
+      makeInvoiceListItem(),
+      makeInvoiceListItem({
+        id: "invoice-2",
+        customer_id: "cust-2",
+        customer_name: "Bob Brown",
+        doc_number: "I-002",
+      }),
+    ]);
+
+    renderScreen();
+    await screen.findByText(/Q-001/);
+
+    const quoteSearchInput = await openSearch();
+    fireEvent.change(quoteSearchInput, { target: { value: "bob" } });
+    expect(quoteSearchInput).toHaveValue("bob");
+
+    fireEvent.click(screen.getByRole("button", { name: "Invoices" }));
+
+    const invoiceSearchInput = await screen.findByLabelText("Search invoices");
+    expect(invoiceSearchInput).toHaveValue("bob");
+    expect(screen.queryByRole("button", { name: "Open search" })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Close search" })).toBeInTheDocument();
+    expect(await screen.findByRole("button", { name: /bob brown/i })).toBeInTheDocument();
+  });
+
   it("uses token-backed emphasis for the active filter and create button", async () => {
     mockedQuoteService.listQuotes.mockResolvedValueOnce([makeQuoteListItem()]);
 
@@ -287,7 +362,7 @@ describe("QuoteList", () => {
     renderScreen();
     await screen.findByText(/Q-001/);
 
-    fireEvent.change(screen.getByLabelText("Search quotes"), {
+    fireEvent.change(await openSearch(), {
       target: { value: "bob" },
     });
 
@@ -312,7 +387,7 @@ describe("QuoteList", () => {
     renderScreen();
     await screen.findByText(/Q-001/);
 
-    fireEvent.change(screen.getByLabelText("Search quotes"), {
+    fireEvent.change(await openSearch(), {
       target: { value: "spring" },
     });
 
@@ -326,7 +401,7 @@ describe("QuoteList", () => {
     renderScreen();
     await screen.findByText(/Q-001/);
 
-    fireEvent.change(screen.getByLabelText("Search quotes"), {
+    fireEvent.change(await openSearch(), {
       target: { value: "does-not-exist" },
     });
 
@@ -482,7 +557,7 @@ describe("QuoteList", () => {
     renderScreen();
     await screen.findByText(/Q-001/);
 
-    const searchInput = screen.getByLabelText("Search quotes");
+    const searchInput = await openSearch();
     const searchLabel = document.querySelector('label[for="document-search"]');
 
     expect(searchInput).toBeInTheDocument();

--- a/frontend/src/shared/components/ScreenHeader.tsx
+++ b/frontend/src/shared/components/ScreenHeader.tsx
@@ -34,9 +34,9 @@ export function ScreenHeader({
             type="button"
             onClick={onBack}
             aria-label={backLabel}
-            className="cursor-pointer rounded-full p-2 text-primary transition-all hover:bg-surface-container-low active:scale-95"
+            className="inline-flex h-10 w-10 cursor-pointer items-center justify-center rounded-full text-primary transition-all hover:bg-surface-container-low active:scale-95"
           >
-            <span className="material-symbols-outlined">arrow_back</span>
+            <span className="material-symbols-outlined block text-[1.125rem] leading-none">arrow_back</span>
           </button>
         ) : null}
         {isTopLevelLayout ? (


### PR DESCRIPTION
## Summary
- hide QuoteList search input by default behind a trailing tab-row search icon
- open search on demand, auto-focus the input, and replace open icon with a close control
- close action now clears query and hides search; tests cover open/focus/close/reset/reopen and tab-switch persistence

## Verification
- make frontend-verify
- cd frontend && npx vitest run src/features/quotes/tests/QuoteList.test.tsx

Closes #273