### PR TITLE
Task #289: add optional fallback extraction model tier

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -63,6 +63,10 @@ GCS_BUCKET_NAME=your-local-or-dev-bucket-name
 
 # AI model selection
 EXTRACTION_MODEL=claude-haiku-4-5-20251001
+# Optional fallback model used only after primary extraction attempts are exhausted.
+EXTRACTION_FALLBACK_MODEL=
+EXTRACTION_PRIMARY_PROMPT_VARIANT=primary_default
+EXTRACTION_FALLBACK_PROMPT_VARIANT=fallback_default
 TRANSCRIPTION_MODEL=whisper-1
 
 # Sentry Monitoring

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -180,6 +180,18 @@ class Settings(BaseSettings):
         default="claude-haiku-4-5-20251001",
         validation_alias="EXTRACTION_MODEL",
     )
+    extraction_fallback_model: str | None = Field(
+        default=None,
+        validation_alias="EXTRACTION_FALLBACK_MODEL",
+    )
+    extraction_primary_prompt_variant: str = Field(
+        default="primary_default",
+        validation_alias="EXTRACTION_PRIMARY_PROMPT_VARIANT",
+    )
+    extraction_fallback_prompt_variant: str = Field(
+        default="fallback_default",
+        validation_alias="EXTRACTION_FALLBACK_PROMPT_VARIANT",
+    )
     transcription_model: str = Field(
         default="whisper-1",
         validation_alias="TRANSCRIPTION_MODEL",
@@ -231,6 +243,7 @@ class Settings(BaseSettings):
         "resend_api_key",
         "email_from_address",
         "email_from_name",
+        "extraction_fallback_model",
         mode="before",
     )
     @classmethod
@@ -244,6 +257,19 @@ class Settings(BaseSettings):
                 return None
             return normalized_value
         return str(value)
+
+    @field_validator(
+        "extraction_primary_prompt_variant",
+        "extraction_fallback_prompt_variant",
+        mode="before",
+    )
+    @classmethod
+    def normalize_prompt_variant(cls, value: Any) -> str:
+        """Reject blank extraction prompt variant tags used for log segmentation."""
+        normalized_value = str(value).strip()
+        if not normalized_value:
+            raise ValueError("Extraction prompt variant tags must be non-empty")
+        return normalized_value
 
     @field_validator("redis_key_prefix", mode="before")
     @classmethod

--- a/backend/app/features/quotes/tests/fixtures/transcripts.py
+++ b/backend/app/features/quotes/tests/fixtures/transcripts.py
@@ -25,4 +25,7 @@ TRANSCRIPTS: dict[str, str] = {
     "no_pricing_at_all": (
         "Inspect attic insulation, check crawlspace moisture barrier, and send me recommendations."
     ),
+    "fallback_tier_probe": (
+        "Replace two porch lights, tighten one loose railing section, and test both GFCI outlets."
+    ),
 }

