### PR TITLE
Harden extraction eval case library

### DIFF
--- a/backend/app/features/quotes/tests/fixtures/extraction_eval_cases.py
+++ b/backend/app/features/quotes/tests/fixtures/extraction_eval_cases.py
@@ -7,6 +7,15 @@ from typing import Any, Literal
 
 from app.features.quotes.tests.fixtures.transcripts import TRANSCRIPTS
 
+_SEMANTIC_EMPTY_LINE_ITEMS_BELOW_TRANSCRIPT = (
+    "Clean gutters flush drains sweep roof patch fascia trim shrubs edge beds "
+    "check lights and confirm work schedule."
+)
+_SEMANTIC_EMPTY_LINE_ITEMS_ABOVE_TRANSCRIPT = (
+    "Clean gutters flush drains sweep roof patch fascia trim shrubs edge beds "
+    "check lights and confirm full work schedule tomorrow morning."
+)
+
 
 @dataclass(frozen=True, slots=True)
 class ExtractionEvalCase:
@@ -18,6 +27,23 @@ class ExtractionEvalCase:
     expected_models: tuple[str, ...]
     expected_invocation_tier: Literal["primary", "fallback"]
     expect_total_matches_priced_sum: bool
+    expect_extraction_tier: Literal["primary", "degraded"] | None = None
+    expect_degraded_reason_code: str | None = None
+    expect_line_item_count_min: int | None = None
+    expect_line_item_count_max: int | None = None
+    expect_confidence_note_substrings: tuple[str, ...] = ()
+    expect_repair_attempted: bool | None = None
+    expect_repair_outcome: (
+        Literal[
+            "not_attempted",
+            "repair_succeeded",
+            "repair_invalid",
+            "repair_request_failed",
+        ]
+        | None
+    ) = None
+    expect_repair_validation_error_count: int | None = None
+    human_notes: str | None = None
 
 
 EXTRACTION_EVAL_CASES: tuple[ExtractionEvalCase, ...] = (
@@ -49,6 +75,12 @@ EXTRACTION_EVAL_CASES: tuple[ExtractionEvalCase, ...] = (
         expected_models=("primary-model",),
         expected_invocation_tier="primary",
         expect_total_matches_priced_sum=True,
+        expect_extraction_tier="primary",
+        expect_line_item_count_min=2,
+        expect_line_item_count_max=2,
+        expect_repair_attempted=False,
+        expect_repair_outcome="not_attempted",
+        human_notes="Baseline primary extraction invariants remain stable.",
     ),
     ExtractionEvalCase(
         name="fallback_tier_after_primary_rate_limit",
@@ -83,5 +115,139 @@ EXTRACTION_EVAL_CASES: tuple[ExtractionEvalCase, ...] = (
         expected_models=("primary-model", "fallback-model"),
         expected_invocation_tier="fallback",
         expect_total_matches_priced_sum=True,
+        expect_extraction_tier="primary",
+        expect_line_item_count_min=2,
+        expect_line_item_count_max=2,
+        expect_confidence_note_substrings=("fallback tier produced extraction output",),
+        expect_repair_attempted=False,
+        expect_repair_outcome="not_attempted",
+        human_notes="Fallback invocation should remain quote-facing primary when usable.",
+    ),
+    ExtractionEvalCase(
+        name="repair_succeeds_after_one_invalid_payload",
+        transcript=TRANSCRIPTS["clean_with_total"],
+        provider_events=(
+            {
+                "type": "tool_use",
+                "input": {
+                    "transcript": TRANSCRIPTS["clean_with_total"],
+                    "line_items": "invalid-shape",
+                    "total": 435,
+                    "confidence_notes": [],
+                },
+            },
+            {
+                "type": "tool_use",
+                "input": {
+                    "transcript": TRANSCRIPTS["clean_with_total"],
+                    "line_items": [
+                        {
+                            "description": "Trim shrubs",
+                            "details": "Front beds",
+                            "price": 125,
+                        }
+                    ],
+                    "total": 125,
+                    "confidence_notes": [],
+                },
+            },
+        ),
+        expected_models=("primary-model", "primary-model"),
+        expected_invocation_tier="primary",
+        expect_total_matches_priced_sum=True,
+        expect_extraction_tier="primary",
+        expect_line_item_count_min=1,
+        expect_line_item_count_max=1,
+        expect_repair_attempted=True,
+        expect_repair_outcome="repair_succeeded",
+        expect_repair_validation_error_count=1,
+        human_notes="One repair turn should recover invalid initial tool output.",
+    ),
+    ExtractionEvalCase(
+        name="repair_still_invalid_degrades_with_reason_code",
+        transcript=TRANSCRIPTS["clean_with_total"],
+        provider_events=(
+            {
+                "type": "tool_use",
+                "input": {
+                    "transcript": TRANSCRIPTS["clean_with_total"],
+                    "line_items": "invalid-shape",
+                    "total": 435,
+                    "confidence_notes": [],
+                },
+            },
+            {
+                "type": "tool_use",
+                "input": {
+                    "transcript": TRANSCRIPTS["clean_with_total"],
+                    "line_items": "still-invalid",
+                    "total": 435,
+                    "confidence_notes": [],
+                },
+            },
+        ),
+        expected_models=("primary-model", "primary-model"),
+        expected_invocation_tier="primary",
+        expect_total_matches_priced_sum=False,
+        expect_extraction_tier="degraded",
+        expect_degraded_reason_code="validation_repair_failed",
+        expect_line_item_count_min=0,
+        expect_line_item_count_max=0,
+        expect_repair_attempted=True,
+        expect_repair_outcome="repair_invalid",
+        expect_repair_validation_error_count=1,
+        human_notes="Invalid repair payload should degrade with validation repair failure.",
+    ),
+    ExtractionEvalCase(
+        name="semantic_empty_items_below_threshold_stays_primary",
+        transcript=_SEMANTIC_EMPTY_LINE_ITEMS_BELOW_TRANSCRIPT,
+        provider_events=(
+            {
+                "type": "tool_use",
+                "input": {
+                    "transcript": _SEMANTIC_EMPTY_LINE_ITEMS_BELOW_TRANSCRIPT,
+                    "line_items": [],
+                    "total": None,
+                    "confidence_notes": [],
+                },
+            },
+        ),
+        expected_models=("primary-model",),
+        expected_invocation_tier="primary",
+        expect_total_matches_priced_sum=False,
+        expect_extraction_tier="primary",
+        expect_line_item_count_min=0,
+        expect_line_item_count_max=0,
+        expect_repair_attempted=False,
+        expect_repair_outcome="not_attempted",
+        human_notes="Boundary probe just below transcript-char threshold.",
+    ),
+    ExtractionEvalCase(
+        name="semantic_empty_items_at_or_above_threshold_degrades",
+        transcript=_SEMANTIC_EMPTY_LINE_ITEMS_ABOVE_TRANSCRIPT,
+        provider_events=(
+            {
+                "type": "tool_use",
+                "input": {
+                    "transcript": _SEMANTIC_EMPTY_LINE_ITEMS_ABOVE_TRANSCRIPT,
+                    "line_items": [],
+                    "total": None,
+                    "confidence_notes": [],
+                },
+            },
+        ),
+        expected_models=("primary-model",),
+        expected_invocation_tier="primary",
+        expect_total_matches_priced_sum=False,
+        expect_extraction_tier="degraded",
+        expect_degraded_reason_code="semantic_empty_line_items_substantial_transcript",
+        expect_line_item_count_min=0,
+        expect_line_item_count_max=0,
+        expect_confidence_note_substrings=(
+            "No line items were extracted from a substantial transcript",
+        ),
+        expect_repair_attempted=False,
+        expect_repair_outcome="not_attempted",
+        human_notes="Boundary probe at/above semantic transcript + word thresholds.",
     ),
 )

--- a/backend/app/features/quotes/tests/test_extraction_eval.py
+++ b/backend/app/features/quotes/tests/test_extraction_eval.py
@@ -18,8 +18,11 @@ from app.features.quotes.tests.fixtures.extraction_eval_cases import (
     EXTRACTION_EVAL_CASES,
     ExtractionEvalCase,
 )
-from app.integrations.extraction import ExtractionIntegration
-from app.shared.input_limits import CONFIDENCE_NOTES_MAX_ITEMS, DOCUMENT_LINE_ITEMS_MAX_ITEMS
+from app.integrations.extraction import ExtractionCallMetadata, ExtractionIntegration
+from app.shared.input_limits import (
+    CONFIDENCE_NOTES_MAX_ITEMS,
+    DOCUMENT_LINE_ITEMS_MAX_ITEMS,
+)
 
 pytestmark = [pytest.mark.asyncio, pytest.mark.extraction_eval]
 
@@ -85,6 +88,36 @@ def _assert_extraction_invariants(
         assert sum(priced_items) == pytest.approx(result.total)
 
 
+def _assert_extraction_quality(
+    case: ExtractionEvalCase,
+    result: ExtractionResult,
+    *,
+    metadata: ExtractionCallMetadata,
+) -> None:
+    if case.expect_extraction_tier is not None:
+        assert result.extraction_tier == case.expect_extraction_tier
+
+    if case.expect_degraded_reason_code is not None:
+        assert result.extraction_degraded_reason_code == case.expect_degraded_reason_code
+
+    line_item_count = len(result.line_items)
+    if case.expect_line_item_count_min is not None:
+        assert line_item_count >= case.expect_line_item_count_min
+    if case.expect_line_item_count_max is not None:
+        assert line_item_count <= case.expect_line_item_count_max
+
+    for substring in case.expect_confidence_note_substrings:
+        normalized_substring = substring.casefold()
+        assert any(normalized_substring in note.casefold() for note in result.confidence_notes)
+
+    if case.expect_repair_attempted is not None:
+        assert metadata.repair_attempted == case.expect_repair_attempted
+    if case.expect_repair_outcome is not None:
+        assert metadata.repair_outcome == case.expect_repair_outcome
+    if case.expect_repair_validation_error_count is not None:
+        assert metadata.repair_validation_error_count == case.expect_repair_validation_error_count
+
+
 async def test_extraction_eval_baseline_invariants_hold_for_primary_fixture() -> None:
     case = EXTRACTION_EVAL_CASES[0]
     client = _SequencedClient(_build_outcomes(case))
@@ -108,6 +141,7 @@ async def test_extraction_eval_baseline_invariants_hold_for_primary_fixture() ->
     metadata = integration.pop_last_call_metadata()
     assert metadata is not None
     assert metadata.invocation_tier == case.expected_invocation_tier
+    _assert_extraction_quality(case, result, metadata=metadata)
 
 
 @pytest.mark.parametrize("case", EXTRACTION_EVAL_CASES, ids=lambda case: case.name)
@@ -133,3 +167,4 @@ async def test_extraction_eval_invariants(case: ExtractionEvalCase) -> None:
     metadata = integration.pop_last_call_metadata()
     assert metadata is not None
     assert metadata.invocation_tier == case.expected_invocation_tier
+    _assert_extraction_quality(case, result, metadata=metadata)


### PR DESCRIPTION
## Summary
- extend ExtractionEvalCase with typed optional quality assertions (final tier/reason code, line-item bounds, confidence-note substrings, repair metadata, and human notes)
- add offline eval fixtures for repair-success, repair-failure, and semantic empty-line-item threshold boundary coverage
- add _assert_extraction_quality to enforce the new case-level expectations while preserving existing invariant/model-sequence/invocation-tier checks

## Verification
- make backend-verify
- make extraction-eval

Closes #298