### PR TITLE
Task 291: Add manual extraction eval harness

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help verify backend-verify frontend-verify db-verify template-verify extraction-live
+.PHONY: help verify backend-verify frontend-verify db-verify template-verify extraction-live extraction-eval
 
 help: ## Show available targets
 	@grep -E '^[a-zA-Z_-]+:.*##' $(MAKEFILE_LIST) | awk -F ':.*## ' '{printf "  %-20s %s\n", $$1, $$2}'
@@ -17,7 +17,7 @@ backend-verify: ## Run backend lint, type checks, security scan, and tests
 		.venv/bin/ruff format --check . && \
 		.venv/bin/mypy . --cache-dir .mypy_cache && \
 		.venv/bin/bandit -r app/ -x app/core/tests,app/features/auth/tests,app/features/customers/tests,app/features/profile/tests,app/features/quotes/tests,app/shared/tests && \
-		.venv/bin/pytest -v -m "not live" -o cache_dir=.pytest_cache
+		.venv/bin/pytest -v -m "not live and not extraction_eval" -o cache_dir=.pytest_cache
 
 frontend-verify: ## Run frontend type checks, lint, tests, and build
 	@if [ "$(SKIP_FILE_SIZE_CHECK)" != "1" ]; then bash scripts/check_file_sizes.sh --scope frontend; fi
@@ -38,3 +38,11 @@ template-verify: ## Check template docs for unresolved placeholders
 extraction-live: ## Run live extraction tests against real Claude API (requires ANTHROPIC_API_KEY in .env)
 	@test -x backend/.venv/bin/pytest || (echo "Missing backend/.venv. Run: cd backend && python3 -m venv .venv && .venv/bin/pip install -r requirements.txt" && exit 1)
 	@cd backend && .venv/bin/pytest -m live -s -v
+
+extraction-eval: ## Run manual extraction eval harness (offline by default, set EXTRACTION_EVAL_LIVE=1 for live probes)
+	@test -x backend/.venv/bin/pytest || (echo "Missing backend/.venv. Run: cd backend && python3 -m venv .venv && .venv/bin/pip install -r requirements.txt" && exit 1)
+	@cd backend && .venv/bin/pytest -v -m extraction_eval -o cache_dir=.pytest_cache
+	@if [ "$$EXTRACTION_EVAL_LIVE" = "1" ]; then \
+		echo "Running optional live extraction probes (requires ANTHROPIC_API_KEY in backend/.env)"; \
+		cd backend && .venv/bin/pytest app/features/quotes/tests/test_extraction_live.py -m live -s -v -o cache_dir=.pytest_cache; \
+	fi

--- a/README.md
+++ b/README.md
@@ -89,6 +89,13 @@ Its main idea is simple: **capture first, refine second**. Instead of pushing th
 - Redis-backed controls support production-style rate limiting and async workflows
 - Stima is an actively evolving portfolio project built with internet-facing deployment concerns in mind
 
+## Extraction Eval Harness
+
+- Run `make extraction-eval` to execute the manual extraction eval harness offline with fake provider responses.
+- Use this command before changing extraction prompts, extraction models, or fallback tier settings.
+- Optional operator-only live probes can be included with `EXTRACTION_EVAL_LIVE=1 make extraction-eval` (requires `ANTHROPIC_API_KEY` in `backend/.env`).
+- `make extraction-eval` is intentionally separate from `make backend-verify` so it does not gate standard verification.
+
 ## License
 
 MIT