--- a/backend/app/features/quotes/tests/test_extraction.py
+++ b/backend/app/features/quotes/tests/test_extraction.py
@@ -389,6 +389,89 @@ async def test_extract_retries_rate_limit_then_succeeds(
     assert sleep_calls == [0.25]
 
 
+async def test_extract_does_not_invoke_fallback_before_primary_exhaustion() -> None:
+    transcript = TRANSCRIPTS["clean_with_total"]
+    request = httpx.Request("POST", "https://api.anthropic.com/v1/messages")
+    rate_limit_error = anthropic.RateLimitError(
+        "rate limited",
+        response=httpx.Response(429, request=request),
+        body=None,
+    )
+    client = _SequencedClient(
+        [
+            rate_limit_error,
+            _FakeResponse(
+                content=[
+                    {
+                        "type": "tool_use",
+                        "input": {
+                            "transcript": transcript,
+                            "line_items": [],
+                            "confidence_notes": [],
+                        },
+                    }
+                ]
+            ),
+        ]
+    )
+    integration = ExtractionIntegration(
+        api_key="test",
+        model="primary-model",
+        fallback_model="fallback-model",
+        max_attempts=2,
+        client=client,
+    )
+
+    await integration.extract(transcript)
+
+    assert [call["model"] for call in client.messages.calls] == ["primary-model", "primary-model"]
+
+
+async def test_extract_invokes_fallback_after_primary_exhaustion_and_tags_metadata() -> None:
+    transcript = TRANSCRIPTS["clean_with_total"]
+    request = httpx.Request("POST", "https://api.anthropic.com/v1/messages")
+    rate_limit_error = anthropic.RateLimitError(
+        "rate limited",
+        response=httpx.Response(429, request=request),
+        body=None,
+    )
+    client = _SequencedClient(
+        [
+            rate_limit_error,
+            _FakeResponse(
+                content=[
+                    {
+                        "type": "tool_use",
+                        "input": {
+                            "transcript": transcript,
+                            "line_items": [],
+                            "confidence_notes": [],
+                        },
+                    }
+                ]
+            ),
+        ]
+    )
+    integration = ExtractionIntegration(
+        api_key="test",
+        model="primary-model",
+        fallback_model="fallback-model",
+        max_attempts=1,
+        client=client,
+    )
+
+    result = await integration.extract(transcript)
+
+    assert result.transcript == transcript
+    assert [call["model"] for call in client.messages.calls] == ["primary-model", "fallback-model"]
+
+    metadata = integration.pop_last_call_metadata()
+    assert metadata is not None
+    assert metadata.invocation_tier == "fallback"
+    assert metadata.model_id == "fallback-model"
+    assert metadata.prompt_variant == "fallback_default"
+
+
 async def test_extract_does_not_retry_non_retryable_provider_status() -> None:
     transcript = TRANSCRIPTS["clean_with_total"]
     request = httpx.Request("POST", "https://api.anthropic.com/v1/messages")

--- a/backend/app/features/quotes/tests/test_extraction_live.py
+++ b/backend/app/features/quotes/tests/test_extraction_live.py
@@ -24,6 +24,9 @@ def _build_integration() -> ExtractionIntegration:
     return ExtractionIntegration(
         api_key=_SETTINGS.anthropic_api_key,
         model=_SETTINGS.extraction_model,
+        fallback_model=_SETTINGS.extraction_fallback_model,
+        primary_prompt_variant=_SETTINGS.extraction_primary_prompt_variant,
+        fallback_prompt_variant=_SETTINGS.extraction_fallback_prompt_variant,
     )
 
 
@@ -109,3 +112,30 @@ async def test_live_no_pricing_at_all() -> None:
     assert result.line_items
     assert all(item.price is None for item in result.line_items)
     assert result.confidence_notes
+
+
+@pytest.mark.live
+@pytest.mark.skipif(
+    not _SETTINGS.extraction_fallback_model,
+    reason="Fallback live probe requires EXTRACTION_FALLBACK_MODEL in backend/.env",
+)
+async def test_live_fallback_tier_probe_uses_fallback_model_after_primary_exhaustion() -> None:
+    integration = ExtractionIntegration(
+        api_key=_SETTINGS.anthropic_api_key,
+        model="stima-invalid-primary-model",
+        fallback_model=_SETTINGS.extraction_fallback_model,
+        max_attempts=1,
+        primary_prompt_variant=_SETTINGS.extraction_primary_prompt_variant,
+        fallback_prompt_variant=_SETTINGS.extraction_fallback_prompt_variant,
+    )
+
+    transcript = TRANSCRIPTS["fallback_tier_probe"]
+    result = await integration.extract(transcript)
+    metadata = integration.pop_last_call_metadata()
+
+    _print_report_card("fallback_tier_probe", result)
+
+    assert result.transcript == transcript
+    assert metadata is not None
+    assert metadata.invocation_tier == "fallback"
+    assert metadata.model_id == _SETTINGS.extraction_fallback_model

--- a/backend/app/integrations/extraction.py
+++ b/backend/app/integrations/extraction.py
@@ -7,7 +7,7 @@ import contextvars
 import json
 import secrets
 from dataclasses import dataclass
-from typing import Any, cast
+from typing import Any, Literal, cast
 
 import anthropic
 from anthropic import AsyncAnthropic
@@ -81,6 +81,11 @@ EXTRACTION_REPAIR_SYSTEM_PROMPT = (
 )
 
 EXTRACTION_DEGRADED_REASON_VALIDATION_REPAIR_FAILED = "validation_repair_failed"
+EXTRACTION_INVOCATION_TIER_PRIMARY: Literal["primary"] = "primary"
+EXTRACTION_INVOCATION_TIER_FALLBACK: Literal["fallback"] = "fallback"
+EXTRACTION_PROMPT_VARIANT_PRIMARY_DEFAULT = "primary_default"
+EXTRACTION_PROMPT_VARIANT_FALLBACK_DEFAULT = "fallback_default"
+EXTRACTION_PROMPT_VARIANT_REPAIR_SUFFIX = "repair"
 
 _RETRY_BASE_DELAY_SECONDS = 0.25
 _RETRY_MAX_DELAY_SECONDS = 2.0
@@ -96,9 +101,18 @@ class ExtractionCallMetadata:
 
     model_id: str | None
     token_usage: dict[str, int] | None
+    invocation_tier: Literal["primary", "fallback"] = EXTRACTION_INVOCATION_TIER_PRIMARY
+    prompt_variant: str | None = None
     repair_attempted: bool = False
     repair_outcome: str | None = None
     repair_validation_error_count: int | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class _ExtractionTierConfig:
+    tier: Literal["primary", "fallback"]
+    model_id: str
+    prompt_variant: str
 
 
 _LAST_CALL_METADATA_VAR: contextvars.ContextVar[ExtractionCallMetadata | None] = (
@@ -114,14 +128,26 @@ class ExtractionIntegration:
         *,
         api_key: str,
         model: str,
+        fallback_model: str | None = None,
         timeout_seconds: float = 30.0,
         max_attempts: int = 3,
+        primary_prompt_variant: str = EXTRACTION_PROMPT_VARIANT_PRIMARY_DEFAULT,
+        fallback_prompt_variant: str = EXTRACTION_PROMPT_VARIANT_FALLBACK_DEFAULT,
         client: object | None = None,
     ) -> None:
         self._api_key = api_key
-        self._model = model
+        self._primary_model = model
+        self._fallback_model = fallback_model.strip() if isinstance(fallback_model, str) else None
+        if self._fallback_model == "":
+            self._fallback_model = None
         self._timeout_seconds = timeout_seconds
         self._max_attempts = max_attempts
+        self._primary_prompt_variant = (
+            primary_prompt_variant.strip() or EXTRACTION_PROMPT_VARIANT_PRIMARY_DEFAULT
+        )
+        self._fallback_prompt_variant = (
+            fallback_prompt_variant.strip() or EXTRACTION_PROMPT_VARIANT_FALLBACK_DEFAULT
+        )
         self._client = client
 
     async def extract(self, notes: str) -> ExtractionResult:
@@ -129,7 +155,12 @@ class ExtractionIntegration:
         normalized_notes = notes.strip()
         if not normalized_notes:
             raise ExtractionError("notes cannot be empty")
-        _set_last_call_metadata(model_id=self._model, token_usage=None)
+        _set_last_call_metadata(
+            model_id=self._primary_model,
+            token_usage=None,
+            invocation_tier=EXTRACTION_INVOCATION_TIER_PRIMARY,
+            prompt_variant=self._primary_prompt_variant,
+        )
 
         if self._client is None:
             if not self._api_key:
@@ -145,12 +176,79 @@ class ExtractionIntegration:
             raise ExtractionError("Claude client was not initialized")
         typed_client = cast(Any, client)
 
-        response = await self._request_with_retry(typed_client, normalized_notes)
-        response_model_id = getattr(response, "model", None) or self._model
+        tier_sequence = self._build_tier_sequence()
+        last_error: ExtractionError | None = None
+        for tier in tier_sequence:
+            try:
+                return await self._extract_for_tier(
+                    typed_client,
+                    normalized_notes,
+                    tier=tier,
+                )
+            except ExtractionError as exc:
+                last_error = exc
+                continue
+
+        if last_error is None:  # pragma: no cover - defensive invariant
+            raise ExtractionError("Claude request failed")
+        raise last_error
+
+    @property
+    def model_id(self) -> str:
+        """Return the configured primary provider model id for extraction calls."""
+        return self._primary_model
+
+    def pop_last_call_metadata(self) -> ExtractionCallMetadata | None:
+        """Return and clear per-task extraction telemetry from the latest call."""
+        metadata = _LAST_CALL_METADATA_VAR.get()
+        _LAST_CALL_METADATA_VAR.set(None)
+        return metadata
+
+    def _build_tier_sequence(self) -> tuple[_ExtractionTierConfig, ...]:
+        primary_tier = _ExtractionTierConfig(
+            tier=EXTRACTION_INVOCATION_TIER_PRIMARY,
+            model_id=self._primary_model,
+            prompt_variant=self._primary_prompt_variant,
+        )
+        if self._fallback_model is None:
+            return (primary_tier,)
+        return (
+            primary_tier,
+            _ExtractionTierConfig(
+                tier=EXTRACTION_INVOCATION_TIER_FALLBACK,
+                model_id=self._fallback_model,
+                prompt_variant=self._fallback_prompt_variant,
+            ),
+        )
+
+    async def _extract_for_tier(
+        self,
+        typed_client: Any,
+        normalized_notes: str,
+        *,
+        tier: _ExtractionTierConfig,
+    ) -> ExtractionResult:
+        _set_last_call_metadata(
+            model_id=tier.model_id,
+            token_usage=None,
+            invocation_tier=tier.tier,
+            prompt_variant=tier.prompt_variant,
+        )
+
+        response = await self._request_with_retry(
+            typed_client,
+            normalized_notes,
+            model_id=tier.model_id,
+            invocation_tier=tier.tier,
+            prompt_variant=tier.prompt_variant,
+        )
+        response_model_id = getattr(response, "model", None) or tier.model_id
         response_token_usage = _extract_token_usage(response)
         _set_last_call_metadata(
             model_id=response_model_id,
             token_usage=response_token_usage,
+            invocation_tier=tier.tier,
+            prompt_variant=tier.prompt_variant,
             repair_attempted=False,
             repair_outcome="not_attempted",
             repair_validation_error_count=None,
@@ -165,6 +263,9 @@ class ExtractionIntegration:
             return ExtractionResult.model_validate(payload)
         except ValidationError as exc:
             validation_errors = _compact_validation_errors(exc)
+            repair_prompt_variant = (
+                f"{tier.prompt_variant}:{EXTRACTION_PROMPT_VARIANT_REPAIR_SUFFIX}"
+            )
             try:
                 repair_response = await self._request_with_retry(
                     typed_client,
@@ -173,19 +274,24 @@ class ExtractionIntegration:
                         invalid_payload=payload,
                         validation_errors=validation_errors,
                     ),
+                    model_id=tier.model_id,
+                    invocation_tier=tier.tier,
+                    prompt_variant=repair_prompt_variant,
                     system_prompt=EXTRACTION_REPAIR_SYSTEM_PROMPT,
                 )
             except ExtractionError:
                 _set_last_call_metadata(
                     model_id=response_model_id,
                     token_usage=response_token_usage,
+                    invocation_tier=tier.tier,
+                    prompt_variant=repair_prompt_variant,
                     repair_attempted=True,
                     repair_outcome="repair_request_failed",
                     repair_validation_error_count=len(validation_errors),
                 )
                 raise
             repair_usage = _extract_token_usage(repair_response)
-            repair_model_id = getattr(repair_response, "model", None) or self._model
+            repair_model_id = getattr(repair_response, "model", None) or tier.model_id
             repair_payload = _extract_tool_payload(repair_response)
             repair_payload.setdefault("transcript", normalized_notes)
             repair_payload.setdefault("line_items", [])
@@ -196,6 +302,8 @@ class ExtractionIntegration:
                 _set_last_call_metadata(
                     model_id=repair_model_id,
                     token_usage=repair_usage,
+                    invocation_tier=tier.tier,
+                    prompt_variant=repair_prompt_variant,
                     repair_attempted=True,
                     repair_outcome="repair_invalid",
                     repair_validation_error_count=len(validation_errors),
@@ -204,35 +312,29 @@ class ExtractionIntegration:
             _set_last_call_metadata(
                 model_id=repair_model_id,
                 token_usage=repair_usage,
+                invocation_tier=tier.tier,
+                prompt_variant=repair_prompt_variant,
                 repair_attempted=True,
                 repair_outcome="repair_succeeded",
                 repair_validation_error_count=len(validation_errors),
             )
             return repaired_result
 
-    @property
-    def model_id(self) -> str:
-        """Return the configured provider model id for extraction calls."""
-        return self._model
-
-    def pop_last_call_metadata(self) -> ExtractionCallMetadata | None:
-        """Return and clear per-task extraction telemetry from the latest call."""
-        metadata = _LAST_CALL_METADATA_VAR.get()
-        _LAST_CALL_METADATA_VAR.set(None)
-        return metadata
-
     async def _request_with_retry(
         self,
         typed_client: Any,
         request_content: str,
         *,
+        model_id: str,
+        invocation_tier: Literal["primary", "fallback"],
+        prompt_variant: str,
         system_prompt: str = EXTRACTION_SYSTEM_PROMPT,
     ) -> object:
         last_error: Exception | None = None
         for attempt in range(1, self._max_attempts + 1):
             try:
                 return await typed_client.messages.create(
-                    model=self._model,
+                    model=model_id,
                     max_tokens=800,
                     temperature=0,
                     system=system_prompt,
@@ -264,6 +366,9 @@ class ExtractionIntegration:
                             upstream_status=upstream_status,
                             attempt=attempt,
                             max_attempts=self._max_attempts,
+                            extraction_invocation_tier=invocation_tier,
+                            extraction_model_id=model_id,
+                            extraction_prompt_variant=prompt_variant,
                         )
                     break
                 retry_delay_seconds = _retry_delay_seconds(attempt)
@@ -274,6 +379,9 @@ class ExtractionIntegration:
                         attempt=attempt,
                         max_attempts=self._max_attempts,
                         backoff_ms=int(retry_delay_seconds * 1000),
+                        extraction_invocation_tier=invocation_tier,
+                        extraction_model_id=model_id,
+                        extraction_prompt_variant=prompt_variant,
                     )
                 await asyncio.sleep(retry_delay_seconds)
 
@@ -360,6 +468,8 @@ def _set_last_call_metadata(
     *,
     model_id: str | None,
     token_usage: dict[str, int] | None,
+    invocation_tier: Literal["primary", "fallback"] = EXTRACTION_INVOCATION_TIER_PRIMARY,
+    prompt_variant: str | None = None,
     repair_attempted: bool = False,
     repair_outcome: str | None = None,
     repair_validation_error_count: int | None = None,
@@ -368,6 +478,8 @@ def _set_last_call_metadata(
         ExtractionCallMetadata(
             model_id=model_id,
             token_usage=token_usage,
+            invocation_tier=invocation_tier,
+            prompt_variant=prompt_variant,
             repair_attempted=repair_attempted,
             repair_outcome=repair_outcome,
             repair_validation_error_count=repair_validation_error_count,

--- a/backend/app/shared/dependencies.py
+++ b/backend/app/shared/dependencies.py
@@ -83,8 +83,11 @@ def get_extraction_integration() -> ExtractionIntegration:
     return ExtractionIntegration(
         api_key=settings.anthropic_api_key,
         model=settings.extraction_model,
+        fallback_model=settings.extraction_fallback_model,
         timeout_seconds=settings.provider_request_timeout_seconds,
         max_attempts=settings.provider_max_retries,
+        primary_prompt_variant=settings.extraction_primary_prompt_variant,
+        fallback_prompt_variant=settings.extraction_fallback_prompt_variant,
     )
 
 

--- a/backend/app/shared/observability.py
+++ b/backend/app/shared/observability.py
@@ -297,6 +297,7 @@ def log_provider_retry(
     attempt: int,
     max_attempts: int,
     backoff_ms: int,
+    **fields: Any,
 ) -> None:
     """Emit a structured provider retry-cycle event."""
     log_security_event(
@@ -309,6 +310,7 @@ def log_provider_retry(
         max_attempts=max_attempts,
         backoff_ms=backoff_ms,
         reason="provider_retryable_error",
+        **fields,
     )
 
 
@@ -318,6 +320,7 @@ def log_provider_quota_exhausted(
     upstream_status: int,
     attempt: int,
     max_attempts: int,
+    **fields: Any,
 ) -> None:
     """Emit a structured provider quota exhaustion event."""
     log_security_event(
@@ -332,6 +335,7 @@ def log_provider_quota_exhausted(
         reason="provider_rate_limited",
         rate_limit_key=f"provider:{provider}:{upstream_status}",
         rate_limit_seconds=60,
+        **fields,
     )
 
 

--- a/backend/app/shared/tests/test_dependencies.py
+++ b/backend/app/shared/tests/test_dependencies.py
@@ -16,6 +16,9 @@ def _reset_dependency_caches(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
     monkeypatch.setenv("ANTHROPIC_API_KEY", "anthropic-test")
     monkeypatch.setenv("OPENAI_API_KEY", "openai-test")
     monkeypatch.setenv("EXTRACTION_MODEL", "claude-test")
+    monkeypatch.setenv("EXTRACTION_FALLBACK_MODEL", "claude-fallback-test")
+    monkeypatch.setenv("EXTRACTION_PRIMARY_PROMPT_VARIANT", "primary_v1")
+    monkeypatch.setenv("EXTRACTION_FALLBACK_PROMPT_VARIANT", "fallback_v1")
     monkeypatch.setenv("TRANSCRIPTION_MODEL", "whisper-test")
     monkeypatch.setenv("PROVIDER_REQUEST_TIMEOUT_SECONDS", "21.5")
     monkeypatch.setenv("PROVIDER_MAX_RETRIES", "4")
@@ -40,6 +43,15 @@ def test_get_transcription_integration_returns_singleton() -> None:
     second = dependencies.get_transcription_integration()
 
     assert first is second
+
+
+def test_get_extraction_integration_applies_fallback_settings() -> None:
+    integration = dependencies.get_extraction_integration()
+
+    assert integration._primary_model == "claude-test"  # noqa: SLF001
+    assert integration._fallback_model == "claude-fallback-test"  # noqa: SLF001
+    assert integration._primary_prompt_variant == "primary_v1"  # noqa: SLF001
+    assert integration._fallback_prompt_variant == "fallback_v1"  # noqa: SLF001
 
 
 def test_get_extraction_service_reuses_provider_singletons() -> None:

--- a/backend/app/worker/job_registry.py
+++ b/backend/app/worker/job_registry.py
@@ -269,6 +269,8 @@ async def _extract_quote_data(
             last_model_id=resolved_last_model_id,
             latency_ms=int((perf_counter() - started_at) * 1000),
             token_usage=metadata.token_usage if metadata is not None else None,
+            extraction_invocation_tier=(metadata.invocation_tier if metadata is not None else None),
+            extraction_prompt_variant=(metadata.prompt_variant if metadata is not None else None),
             repair_attempted=metadata.repair_attempted if metadata is not None else False,
             repair_outcome=metadata.repair_outcome if metadata is not None else None,
             repair_validation_error_count=(
@@ -306,6 +308,8 @@ async def _extract_quote_data(
             job_name=EXTRACTION_JOB_NAME,
             job_id=str(job_id),
             last_model_id=resolved_last_model_id,
+            extraction_invocation_tier=metadata.invocation_tier,
+            extraction_prompt_variant=metadata.prompt_variant,
             extraction_tier=result.extraction_tier,
             extraction_degraded_reason_code=result.extraction_degraded_reason_code,
             repair_validation_error_count=metadata.repair_validation_error_count,

--- a/backend/app/worker/tests/test_job_registry.py
+++ b/backend/app/worker/tests/test_job_registry.py
@@ -304,6 +304,8 @@ async def test_extraction_job_uses_enqueued_correlation_id_and_logs_failure_meta
     assert extraction_failure["job_id"] == str(record.id)  # nosec B101 - pytest assertion
     assert extraction_failure["correlation_id"] == ingress_correlation_id  # nosec B101 - pytest assertion
     assert extraction_failure["last_model_id"] == "claude-haiku-4-5-20251001"  # nosec B101 - pytest assertion
+    assert extraction_failure["extraction_invocation_tier"] == "fallback"  # nosec B101 - pytest assertion
+    assert extraction_failure["extraction_prompt_variant"] == "fallback_default"  # nosec B101 - pytest assertion
     assert extraction_failure["error_class"] == "_NonRetryableProviderError"  # nosec B101 - pytest assertion
     assert isinstance(extraction_failure["latency_ms"], int)  # nosec B101 - pytest assertion
     assert extraction_failure["token_usage"] == {  # nosec B101 - pytest assertion
@@ -389,6 +391,8 @@ class _MetadataFailureExtractionIntegration:
         return ExtractionCallMetadata(
             model_id=self.model_id,
             token_usage={"input_tokens": 91, "output_tokens": 0},
+            invocation_tier="fallback",
+            prompt_variant="fallback_default",
         )
 
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -160,6 +160,7 @@ Unique constraints:
 | job_type | String(20) | constrained enum: `extraction \| pdf \| email` |
 | status | String(20) | constrained enum: `pending \| running \| success \| failed \| terminal` |
 | attempts | Integer | default `0`; incremented when a worker attempt starts |
+| last_model_id | String(128) | nullable; most recent extraction provider model used for the job |
 | terminal_error | Text | nullable final failure reason once retries are exhausted |
 | created_at, updated_at | DateTime(tz) | server defaults |
 
@@ -291,9 +292,11 @@ For `job_type = "extraction"`:
 
 Quote extraction guardrails:
 - `POST /quotes/convert-notes`, `POST /quotes/capture-audio`, and `POST /quotes/extract` use user-keyed rate limits when a valid access cookie is present, with IP fallback only for unauthenticated resolution failures.
+- Extraction integration can be configured with an optional fallback model tier that runs only after primary attempts are exhausted; `ExtractionResult` and persisted `documents.extraction_tier` remain `primary|degraded` for storage compatibility.
 - `POST /quotes/convert-notes` and the sync fallback path of `POST /quotes/extract` return `429 { "detail": "Extraction quota or concurrency exhausted. Please retry later." }` when the per-user daily quota or concurrent in-flight extraction limit is exhausted before provider work starts.
 - The async `POST /quotes/extract` path uses durable `job_records` plus a count of user-owned extraction jobs in `pending|running` state to reject new enqueue attempts with the same `429` detail when the active-job cap is already reached.
 - `POST /quotes/{id}/append-extraction` inherits the same user-keyed limiter and extraction capacity/concurrency behavior as `/quotes/extract` (sync and async paths), and emits `quote_append_extracted` after successful append persistence.
+- Extraction worker security logs include segmentation metadata (`last_model_id`, `extraction_invocation_tier`, and `extraction_prompt_variant`) for primary vs fallback analysis.
 - `POST /quotes/{id}/pdf`, `POST /quotes/{id}/send-email`, `POST /invoices/{id}/pdf`, and `POST /invoices/{id}/send-email` are also user-keyed and rate-limited.
 
 ### Invoice endpoints (`/api/invoices`)


### PR DESCRIPTION
## Summary
- add optional fallback extraction tier that runs only after primary attempt exhaustion
- keep the shared ExtractionResult contract unchanged while preserving existing extraction_tier storage values
- tag extraction invocation tier, model id, and prompt variant in extraction metadata/security logs
- add fallback-focused tests and a minimal live/manual fallback fixture path

## Verification
- make backend-verify

Closes #289