### PR TITLE
Task #286: Persist degraded extraction outcomes

### DIFF
--- a/backend/alembic/versions/20260410_0019_add_extraction_outcome_fields_to_documents.py
+++ b/backend/alembic/versions/20260410_0019_add_extraction_outcome_fields_to_documents.py
@@ -1,0 +1,56 @@
+"""Add extraction outcome metadata columns to documents.
+
+Revision ID: 20260410_0019
+Revises: 20260408_0018
+Create Date: 2026-04-10
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "20260410_0019"
+down_revision: str | None = "20260408_0018"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_VALID_EXTRACTION_TIER_CHECK = "ck_documents_extraction_tier_valid"
+_DEGRADED_REASON_REQUIRES_TIER_CHECK = "ck_documents_degraded_reason_requires_tier"
+_INVOICE_EXTRACTION_FIELDS_NULL_CHECK = "ck_documents_invoice_extraction_fields_null"
+
+
+def upgrade() -> None:
+    op.add_column("documents", sa.Column("extraction_tier", sa.String(length=20), nullable=True))
+    op.add_column(
+        "documents",
+        sa.Column("extraction_degraded_reason_code", sa.String(length=64), nullable=True),
+    )
+    op.create_check_constraint(
+        _VALID_EXTRACTION_TIER_CHECK,
+        "documents",
+        "extraction_tier IS NULL OR extraction_tier IN ('primary', 'degraded')",
+    )
+    op.create_check_constraint(
+        _DEGRADED_REASON_REQUIRES_TIER_CHECK,
+        "documents",
+        "extraction_degraded_reason_code IS NULL OR extraction_tier = 'degraded'",
+    )
+    op.create_check_constraint(
+        _INVOICE_EXTRACTION_FIELDS_NULL_CHECK,
+        "documents",
+        "doc_type <> 'invoice' OR ("
+        "extraction_tier IS NULL AND extraction_degraded_reason_code IS NULL"
+        ")",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(_INVOICE_EXTRACTION_FIELDS_NULL_CHECK, "documents", type_="check")
+    op.drop_constraint(_DEGRADED_REASON_REQUIRES_TIER_CHECK, "documents", type_="check")
+    op.drop_constraint(_VALID_EXTRACTION_TIER_CHECK, "documents", type_="check")
+    op.drop_column("documents", "extraction_degraded_reason_code")
+    op.drop_column("documents", "extraction_tier")

--- a/backend/app/features/jobs/tests/test_jobs_api.py
+++ b/backend/app/features/jobs/tests/test_jobs_api.py
@@ -64,6 +64,8 @@ async def test_get_job_status_returns_owned_extraction_result(
         "line_items": [],
         "total": None,
         "confidence_notes": [],
+        "extraction_tier": "primary",
+        "extraction_degraded_reason_code": None,
     }
 
 

--- a/backend/app/features/quotes/api.py
+++ b/backend/app/features/quotes/api.py
@@ -32,6 +32,10 @@ from app.features.jobs.models import JobStatus, JobType
 from app.features.jobs.schemas import JobRecordResponse, job_record_to_response
 from app.features.jobs.service import JobService
 from app.features.quotes.email_delivery_service import QuoteEmailDeliveryService
+from app.features.quotes.extraction_outcomes import (
+    log_draft_generated_event,
+    log_draft_generation_failed_event,
+)
 from app.features.quotes.extraction_service import CaptureAudioClip, ExtractionService
 from app.features.quotes.schemas import (
     ConvertNotesRequest,
@@ -245,6 +249,7 @@ async def extract_combined(
                     clip_inputs,
                     notes,
                     user_id=user.id,
+                    allow_degraded_persist_on_retryable_failure=True,
                 )
             except QuoteServiceError as exc:
                 raise HTTPException(status_code=exc.status_code, detail=exc.detail) from exc
@@ -258,7 +263,10 @@ async def extract_combined(
                 )
             except QuoteServiceError as exc:
                 if exc.status_code == status.HTTP_503_SERVICE_UNAVAILABLE:
-                    log_event("draft_generation_failed", user_id=user.id, detail=capture_detail)
+                    log_draft_generation_failed_event(
+                        user_id=user.id,
+                        capture_detail=capture_detail,
+                    )
                 raise HTTPException(status_code=exc.status_code, detail=exc.detail) from exc
         log_event(
             "quote.created",
@@ -266,12 +274,12 @@ async def extract_combined(
             quote_id=quote.id,
             customer_id=quote.customer_id,
         )
-        log_event(
-            "draft_generated",
+        log_draft_generated_event(
             user_id=user.id,
             quote_id=quote.id,
             customer_id=quote.customer_id,
-            detail=capture_detail,
+            capture_detail=capture_detail,
+            extraction_result=extraction,
         )
         return PersistedExtractionResponse(
             quote_id=quote.id,
@@ -360,6 +368,7 @@ async def append_extraction(
                     clip_inputs,
                     notes,
                     user_id=user.id,
+                    allow_degraded_persist_on_retryable_failure=True,
                 )
                 updated_quote, merged_extraction = await quote_service.append_extraction_to_quote(
                     user_id=user.id,
@@ -368,7 +377,10 @@ async def append_extraction(
                 )
             except QuoteServiceError as exc:
                 if exc.status_code == status.HTTP_503_SERVICE_UNAVAILABLE:
-                    log_event("draft_generation_failed", user_id=user.id, detail=capture_detail)
+                    log_draft_generation_failed_event(
+                        user_id=user.id,
+                        capture_detail=capture_detail,
+                    )
                 raise HTTPException(status_code=exc.status_code, detail=exc.detail) from exc
 
         log_event(
@@ -473,6 +485,8 @@ async def get_quote(
         status=cast(str, quote.status),
         source_type=cast(Literal["text", "voice"], quote.source_type),
         transcript=quote.transcript,
+        extraction_tier=cast(Literal["primary", "degraded"] | None, quote.extraction_tier),
+        extraction_degraded_reason_code=quote.extraction_degraded_reason_code,
         total_amount=float(quote.total_amount) if quote.total_amount is not None else None,
         tax_rate=float(quote.tax_rate) if quote.tax_rate is not None else None,
         discount_type=cast(DiscountType | None, quote.discount_type),

--- a/backend/app/features/quotes/extraction_outcomes.py
+++ b/backend/app/features/quotes/extraction_outcomes.py
@@ -1,0 +1,123 @@
+"""Shared extraction outcome helpers for sync/async quote flows."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+from uuid import UUID
+
+from app.features.quotes.schemas import ExtractionResult
+from app.integrations.extraction import is_retryable_extraction_error
+from app.shared.event_logger import log_event
+
+ExtractionTier = Literal["primary", "degraded"]
+ExtractionOutcome = Literal["primary", "degraded"]
+
+EXTRACTION_TIER_PRIMARY: ExtractionTier = "primary"
+EXTRACTION_TIER_DEGRADED: ExtractionTier = "degraded"
+EXTRACTION_OUTCOME_PRIMARY: ExtractionOutcome = "primary"
+EXTRACTION_OUTCOME_DEGRADED: ExtractionOutcome = "degraded"
+DEGRADED_REASON_PROVIDER_RETRYABLE_ERROR = "provider_retryable_error"
+
+
+@dataclass(frozen=True, slots=True)
+class ExtractionOutcomeMetadata:
+    """Normalized extraction metadata persisted on quote documents and events."""
+
+    tier: ExtractionTier
+    degraded_reason_code: str | None
+    outcome: ExtractionOutcome
+
+
+def classify_extraction_result(result: ExtractionResult) -> ExtractionOutcomeMetadata:
+    """Normalize extraction metadata so sync and async paths share one contract."""
+    if result.extraction_tier == EXTRACTION_TIER_DEGRADED:
+        reason_code = (
+            result.extraction_degraded_reason_code or DEGRADED_REASON_PROVIDER_RETRYABLE_ERROR
+        )
+        return ExtractionOutcomeMetadata(
+            tier=EXTRACTION_TIER_DEGRADED,
+            degraded_reason_code=reason_code,
+            outcome=EXTRACTION_OUTCOME_DEGRADED,
+        )
+    return ExtractionOutcomeMetadata(
+        tier=EXTRACTION_TIER_PRIMARY,
+        degraded_reason_code=None,
+        outcome=EXTRACTION_OUTCOME_PRIMARY,
+    )
+
+
+def build_degraded_extraction_result(
+    *,
+    transcript: str,
+    reason_code: str = DEGRADED_REASON_PROVIDER_RETRYABLE_ERROR,
+) -> ExtractionResult:
+    """Build a degraded sentinel result that still preserves user transcript work."""
+    return ExtractionResult(
+        transcript=transcript,
+        line_items=[],
+        total=None,
+        confidence_notes=[],
+        extraction_tier=EXTRACTION_TIER_DEGRADED,
+        extraction_degraded_reason_code=reason_code,
+    )
+
+
+def should_persist_degraded_retryable_error(
+    error: Exception,
+    *,
+    is_final_attempt: bool,
+) -> bool:
+    """Return whether this exception chain qualifies for final-attempt degraded persist."""
+    if not is_final_attempt:
+        return False
+    return any(
+        is_retryable_extraction_error(candidate) for candidate in _iter_exception_chain(error)
+    )
+
+
+def log_draft_generated_event(
+    *,
+    user_id: UUID,
+    quote_id: UUID,
+    customer_id: UUID | None,
+    capture_detail: str,
+    extraction_result: ExtractionResult,
+) -> None:
+    """Emit draft-generated analytics with required extraction outcome metadata."""
+    metadata = classify_extraction_result(extraction_result)
+    log_event(
+        "draft_generated",
+        user_id=user_id,
+        quote_id=quote_id,
+        customer_id=customer_id,
+        detail=capture_detail,
+        extraction_outcome=metadata.outcome,
+    )
+
+
+def log_draft_generation_failed_event(*, user_id: UUID, capture_detail: str) -> None:
+    """Emit one draft-generation-failed analytics event."""
+    log_event(
+        "draft_generation_failed",
+        user_id=user_id,
+        detail=capture_detail,
+    )
+
+
+def _iter_exception_chain(error: Exception) -> list[Exception]:
+    chain: list[Exception] = []
+    seen_ids: set[int] = set()
+    candidate: Exception | None = error
+    while candidate is not None and id(candidate) not in seen_ids:
+        chain.append(candidate)
+        seen_ids.add(id(candidate))
+        next_candidate = (
+            candidate.__cause__
+            if isinstance(candidate.__cause__, Exception)
+            else candidate.__context__
+            if isinstance(candidate.__context__, Exception)
+            else None
+        )
+        candidate = next_candidate
+    return chain