--- a/backend/app/features/quotes/tests/fixtures/extraction_eval_cases.py
+++ b/backend/app/features/quotes/tests/fixtures/extraction_eval_cases.py
@@ -1,0 +1,87 @@
+"""Fixture cases for manual extraction eval harness runs."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Literal
+
+from app.features.quotes.tests.fixtures.transcripts import TRANSCRIPTS
+
+
+@dataclass(frozen=True, slots=True)
+class ExtractionEvalCase:
+    """Declarative extraction eval fixture used by manual property checks."""
+
+    name: str
+    transcript: str
+    provider_events: tuple[dict[str, Any], ...]
+    expected_models: tuple[str, ...]
+    expected_invocation_tier: Literal["primary", "fallback"]
+    expect_total_matches_priced_sum: bool
+
+
+EXTRACTION_EVAL_CASES: tuple[ExtractionEvalCase, ...] = (
+    ExtractionEvalCase(
+        name="baseline_primary_contract_invariants",
+        transcript=TRANSCRIPTS["clean_with_total"],
+        provider_events=(
+            {
+                "type": "tool_use",
+                "input": {
+                    "transcript": TRANSCRIPTS["clean_with_total"],
+                    "line_items": [
+                        {
+                            "description": "Rear garage floodlights",
+                            "details": "Install 2 units",
+                            "price": 360,
+                        },
+                        {
+                            "description": "Porch switch replacement",
+                            "details": None,
+                            "price": 75,
+                        },
+                    ],
+                    "total": 435,
+                    "confidence_notes": [],
+                },
+            },
+        ),
+        expected_models=("primary-model",),
+        expected_invocation_tier="primary",
+        expect_total_matches_priced_sum=True,
+    ),
+    ExtractionEvalCase(
+        name="fallback_tier_after_primary_rate_limit",
+        transcript=TRANSCRIPTS["fallback_tier_probe"],
+        provider_events=(
+            {
+                "error": "rate_limit",
+            },
+            {
+                "type": "tool_use",
+                "input": {
+                    "transcript": TRANSCRIPTS["fallback_tier_probe"],
+                    "line_items": [
+                        {
+                            "description": "Replace porch lights",
+                            "details": "Two fixtures",
+                            "price": 120,
+                        },
+                        {
+                            "description": "Tighten loose railing",
+                            "details": None,
+                            "price": 45,
+                        },
+                    ],
+                    "total": 165,
+                    "confidence_notes": [
+                        "Primary model unavailable; fallback tier produced extraction output."
+                    ],
+                },
+            },
+        ),
+        expected_models=("primary-model", "fallback-model"),
+        expected_invocation_tier="fallback",
+        expect_total_matches_priced_sum=True,
+    ),
+)

--- a/backend/app/features/quotes/tests/test_extraction_eval.py
+++ b/backend/app/features/quotes/tests/test_extraction_eval.py
@@ -1,0 +1,135 @@
+"""Manual property-based extraction eval harness.
+
+This suite is intentionally excluded from ``make backend-verify`` and can be run
+manually with ``make extraction-eval`` before prompt/model changes.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import anthropic
+import httpx
+import pytest
+
+from app.features.quotes.schemas import ExtractionResult
+from app.features.quotes.tests.fixtures.extraction_eval_cases import (
+    EXTRACTION_EVAL_CASES,
+    ExtractionEvalCase,
+)
+from app.integrations.extraction import ExtractionIntegration
+from app.shared.input_limits import CONFIDENCE_NOTES_MAX_ITEMS, DOCUMENT_LINE_ITEMS_MAX_ITEMS
+
+pytestmark = [pytest.mark.asyncio, pytest.mark.extraction_eval]
+
+
+@dataclass
+class _FakeResponse:
+    content: list[dict[str, Any]]
+
+
+class _SequencedMessages:
+    def __init__(self, outcomes: list[object]) -> None:
+        self._outcomes = iter(outcomes)
+        self.calls: list[dict[str, object]] = []
+
+    async def create(self, **kwargs: object) -> object:
+        self.calls.append(kwargs)
+        outcome = next(self._outcomes)
+        if isinstance(outcome, Exception):
+            raise outcome
+        return outcome
+
+
+class _SequencedClient:
+    def __init__(self, outcomes: list[object]) -> None:
+        self.messages = _SequencedMessages(outcomes)
+
+
+def _build_outcomes(case: ExtractionEvalCase) -> list[object]:
+    outcomes: list[object] = []
+    for event in case.provider_events:
+        if event.get("error") == "rate_limit":
+            request = httpx.Request("POST", "https://api.anthropic.com/v1/messages")
+            outcomes.append(
+                anthropic.RateLimitError(
+                    "rate limited",
+                    response=httpx.Response(429, request=request),
+                    body=None,
+                )
+            )
+            continue
+        outcomes.append(_FakeResponse(content=[event]))
+    return outcomes
+
+
+def _assert_extraction_invariants(
+    result: ExtractionResult,
+    *,
+    transcript: str,
+    expect_total_matches_priced_sum: bool,
+) -> None:
+    assert result.transcript == transcript
+    assert len(result.line_items) <= DOCUMENT_LINE_ITEMS_MAX_ITEMS
+    assert len(result.confidence_notes) <= CONFIDENCE_NOTES_MAX_ITEMS
+    assert all(item.description.strip() for item in result.line_items)
+    if result.extraction_tier == "degraded":
+        assert result.extraction_degraded_reason_code is not None
+    else:
+        assert result.extraction_degraded_reason_code is None
+
+    if expect_total_matches_priced_sum and result.total is not None:
+        priced_items = [item.price for item in result.line_items if item.price is not None]
+        assert priced_items
+        assert sum(priced_items) == pytest.approx(result.total)
+
+
+async def test_extraction_eval_baseline_invariants_hold_for_primary_fixture() -> None:
+    case = EXTRACTION_EVAL_CASES[0]
+    client = _SequencedClient(_build_outcomes(case))
+    integration = ExtractionIntegration(
+        api_key="",
+        model="primary-model",
+        fallback_model="fallback-model",
+        max_attempts=1,
+        client=client,
+    )
+
+    result = await integration.extract(case.transcript)
+
+    _assert_extraction_invariants(
+        result,
+        transcript=case.transcript,
+        expect_total_matches_priced_sum=case.expect_total_matches_priced_sum,
+    )
+    assert [call["model"] for call in client.messages.calls] == list(case.expected_models)
+
+    metadata = integration.pop_last_call_metadata()
+    assert metadata is not None
+    assert metadata.invocation_tier == case.expected_invocation_tier
+
+
+@pytest.mark.parametrize("case", EXTRACTION_EVAL_CASES, ids=lambda case: case.name)
+async def test_extraction_eval_invariants(case: ExtractionEvalCase) -> None:
+    client = _SequencedClient(_build_outcomes(case))
+    integration = ExtractionIntegration(
+        api_key="",
+        model="primary-model",
+        fallback_model="fallback-model",
+        max_attempts=1,
+        client=client,
+    )
+
+    result = await integration.extract(case.transcript)
+
+    _assert_extraction_invariants(
+        result,
+        transcript=case.transcript,
+        expect_total_matches_priced_sum=case.expect_total_matches_priced_sum,
+    )
+    assert [call["model"] for call in client.messages.calls] == list(case.expected_models)
+
+    metadata = integration.pop_last_call_metadata()
+    assert metadata is not None
+    assert metadata.invocation_tier == case.expected_invocation_tier

--- a/backend/pytest.ini
+++ b/backend/pytest.ini
@@ -5,3 +5,4 @@ asyncio_default_fixture_loop_scope = function
 addopts = -v --tb=short
 markers =
     live: Tests that call real external APIs (excluded from CI)
+    extraction_eval: Manual extraction eval harness checks (manual-only, excluded from backend-verify)


### PR DESCRIPTION
## Summary
- Add a manual property-based extraction eval harness with seeded primary and fallback fixture cases
- Add `make extraction-eval` (offline by default) and optional live probes behind `EXTRACTION_EVAL_LIVE=1`
- Keep eval harness out of `make backend-verify` by introducing an `extraction_eval` pytest marker and exclusion
- Document when operators should run extraction evals in README

## Verification
- `make backend-verify`
- `make extraction-eval`

Closes #291