### PR TITLE
Task #288: one-shot validation repair degraded fallback

### DIFF
--- a/backend/app/features/quotes/tests/test_extraction.py
+++ b/backend/app/features/quotes/tests/test_extraction.py
@@ -260,6 +260,50 @@ async def test_extract_attempts_one_repair_then_accepts_valid_repaired_payload()
     assert "Schema validation errors:" in repair_user_content
 
 
+async def test_extract_sets_repair_failure_metadata_when_repair_request_errors() -> None:
+    transcript = TRANSCRIPTS["clean_with_total"]
+    request = httpx.Request("POST", "https://api.anthropic.com/v1/messages")
+    rate_limit_error = anthropic.RateLimitError(
+        "rate limited",
+        response=httpx.Response(429, request=request),
+        body=None,
+    )
+    client = _SequencedClient(
+        [
+            _FakeResponse(
+                content=[
+                    {
+                        "type": "tool_use",
+                        "input": {
+                            "transcript": transcript,
+                            "line_items": "invalid-shape",
+                            "total": 435,
+                            "confidence_notes": [],
+                        },
+                    }
+                ]
+            ),
+            rate_limit_error,
+        ]
+    )
+    integration = ExtractionIntegration(
+        api_key="test",
+        model="test-model",
+        max_attempts=1,
+        client=client,
+    )
+
+    with pytest.raises(ExtractionError, match="Claude request failed"):
+        await integration.extract(transcript)
+
+    metadata = integration.pop_last_call_metadata()
+    assert metadata is not None
+    assert metadata.repair_attempted is True
+    assert metadata.repair_outcome == "repair_request_failed"
+    assert metadata.repair_validation_error_count == 1
+    assert len(client.messages.calls) == 2
+
+
 async def test_extract_builds_client_with_configured_timeout_and_disabled_sdk_retries(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/backend/app/features/quotes/tests/test_extraction.py
+++ b/backend/app/features/quotes/tests/test_extraction.py
@@ -163,27 +163,101 @@ async def test_extract_handles_ambiguous_partial_input_without_raising() -> None
     assert "ambiguous" in result.confidence_notes[0].lower()
 
 
-async def test_extract_raises_typed_error_for_malformed_payload() -> None:
+async def test_extract_returns_degraded_result_when_repair_is_still_invalid() -> None:
     transcript = TRANSCRIPTS["clean_with_total"]
-    client = _FakeClient(
-        lambda _: _FakeResponse(
-            content=[
-                {
-                    "type": "tool_use",
-                    "input": {
-                        "transcript": transcript,
-                        "line_items": "invalid-shape",
-                        "total": 435,
-                        "confidence_notes": [],
-                    },
-                }
-            ]
-        )
+    client = _SequencedClient(
+        [
+            _FakeResponse(
+                content=[
+                    {
+                        "type": "tool_use",
+                        "input": {
+                            "transcript": transcript,
+                            "line_items": "invalid-shape",
+                            "total": 435,
+                            "confidence_notes": [],
+                        },
+                    }
+                ]
+            ),
+            _FakeResponse(
+                content=[
+                    {
+                        "type": "tool_use",
+                        "input": {
+                            "transcript": transcript,
+                            "line_items": "still-invalid",
+                            "total": 435,
+                            "confidence_notes": [],
+                        },
+                    }
+                ]
+            ),
+        ]
     )
     integration = ExtractionIntegration(api_key="test", model="test-model", client=client)
 
-    with pytest.raises(ExtractionError, match="schema"):
-        await integration.extract(transcript)
+    result = await integration.extract(transcript)
+
+    assert result.extraction_tier == "degraded"
+    assert result.extraction_degraded_reason_code == "validation_repair_failed"
+    assert result.line_items == []
+    assert len(client.messages.calls) == 2
+
+
+async def test_extract_attempts_one_repair_then_accepts_valid_repaired_payload() -> None:
+    transcript = TRANSCRIPTS["clean_with_total"]
+    client = _SequencedClient(
+        [
+            _FakeResponse(
+                content=[
+                    {
+                        "type": "tool_use",
+                        "input": {
+                            "transcript": transcript,
+                            "line_items": "invalid-shape",
+                            "total": 435,
+                            "confidence_notes": [],
+                        },
+                    }
+                ]
+            ),
+            _FakeResponse(
+                content=[
+                    {
+                        "type": "tool_use",
+                        "input": {
+                            "transcript": transcript,
+                            "line_items": [
+                                {
+                                    "description": "Trim shrubs",
+                                    "details": "Front beds",
+                                    "price": 125,
+                                }
+                            ],
+                            "total": 125,
+                            "confidence_notes": [],
+                        },
+                    }
+                ]
+            ),
+        ]
+    )
+    integration = ExtractionIntegration(api_key="test", model="test-model", client=client)
+
+    result = await integration.extract(transcript)
+
+    assert len(client.messages.calls) == 2
+    assert result.extraction_tier == "primary"
+    assert result.total == 125
+    assert result.line_items[0].description == "Trim shrubs"
+
+    repair_messages = client.messages.calls[1]["messages"]
+    assert isinstance(repair_messages, list)
+    assert repair_messages
+    repair_user_content = repair_messages[0]["content"]
+    assert isinstance(repair_user_content, str)
+    assert "Schema validation errors:" in repair_user_content
 
 
 async def test_extract_builds_client_with_configured_timeout_and_disabled_sdk_retries(

--- a/backend/app/integrations/extraction.py
+++ b/backend/app/integrations/extraction.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import contextvars
+import json
 import secrets
 from dataclasses import dataclass
 from typing import Any, cast
@@ -74,6 +75,13 @@ EXTRACTION_SYSTEM_PROMPT = (
     "Return only structured tool output."
 )
 
+EXTRACTION_REPAIR_SYSTEM_PROMPT = (
+    "You are repairing invalid structured extraction tool output. "
+    "Return only corrected tool output that strictly matches the extraction schema."
+)
+
+EXTRACTION_DEGRADED_REASON_VALIDATION_REPAIR_FAILED = "validation_repair_failed"
+
 _RETRY_BASE_DELAY_SECONDS = 0.25
 _RETRY_MAX_DELAY_SECONDS = 2.0
 
@@ -88,6 +96,9 @@ class ExtractionCallMetadata:
 
     model_id: str | None
     token_usage: dict[str, int] | None
+    repair_attempted: bool = False
+    repair_outcome: str | None = None
+    repair_validation_error_count: int | None = None
 
 
 _LAST_CALL_METADATA_VAR: contextvars.ContextVar[ExtractionCallMetadata | None] = (
@@ -138,6 +149,9 @@ class ExtractionIntegration:
         _set_last_call_metadata(
             model_id=getattr(response, "model", None) or self._model,
             token_usage=_extract_token_usage(response),
+            repair_attempted=False,
+            repair_outcome="not_attempted",
+            repair_validation_error_count=None,
         )
 
         payload = _extract_tool_payload(response)
@@ -148,7 +162,41 @@ class ExtractionIntegration:
         try:
             return ExtractionResult.model_validate(payload)
         except ValidationError as exc:
-            raise ExtractionError("Claude response did not match extraction schema") from exc
+            validation_errors = _compact_validation_errors(exc)
+            repair_response = await self._request_with_retry(
+                typed_client,
+                _build_repair_request(
+                    notes=normalized_notes,
+                    invalid_payload=payload,
+                    validation_errors=validation_errors,
+                ),
+                system_prompt=EXTRACTION_REPAIR_SYSTEM_PROMPT,
+            )
+            repair_usage = _extract_token_usage(repair_response)
+            repair_model_id = getattr(repair_response, "model", None) or self._model
+            repair_payload = _extract_tool_payload(repair_response)
+            repair_payload.setdefault("transcript", normalized_notes)
+            repair_payload.setdefault("line_items", [])
+            repair_payload.setdefault("confidence_notes", [])
+            try:
+                repaired_result = ExtractionResult.model_validate(repair_payload)
+            except ValidationError:
+                _set_last_call_metadata(
+                    model_id=repair_model_id,
+                    token_usage=repair_usage,
+                    repair_attempted=True,
+                    repair_outcome="repair_invalid",
+                    repair_validation_error_count=len(validation_errors),
+                )
+                return _build_validation_repair_failed_result(transcript=normalized_notes)
+            _set_last_call_metadata(
+                model_id=repair_model_id,
+                token_usage=repair_usage,
+                repair_attempted=True,
+                repair_outcome="repair_succeeded",
+                repair_validation_error_count=len(validation_errors),
+            )
+            return repaired_result
 
     @property
     def model_id(self) -> str:
@@ -161,7 +209,13 @@ class ExtractionIntegration:
         _LAST_CALL_METADATA_VAR.set(None)
         return metadata
 
-    async def _request_with_retry(self, typed_client: Any, normalized_notes: str) -> object:
+    async def _request_with_retry(
+        self,
+        typed_client: Any,
+        request_content: str,
+        *,
+        system_prompt: str = EXTRACTION_SYSTEM_PROMPT,
+    ) -> object:
         last_error: Exception | None = None
         for attempt in range(1, self._max_attempts + 1):
             try:
@@ -169,11 +223,11 @@ class ExtractionIntegration:
                     model=self._model,
                     max_tokens=800,
                     temperature=0,
-                    system=EXTRACTION_SYSTEM_PROMPT,
+                    system=system_prompt,
                     messages=[
                         {
                             "role": "user",
-                            "content": normalized_notes,
+                            "content": request_content,
                         }
                     ],
                     tools=[
@@ -290,11 +344,21 @@ def _retry_delay_seconds(attempt: int) -> float:
     return base_delay + (secrets.randbelow(1000) / 1000) * jitter_bound
 
 
-def _set_last_call_metadata(*, model_id: str | None, token_usage: dict[str, int] | None) -> None:
+def _set_last_call_metadata(
+    *,
+    model_id: str | None,
+    token_usage: dict[str, int] | None,
+    repair_attempted: bool = False,
+    repair_outcome: str | None = None,
+    repair_validation_error_count: int | None = None,
+) -> None:
     _LAST_CALL_METADATA_VAR.set(
         ExtractionCallMetadata(
             model_id=model_id,
             token_usage=token_usage,
+            repair_attempted=repair_attempted,
+            repair_outcome=repair_outcome,
+            repair_validation_error_count=repair_validation_error_count,
         )
     )
 
@@ -323,3 +387,46 @@ def _token_usage_int(usage: object, key: str) -> int | None:
     else:
         candidate = getattr(usage, key, None)
     return candidate if isinstance(candidate, int) else None
+
+
+def _build_repair_request(
+    *,
+    notes: str,
+    invalid_payload: dict[str, Any],
+    validation_errors: list[str],
+) -> str:
+    compact_payload = json.dumps(invalid_payload, ensure_ascii=True, separators=(",", ":"))
+    compact_errors = "\n".join(f"- {error}" for error in validation_errors)
+    return (
+        "Original notes:\n"
+        f"{notes}\n\n"
+        "Invalid tool output JSON:\n"
+        f"{compact_payload}\n\n"
+        "Schema validation errors:\n"
+        f"{compact_errors}\n\n"
+        "Return corrected structured tool output only."
+    )
+
+
+def _compact_validation_errors(error: ValidationError) -> list[str]:
+    compact: list[str] = []
+    for item in error.errors(include_url=False):
+        location = ".".join(str(part) for part in item.get("loc", ()))
+        message = str(item.get("msg", "Invalid value"))
+        issue_type = str(item.get("type", "validation_error"))
+        if location:
+            compact.append(f"{location}: {message} ({issue_type})")
+        else:
+            compact.append(f"{message} ({issue_type})")
+    return compact
+
+
+def _build_validation_repair_failed_result(*, transcript: str) -> ExtractionResult:
+    return ExtractionResult(
+        transcript=transcript,
+        line_items=[],
+        total=None,
+        confidence_notes=[],
+        extraction_tier="degraded",
+        extraction_degraded_reason_code=EXTRACTION_DEGRADED_REASON_VALIDATION_REPAIR_FAILED,
+    )

--- a/backend/app/integrations/extraction.py
+++ b/backend/app/integrations/extraction.py
@@ -146,9 +146,11 @@ class ExtractionIntegration:
         typed_client = cast(Any, client)
 
         response = await self._request_with_retry(typed_client, normalized_notes)
+        response_model_id = getattr(response, "model", None) or self._model
+        response_token_usage = _extract_token_usage(response)
         _set_last_call_metadata(
-            model_id=getattr(response, "model", None) or self._model,
-            token_usage=_extract_token_usage(response),
+            model_id=response_model_id,
+            token_usage=response_token_usage,
             repair_attempted=False,
             repair_outcome="not_attempted",
             repair_validation_error_count=None,
@@ -163,15 +165,25 @@ class ExtractionIntegration:
             return ExtractionResult.model_validate(payload)
         except ValidationError as exc:
             validation_errors = _compact_validation_errors(exc)
-            repair_response = await self._request_with_retry(
-                typed_client,
-                _build_repair_request(
-                    notes=normalized_notes,
-                    invalid_payload=payload,
-                    validation_errors=validation_errors,
-                ),
-                system_prompt=EXTRACTION_REPAIR_SYSTEM_PROMPT,
-            )
+            try:
+                repair_response = await self._request_with_retry(
+                    typed_client,
+                    _build_repair_request(
+                        notes=normalized_notes,
+                        invalid_payload=payload,
+                        validation_errors=validation_errors,
+                    ),
+                    system_prompt=EXTRACTION_REPAIR_SYSTEM_PROMPT,
+                )
+            except ExtractionError:
+                _set_last_call_metadata(
+                    model_id=response_model_id,
+                    token_usage=response_token_usage,
+                    repair_attempted=True,
+                    repair_outcome="repair_request_failed",
+                    repair_validation_error_count=len(validation_errors),
+                )
+                raise
             repair_usage = _extract_token_usage(repair_response)
             repair_model_id = getattr(repair_response, "model", None) or self._model
             repair_payload = _extract_tool_payload(repair_response)

--- a/backend/app/worker/job_registry.py
+++ b/backend/app/worker/job_registry.py
@@ -269,6 +269,11 @@ async def _extract_quote_data(
             last_model_id=resolved_last_model_id,
             latency_ms=int((perf_counter() - started_at) * 1000),
             token_usage=metadata.token_usage if metadata is not None else None,
+            repair_attempted=metadata.repair_attempted if metadata is not None else False,
+            repair_outcome=metadata.repair_outcome if metadata is not None else None,
+            repair_validation_error_count=(
+                metadata.repair_validation_error_count if metadata is not None else None
+            ),
             error_class=_compact_error_class(exc),
             transcript_sha256=_transcript_sha256(transcript),
         )
@@ -291,6 +296,22 @@ async def _extract_quote_data(
         job_id=job_id,
         last_model_id=resolved_last_model_id,
     )
+    if metadata is not None and metadata.repair_attempted:
+        repair_outcome = metadata.repair_outcome or "unknown"
+        log_security_event(
+            "quotes.extract_repair",
+            outcome=repair_outcome,
+            level=logging.INFO if repair_outcome == "repair_succeeded" else logging.WARNING,
+            reason=repair_outcome,
+            job_name=EXTRACTION_JOB_NAME,
+            job_id=str(job_id),
+            last_model_id=resolved_last_model_id,
+            extraction_tier=result.extraction_tier,
+            extraction_degraded_reason_code=result.extraction_degraded_reason_code,
+            repair_validation_error_count=metadata.repair_validation_error_count,
+            token_usage=metadata.token_usage,
+            transcript_sha256=_transcript_sha256(transcript),
+        )
     return result
 
 

--- a/backend/app/worker/tests/test_job_registry.py
+++ b/backend/app/worker/tests/test_job_registry.py
@@ -183,6 +183,52 @@ async def test_extraction_job_retries_provider_429_then_persists_degraded_on_fin
     assert stored_result.line_items == []  # nosec B101 - pytest assertion
 
 
+async def test_extraction_job_persists_validation_repair_failed_degraded_result_without_retry(
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    security_logs: list[dict[str, object]] = []
+
+    def _capture_security(payload: dict[str, object], *, level: int) -> None:
+        security_logs.append({**payload, "_level": level})
+
+    monkeypatch.setattr(observability, "_emit_security_payload", _capture_security)
+
+    user = await _seed_user(db_session)
+    repository = JobRepository(db_session)
+    record = await repository.create(user_id=user.id, job_type=JobType.EXTRACTION)
+    await db_session.commit()
+
+    await extraction_job(
+        _worker_context(
+            db_session,
+            extraction_integration=_ValidationRepairFailedExtractionIntegration(),
+        ),
+        str(record.id),
+        transcript="mulch the front beds",
+        source_type="text",
+        capture_detail="notes",
+    )
+
+    refreshed = await _load_job_record(db_session, record.id)
+    assert refreshed is not None  # nosec B101 - pytest assertion
+    assert refreshed.status == JobStatus.SUCCESS  # nosec B101 - pytest assertion
+    assert refreshed.document_id is not None  # nosec B101 - pytest assertion
+
+    persisted_quote = await db_session.get(Document, refreshed.document_id)
+    assert persisted_quote is not None  # nosec B101 - pytest assertion
+    assert persisted_quote.extraction_tier == "degraded"  # nosec B101 - pytest assertion
+    assert persisted_quote.extraction_degraded_reason_code == "validation_repair_failed"  # nosec B101 - pytest assertion
+
+    repair_log = next(log for log in security_logs if log.get("event") == "quotes.extract_repair")
+    assert repair_log["outcome"] == "repair_invalid"  # nosec B101 - pytest assertion
+    assert repair_log["repair_validation_error_count"] == 1  # nosec B101 - pytest assertion
+    assert repair_log["extraction_tier"] == "degraded"  # nosec B101 - pytest assertion
+    assert (  # nosec B101 - pytest assertion
+        repair_log["extraction_degraded_reason_code"] == "validation_repair_failed"
+    )
+
+
 async def test_extraction_job_logs_draft_generation_failed_on_terminal_failure(
     db_session: AsyncSession,
     monkeypatch: pytest.MonkeyPatch,
@@ -293,6 +339,29 @@ class _RetryableFailureExtractionIntegration:
     async def extract(self, notes: str) -> ExtractionResult:
         del notes
         raise ExtractionError("Claude request failed: retryable") from _RetryableProviderError(429)
+
+
+class _ValidationRepairFailedExtractionIntegration:
+    model_id = "claude-haiku-4-5-20251001"
+
+    async def extract(self, notes: str) -> ExtractionResult:
+        return ExtractionResult(
+            transcript=notes,
+            line_items=[],
+            total=None,
+            confidence_notes=[],
+            extraction_tier="degraded",
+            extraction_degraded_reason_code="validation_repair_failed",
+        )
+
+    def pop_last_call_metadata(self) -> ExtractionCallMetadata:
+        return ExtractionCallMetadata(
+            model_id=self.model_id,
+            token_usage={"input_tokens": 91, "output_tokens": 44},
+            repair_attempted=True,
+            repair_outcome="repair_invalid",
+            repair_validation_error_count=1,
+        )
 
 
 class _NonRetryableFailureExtractionIntegration:


### PR DESCRIPTION
## Summary
- add one-shot extraction schema repair turn after initial Pydantic validation failure
- return degraded sentinel extraction result with reason "validation_repair_failed" when repair output is still invalid
- add repair observability metadata/log fields and focused tests for repair/degraded behavior

## Verification
- make backend-verify

Closes #288