--- a/backend/app/features/quotes/extraction_service.py
+++ b/backend/app/features/quotes/extraction_service.py
@@ -10,6 +10,11 @@ from uuid import UUID
 
 import sentry_sdk
 
+from app.features.quotes.extraction_outcomes import (
+    build_degraded_extraction_result,
+    log_draft_generation_failed_event,
+    should_persist_degraded_retryable_error,
+)
 from app.features.quotes.schemas import ExtractionResult
 from app.features.quotes.service import QuoteServiceError
 from app.integrations.audio import AudioClip, AudioError
@@ -121,6 +126,7 @@ class ExtractionService:
         notes: str | None,
         *,
         user_id: UUID | None = None,
+        allow_degraded_persist_on_retryable_failure: bool = False,
     ) -> ExtractionResult:
         """Extract quote line items from optional clips plus optional typed notes."""
         try:
@@ -129,12 +135,25 @@ class ExtractionService:
                 notes,
                 user_id=user_id,
             )
-            extraction = await self.convert_notes(combined_text)
+            try:
+                extraction = await self.convert_notes(combined_text)
+            except QuoteServiceError as exc:
+                should_persist_degraded = (
+                    allow_degraded_persist_on_retryable_failure
+                    and should_persist_degraded_retryable_error(
+                        exc,
+                        is_final_attempt=True,
+                    )
+                )
+                if should_persist_degraded:
+                    return build_degraded_extraction_result(transcript=combined_text)
+                raise
         except QuoteServiceError:
             source_type = (
                 "audio+notes" if clips and (notes or "").strip() else "audio" if clips else "notes"
             )
-            log_event("draft_generation_failed", user_id=user_id, detail=source_type)
+            if user_id is not None:
+                log_draft_generation_failed_event(user_id=user_id, capture_detail=source_type)
             raise
         return extraction
 

--- a/backend/app/features/quotes/models.py
+++ b/backend/app/features/quotes/models.py
@@ -83,6 +83,11 @@ class Document(Base):
     )
     source_type: Mapped[str] = mapped_column(sa.String(20), nullable=False)
     transcript: Mapped[str] = mapped_column(sa.Text, nullable=False)
+    extraction_tier: Mapped[str | None] = mapped_column(sa.String(20), nullable=True)
+    extraction_degraded_reason_code: Mapped[str | None] = mapped_column(
+        sa.String(64),
+        nullable=True,
+    )
     total_amount: Mapped[Decimal | None] = mapped_column(sa.Numeric(10, 2), nullable=True)
     tax_rate: Mapped[Decimal | None] = mapped_column(sa.Numeric(5, 4), nullable=True)
     discount_type: Mapped[str | None] = mapped_column(sa.String(7), nullable=True)

--- a/backend/app/features/quotes/repository.py
+++ b/backend/app/features/quotes/repository.py
@@ -133,6 +133,8 @@ class QuoteDetailRow:
     status: str
     source_type: str
     transcript: str
+    extraction_tier: str | None
+    extraction_degraded_reason_code: str | None
     total_amount: Decimal | None
     tax_rate: Decimal | None
     discount_type: str | None
