### PR TITLE
Fix business name fallback on public pages and PDFs

### DIFF
--- a/backend/app/features/quotes/api.py
+++ b/backend/app/features/quotes/api.py
@@ -959,6 +959,7 @@ async def get_public_quote(
         return PublicInvoiceResponse(
             doc_type="invoice",
             business_name=_resolve_public_business_name(quote),
+            owner_name=_resolve_public_owner_name(quote),
             customer_name=quote.customer_name,
             doc_number=quote.doc_number,
             title=quote.title,
@@ -983,6 +984,7 @@ async def get_public_quote(
     return PublicQuoteResponse(
         doc_type="quote",
         business_name=_resolve_public_business_name(quote),
+        owner_name=_resolve_public_owner_name(quote),
         customer_name=quote.customer_name,
         doc_number=quote.doc_number,
         title=quote.title,
@@ -1046,10 +1048,15 @@ def _resolve_public_business_name(quote: _BusinessNameContext) -> str | None:
     if quote.business_name and quote.business_name.strip():
         return quote.business_name.strip()
 
-    fallback_name = " ".join(
+    return _resolve_public_owner_name(quote)
+
+
+def _resolve_public_owner_name(quote: _BusinessNameContext) -> str | None:
+    """Return owner full name when profile first/last name fields are present."""
+    owner_name = " ".join(
         value.strip() for value in (quote.first_name, quote.last_name) if value and value.strip()
     )
-    return fallback_name or None
+    return owner_name or None
 
 
 def _build_authenticated_pdf_artifact_response(

--- a/backend/app/features/quotes/schemas.py
+++ b/backend/app/features/quotes/schemas.py
@@ -234,6 +234,7 @@ class PublicQuoteResponse(BaseModel):
 
     doc_type: Literal["quote"]
     business_name: str | None
+    owner_name: str | None = None
     customer_name: str
     doc_number: str
     title: str | None
@@ -255,6 +256,7 @@ class PublicInvoiceResponse(BaseModel):
 
     doc_type: Literal["invoice"]
     business_name: str | None
+    owner_name: str | None = None
     customer_name: str
     doc_number: str
     title: str | None

--- a/backend/app/features/quotes/tests/test_pdf_template.py
+++ b/backend/app/features/quotes/tests/test_pdf_template.py
@@ -23,6 +23,7 @@ from app.integrations.pdf import PdfIntegration
 
 def _make_context(
     *,
+    business_name: str | None = "Acme Landscaping",
     title: str | None = None,
     doc_label: str = "Quote",
     doc_number: str = "Q-201",
@@ -54,7 +55,7 @@ def _make_context(
         quote_id=uuid4(),
         user_id=uuid4(),
         customer_id=uuid4(),
-        business_name="Acme Landscaping",
+        business_name=business_name,
         first_name=first_name,
         last_name=last_name,
         phone_number=phone_number,
@@ -438,6 +439,73 @@ def test_render_hides_owner_name_when_both_name_fields_are_null(
 
     assert result == b"fake-pdf"
     assert 'class="owner-name"' not in captured_html[0]
+
+
+def test_render_falls_back_to_owner_name_when_business_name_is_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured_html: list[str] = []
+
+    class _FakeHTML:
+        def __init__(self, *, string: str, base_url: str) -> None:
+            del base_url
+            captured_html.append(string)
+
+        def write_pdf(self) -> bytes:
+            return b"fake-pdf"
+
+    monkeypatch.setattr("app.integrations.pdf.HTML", _FakeHTML)
+    template_dir = Path(__file__).resolve().parents[3] / "templates"
+    integration = PdfIntegration(template_dir=template_dir)
+
+    result = integration.render(
+        _make_context(
+            business_name=None,
+            first_name="Jamie",
+            last_name="Owner",
+            line_item_price=Decimal("120.00"),
+            total=Decimal("120.00"),
+        )
+    )
+
+    assert result == b"fake-pdf"
+    rendered_html = captured_html[0]
+    assert '<h1 class="company-name">Jamie Owner</h1>' in rendered_html
+    assert 'class="owner-name"' not in rendered_html
+    assert "Stima" not in rendered_html
+
+
+def test_render_omits_company_name_when_business_and_owner_names_are_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured_html: list[str] = []
+
+    class _FakeHTML:
+        def __init__(self, *, string: str, base_url: str) -> None:
+            del base_url
+            captured_html.append(string)
+
+        def write_pdf(self) -> bytes:
+            return b"fake-pdf"
+
+    monkeypatch.setattr("app.integrations.pdf.HTML", _FakeHTML)
+    template_dir = Path(__file__).resolve().parents[3] / "templates"
+    integration = PdfIntegration(template_dir=template_dir)
+
+    result = integration.render(
+        _make_context(
+            business_name=None,
+            first_name=None,
+            last_name=None,
+            line_item_price=Decimal("120.00"),
+            total=Decimal("120.00"),
+        )
+    )
+
+    assert result == b"fake-pdf"
+    rendered_html = captured_html[0]
+    assert 'class="company-name"' not in rendered_html
+    assert "Stima" not in rendered_html
 
 
 def test_render_includes_logo_image_only_when_logo_data_uri_is_present(

--- a/backend/app/features/quotes/tests/test_public_name_resolution.py
+++ b/backend/app/features/quotes/tests/test_public_name_resolution.py
@@ -1,0 +1,25 @@
+from types import SimpleNamespace
+
+from app.features.quotes.api import _resolve_public_business_name, _resolve_public_owner_name
+
+
+def test_resolve_public_business_name_falls_back_to_owner_name() -> None:
+    context = SimpleNamespace(
+        business_name="   ",
+        first_name="Jamie",
+        last_name="Owner",
+    )
+
+    assert _resolve_public_business_name(context) == "Jamie Owner"
+    assert _resolve_public_owner_name(context) == "Jamie Owner"
+
+
+def test_resolve_public_business_name_returns_none_when_no_names_present() -> None:
+    context = SimpleNamespace(
+        business_name=None,
+        first_name=" ",
+        last_name=None,
+    )
+
+    assert _resolve_public_business_name(context) is None
+    assert _resolve_public_owner_name(context) is None

--- a/backend/app/templates/quote.html
+++ b/backend/app/templates/quote.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Stima {{ doc_label }}</title>
+    <title>{{ (business_name or (((first_name or "") ~ " " ~ (last_name or "")).strip()) or doc_label) }} {{ doc_label }}</title>
     <style>
       @page {
         size: A4;
@@ -273,14 +273,18 @@
   </head>
   <body>
     <main>
+      {% set business_name = (business_name or "").strip() %}
       {% set owner_name = ((first_name or "") ~ " " ~ (last_name or "")).strip() %}
+      {% set display_name = business_name or owner_name %}
       <header class="header">
         <table class="header-grid">
           <tbody>
             <tr>
               <td>
-                <h1 class="company-name">{{ business_name or ("Stima " ~ doc_label) }}</h1>
-                {% if owner_name %}
+                {% if display_name %}
+                <h1 class="company-name">{{ display_name }}</h1>
+                {% endif %}
+                {% if business_name and owner_name %}
                 <p class="owner-name">{{ owner_name }}</p>
                 {% endif %}
                 {% if phone_number %}

--- a/frontend/src/features/public/components/PublicQuotePage.tsx
+++ b/frontend/src/features/public/components/PublicQuotePage.tsx
@@ -30,11 +30,17 @@ function getDisplayTitle(documentData: PublicDocument | null): string {
   return documentData.title?.trim() || documentData.doc_number;
 }
 
-function getDisplayBusinessName(documentData: PublicDocument | null): string {
+function getDisplayBusinessName(documentData: PublicDocument | null): string | null {
   if (!documentData) {
-    return "Stima";
+    return null;
   }
-  return documentData.business_name?.trim() || "Stima";
+  const businessName = documentData.business_name?.trim();
+  if (businessName) {
+    return businessName;
+  }
+
+  const ownerName = documentData.owner_name?.trim();
+  return ownerName || null;
 }
 
 function getDocumentLabel(documentData: PublicDocument | null): string {
@@ -86,7 +92,9 @@ export function PublicQuotePage(): React.ReactElement {
       document.title = "Shared Document";
       return;
     }
-    document.title = `${getDisplayTitle(documentData)} | ${getDisplayBusinessName(documentData)}`;
+    const businessName = getDisplayBusinessName(documentData);
+    const displayTitle = getDisplayTitle(documentData);
+    document.title = businessName ? `${displayTitle} | ${businessName}` : displayTitle;
   }, [documentData, hasToken, loadState]);
 
   useEffect(() => {
@@ -174,7 +182,8 @@ export function PublicQuotePage(): React.ReactElement {
     && (documentData.status === "approved" || documentData.status === "declined")
     ? statusCopy[documentData.status]
     : null;
-  const businessInitial = getDisplayBusinessName(documentData).slice(0, 1).toUpperCase();
+  const displayBusinessName = getDisplayBusinessName(documentData);
+  const businessInitial = (displayBusinessName ?? getDocumentLabel(documentData)).slice(0, 1).toUpperCase();
   const pricingBreakdown = calculatePricingFromPersisted(
     {
       totalAmount: documentData.total_amount,
@@ -196,7 +205,7 @@ export function PublicQuotePage(): React.ReactElement {
                 {showLogo ? (
                   <img
                     src={documentData.logo_url}
-                    alt={`${getDisplayBusinessName(documentData)} logo`}
+                    alt={displayBusinessName ? `${displayBusinessName} logo` : `${getDocumentLabel(documentData)} logo`}
                     className="h-full w-full object-cover"
                     onError={() => setHiddenLogoUrl(documentData.logo_url)}
                   />
@@ -205,9 +214,11 @@ export function PublicQuotePage(): React.ReactElement {
                 )}
               </div>
               <div className="min-w-0">
-                <p className="text-xs font-semibold uppercase tracking-[0.3em] text-on-primary/70">
-                  {getDisplayBusinessName(documentData)}
-                </p>
+                {displayBusinessName ? (
+                  <p className="text-xs font-semibold uppercase tracking-[0.3em] text-on-primary/70">
+                    {displayBusinessName}
+                  </p>
+                ) : null}
                 <h1 className="mt-3 text-3xl font-semibold leading-tight">
                   {getDisplayTitle(documentData)}
                 </h1>

--- a/frontend/src/features/public/tests/PublicQuotePage.test.tsx
+++ b/frontend/src/features/public/tests/PublicQuotePage.test.tsx
@@ -28,6 +28,7 @@ function makePublicQuote(overrides: Partial<PublicQuote> = {}): PublicQuote {
   return {
     doc_type: "quote",
     business_name: "Northline Landscaping",
+    owner_name: "Taylor Owner",
     customer_name: "Taylor Morgan",
     doc_number: "Q-001",
     title: "Spring Cleanup",
@@ -61,6 +62,7 @@ function makePublicInvoice(overrides: Partial<PublicInvoice> = {}): PublicInvoic
   return {
     doc_type: "invoice",
     business_name: "Northline Landscaping",
+    owner_name: "Taylor Owner",
     customer_name: "Taylor Morgan",
     doc_number: "I-001",
     title: "Spring Cleanup Invoice",
@@ -207,5 +209,35 @@ describe("PublicQuotePage", () => {
     expect(screen.getByText("Due Date")).toBeInTheDocument();
     expect(screen.getByText("May 04, 2026")).toBeInTheDocument();
     expect(screen.queryByText("This quote has been accepted")).not.toBeInTheDocument();
+  });
+
+  it("falls back to owner name when business name is missing", async () => {
+    mockedPublicService.getDocument.mockResolvedValueOnce(
+      makePublicQuote({
+        business_name: null,
+        owner_name: "Jamie Owner",
+      }),
+    );
+
+    renderScreen();
+
+    expect(await screen.findByText("Jamie Owner")).toBeInTheDocument();
+    expect(document.title).toContain("Jamie Owner");
+  });
+
+  it("omits the business name line when both business and owner names are missing", async () => {
+    mockedPublicService.getDocument.mockResolvedValueOnce(
+      makePublicQuote({
+        business_name: null,
+        owner_name: null,
+      }),
+    );
+
+    renderScreen();
+
+    expect(await screen.findByRole("heading", { name: "Spring Cleanup" })).toBeInTheDocument();
+    expect(screen.queryByText("Northline Landscaping")).not.toBeInTheDocument();
+    expect(screen.queryByText("Taylor Owner")).not.toBeInTheDocument();
+    expect(screen.getByRole("img", { name: /quote logo/i })).toBeInTheDocument();
   });
 });

--- a/frontend/src/features/public/types/public.types.ts
+++ b/frontend/src/features/public/types/public.types.ts
@@ -11,6 +11,7 @@ export interface PublicDocumentLineItem {
 
 interface PublicDocumentBase {
   business_name: string | null;
+  owner_name?: string | null;
   customer_name: string;
   doc_number: string;
   title: string | null;


### PR DESCRIPTION
## Summary
- remove Stima fallback from public quote/invoice display flows
- use business name then owner name fallback for public payload and UI
- omit the company name line when both names are empty
- add backend/frontend tests covering owner fallback and no-name cases

## Verification
- make backend-verify
- make frontend-verify

Closes #300