### PR TITLE
Task #287: Phase 2 extraction correlation + failure telemetry

### DIFF
--- a/backend/alembic/versions/20260410_0020_add_job_records_last_model_id.py
+++ b/backend/alembic/versions/20260410_0020_add_job_records_last_model_id.py
@@ -1,0 +1,27 @@
+"""Add last_model_id to job_records.
+
+Revision ID: 20260410_0020
+Revises: 20260410_0019
+Create Date: 2026-04-10
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "20260410_0020"
+down_revision: str | None = "20260410_0019"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column("job_records", sa.Column("last_model_id", sa.String(length=128), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("job_records", "last_model_id")

--- a/backend/app/core/tests/test_main.py
+++ b/backend/app/core/tests/test_main.py
@@ -29,7 +29,7 @@ def _required_settings(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
 @pytest_asyncio.fixture()
 async def boundary_client() -> AsyncGenerator[AsyncClient, None]:
     app = create_app()
-    transport = ASGITransport(app=app)
+    transport = ASGITransport(app=app, client=("127.0.0.1", 4321))
     async with AsyncClient(transport=transport, base_url="http://api.stima.dev") as client:
         yield client
 
@@ -49,7 +49,7 @@ async def test_invalid_host_is_rejected(monkeypatch: pytest.MonkeyPatch) -> None
     get_settings.cache_clear()
 
     app = create_app()
-    transport = ASGITransport(app=app)
+    transport = ASGITransport(app=app, client=("127.0.0.1", 4321))
     async with AsyncClient(transport=transport, base_url="http://api.stima.dev") as client:
         response = await client.get("/health", headers={"host": "evil.example"})
 
@@ -69,7 +69,7 @@ async def test_trusted_proxy_headers_prevent_https_redirect_loops(
     get_settings.cache_clear()
 
     app = create_app()
-    transport = ASGITransport(app=app)
+    transport = ASGITransport(app=app, client=("127.0.0.1", 4321))
     async with AsyncClient(
         transport=transport,
         base_url="http://api.stima.odysian.dev",
@@ -96,7 +96,7 @@ async def test_https_redirect_ignores_untrusted_forwarded_proto(
     get_settings.cache_clear()
 
     app = create_app()
-    transport = ASGITransport(app=app)
+    transport = ASGITransport(app=app, client=("127.0.0.1", 4321))
     async with AsyncClient(
         transport=transport,
         base_url="http://api.stima.dev",
@@ -112,6 +112,58 @@ async def test_https_redirect_ignores_untrusted_forwarded_proto(
 
     assert response.status_code == 307
     assert response.headers["location"] == "https://api.stima.dev/health"
+
+
+async def test_trusted_ingress_correlation_header_is_preserved(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    trusted_correlation_id = "trusted-correlation-id-123"
+    monkeypatch.setenv("TRUSTED_PROXY_IPS", "127.0.0.1")
+    get_settings.cache_clear()
+
+    app = create_app()
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://api.stima.dev") as client:
+        response = await client.get(
+            "/health",
+            headers={
+                "host": "api.stima.dev",
+                "x-correlation-id": trusted_correlation_id,
+            },
+        )
+
+    assert response.status_code == 200
+    assert response.headers["x-correlation-id"] == trusted_correlation_id
+
+
+async def test_missing_or_invalid_ingress_correlation_id_generates_new_value(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("TRUSTED_PROXY_IPS", "127.0.0.1")
+    get_settings.cache_clear()
+
+    app = create_app()
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://api.stima.dev") as client:
+        invalid_response = await client.get(
+            "/health",
+            headers={
+                "host": "api.stima.dev",
+                "x-correlation-id": "invalid id with spaces",
+            },
+        )
+        missing_response = await client.get(
+            "/health",
+            headers={"host": "api.stima.dev"},
+        )
+
+    generated_invalid = invalid_response.headers["x-correlation-id"]
+    generated_missing = missing_response.headers["x-correlation-id"]
+    assert generated_invalid != "invalid id with spaces"
+    assert len(generated_invalid) == 32
+    assert generated_invalid.isalnum()
+    assert len(generated_missing) == 32
+    assert generated_missing.isalnum()
 
 
 @pytest.mark.asyncio

--- a/backend/app/features/jobs/models.py
+++ b/backend/app/features/jobs/models.py
@@ -77,6 +77,7 @@ class JobRecord(Base):
         nullable=False,
         server_default=sa.text("0"),
     )
+    last_model_id: Mapped[str | None] = mapped_column(sa.String(length=128), nullable=True)
     terminal_error: Mapped[str | None] = mapped_column(sa.Text, nullable=True)
     result_json: Mapped[str | None] = mapped_column(sa.Text, nullable=True)
     created_at: Mapped[datetime] = mapped_column(

--- a/backend/app/features/jobs/repository.py
+++ b/backend/app/features/jobs/repository.py
@@ -145,6 +145,20 @@ class JobRepository:
         await self._session.refresh(record)
         return record
 
+    async def set_last_model_id(
+        self,
+        job_id: UUID,
+        *,
+        last_model_id: str | None,
+        expected_job_type: JobType | None = None,
+    ) -> JobRecord:
+        """Persist the most recent extraction model id used for one job."""
+        record = await self._get_required(job_id, expected_job_type=expected_job_type)
+        record.last_model_id = last_model_id
+        await self._session.flush()
+        await self._session.refresh(record)
+        return record
+
     async def set_failed(
         self,
         job_id: UUID,

--- a/backend/app/features/jobs/tests/test_jobs_repository.py
+++ b/backend/app/features/jobs/tests/test_jobs_repository.py
@@ -112,6 +112,25 @@ async def test_create_extraction_job_with_capacity_limit_rejects_when_at_limit(
     assert second is None  # nosec B101 - pytest assertion
 
 
+async def test_set_last_model_id_persists_operator_model_telemetry(
+    db_session: AsyncSession,
+) -> None:
+    user = await _seed_user(db_session)
+    repository = JobRepository(db_session)
+    record = await repository.create(user_id=user.id, job_type=JobType.EXTRACTION)
+
+    await repository.set_last_model_id(
+        record.id,
+        last_model_id="claude-haiku-4-5-20251001",
+        expected_job_type=JobType.EXTRACTION,
+    )
+    await db_session.commit()
+
+    refreshed = await repository.get_by_id(record.id)
+    assert refreshed is not None  # nosec B101 - pytest assertion
+    assert refreshed.last_model_id == "claude-haiku-4-5-20251001"  # nosec B101 - pytest assertion
+
+
 async def test_reap_stale_extraction_jobs_terminalizes_only_stale_active_extraction_rows(
     db_session: AsyncSession,
 ) -> None:

--- a/backend/app/features/quotes/api.py
+++ b/backend/app/features/quotes/api.py
@@ -77,7 +77,7 @@ from app.shared.input_limits import (
     MAX_AUDIO_TOTAL_BYTES,
     NOTE_INPUT_MAX_CHARS,
 )
-from app.shared.observability import log_security_event
+from app.shared.observability import current_correlation_id, log_security_event
 from app.shared.pdf_artifacts import resolve_pdf_artifact_state
 from app.shared.rate_limit import get_ip_key, get_user_key, limiter
 from app.worker.job_registry import EMAIL_JOB_NAME, EXTRACTION_JOB_NAME
@@ -310,6 +310,7 @@ async def extract_combined(
             EXTRACTION_JOB_NAME,
             str(job.id),
             _job_id=str(job.id),
+            correlation_id=current_correlation_id(),
             transcript=transcript,
             source_type=source_type,
             capture_detail=capture_detail,
@@ -420,6 +421,7 @@ async def append_extraction(
             EXTRACTION_JOB_NAME,
             str(job.id),
             _job_id=str(job.id),
+            correlation_id=current_correlation_id(),
             transcript=transcript,
             source_type=source_type,
             capture_detail=capture_detail,

--- a/backend/app/features/quotes/tests/test_quotes.py
+++ b/backend/app/features/quotes/tests/test_quotes.py
@@ -3148,6 +3148,7 @@ async def test_extract_combined_enqueues_async_job_when_arq_pool_is_available(
         files=[("notes", (None, "mulch the front beds"))],
         headers={"X-CSRF-Token": csrf_token},
     )
+    response_correlation_id = response.headers["x-correlation-id"]
 
     jobs = (await db_session.scalars(select(JobRecord))).all()
 
@@ -3165,6 +3166,7 @@ async def test_extract_combined_enqueues_async_job_when_arq_pool_is_available(
             "args": (str(jobs[0].id),),
             "kwargs": {
                 "_job_id": str(jobs[0].id),
+                "correlation_id": response_correlation_id,
                 "transcript": "mulch the front beds",
                 "source_type": "text",
                 "capture_detail": "notes",
@@ -3172,6 +3174,32 @@ async def test_extract_combined_enqueues_async_job_when_arq_pool_is_available(
             },
         }
     ]
+
+
+async def test_extract_combined_preserves_trusted_ingress_correlation_id_in_queue_payload(
+    client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    ingress_correlation_id = "ingress-correlation-id-123"
+    monkeypatch.setenv("TRUSTED_PROXY_IPS", "127.0.0.1")
+    get_settings.cache_clear()
+
+    csrf_token = await _register_and_login(client, _credentials())
+    pool = _MockArqPool()
+    app.state.arq_pool = pool
+
+    response = await client.post(
+        "/api/quotes/extract",
+        files=[("notes", (None, "mulch the front beds"))],
+        headers={
+            "X-CSRF-Token": csrf_token,
+            "X-Correlation-ID": ingress_correlation_id,
+        },
+    )
+
+    assert response.status_code == 202
+    assert response.headers["x-correlation-id"] == ingress_correlation_id
+    assert pool.calls[0]["kwargs"]["correlation_id"] == ingress_correlation_id
 
 
 async def test_extract_combined_async_worker_persists_draft_and_returns_quote_id(
@@ -3421,6 +3449,7 @@ async def test_append_extraction_enqueues_async_job_for_owned_quote(
         files=[("notes", (None, "append this"))],
         headers={"X-CSRF-Token": csrf_token},
     )
+    response_correlation_id = response.headers["x-correlation-id"]
 
     jobs = (await db_session.scalars(select(JobRecord))).all()
 
@@ -3438,6 +3467,7 @@ async def test_append_extraction_enqueues_async_job_for_owned_quote(
             "args": (str(jobs[0].id),),
             "kwargs": {
                 "_job_id": str(jobs[0].id),
+                "correlation_id": response_correlation_id,
                 "transcript": "append this",
                 "source_type": "text",
                 "capture_detail": "notes",
@@ -5940,6 +5970,7 @@ async def _run_extraction_job(
     transcript: str = "mulch the front beds",
     job_try: int = 1,
     extraction_integration: object | None = None,
+    correlation_id: str | None = None,
 ) -> None:
     assert isinstance(job_id, str)
     session_maker = async_sessionmaker(
@@ -5961,6 +5992,7 @@ async def _run_extraction_job(
             "extraction_integration": resolved_extraction_integration,
         },
         job_id,
+        correlation_id=correlation_id,
         transcript=transcript,
         source_type=source_type,
         capture_detail=capture_detail,

--- a/backend/app/integrations/extraction.py
+++ b/backend/app/integrations/extraction.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import asyncio
+import contextvars
 import secrets
+from dataclasses import dataclass
 from typing import Any, cast
 
 import anthropic
@@ -80,6 +82,19 @@ class ExtractionError(Exception):
     """Raised when quote extraction cannot produce a valid structured payload."""
 
 
+@dataclass(frozen=True, slots=True)
+class ExtractionCallMetadata:
+    """Telemetry captured from the most recent extraction provider call."""
+
+    model_id: str | None
+    token_usage: dict[str, int] | None
+
+
+_LAST_CALL_METADATA_VAR: contextvars.ContextVar[ExtractionCallMetadata | None] = (
+    contextvars.ContextVar("stima_extraction_call_metadata", default=None)
+)
+
+
 class ExtractionIntegration:
     """Convert typed notes to a validated extraction result via Claude."""
 
@@ -103,6 +118,7 @@ class ExtractionIntegration:
         normalized_notes = notes.strip()
         if not normalized_notes:
             raise ExtractionError("notes cannot be empty")
+        _set_last_call_metadata(model_id=self._model, token_usage=None)
 
         if self._client is None:
             if not self._api_key:
@@ -119,6 +135,10 @@ class ExtractionIntegration:
         typed_client = cast(Any, client)
 
         response = await self._request_with_retry(typed_client, normalized_notes)
+        _set_last_call_metadata(
+            model_id=getattr(response, "model", None) or self._model,
+            token_usage=_extract_token_usage(response),
+        )
 
         payload = _extract_tool_payload(response)
         payload.setdefault("transcript", normalized_notes)
@@ -129,6 +149,17 @@ class ExtractionIntegration:
             return ExtractionResult.model_validate(payload)
         except ValidationError as exc:
             raise ExtractionError("Claude response did not match extraction schema") from exc
+
+    @property
+    def model_id(self) -> str:
+        """Return the configured provider model id for extraction calls."""
+        return self._model
+
+    def pop_last_call_metadata(self) -> ExtractionCallMetadata | None:
+        """Return and clear per-task extraction telemetry from the latest call."""
+        metadata = _LAST_CALL_METADATA_VAR.get()
+        _LAST_CALL_METADATA_VAR.set(None)
+        return metadata
 
     async def _request_with_retry(self, typed_client: Any, normalized_notes: str) -> object:
         last_error: Exception | None = None
@@ -257,3 +288,38 @@ def _retry_delay_seconds(attempt: int) -> float:
     if jitter_bound <= 0:
         return base_delay
     return base_delay + (secrets.randbelow(1000) / 1000) * jitter_bound
+
+
+def _set_last_call_metadata(*, model_id: str | None, token_usage: dict[str, int] | None) -> None:
+    _LAST_CALL_METADATA_VAR.set(
+        ExtractionCallMetadata(
+            model_id=model_id,
+            token_usage=token_usage,
+        )
+    )
+
+
+def _extract_token_usage(response: object) -> dict[str, int] | None:
+    usage = getattr(response, "usage", None)
+    if usage is None:
+        return None
+
+    usage_payload: dict[str, int] = {}
+    for key in (
+        "input_tokens",
+        "output_tokens",
+        "cache_creation_input_tokens",
+        "cache_read_input_tokens",
+    ):
+        value = _token_usage_int(usage, key)
+        if value is not None:
+            usage_payload[key] = value
+    return usage_payload or None
+
+
+def _token_usage_int(usage: object, key: str) -> int | None:
+    if isinstance(usage, dict):
+        candidate = usage.get(key)
+    else:
+        candidate = getattr(usage, key, None)
+    return candidate if isinstance(candidate, int) else None

--- a/backend/app/shared/observability.py
+++ b/backend/app/shared/observability.py
@@ -6,6 +6,7 @@ import contextvars
 import hmac
 import json
 import logging
+import string
 import sys
 import time
 from dataclasses import dataclass
@@ -22,12 +23,16 @@ from starlette.requests import Request as StarletteRequest
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 from app.core.config import get_settings
+from app.shared.proxy_headers import is_trusted_proxy, parse_ip, trusted_proxy_networks
 from app.shared.rate_limit import get_ip_key
 
 SECURITY_LOGGER_NAME = "stima.security"
 CORRELATION_HEADER_NAME = "X-Correlation-ID"
 _HANDLER_SENTINEL = "_stima_security_handler"
 _SECURITY_LOGGER = logging.getLogger(SECURITY_LOGGER_NAME)
+_CORRELATION_ID_MIN_LENGTH = 8
+_CORRELATION_ID_MAX_LENGTH = 128
+_CORRELATION_ID_ALLOWED_CHARS = frozenset(string.ascii_letters + string.digits + "-_.")
 _correlation_id_var: contextvars.ContextVar[str | None] = contextvars.ContextVar(
     "stima_correlation_id",
     default=None,
@@ -70,7 +75,7 @@ class RequestObservabilityMiddleware:
             return
 
         request = StarletteRequest(scope, receive=receive)
-        correlation_id = uuid4().hex
+        correlation_id = _resolve_request_correlation_id(scope, request)
         method = request.method.upper()
         route_template = sanitize_route_template(request.url.path)
         client_ip_hash = hash_client_ip(get_ip_key(request))
@@ -161,10 +166,16 @@ def reset_observability_state() -> None:
     _rate_limited_events.clear()
 
 
-def bind_worker_correlation(*, job_name: str, job_id: str) -> contextvars.Token[str | None]:
-    """Bind a fresh background correlation id for one worker job execution."""
+def bind_worker_correlation(
+    *,
+    job_name: str,
+    job_id: str,
+    correlation_id: str | None = None,
+) -> contextvars.Token[str | None]:
+    """Bind worker correlation context, preserving validated API ids when provided."""
     del job_name, job_id
-    return _correlation_id_var.set(uuid4().hex)
+    normalized_correlation = _normalize_correlation_id(correlation_id)
+    return _correlation_id_var.set(normalized_correlation or uuid4().hex)
 
 
 def suspend_request_context() -> contextvars.Token[RequestLogContext | None]:
@@ -200,6 +211,37 @@ def current_correlation_id() -> str:
     generated = uuid4().hex
     _correlation_id_var.set(generated)
     return generated
+
+
+def _resolve_request_correlation_id(scope: Scope, request: StarletteRequest) -> str:
+    header_value = request.headers.get(CORRELATION_HEADER_NAME)
+    if _is_trusted_ingress(scope):
+        normalized_header = _normalize_correlation_id(header_value)
+        if normalized_header is not None:
+            return normalized_header
+    return uuid4().hex
+
+
+def _is_trusted_ingress(scope: Scope) -> bool:
+    trusted_networks = trusted_proxy_networks(get_settings().trusted_proxy_ips)
+    if not trusted_networks:
+        return False
+    client_addr = scope.get("client")
+    peer_ip = parse_ip(client_addr[0]) if client_addr is not None else None
+    if peer_ip is None:
+        return False
+    return is_trusted_proxy(peer_ip, trusted_networks)
+
+
+def _normalize_correlation_id(candidate: str | None) -> str | None:
+    if candidate is None:
+        return None
+    normalized_candidate = candidate.strip()
+    if not (_CORRELATION_ID_MIN_LENGTH <= len(normalized_candidate) <= _CORRELATION_ID_MAX_LENGTH):
+        return None
+    if any(char not in _CORRELATION_ID_ALLOWED_CHARS for char in normalized_candidate):
+        return None
+    return normalized_candidate
 
 
 def log_security_event(

--- a/backend/app/worker/job_registry.py
+++ b/backend/app/worker/job_registry.py
@@ -6,6 +6,8 @@ import asyncio
 import base64
 import logging
 from dataclasses import dataclass
+from hashlib import sha256
+from time import perf_counter
 from typing import Any, Literal, cast
 from uuid import UUID
 
@@ -27,7 +29,11 @@ from app.features.quotes.repository import QuoteEmailContext, QuoteRepository
 from app.features.quotes.schemas import ExtractionResult
 from app.features.quotes.service import QuoteService, QuoteServiceError
 from app.integrations.email import EmailService
-from app.integrations.extraction import ExtractionError, is_retryable_extraction_error
+from app.integrations.extraction import (
+    ExtractionCallMetadata,
+    ExtractionError,
+    is_retryable_extraction_error,
+)
 from app.integrations.pdf import (
     PdfRenderError,
     PdfRenderValidationError,
@@ -74,6 +80,7 @@ async def extraction_job(
     ctx: dict[str, Any],
     job_id: str,
     *,
+    correlation_id: str | None = None,
     transcript: str,
     source_type: str = "text",
     capture_detail: str | None = None,
@@ -92,7 +99,8 @@ async def extraction_job(
             job_id=parsed_job_id,
             job_type=JobType.EXTRACTION,
             job_name=EXTRACTION_JOB_NAME,
-            handler=lambda: _extract_quote_data(ctx, transcript),
+            correlation_id=correlation_id,
+            handler=lambda: _extract_quote_data(ctx, transcript, job_id=parsed_job_id),
             on_success=lambda runtime, result: _store_extraction_result(
                 runtime,
                 job_id=parsed_job_id,
@@ -219,24 +227,71 @@ async def _deliver_email(ctx: dict[str, Any], *, job_id: UUID) -> None:
 async def _extract_quote_data(
     ctx: dict[str, Any],
     transcript: str,
+    *,
+    job_id: UUID,
 ) -> ExtractionResult:
     extraction_integration = ctx.get("extraction_integration")
     if extraction_integration is None or not hasattr(extraction_integration, "extract"):
         raise RuntimeError("Worker extraction integration is not initialized")
 
+    started_at = perf_counter()
+    runtime = _get_runtime(ctx)
+    attempt_number = max(int(ctx.get("job_try", 1)), 1)
+    configured_model_id = getattr(extraction_integration, "model_id", None)
+    await _persist_last_model_id(
+        runtime,
+        job_id=job_id,
+        last_model_id=configured_model_id if isinstance(configured_model_id, str) else None,
+    )
+
     try:
-        return await extraction_integration.extract(transcript)
+        result = await extraction_integration.extract(transcript)
     except ExtractionError as exc:
-        runtime = _get_runtime(ctx)
-        attempt_number = max(int(ctx.get("job_try", 1)), 1)
+        metadata = _pop_extraction_call_metadata(extraction_integration)
+        resolved_last_model_id = _resolve_last_model_id(
+            configured_model_id=configured_model_id,
+            metadata=metadata,
+        )
+        await _persist_last_model_id(
+            runtime,
+            job_id=job_id,
+            last_model_id=resolved_last_model_id,
+        )
+        is_retryable = is_retryable_extraction_error(exc)
+        is_final_attempt = attempt_number >= runtime.max_tries
+        log_security_event(
+            "quotes.extract_failed",
+            outcome="retrying" if is_retryable and not is_final_attempt else "failure",
+            level=logging.WARNING if is_retryable and not is_final_attempt else logging.ERROR,
+            reason="provider_retryable_error" if is_retryable else "provider_non_retryable_error",
+            job_name=EXTRACTION_JOB_NAME,
+            job_id=str(job_id),
+            last_model_id=resolved_last_model_id,
+            latency_ms=int((perf_counter() - started_at) * 1000),
+            token_usage=metadata.token_usage if metadata is not None else None,
+            error_class=_compact_error_class(exc),
+            transcript_sha256=_transcript_sha256(transcript),
+        )
         if should_persist_degraded_retryable_error(
             exc,
-            is_final_attempt=attempt_number >= runtime.max_tries,
+            is_final_attempt=is_final_attempt,
         ):
             return build_degraded_extraction_result(transcript=transcript)
-        if is_retryable_extraction_error(exc):
+        if is_retryable:
             raise RetryableJobError(str(exc)) from exc
         raise
+
+    metadata = _pop_extraction_call_metadata(extraction_integration)
+    resolved_last_model_id = _resolve_last_model_id(
+        configured_model_id=configured_model_id,
+        metadata=metadata,
+    )
+    await _persist_last_model_id(
+        runtime,
+        job_id=job_id,
+        last_model_id=resolved_last_model_id,
+    )
+    return result
 
 
 async def _render_pdf(ctx: dict[str, Any], *, job_id: UUID) -> _RenderedPdfArtifact:
@@ -663,3 +718,51 @@ async def _log_extraction_terminal_failure(
         user_id=job_record.user_id,
         capture_detail=capture_detail,
     )
+
+
+async def _persist_last_model_id(
+    runtime: WorkerRuntimeSettings,
+    *,
+    job_id: UUID,
+    last_model_id: str | None,
+) -> None:
+    if last_model_id is None:
+        return
+    async with runtime.session_maker() as session:
+        repository = JobRepository(session)
+        await repository.set_last_model_id(
+            job_id,
+            last_model_id=last_model_id,
+            expected_job_type=JobType.EXTRACTION,
+        )
+        await session.commit()
+
+
+def _pop_extraction_call_metadata(extraction_integration: object) -> ExtractionCallMetadata | None:
+    pop_metadata = getattr(extraction_integration, "pop_last_call_metadata", None)
+    if not callable(pop_metadata):
+        return None
+    metadata = pop_metadata()
+    return metadata if isinstance(metadata, ExtractionCallMetadata) else None
+
+
+def _resolve_last_model_id(
+    *,
+    configured_model_id: object,
+    metadata: ExtractionCallMetadata | None,
+) -> str | None:
+    metadata_model_id = metadata.model_id if metadata is not None else None
+    if isinstance(metadata_model_id, str) and metadata_model_id:
+        return metadata_model_id
+    if isinstance(configured_model_id, str) and configured_model_id:
+        return configured_model_id
+    return None
+
+
+def _compact_error_class(error: Exception) -> str:
+    candidate = error.__cause__ if isinstance(error.__cause__, Exception) else error
+    return type(candidate).__name__
+
+
+def _transcript_sha256(transcript: str) -> str:
+    return sha256(transcript.encode("utf-8")).hexdigest()

--- a/backend/app/worker/runtime.py
+++ b/backend/app/worker/runtime.py
@@ -119,13 +119,18 @@ async def process_job[T](
     job_type: JobType,
     job_name: str | None = None,
     handler: Callable[[], Awaitable[T]],
+    correlation_id: str | None = None,
     on_success: Callable[[WorkerRuntimeSettings, T], Awaitable[None]] | None = None,
 ) -> None:
     """Wrap domain handlers with durable job status transitions and retry policy."""
     runtime = _get_runtime(ctx)
     attempt_number = max(int(ctx.get("job_try", 1)), 1)
     resolved_job_name = job_name or job_type.value
-    correlation_token = bind_worker_correlation(job_name=resolved_job_name, job_id=str(job_id))
+    correlation_token = bind_worker_correlation(
+        job_name=resolved_job_name,
+        job_id=str(job_id),
+        correlation_id=correlation_id,
+    )
     request_context_token = suspend_request_context()
 
     try:

--- a/backend/app/worker/tests/test_job_registry.py
+++ b/backend/app/worker/tests/test_job_registry.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from hashlib import sha256
 from uuid import UUID, uuid4
 
 import pytest
@@ -12,8 +13,8 @@ from app.features.jobs.repository import JobRepository
 from app.features.quotes.models import Document
 from app.features.quotes.schemas import ExtractionResult
 from app.features.quotes.service import QuoteServiceError
-from app.integrations.extraction import ExtractionError
-from app.shared import event_logger
+from app.integrations.extraction import ExtractionCallMetadata, ExtractionError
+from app.shared import event_logger, observability
 from app.worker.job_registry import TERMINAL_ERROR_DRAFT_PERSISTENCE_FAILED, extraction_job
 from app.worker.runtime import (
     NonRetryableJobError,
@@ -217,6 +218,61 @@ async def test_extraction_job_logs_draft_generation_failed_on_terminal_failure(
     assert "quote_id" not in emitted_events[0]  # nosec B101 - pytest assertion
 
 
+async def test_extraction_job_uses_enqueued_correlation_id_and_logs_failure_metadata(
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    security_logs: list[dict[str, object]] = []
+
+    def _capture_security(payload: dict[str, object], *, level: int) -> None:
+        security_logs.append({**payload, "_level": level})
+
+    monkeypatch.setattr(observability, "_emit_security_payload", _capture_security)
+    user = await _seed_user(db_session)
+    repository = JobRepository(db_session)
+    record = await repository.create(user_id=user.id, job_type=JobType.EXTRACTION)
+    await db_session.commit()
+
+    ingress_correlation_id = "ingress-correlation-id-123"
+    transcript = "mulch the front beds"
+    with pytest.raises(ExtractionError, match="Claude request failed: malformed payload"):
+        await extraction_job(
+            _worker_context(
+                db_session,
+                extraction_integration=_MetadataFailureExtractionIntegration(),
+            ),
+            str(record.id),
+            correlation_id=ingress_correlation_id,
+            transcript=transcript,
+            source_type="text",
+            capture_detail="notes",
+        )
+
+    refreshed = await _load_job_record(db_session, record.id)
+    assert refreshed is not None  # nosec B101 - pytest assertion
+    assert refreshed.last_model_id == "claude-haiku-4-5-20251001"  # nosec B101 - pytest assertion
+
+    extraction_failure = next(
+        log for log in security_logs if log.get("event") == "quotes.extract_failed"
+    )
+    assert extraction_failure["job_id"] == str(record.id)  # nosec B101 - pytest assertion
+    assert extraction_failure["correlation_id"] == ingress_correlation_id  # nosec B101 - pytest assertion
+    assert extraction_failure["last_model_id"] == "claude-haiku-4-5-20251001"  # nosec B101 - pytest assertion
+    assert extraction_failure["error_class"] == "_NonRetryableProviderError"  # nosec B101 - pytest assertion
+    assert isinstance(extraction_failure["latency_ms"], int)  # nosec B101 - pytest assertion
+    assert extraction_failure["token_usage"] == {  # nosec B101 - pytest assertion
+        "input_tokens": 91,
+        "output_tokens": 0,
+    }
+    assert (
+        extraction_failure["transcript_sha256"]
+        == sha256(  # nosec B101 - pytest assertion
+            transcript.encode("utf-8")
+        ).hexdigest()
+    )
+    assert transcript not in json.dumps(extraction_failure)  # nosec B101 - pytest assertion
+
+
 class _SuccessfulExtractionIntegration:
     async def extract(self, notes: str) -> ExtractionResult:
         return ExtractionResult(
@@ -243,6 +299,28 @@ class _NonRetryableFailureExtractionIntegration:
     async def extract(self, notes: str) -> ExtractionResult:
         del notes
         raise ExtractionError("Claude request failed: malformed payload")
+
+
+class _NonRetryableProviderError(Exception):
+    def __init__(self, status_code: int) -> None:
+        super().__init__(f"provider error {status_code}")
+        self.status_code = status_code
+
+
+class _MetadataFailureExtractionIntegration:
+    model_id = "claude-haiku-4-5-20251001"
+
+    async def extract(self, notes: str) -> ExtractionResult:
+        del notes
+        raise ExtractionError(
+            "Claude request failed: malformed payload"
+        ) from _NonRetryableProviderError(status_code=400)
+
+    def pop_last_call_metadata(self) -> ExtractionCallMetadata:
+        return ExtractionCallMetadata(
+            model_id=self.model_id,
+            token_usage={"input_tokens": 91, "output_tokens": 0},
+        )
 
 
 async def _seed_user(db_session: AsyncSession) -> User:


### PR DESCRIPTION
## Summary
- accept trusted ingress `X-Correlation-ID` values only when valid; otherwise generate a new correlation id and return it in the response header
- propagate correlation id through extraction enqueue payloads into worker runtime context so API, queue, worker, and provider logs share the same trace id
- add `job_records.last_model_id` persistence (SQLAlchemy + Alembic migration) and enrich extraction failure security logs with latency, token usage (when available), compact error class, and transcript hash (never raw transcript)
- extend backend tests for trusted-ingress correlation behavior, API->queue propagation, worker failure telemetry, and job repository model-id persistence

## Verification
- `make backend-verify`

Closes #287