@@ -335,6 +337,8 @@ class QuoteRepository:
             status=status,
             source_type=document.source_type,
             transcript=document.transcript,
+            extraction_tier=document.extraction_tier,
+            extraction_degraded_reason_code=document.extraction_degraded_reason_code,
             total_amount=document.total_amount,
             tax_rate=document.tax_rate,
             discount_type=document.discount_type,
@@ -609,6 +613,8 @@ class QuoteRepository:
         deposit_amount: float | None,
         notes: str | None,
         source_type: str,
+        extraction_tier: str | None = None,
+        extraction_degraded_reason_code: str | None = None,
     ) -> Document:
         """Create a quote and optional line items for the owning user."""
         next_sequence = await self.get_next_doc_sequence_for_type(
@@ -624,6 +630,8 @@ class QuoteRepository:
             title=title,
             source_type=source_type,
             transcript=transcript,
+            extraction_tier=extraction_tier,
+            extraction_degraded_reason_code=extraction_degraded_reason_code,
             total_amount=_to_decimal(total_amount),
             tax_rate=_to_decimal(tax_rate),
             discount_type=discount_type,
@@ -706,10 +714,14 @@ class QuoteRepository:
         transcript: str,
         total_amount: float | None,
         line_items: list[LineItemDraft],
+        extraction_tier: str | None = None,
+        extraction_degraded_reason_code: str | None = None,
     ) -> Document:
         """Append extracted line items while preserving existing rows and order."""
         document.transcript = transcript
         document.total_amount = _to_decimal(total_amount)
+        document.extraction_tier = extraction_tier
+        document.extraction_degraded_reason_code = extraction_degraded_reason_code
 
         next_sort_order = len(document.line_items)
         for index, item in enumerate(line_items):

--- a/backend/app/features/quotes/schemas.py
+++ b/backend/app/features/quotes/schemas.py
@@ -58,6 +58,8 @@ class ExtractionResult(BaseModel):
         default_factory=list,
         max_length=CONFIDENCE_NOTES_MAX_ITEMS,
     )
+    extraction_tier: Literal["primary", "degraded"] = "primary"
+    extraction_degraded_reason_code: str | None = None
 
 
 class PersistedExtractionResponse(ExtractionResult):
@@ -216,6 +218,8 @@ class PdfArtifactResponse(BaseModel):
 class QuoteDetailResponse(QuoteResponse):
     """Quote detail payload including customer display fields."""
 
+    extraction_tier: Literal["primary", "degraded"] | None
+    extraction_degraded_reason_code: str | None
     customer_name: str | None
     customer_email: str | None
     customer_phone: str | None

--- a/backend/app/features/quotes/service.py
+++ b/backend/app/features/quotes/service.py
@@ -19,6 +19,7 @@ from app.core.config import get_settings
 from app.features.auth.models import User
 from app.features.jobs.models import JobRecord, JobStatus, JobType
 from app.features.jobs.service import JobService
+from app.features.quotes.extraction_outcomes import classify_extraction_result
 from app.features.quotes.models import Document, QuoteStatus
 from app.features.quotes.repository import (
     PublicShareRecord,
@@ -178,6 +179,8 @@ class QuoteRepositoryProtocol(Protocol):
         deposit_amount: float | None,
         notes: str | None,
         source_type: str,
+        extraction_tier: str | None = None,
+        extraction_degraded_reason_code: str | None = None,
     ) -> Document: ...
 
     async def update(
@@ -215,6 +218,8 @@ class QuoteRepositoryProtocol(Protocol):
         transcript: str,
         total_amount: float | None,
         line_items: list[LineItemDraft],
+        extraction_tier: str | None = None,
+        extraction_degraded_reason_code: str | None = None,
     ) -> Document: ...
 
     async def delete(self, document_id: UUID) -> None: ...
@@ -317,6 +322,7 @@ class QuoteService:
             user_id=user_id,
             customer_id=customer_id,
         )
+        extraction_metadata = classify_extraction_result(extraction_result)
         try:
             quote = await _create_quote_document(
                 self,
@@ -339,6 +345,8 @@ class QuoteService:
                 deposit_amount=None,
                 notes=None,
                 source_type=source_type,
+                extraction_tier=extraction_metadata.tier,
+                extraction_degraded_reason_code=extraction_metadata.degraded_reason_code,
             )
         except QuoteServiceError:
             raise
@@ -430,11 +438,14 @@ class QuoteService:
             current_transcript=quote.transcript,
             appended_transcript=extraction_result.transcript,
         )
+        extraction_metadata = classify_extraction_result(extraction_result)
         updated_quote = await self._repository.append_extraction(
             document=quote,
             transcript=next_transcript,
             total_amount=document_field_float_or_none(validated_pricing.total_amount),
             line_items=appended_line_items,
+            extraction_tier=extraction_metadata.tier,
+            extraction_degraded_reason_code=extraction_metadata.degraded_reason_code,
         )
         obsolete_artifact_path = await self._repository.invalidate_pdf_artifact(updated_quote)
         if not commit:
@@ -1047,6 +1058,8 @@ async def _create_quote_document(
     deposit_amount: float | None,
     notes: str | None,
     source_type: Literal["text", "voice"],
+    extraction_tier: str | None = None,
+    extraction_degraded_reason_code: str | None = None,
 ) -> Document:
     for attempt in range(2):
         try:
@@ -1063,6 +1076,8 @@ async def _create_quote_document(
                 deposit_amount=deposit_amount,
                 notes=notes,
                 source_type=source_type,
+                extraction_tier=extraction_tier,
+                extraction_degraded_reason_code=extraction_degraded_reason_code,
             )
         except IntegrityError as exc:
             await service._repository.rollback()

--- a/backend/app/features/quotes/tests/test_quotes.py
+++ b/backend/app/features/quotes/tests/test_quotes.py
@@ -231,6 +231,18 @@ class _FailingArqPool:
         raise RuntimeError("redis unavailable")
 
 
+class _RetryableProviderError(Exception):
+    def __init__(self, status_code: int) -> None:
+        super().__init__(f"provider error {status_code}")
+        self.status_code = status_code
+
+
+class _RetryableFailureExtractionIntegration:
+    async def extract(self, notes: str) -> ExtractionResult:
+        del notes
+        raise ExtractionError("Claude request failed: retryable") from _RetryableProviderError(429)
+
+
 def _send_email_headers(csrf_token: str, *, idempotency_key: str | None = None) -> dict[str, str]:
     return {
         "X-CSRF-Token": csrf_token,
@@ -938,6 +950,7 @@ async def test_business_events_are_logged_for_quote_customer_and_extraction_flow
     assert emitted_events[2]["detail"] == "notes"
     assert emitted_events[3]["quote_id"] != quote_payload["id"]
     assert emitted_events[4]["detail"] == "notes"
+    assert emitted_events[4]["extraction_outcome"] == "primary"
     assert emitted_events[6]["quote_id"] == quote_payload["id"]
     assert emitted_events[8]["quote_id"] == delete_quote_payload["id"]
     assert all(
@@ -3018,6 +3031,8 @@ async def test_extract_combined_falls_back_to_sync_when_no_arq_pool_is_available
     payload = response.json()
     assert payload["quote_id"]
     assert payload["transcript"] == "mulch the front beds"
+    assert payload["extraction_tier"] == "primary"
+    assert payload["extraction_degraded_reason_code"] is None
     assert int(job_count or 0) == 0
 
     persisted_quote = await db_session.get(Document, UUID(payload["quote_id"]))
@@ -3025,6 +3040,99 @@ async def test_extract_combined_falls_back_to_sync_when_no_arq_pool_is_available
     assert persisted_quote.status == QuoteStatus.DRAFT
     assert persisted_quote.customer_id is None
     assert persisted_quote.transcript == "mulch the front beds"
+    assert persisted_quote.extraction_tier == "primary"
+    assert persisted_quote.extraction_degraded_reason_code is None
+
+
+async def test_extract_combined_sync_retryable_failure_persists_degraded_draft(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    emitted_events: list[dict[str, str]] = []
+
+    def _capture(message: str) -> None:
+        emitted_events.append(json.loads(message))
+
+    async def _retryable_extract(self, notes: str) -> ExtractionResult:  # noqa: ANN001
+        del self, notes
+        raise ExtractionError("Claude request failed: retryable") from _RetryableProviderError(429)
+
+    monkeypatch.setattr(event_logger._EVENT_LOGGER, "info", _capture)  # noqa: SLF001
+    monkeypatch.setattr(_MockExtractionIntegration, "extract", _retryable_extract)
+
+    csrf_token = await _register_and_login(client, _credentials())
+    app.state.arq_pool = None
+
+    response = await client.post(
+        "/api/quotes/extract",
+        files=[("notes", (None, "mulch the front beds"))],
+        headers={"X-CSRF-Token": csrf_token},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["quote_id"]
+    assert payload["line_items"] == []
+    assert payload["extraction_tier"] == "degraded"
+    assert payload["extraction_degraded_reason_code"] == "provider_retryable_error"
+
+    persisted_quote = await db_session.get(Document, UUID(payload["quote_id"]))
+    assert persisted_quote is not None
+    assert persisted_quote.extraction_tier == "degraded"
+    assert persisted_quote.extraction_degraded_reason_code == "provider_retryable_error"
+    assert [event["event"] for event in emitted_events] == [
+        "quote_started",
+        "quote.created",
+        "draft_generated",
+    ]
+    assert emitted_events[-1]["extraction_outcome"] == "degraded"
+
+
+async def test_append_extraction_sync_retryable_failure_uses_degraded_append_semantics(
+    client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def _retryable_extract(self, notes: str) -> ExtractionResult:  # noqa: ANN001
+        del self, notes
+        raise ExtractionError("Claude request failed: retryable") from _RetryableProviderError(429)
+
+    monkeypatch.setattr(_MockExtractionIntegration, "extract", _retryable_extract)
+
+    csrf_token = await _register_and_login(client, _credentials())
+    customer_id = await _create_customer(client, csrf_token)
+    quote = await _create_quote(client, csrf_token, customer_id)
+    quote_id = quote["id"]
+    app.state.arq_pool = None
+
+    first_append = await client.post(
+        f"/api/quotes/{quote_id}/append-extraction",
+        files=[("notes", (None, "first degraded note"))],
+        headers={"X-CSRF-Token": csrf_token},
+    )
+    second_append = await client.post(
+        f"/api/quotes/{quote_id}/append-extraction",
+        files=[("notes", (None, "second degraded note"))],
+        headers={"X-CSRF-Token": csrf_token},
+    )
+
+    assert first_append.status_code == 200
+    assert second_append.status_code == 200
+    assert first_append.json()["line_items"] == []
+    assert second_append.json()["line_items"] == []
+    assert first_append.json()["extraction_tier"] == "degraded"
+    assert second_append.json()["extraction_tier"] == "degraded"
+
+    detail_response = await client.get(f"/api/quotes/{quote_id}")
+    assert detail_response.status_code == 200
+    payload = detail_response.json()
+    assert len(payload["line_items"]) == 1
+    assert payload["extraction_tier"] == "degraded"
+    assert payload["extraction_degraded_reason_code"] == "provider_retryable_error"
+    assert payload["transcript"].count("Added later:") == 1
+    assert "- first degraded note" in payload["transcript"]
+    assert "- second degraded note" in payload["transcript"]
+    assert "Added later (2):" not in payload["transcript"]
 
 
 async def test_extract_combined_enqueues_async_job_when_arq_pool_is_available(
@@ -3110,6 +3218,8 @@ async def test_extract_combined_async_worker_persists_draft_and_returns_quote_id
     assert quote_payload["status"] == "draft"
     assert quote_payload["customer_id"] is None
     assert quote_payload["transcript"] == "mulch the front beds"
+    assert quote_payload["extraction_tier"] == "primary"
+    assert quote_payload["extraction_degraded_reason_code"] is None
     assert len(quote_payload["line_items"]) == 1
 
     matching_quote_events = [
@@ -3119,6 +3229,69 @@ async def test_extract_combined_async_worker_persists_draft_and_returns_quote_id
         and event.get("quote_id") == status_payload["quote_id"]
     ]
     assert len(matching_quote_events) == 1
+    assert matching_quote_events[0]["extraction_outcome"] == "primary"
+
+
+async def test_extract_combined_async_final_retryable_failure_persists_degraded_draft(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    emitted_events: list[dict[str, str]] = []
+
+    def _capture(message: str) -> None:
+        emitted_events.append(json.loads(message))
+
+    monkeypatch.setattr(event_logger._EVENT_LOGGER, "info", _capture)  # noqa: SLF001
+
+    csrf_token = await _register_and_login(client, _credentials())
+    pool = _MockArqPool()
+    app.state.arq_pool = pool
+
+    response = await client.post(
+        "/api/quotes/extract",
+        files=[("notes", (None, "mulch the front beds"))],
+        headers={"X-CSRF-Token": csrf_token},
+    )
+    assert response.status_code == 202
+
+    payload = response.json()
+    await _run_extraction_job(
+        db_session,
+        job_id=payload["id"],
+        source_type="text",
+        capture_detail="notes",
+        job_try=3,
+        extraction_integration=_RetryableFailureExtractionIntegration(),
+    )
+
+    status_response = await client.get(f"/api/jobs/{payload['id']}")
+    assert status_response.status_code == 200
+    status_payload = status_response.json()
+    assert status_payload["status"] == "success"
+    assert status_payload["quote_id"] is not None
+    assert status_payload["extraction_result"]["line_items"] == []
+    assert status_payload["extraction_result"]["extraction_tier"] == "degraded"
+    assert (
+        status_payload["extraction_result"]["extraction_degraded_reason_code"]
+        == "provider_retryable_error"
+    )
+
+    quote_response = await client.get(f"/api/quotes/{status_payload['quote_id']}")
+    assert quote_response.status_code == 200
+    quote_payload = quote_response.json()
+    assert quote_payload["extraction_tier"] == "degraded"
+    assert quote_payload["extraction_degraded_reason_code"] == "provider_retryable_error"
+
+    matching_quote_events = [
+        event
+        for event in emitted_events
+        if event.get("event") == "draft_generated"
+        and event.get("quote_id") == status_payload["quote_id"]
+    ]
+    assert len(matching_quote_events) == 1
+    assert matching_quote_events[0]["extraction_outcome"] == "degraded"
+    assert all(event["event"] != "draft_generation_failed" for event in emitted_events)
 
 
 async def test_extract_combined_sync_fallback_persists_preselected_customer(
@@ -5765,6 +5938,8 @@ async def _run_extraction_job(
     customer_id: str | None = None,
     append_to_quote: bool = False,
     transcript: str = "mulch the front beds",
+    job_try: int = 1,
+    extraction_integration: object | None = None,
 ) -> None:
     assert isinstance(job_id, str)
     session_maker = async_sessionmaker(
@@ -5778,11 +5953,12 @@ async def _run_extraction_job(
         retry_base_seconds=DEFAULT_RETRY_BASE_SECONDS,
         retry_jitter_seconds=DEFAULT_RETRY_JITTER_SECONDS,
     )
+    resolved_extraction_integration = extraction_integration or _MockExtractionIntegration()
     await extraction_job(
         {
-            "job_try": 1,
+            "job_try": job_try,
             "worker_runtime": runtime,
-            "extraction_integration": _MockExtractionIntegration(),
+            "extraction_integration": resolved_extraction_integration,
         },
         job_id,
         transcript=transcript,

--- a/backend/app/features/quotes/tests/test_schema_constraints.py
+++ b/backend/app/features/quotes/tests/test_schema_constraints.py
@@ -39,3 +39,31 @@ async def test_invoice_rows_require_customer_id_at_db_layer(
 
     with pytest.raises(IntegrityError):
         await db_session.flush()
+
+
+async def test_invoice_rows_reject_extraction_outcome_fields(
+    db_session: AsyncSession,
+) -> None:
+    user = User(
+        email=f"user-{uuid4().hex[:12]}@example.com",
+        password_hash="hash",  # nosec B106 - test-only stub value
+    )
+    db_session.add(user)
+    await db_session.flush()
+
+    db_session.add(
+        Document(
+            user_id=user.id,
+            customer_id=uuid4(),
+            doc_type="invoice",
+            doc_sequence=1,
+            doc_number="I-001",
+            status=QuoteStatus.DRAFT,
+            source_type="text",
+            transcript="invoice transcript",
+            extraction_tier="primary",
+        )
+    )
+
+    with pytest.raises(IntegrityError):
+        await db_session.flush()

--- a/backend/app/shared/event_logger.py
+++ b/backend/app/shared/event_logger.py
@@ -8,6 +8,7 @@ import logging
 import sys
 from collections.abc import Mapping
 from datetime import UTC, datetime
+from typing import Literal
 from uuid import UUID
 
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
@@ -65,9 +66,13 @@ def log_event(
     invoice_id: UUID | None = None,
     customer_id: UUID | None = None,
     detail: str | None = None,
+    extraction_outcome: Literal["primary", "degraded"] | None = None,
     persist_async: bool = True,
 ) -> None:
     """Emit a structured JSON log record for one business event."""
+    if event == "draft_generated" and extraction_outcome is None:
+        raise ValueError("draft_generated events require extraction_outcome")
+
     payload = {
         "event": event,
         "timestamp": datetime.now(UTC).isoformat(),
@@ -76,6 +81,7 @@ def log_event(
         "invoice_id": str(invoice_id) if invoice_id else None,
         "customer_id": str(customer_id) if customer_id else None,
         "detail": detail,
+        "extraction_outcome": extraction_outcome,
     }
     _EVENT_LOGGER.info(
         json.dumps({key: value for key, value in payload.items() if value is not None})
@@ -100,6 +106,7 @@ def log_event(
                     invoice_id=invoice_id,
                     customer_id=customer_id,
                     detail=detail,
+                    extraction_outcome=extraction_outcome,
                 ),
             )
         )
@@ -124,6 +131,7 @@ def _build_metadata_payload(
     invoice_id: UUID | None,
     customer_id: UUID | None,
     detail: str | None,
+    extraction_outcome: Literal["primary", "degraded"] | None,
 ) -> dict[str, str]:
     metadata: dict[str, str] = {}
     if quote_id is not None:
@@ -134,6 +142,8 @@ def _build_metadata_payload(
         metadata["customer_id"] = str(customer_id)
     if detail is not None:
         metadata["detail"] = detail
+    if extraction_outcome is not None:
+        metadata["extraction_outcome"] = extraction_outcome
     return metadata
 
 

--- a/backend/app/shared/tests/test_event_logger.py
+++ b/backend/app/shared/tests/test_event_logger.py
@@ -87,6 +87,16 @@ def test_log_event_can_skip_async_persistence(monkeypatch) -> None:
     assert not event_logger._PENDING_EVENT_TASKS  # noqa: SLF001
 
 
+def test_log_event_requires_extraction_outcome_for_draft_generated() -> None:
+    with pytest.raises(ValueError, match="extraction_outcome"):
+        event_logger.log_event(
+            "draft_generated",
+            user_id=uuid4(),
+            quote_id=uuid4(),
+            detail="notes",
+        )
+
+
 @pytest.mark.asyncio
 async def test_flush_event_tasks_waits_for_pending_persistence(monkeypatch) -> None:
     gate = asyncio.Event()
@@ -280,6 +290,61 @@ async def test_log_event_persists_invoice_id_metadata() -> None:
     assert fake_session.added[0].metadata_json == {
         "invoice_id": str(invoice_id),
         "customer_id": str(customer_id),
+    }
+
+
+@pytest.mark.asyncio
+async def test_log_event_persists_draft_generated_extraction_outcome() -> None:
+    class _FakeSession:
+        def __init__(self) -> None:
+            self.added: list[EventLog] = []
+            self.committed = False
+
+        def add(self, instance: EventLog) -> None:
+            self.added.append(instance)
+
+        async def commit(self) -> None:
+            self.committed = True
+
+    class _FakeSessionContext:
+        def __init__(self, session: _FakeSession) -> None:
+            self._session = session
+
+        async def __aenter__(self) -> _FakeSession:
+            return self._session
+
+        async def __aexit__(self, exc_type, exc, tb) -> None:
+            del exc_type, exc, tb
+
+    class _FakeSessionFactory:
+        def __init__(self, session: _FakeSession) -> None:
+            self._session = session
+
+        def __call__(self) -> _FakeSessionContext:
+            return _FakeSessionContext(self._session)
+
+    fake_session = _FakeSession()
+    quote_id = uuid4()
+    user_id = uuid4()
+    event_logger.configure_event_logging(
+        session_factory=_FakeSessionFactory(fake_session),  # type: ignore[arg-type]
+    )
+
+    event_logger.log_event(
+        "draft_generated",
+        user_id=user_id,
+        quote_id=quote_id,
+        detail="notes",
+        extraction_outcome="degraded",
+    )
+    await event_logger.flush_event_tasks()
+
+    assert fake_session.committed is True
+    assert len(fake_session.added) == 1
+    assert fake_session.added[0].metadata_json == {
+        "quote_id": str(quote_id),
+        "detail": "notes",
+        "extraction_outcome": "degraded",
     }
 
 

--- a/backend/app/worker/job_registry.py
+++ b/backend/app/worker/job_registry.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass
 from typing import Any, Literal, cast
 from uuid import UUID
 
-from arq.worker import func
+from arq.worker import Retry, func
 
 from app.core.config import get_settings
 from app.features.invoices.email_delivery_service import InvoiceEmailDeliveryService
@@ -17,6 +17,12 @@ from app.features.invoices.repository import InvoiceEmailContext, InvoiceReposit
 from app.features.jobs.models import JobType
 from app.features.jobs.repository import JobRepository
 from app.features.quotes.email_delivery_service import QuoteEmailDeliveryService
+from app.features.quotes.extraction_outcomes import (
+    build_degraded_extraction_result,
+    log_draft_generated_event,
+    log_draft_generation_failed_event,
+    should_persist_degraded_retryable_error,
+)
 from app.features.quotes.repository import QuoteEmailContext, QuoteRepository
 from app.features.quotes.schemas import ExtractionResult
 from app.features.quotes.service import QuoteService, QuoteServiceError
@@ -75,25 +81,37 @@ async def extraction_job(
     append_to_quote: bool = False,
 ) -> None:
     """Run durable quote extraction against the transcript prepared by the API."""
-    await process_job(
-        ctx,
-        job_id=UUID(job_id),
-        job_type=JobType.EXTRACTION,
-        job_name=EXTRACTION_JOB_NAME,
-        handler=lambda: _extract_quote_data(ctx, transcript),
-        on_success=lambda runtime, result: _store_extraction_result(
-            runtime,
-            job_id=UUID(job_id),
-            result=result,
-            source_type=source_type,
-            capture_detail=_resolve_worker_capture_detail(
-                source_type=source_type,
-                capture_detail=capture_detail,
-            ),
-            customer_id=customer_id,
-            append_to_quote=append_to_quote,
-        ),
+    parsed_job_id = UUID(job_id)
+    resolved_capture_detail = _resolve_worker_capture_detail(
+        source_type=source_type,
+        capture_detail=capture_detail,
     )
+    try:
+        await process_job(
+            ctx,
+            job_id=parsed_job_id,
+            job_type=JobType.EXTRACTION,
+            job_name=EXTRACTION_JOB_NAME,
+            handler=lambda: _extract_quote_data(ctx, transcript),
+            on_success=lambda runtime, result: _store_extraction_result(
+                runtime,
+                job_id=parsed_job_id,
+                result=result,
+                source_type=source_type,
+                capture_detail=resolved_capture_detail,
+                customer_id=customer_id,
+                append_to_quote=append_to_quote,
+            ),
+        )
+    except Retry:
+        raise
+    except Exception:
+        await _log_extraction_terminal_failure(
+            ctx,
+            job_id=parsed_job_id,
+            capture_detail=resolved_capture_detail,
+        )
+        raise
 
 
 async def pdf_job(ctx: dict[str, Any], job_id: str) -> None:
@@ -209,6 +227,13 @@ async def _extract_quote_data(
     try:
         return await extraction_integration.extract(transcript)
     except ExtractionError as exc:
+        runtime = _get_runtime(ctx)
+        attempt_number = max(int(ctx.get("job_try", 1)), 1)
+        if should_persist_degraded_retryable_error(
+            exc,
+            is_final_attempt=attempt_number >= runtime.max_tries,
+        ):
+            return build_degraded_extraction_result(transcript=transcript)
         if is_retryable_extraction_error(exc):
             raise RetryableJobError(str(exc)) from exc
         raise
@@ -544,12 +569,12 @@ async def _store_extraction_result(
             quote_id=quote_id,
             customer_id=resolved_customer_id,
         )
-        log_event(
-            "draft_generated",
+        log_draft_generated_event(
             user_id=job_record.user_id,
             quote_id=quote_id,
             customer_id=resolved_customer_id,
-            detail=capture_detail,
+            capture_detail=capture_detail,
+            extraction_result=result_payload,
         )
     elif append_to_quote:
         log_event(
@@ -621,3 +646,20 @@ async def _store_pdf_artifact(
             await asyncio.to_thread(storage_service.delete, persistence_result.previous_path)
         except Exception:  # noqa: BLE001
             logger.warning("Failed to delete superseded PDF artifact", exc_info=True)
+
+
+async def _log_extraction_terminal_failure(
+    ctx: dict[str, Any],
+    *,
+    job_id: UUID,
+    capture_detail: str,
+) -> None:
+    runtime = _get_runtime(ctx)
+    async with runtime.session_maker() as session:
+        job_record = await JobRepository(session).get_by_id(job_id)
+    if job_record is None:
+        return
+    log_draft_generation_failed_event(
+        user_id=job_record.user_id,
+        capture_detail=capture_detail,
+    )

--- a/backend/app/worker/tests/test_job_registry.py
+++ b/backend/app/worker/tests/test_job_registry.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from uuid import UUID, uuid4
 
 import pytest
@@ -12,11 +13,10 @@ from app.features.quotes.models import Document
 from app.features.quotes.schemas import ExtractionResult
 from app.features.quotes.service import QuoteServiceError
 from app.integrations.extraction import ExtractionError
+from app.shared import event_logger
 from app.worker.job_registry import TERMINAL_ERROR_DRAFT_PERSISTENCE_FAILED, extraction_job
 from app.worker.runtime import (
-    TERMINAL_ERROR_RETRY_EXHAUSTED,
     NonRetryableJobError,
-    RetryableJobError,
     WorkerRuntimeSettings,
 )
 from arq.worker import Retry
@@ -122,7 +122,7 @@ async def test_extraction_job_marks_terminal_when_draft_persistence_fails(
     assert refreshed.result_json is None  # nosec B101 - pytest assertion
 
 
-async def test_extraction_job_retries_provider_429_and_marks_terminal_after_final_attempt(
+async def test_extraction_job_retries_provider_429_then_persists_degraded_on_final_attempt(
     db_session: AsyncSession,
 ) -> None:
     user = await _seed_user(db_session)
@@ -149,12 +149,57 @@ async def test_extraction_job_retries_provider_429_and_marks_terminal_after_fina
     assert after_first_failure is not None  # nosec B101 - pytest assertion
     assert after_first_failure.status == JobStatus.FAILED  # nosec B101 - pytest assertion
 
-    with pytest.raises(RetryableJobError):
+    await extraction_job(
+        _worker_context(
+            db_session,
+            job_try=3,
+            extraction_integration=failing_integration,
+        ),
+        str(record.id),
+        transcript="mulch the front beds",
+        source_type="text",
+        capture_detail="notes",
+    )
+
+    degraded_record = await _load_job_record(db_session, record.id)
+    assert degraded_record is not None  # nosec B101 - pytest assertion
+    assert degraded_record.status == JobStatus.SUCCESS  # nosec B101 - pytest assertion
+    assert degraded_record.terminal_error is None  # nosec B101 - pytest assertion
+    assert degraded_record.document_id is not None  # nosec B101 - pytest assertion
+    assert degraded_record.result_json is not None  # nosec B101 - pytest assertion
+
+    persisted_quote = await db_session.get(Document, degraded_record.document_id)
+    assert persisted_quote is not None  # nosec B101 - pytest assertion
+    assert persisted_quote.extraction_tier == "degraded"  # nosec B101 - pytest assertion
+    assert persisted_quote.extraction_degraded_reason_code == "provider_retryable_error"  # nosec B101 - pytest assertion
+    assert persisted_quote.transcript == "mulch the front beds"  # nosec B101 - pytest assertion
+
+    stored_result = ExtractionResult.model_validate_json(degraded_record.result_json)
+    assert stored_result.extraction_tier == "degraded"  # nosec B101 - pytest assertion
+    assert stored_result.extraction_degraded_reason_code == "provider_retryable_error"  # nosec B101 - pytest assertion
+    assert stored_result.line_items == []  # nosec B101 - pytest assertion
+
+
+async def test_extraction_job_logs_draft_generation_failed_on_terminal_failure(
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    emitted_events: list[dict[str, str]] = []
+
+    def _capture(message: str) -> None:
+        emitted_events.append(json.loads(message))
+
+    monkeypatch.setattr(event_logger._EVENT_LOGGER, "info", _capture)  # noqa: SLF001
+    user = await _seed_user(db_session)
+    repository = JobRepository(db_session)
+    record = await repository.create(user_id=user.id, job_type=JobType.EXTRACTION)
+    await db_session.commit()
+
+    with pytest.raises(ExtractionError):
         await extraction_job(
             _worker_context(
                 db_session,
-                job_try=3,
-                extraction_integration=failing_integration,
+                extraction_integration=_NonRetryableFailureExtractionIntegration(),
             ),
             str(record.id),
             transcript="mulch the front beds",
@@ -162,10 +207,12 @@ async def test_extraction_job_retries_provider_429_and_marks_terminal_after_fina
             capture_detail="notes",
         )
 
-    terminal_record = await _load_job_record(db_session, record.id)
-    assert terminal_record is not None  # nosec B101 - pytest assertion
-    assert terminal_record.status == JobStatus.TERMINAL  # nosec B101 - pytest assertion
-    assert terminal_record.terminal_error == TERMINAL_ERROR_RETRY_EXHAUSTED  # nosec B101 - pytest assertion
+    refreshed = await _load_job_record(db_session, record.id)
+    assert refreshed is not None  # nosec B101 - pytest assertion
+    assert refreshed.status == JobStatus.TERMINAL  # nosec B101 - pytest assertion
+    assert [event["event"] for event in emitted_events] == ["draft_generation_failed"]  # nosec B101 - pytest assertion
+    assert emitted_events[0]["detail"] == "notes"  # nosec B101 - pytest assertion
+    assert "quote_id" not in emitted_events[0]  # nosec B101 - pytest assertion
 
 
 class _SuccessfulExtractionIntegration:
@@ -188,6 +235,12 @@ class _RetryableFailureExtractionIntegration:
     async def extract(self, notes: str) -> ExtractionResult:
         del notes
         raise ExtractionError("Claude request failed: retryable") from _RetryableProviderError(429)
+
+
+class _NonRetryableFailureExtractionIntegration:
+    async def extract(self, notes: str) -> ExtractionResult:
+        del notes
+        raise ExtractionError("Claude request failed: malformed payload")
 
 
 async def _seed_user(db_session: AsyncSession) -> User:

--- a/backend/app/worker/tests/test_job_registry.py
+++ b/backend/app/worker/tests/test_job_registry.py
@@ -148,6 +148,8 @@ async def test_extraction_job_retries_provider_429_then_persists_degraded_on_fin
     after_first_failure = await _load_job_record(db_session, record.id)
     assert after_first_failure is not None  # nosec B101 - pytest assertion
     assert after_first_failure.status == JobStatus.FAILED  # nosec B101 - pytest assertion
+    assert after_first_failure.document_id is None  # nosec B101 - pytest assertion
+    assert after_first_failure.result_json is None  # nosec B101 - pytest assertion
 
     await extraction_job(
         _worker_context(

--- a/frontend/src/features/quotes/components/QuotePreview.tsx
+++ b/frontend/src/features/quotes/components/QuotePreview.tsx
@@ -11,6 +11,7 @@ import {
   buildOverflowItems,
   getEmailActionLabel,
   readOptionalQuoteText,
+  resolveExtractionDegradedCopy,
   resolveActionState,
 } from "@/features/quotes/components/quotePreview.helpers";
 import { useQuoteDetail } from "@/features/quotes/hooks/useQuoteDetail";
@@ -44,6 +45,7 @@ export function QuotePreview(): React.ReactElement {
   const customerNameForHeader = readOptionalQuoteText(quote, "customer_name");
   const clientName = readOptionalQuoteText(quote, "customer_name") ?? quote?.customer_id ?? "Unknown customer";
   const clientContact = readOptionalQuoteText(quote, "customer_phone") ?? readOptionalQuoteText(quote, "customer_email") ?? "No contact details";
+  const extractionDegradedCopy = resolveExtractionDegradedCopy(quote);
   const canEdit = Boolean(quote && id && isQuoteEditableStatus(actionState));
   const requiresCustomerAssignment = quote
     ? (quote.requires_customer_assignment ?? quote.customer_id === null)
@@ -169,6 +171,11 @@ export function QuotePreview(): React.ReactElement {
 
         {!isLoadingQuote && !loadError ? (
           <>
+            {quote && extractionDegradedCopy ? (
+              <div className="mx-4 mt-4 rounded-lg border border-warning-accent/40 bg-warning-container p-4 text-sm text-warning">
+                {extractionDegradedCopy}
+              </div>
+            ) : null}
             {quote ? (
               <QuoteDetailsCard
                 documentLabel="QUOTE"

--- a/frontend/src/features/quotes/components/quotePreview.helpers.ts
+++ b/frontend/src/features/quotes/components/quotePreview.helpers.ts
@@ -4,6 +4,11 @@ import { isHttpRequestError } from "@/shared/lib/http";
 
 export type QuotePreviewActionState = QuoteStatus;
 
+const DEGRADED_REASON_COPY: Record<string, string> = {
+  provider_retryable_error:
+    "We saved your transcript, but line item extraction was temporarily unavailable. Please review and complete this draft before sharing.",
+};
+
 export function isShareAbortError(error: unknown): boolean {
   return (
     typeof error === "object" &&
@@ -21,6 +26,19 @@ export function readOptionalQuoteText(
   if (typeof value !== "string") return null;
   const trimmedValue = value.trim();
   return trimmedValue.length > 0 ? trimmedValue : null;
+}
+
+export function resolveExtractionDegradedCopy(quote: QuoteDetail | null): string | null {
+  if (!quote || quote.extraction_tier !== "degraded") {
+    return null;
+  }
+  if (!quote.extraction_degraded_reason_code) {
+    return "We saved your transcript, but extraction quality was degraded. Please review this draft before sharing.";
+  }
+  return (
+    DEGRADED_REASON_COPY[quote.extraction_degraded_reason_code]
+    ?? "We saved your transcript, but extraction quality was degraded. Please review this draft before sharing."
+  );
 }
 
 export function resolveActionState(

--- a/frontend/src/features/quotes/services/quoteService.ts
+++ b/frontend/src/features/quotes/services/quoteService.ts
@@ -106,6 +106,8 @@ async function submitExtraction(
       line_items: persistedExtraction.line_items,
       total: persistedExtraction.total,
       confidence_notes: persistedExtraction.confidence_notes,
+      extraction_tier: persistedExtraction.extraction_tier,
+      extraction_degraded_reason_code: persistedExtraction.extraction_degraded_reason_code,
     },
   };
 }

--- a/frontend/src/features/quotes/tests/CaptureScreen.test.tsx
+++ b/frontend/src/features/quotes/tests/CaptureScreen.test.tsx
@@ -80,6 +80,8 @@ const extractionFixture: ExtractionResult = {
   ],
   total: 120,
   confidence_notes: [],
+  extraction_tier: "primary",
+  extraction_degraded_reason_code: null,
 };
 
 const clipFixture: VoiceClip = {

--- a/frontend/src/features/quotes/tests/QuotePreview.test.tsx
+++ b/frontend/src/features/quotes/tests/QuotePreview.test.tsx
@@ -52,6 +52,8 @@ function makeQuoteDetail(overrides: Partial<QuoteDetail> = {}): QuoteDetail {
   return {
     id: "quote-1",
     customer_id: "cust-1",
+    extraction_tier: "primary",
+    extraction_degraded_reason_code: null,
     customer_name: "Test Customer",
     customer_email: null,
     customer_phone: null,
@@ -236,6 +238,23 @@ describe("QuotePreview", () => {
     expect(screen.queryByText(/doc\/share-token/i)).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: /quotes/i })).toHaveClass("text-primary");
     expect(screen.getByText("QUOTE")).toBeInTheDocument();
+  });
+
+  it("renders canonical degraded extraction copy from reason code", async () => {
+    mockedQuoteService.getQuote.mockResolvedValueOnce(
+      makeQuoteDetail({
+        extraction_tier: "degraded",
+        extraction_degraded_reason_code: "provider_retryable_error",
+      }),
+    );
+
+    renderScreen();
+
+    expect(
+      await screen.findByText(
+        /line item extraction was temporarily unavailable/i,
+      ),
+    ).toBeInTheDocument();
   });
 
   it.each(["approved", "declined"] as const)(

--- a/frontend/src/features/quotes/tests/ReviewScreen.test.tsx
+++ b/frontend/src/features/quotes/tests/ReviewScreen.test.tsx
@@ -83,6 +83,8 @@ function makeQuote(overrides: Partial<QuoteDetail> = {}): QuoteDetail {
   return {
     id: "quote-1",
     customer_id: "cust-1",
+    extraction_tier: "primary",
+    extraction_degraded_reason_code: null,
     customer_name: "Alice Johnson",
     customer_email: "alice@example.com",
     customer_phone: "+1-555-0100",

--- a/frontend/src/features/quotes/tests/quoteService.integration.test.ts
+++ b/frontend/src/features/quotes/tests/quoteService.integration.test.ts
@@ -247,6 +247,8 @@ describe("quoteService integration (MSW)", () => {
     const response: QuoteDetail = {
       id: "quote-1",
       customer_id: "cust-1",
+      extraction_tier: "primary",
+      extraction_degraded_reason_code: null,
       customer_name: "Alice Johnson",
       customer_email: "alice@example.com",
       customer_phone: "+1-555-0100",

--- a/frontend/src/features/quotes/tests/usePersistedReview.test.tsx
+++ b/frontend/src/features/quotes/tests/usePersistedReview.test.tsx
@@ -17,6 +17,8 @@ function makeQuote(overrides: Partial<QuoteDetail> = {}): QuoteDetail {
   return {
     id: "quote-1",
     customer_id: "cust-1",
+    extraction_tier: "primary",
+    extraction_degraded_reason_code: null,
     customer_name: "Alice Johnson",
     customer_email: "alice@example.com",
     customer_phone: "+1-555-0100",

--- a/frontend/src/features/quotes/types/quote.types.ts
+++ b/frontend/src/features/quotes/types/quote.types.ts
@@ -22,6 +22,8 @@ export interface ExtractionResult {
   line_items: LineItemExtracted[];
   total: number | null;
   confidence_notes: string[];
+  extraction_tier: ExtractionTier;
+  extraction_degraded_reason_code: string | null;
 }
 
 export type JobStatus = "pending" | "running" | "success" | "failed" | "terminal";

--- a/frontend/src/features/quotes/types/quote.types.ts
+++ b/frontend/src/features/quotes/types/quote.types.ts
@@ -74,6 +74,7 @@ export type QuoteStatus =
   | "approved"
   | "declined";
 export type QuoteSourceType = "text" | "voice";
+export type ExtractionTier = "primary" | "degraded";
 
 export interface QuotePricingFields {
   total_amount: number | null;
@@ -114,6 +115,8 @@ export interface LinkedInvoiceSummary {
 }
 
 export interface QuoteDetail extends Quote {
+  extraction_tier: ExtractionTier | null;
+  extraction_degraded_reason_code: string | null;
   customer_name: string | null;
   customer_email: string | null;
   customer_phone: string | null;


### PR DESCRIPTION
## Summary
- persist extraction outcome metadata (`extraction_tier`, `extraction_degraded_reason_code`) on quote draft documents
- add degraded retryable provider handling for sync + async extraction flows on final attempts, while preserving normal retry behavior before final attempts
- enforce analytics contract for `draft_generated` (`extraction_outcome=primary|degraded`) and keep `draft_generation_failed` only for terminal no-draft outcomes
- add DB constraints + migration, update quote/job contracts, and surface degraded status copy in Quote Preview
- extend backend/frontend tests to cover degraded persistence and metadata expectations

## Verification
- make backend-verify
- make frontend-verify

Closes #286