### PR TITLE
Add backend password reset flow

### DIFF
--- a/backend/alembic/versions/20260410_0021_add_password_reset_tokens.py
+++ b/backend/alembic/versions/20260410_0021_add_password_reset_tokens.py
@@ -1,0 +1,57 @@
+"""Add password_reset_tokens table.
+
+Revision ID: 20260410_0021
+Revises: 20260410_0020
+Create Date: 2026-04-10
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = "20260410_0021"
+down_revision: str | None = "20260410_0020"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "password_reset_tokens",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("user_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("token_hash", sa.String(length=64), nullable=False),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("used_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        op.f("ix_password_reset_tokens_token_hash"),
+        "password_reset_tokens",
+        ["token_hash"],
+        unique=True,
+    )
+    op.create_index(
+        op.f("ix_password_reset_tokens_user_id"),
+        "password_reset_tokens",
+        ["user_id"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("ix_password_reset_tokens_user_id"), table_name="password_reset_tokens")
+    op.drop_index(op.f("ix_password_reset_tokens_token_hash"), table_name="password_reset_tokens")
+    op.drop_table("password_reset_tokens")

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -80,6 +80,10 @@ class Settings(BaseSettings):
         default="5/minute",
         validation_alias="AUTH_LOGIN_RATE_LIMIT",
     )
+    auth_forgot_password_rate_limit: str = Field(
+        default="3/hour",
+        validation_alias="AUTH_FORGOT_PASSWORD_RATE_LIMIT",
+    )
     auth_refresh_rate_limit: str = Field(
         default="10/minute",
         validation_alias="AUTH_REFRESH_RATE_LIMIT",

--- a/backend/app/features/auth/api.py
+++ b/backend/app/features/auth/api.py
@@ -10,11 +10,14 @@ from fastapi import APIRouter, Cookie, Depends, HTTPException, Request, Response
 from app.core.config import get_settings
 from app.features.auth.models import User
 from app.features.auth.schemas import (
+    AuthMessageResponse,
     AuthSessionResponse,
     AuthUserResponse,
+    ForgotPasswordRequest,
     LoginRequest,
     RegisterRequest,
     RegisterResponse,
+    ResetPasswordRequest,
 )
 from app.features.auth.service import (
     ACCESS_COOKIE_NAME,
@@ -28,6 +31,20 @@ from app.shared.observability import log_security_event
 from app.shared.rate_limit import get_ip_key, limiter
 
 router = APIRouter(prefix="/auth", tags=["auth"])
+
+
+async def _bind_forgot_password_rate_limit_email(
+    request: Request,
+    payload: ForgotPasswordRequest,
+) -> None:
+    request.state.forgot_password_email = str(payload.email).strip().lower()
+
+
+def _get_forgot_password_rate_limit_key(request: Request) -> str:
+    email = getattr(request.state, "forgot_password_email", None)
+    if isinstance(email, str) and email:
+        return f"email:{email}"
+    return f"ip:{get_ip_key(request)}"
 
 
 @router.post(
@@ -89,6 +106,53 @@ async def login(
         user=_serialize_user(session.user),
         csrf_token=session.csrf_token,
     )
+
+
+@router.post(
+    "/forgot-password",
+    response_model=AuthMessageResponse,
+)
+@limiter.limit(
+    lambda: get_settings().auth_forgot_password_rate_limit,
+    key_func=_get_forgot_password_rate_limit_key,
+)
+async def forgot_password(
+    request: Request,
+    payload: ForgotPasswordRequest,
+    auth_service: Annotated[AuthService, Depends(get_auth_service)],
+    _bound_email: Annotated[None, Depends(_bind_forgot_password_rate_limit_email)],
+) -> AuthMessageResponse:
+    """Issue password reset instructions while preserving account enumeration resistance."""
+    del request
+    del _bound_email
+    try:
+        await auth_service.request_password_reset(email=str(payload.email))
+    except AuthServiceError as exc:
+        raise HTTPException(status_code=exc.status_code, detail=exc.detail) from exc
+    return AuthMessageResponse(
+        detail="If an account exists for that email, a reset link has been sent.",
+    )
+
+
+@router.post(
+    "/reset-password",
+    response_model=AuthMessageResponse,
+)
+async def reset_password(
+    request: Request,
+    payload: ResetPasswordRequest,
+    auth_service: Annotated[AuthService, Depends(get_auth_service)],
+) -> AuthMessageResponse:
+    """Validate reset token, update password, and revoke active sessions."""
+    del request
+    try:
+        await auth_service.reset_password(
+            token=payload.token,
+            new_password=payload.new_password,
+        )
+    except AuthServiceError as exc:
+        raise HTTPException(status_code=exc.status_code, detail=exc.detail) from exc
+    return AuthMessageResponse(detail="Password has been reset.")
 
 
 @router.post(

--- a/backend/app/features/auth/models.py
+++ b/backend/app/features/auth/models.py
@@ -49,6 +49,10 @@ class User(Base):
         back_populates="user",
         cascade="all, delete-orphan",
     )
+    password_reset_tokens: Mapped[list[PasswordResetToken]] = relationship(
+        back_populates="user",
+        cascade="all, delete-orphan",
+    )
 
     @property
     def is_onboarded(self) -> bool:
@@ -90,3 +94,31 @@ class RefreshToken(Base):
     )
 
     user: Mapped[User] = relationship(back_populates="refresh_tokens")
+
+
+class PasswordResetToken(Base):
+    """Password reset token model with one-time use enforcement."""
+
+    __tablename__ = "password_reset_tokens"
+
+    id: Mapped[UUID] = mapped_column(sa.Uuid, primary_key=True, default=uuid4)
+    user_id: Mapped[UUID] = mapped_column(
+        sa.ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    token_hash: Mapped[str] = mapped_column(
+        sa.String(64),
+        nullable=False,
+        unique=True,
+        index=True,
+    )
+    expires_at: Mapped[datetime] = mapped_column(sa.DateTime(timezone=True), nullable=False)
+    used_at: Mapped[datetime | None] = mapped_column(sa.DateTime(timezone=True), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        sa.DateTime(timezone=True),
+        nullable=False,
+        server_default=sa.func.now(),
+    )
+
+    user: Mapped[User] = relationship(back_populates="password_reset_tokens")

--- a/backend/app/features/auth/repository.py
+++ b/backend/app/features/auth/repository.py
@@ -10,7 +10,7 @@ from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
-from app.features.auth.models import RefreshToken, User
+from app.features.auth.models import PasswordResetToken, RefreshToken, User
 
 
 class RefreshRotationOutcome(StrEnum):
@@ -76,6 +76,72 @@ class AuthRepository:
         self._session.add(refresh_token)
         await self._session.flush()
         return refresh_token
+
+    async def create_reset_token(
+        self,
+        *,
+        user_id: UUID,
+        token_hash: str,
+        expires_at: datetime,
+    ) -> PasswordResetToken:
+        """Store a new password reset token row."""
+        reset_token = PasswordResetToken(
+            user_id=user_id,
+            token_hash=token_hash,
+            expires_at=expires_at,
+        )
+        self._session.add(reset_token)
+        await self._session.flush()
+        return reset_token
+
+    async def count_recent_reset_tokens_for_user(
+        self,
+        *,
+        user_id: UUID,
+        since: datetime,
+    ) -> int:
+        """Count password reset requests created in a time window for one user."""
+        stmt = select(PasswordResetToken.id).where(
+            PasswordResetToken.user_id == user_id,
+            PasswordResetToken.created_at >= since,
+        )
+        result = await self._session.execute(stmt)
+        return len(result.scalars().all())
+
+    async def get_valid_reset_token(
+        self,
+        *,
+        token_hash: str,
+        now: datetime,
+    ) -> PasswordResetToken | None:
+        """Fetch an active password reset token for one-time password change."""
+        stmt = (
+            select(PasswordResetToken)
+            .options(selectinload(PasswordResetToken.user))
+            .where(
+                PasswordResetToken.token_hash == token_hash,
+                PasswordResetToken.used_at.is_(None),
+                PasswordResetToken.expires_at > now,
+            )
+            .with_for_update()
+        )
+        result = await self._session.execute(stmt)
+        return result.scalar_one_or_none()
+
+    async def mark_reset_token_used(
+        self,
+        *,
+        token_id: UUID,
+        used_at: datetime,
+    ) -> None:
+        """Mark a password reset token as consumed."""
+        stmt = select(PasswordResetToken).where(PasswordResetToken.id == token_id).with_for_update()
+        result = await self._session.execute(stmt)
+        reset_token = result.scalar_one_or_none()
+        if reset_token is None:
+            return
+        reset_token.used_at = used_at
+        await self._session.flush()
 
     async def consume_and_rotate_refresh_token(
         self,

--- a/backend/app/features/auth/repository.py
+++ b/backend/app/features/auth/repository.py
@@ -94,20 +94,6 @@ class AuthRepository:
         await self._session.flush()
         return reset_token
 
-    async def count_recent_reset_tokens_for_user(
-        self,
-        *,
-        user_id: UUID,
-        since: datetime,
-    ) -> int:
-        """Count password reset requests created in a time window for one user."""
-        stmt = select(PasswordResetToken.id).where(
-            PasswordResetToken.user_id == user_id,
-            PasswordResetToken.created_at >= since,
-        )
-        result = await self._session.execute(stmt)
-        return len(result.scalars().all())
-
     async def get_valid_reset_token(
         self,
         *,

--- a/backend/app/features/auth/schemas.py
+++ b/backend/app/features/auth/schemas.py
@@ -21,6 +21,19 @@ class LoginRequest(BaseModel):
     password: str = Field(min_length=8, max_length=128)
 
 
+class ForgotPasswordRequest(BaseModel):
+    """Request body for password reset initiation."""
+
+    email: EmailStr
+
+
+class ResetPasswordRequest(BaseModel):
+    """Request body for password reset completion."""
+
+    token: str = Field(min_length=1, max_length=512)
+    new_password: str = Field(min_length=8, max_length=128)
+
+
 class AuthUserResponse(BaseModel):
     """Serializable auth user payload."""
 
@@ -42,3 +55,9 @@ class AuthSessionResponse(BaseModel):
 
     user: AuthUserResponse
     csrf_token: str
+
+
+class AuthMessageResponse(BaseModel):
+    """Generic auth success payload."""
+
+    detail: str

--- a/backend/app/features/auth/service.py
+++ b/backend/app/features/auth/service.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
+from functools import lru_cache
 from pathlib import Path
 from secrets import token_urlsafe
 from typing import Protocol
@@ -144,13 +145,10 @@ class AuthService:
         self._email_service = email_service
         base_frontend_url = (frontend_url or "").strip().rstrip("/")
         self._frontend_url = base_frontend_url
-        resolved_template_dir = template_dir or (Path(__file__).resolve().parents[2] / "templates")
-        self._template_environment = Environment(
-            loader=FileSystemLoader(str(resolved_template_dir)),
-            autoescape=select_autoescape(["html", "xml"]),
-            trim_blocks=True,
-            lstrip_blocks=True,
-        )
+        resolved_template_dir = (
+            template_dir or (Path(__file__).resolve().parents[2] / "templates")
+        ).resolve()
+        self._template_environment = _template_environment_for(resolved_template_dir)
 
     async def register(self, *, email: str, password: str) -> User:
         """Register a new user with email/password credentials."""
@@ -364,4 +362,14 @@ def _render_reset_password_text(*, reset_link: str) -> str:
         "We received a request to reset your Stima password.\n\n"
         f"Reset your password: {reset_link}\n\n"
         "This link expires in 1 hour. If you did not request this, you can ignore this email."
+    )
+
+
+@lru_cache(maxsize=4)
+def _template_environment_for(template_dir: Path) -> Environment:
+    return Environment(
+        loader=FileSystemLoader(str(template_dir)),
+        autoescape=select_autoescape(["html", "xml"]),
+        trim_blocks=True,
+        lstrip_blocks=True,
     )

--- a/backend/app/features/auth/service.py
+++ b/backend/app/features/auth/service.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
 from secrets import token_urlsafe
 from typing import Protocol
 from uuid import UUID, uuid4
 
+from jinja2 import Environment, FileSystemLoader, select_autoescape
 from sqlalchemy.exc import IntegrityError
 
 from app.core.security import (
@@ -18,12 +21,15 @@ from app.core.security import (
     hash_token,
     verify_password,
 )
-from app.features.auth.models import User
+from app.features.auth.models import PasswordResetToken, User
 from app.features.auth.repository import RefreshRotationOutcome, RefreshRotationResult
+from app.integrations.email import EmailConfigurationError, EmailMessage, EmailSendError
 
 ACCESS_COOKIE_NAME = "stima_access_token"
 REFRESH_COOKIE_NAME = "stima_refresh_token"
 CSRF_COOKIE_NAME = "stima_csrf_token"
+PASSWORD_RESET_TTL = timedelta(hours=1)
+LOGGER = logging.getLogger(__name__)
 
 
 class AuthServiceError(Exception):
@@ -49,6 +55,13 @@ class ConflictError(AuthServiceError):
         super().__init__(detail=detail, status_code=409)
 
 
+class InvalidResetTokenError(AuthServiceError):
+    """Raised when password reset token validation fails."""
+
+    def __init__(self, detail: str = "Invalid or expired token") -> None:
+        super().__init__(detail=detail, status_code=400)
+
+
 @dataclass(slots=True)
 class AuthSession:
     """Session payload returned by login/refresh service operations."""
@@ -57,6 +70,12 @@ class AuthSession:
     access_token: str
     refresh_token: str
     csrf_token: str
+
+
+class EmailServiceProtocol(Protocol):
+    """Structural protocol for transactional email delivery."""
+
+    async def send(self, message: EmailMessage) -> None: ...
 
 
 class AuthRepositoryProtocol(Protocol):
@@ -76,6 +95,23 @@ class AuthRepositoryProtocol(Protocol):
         expires_at: datetime,
     ) -> object: ...
 
+    async def create_reset_token(
+        self,
+        *,
+        user_id: UUID,
+        token_hash: str,
+        expires_at: datetime,
+    ) -> object: ...
+
+    async def get_valid_reset_token(
+        self,
+        *,
+        token_hash: str,
+        now: datetime,
+    ) -> PasswordResetToken | None: ...
+
+    async def mark_reset_token_used(self, *, token_id: UUID, used_at: datetime) -> None: ...
+
     async def consume_and_rotate_refresh_token(
         self,
         *,
@@ -88,14 +124,33 @@ class AuthRepositoryProtocol(Protocol):
 
     async def revoke_refresh_token(self, *, token_hash: str, revoked_at: datetime) -> None: ...
 
+    async def revoke_all_user_tokens(self, *, user_id: UUID, revoked_at: datetime) -> None: ...
+
     async def commit(self) -> None: ...
 
 
 class AuthService:
     """Coordinate auth domain rules with persistence and token helpers."""
 
-    def __init__(self, repository: AuthRepositoryProtocol) -> None:
+    def __init__(
+        self,
+        repository: AuthRepositoryProtocol,
+        *,
+        email_service: EmailServiceProtocol | None = None,
+        frontend_url: str | None = None,
+        template_dir: Path | None = None,
+    ) -> None:
         self._repository = repository
+        self._email_service = email_service
+        base_frontend_url = (frontend_url or "").strip().rstrip("/")
+        self._frontend_url = base_frontend_url
+        resolved_template_dir = template_dir or (Path(__file__).resolve().parents[2] / "templates")
+        self._template_environment = Environment(
+            loader=FileSystemLoader(str(resolved_template_dir)),
+            autoescape=select_autoescape(["html", "xml"]),
+            trim_blocks=True,
+            lstrip_blocks=True,
+        )
 
     async def register(self, *, email: str, password: str) -> User:
         """Register a new user with email/password credentials."""
@@ -200,11 +255,74 @@ class AuthService:
             raise InvalidCredentialsError("Authentication required")
         return user
 
+    async def request_password_reset(self, *, email: str) -> None:
+        """Issue a one-time reset token for known emails and send reset instructions."""
+        normalized_email = email.strip().lower()
+        if not normalized_email:
+            return
+
+        user = await self._repository.get_user_by_email(normalized_email)
+        if user is None:
+            return
+
+        raw_token = token_urlsafe(32)
+        expires_at = _utcnow() + PASSWORD_RESET_TTL
+        await self._repository.create_reset_token(
+            user_id=user.id,
+            token_hash=hash_token(raw_token),
+            expires_at=expires_at,
+        )
+        await self._repository.commit()
+
+        if self._email_service is None:
+            return
+
+        reset_link = self._build_reset_link(raw_token)
+        try:
+            await self._email_service.send(
+                EmailMessage(
+                    to_email=user.email,
+                    subject="Reset your Stima password",
+                    html_content=self._render_reset_password_html(reset_link=reset_link),
+                    text_content=_render_reset_password_text(reset_link=reset_link),
+                )
+            )
+        except (EmailConfigurationError, EmailSendError):
+            LOGGER.warning(
+                "password reset email delivery failed",
+                exc_info=True,
+                extra={"user_id": str(user.id)},
+            )
+
+    async def reset_password(self, *, token: str, new_password: str) -> None:
+        """Consume a valid reset token, update password, and revoke refresh tokens."""
+        now = _utcnow()
+        reset_token = await self._repository.get_valid_reset_token(
+            token_hash=hash_token(token),
+            now=now,
+        )
+        if reset_token is None:
+            raise InvalidResetTokenError()
+        if not reset_token.user.is_active:
+            raise InvalidResetTokenError()
+
+        reset_token.user.password_hash = hash_password(new_password)
+        await self._repository.mark_reset_token_used(token_id=reset_token.id, used_at=now)
+        await self._repository.revoke_all_user_tokens(user_id=reset_token.user_id, revoked_at=now)
+        await self._repository.commit()
+
     def _create_refresh_token(self, *, subject: str) -> str:
         return create_refresh_token(
             subject=subject,
             extra_claims={"jti": str(uuid4())},
         )
+
+    def _build_reset_link(self, raw_token: str) -> str:
+        return f"{self._frontend_url}/reset-password?token={raw_token}"
+
+    def _render_reset_password_html(self, *, reset_link: str) -> str:
+        template = self._template_environment.get_template("password_reset_email.html")
+        return template.render(reset_link=reset_link)
 
 
 def _decode_token_of_type(raw_token: str, *, expected_kind: str) -> dict[str, object]:
@@ -239,3 +357,11 @@ def _exp_to_datetime(exp: object) -> datetime:
 
 def _utcnow() -> datetime:
     return datetime.now(UTC)
+
+
+def _render_reset_password_text(*, reset_link: str) -> str:
+    return (
+        "We received a request to reset your Stima password.\n\n"
+        f"Reset your password: {reset_link}\n\n"
+        "This link expires in 1 hour. If you did not request this, you can ignore this email."
+    )

--- a/backend/app/features/auth/tests/test_auth.py
+++ b/backend/app/features/auth/tests/test_auth.py
@@ -1,14 +1,16 @@
 """Auth foundation model tests."""
 
 from app.core.database import Base
-from app.features.auth.models import RefreshToken, User
+from app.features.auth.models import PasswordResetToken, RefreshToken, User
 
 
 def test_auth_tables_registered_in_metadata() -> None:
     assert User.__tablename__ == "users"
     assert RefreshToken.__tablename__ == "refresh_tokens"
+    assert PasswordResetToken.__tablename__ == "password_reset_tokens"
     assert "users" in Base.metadata.tables
     assert "refresh_tokens" in Base.metadata.tables
+    assert "password_reset_tokens" in Base.metadata.tables
 
 
 def test_onboarding_fields_are_nullable() -> None:
@@ -38,4 +40,11 @@ def test_refresh_tokens_support_soft_revocation() -> None:
     assert RefreshToken.__table__.c["revoked_at"].nullable is True
 
     foreign_key = next(iter(RefreshToken.__table__.c["user_id"].foreign_keys))
+    assert foreign_key.ondelete == "CASCADE"
+
+
+def test_password_reset_tokens_support_one_time_use() -> None:
+    assert PasswordResetToken.__table__.c["used_at"].nullable is True
+
+    foreign_key = next(iter(PasswordResetToken.__table__.c["user_id"].foreign_keys))
     assert foreign_key.ondelete == "CASCADE"

--- a/backend/app/features/auth/tests/test_auth_api.py
+++ b/backend/app/features/auth/tests/test_auth_api.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import re
 from collections.abc import Iterator
 from datetime import timedelta
 from uuid import UUID, uuid4
@@ -14,11 +15,13 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import get_settings
 from app.core.database import get_engine, get_session_maker
-from app.core.security import create_refresh_token, hash_token
-from app.features.auth.models import RefreshToken, User
+from app.core.security import create_refresh_token, hash_token, verify_password
+from app.features.auth.models import PasswordResetToken, RefreshToken, User
 from app.features.auth.service import ACCESS_COOKIE_NAME, CSRF_COOKIE_NAME, REFRESH_COOKIE_NAME
+from app.integrations.email import EmailMessage
 from app.main import app
 from app.shared import observability
+from app.shared.dependencies import get_email_service
 from app.shared.rate_limit import reset_local_rate_limit_state
 
 pytestmark = pytest.mark.asyncio
@@ -48,6 +51,22 @@ def _reset_rate_limiter() -> Iterator[None]:
     reset_local_rate_limit_state()
     yield
     reset_local_rate_limit_state()
+
+
+class _MockEmailService:
+    def __init__(self) -> None:
+        self.messages: list[EmailMessage] = []
+
+    async def send(self, message: EmailMessage) -> None:
+        self.messages.append(message)
+
+
+@pytest.fixture(autouse=True)
+def _mock_email_service() -> Iterator[_MockEmailService]:
+    service = _MockEmailService()
+    app.dependency_overrides[get_email_service] = lambda: service
+    yield service
+    app.dependency_overrides.pop(get_email_service, None)
 
 
 async def test_register_returns_201_with_user_payload(client: AsyncClient) -> None:
@@ -307,6 +326,188 @@ async def test_login_rate_limit_emits_structured_auth_throttle_event(
     assert throttle_event["route_template"] == "/api/auth/login"
     assert isinstance(throttle_event["client_ip_hash"], str)
     assert throttle_event["_level"] == logging.WARNING
+
+
+async def test_forgot_password_returns_200_for_known_and_unknown_emails(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    _mock_email_service: _MockEmailService,
+) -> None:
+    credentials = _credentials()
+    register_response = await client.post("/api/auth/register", json=credentials)
+    assert register_response.status_code == 201
+
+    known_response = await client.post(
+        "/api/auth/forgot-password",
+        json={"email": credentials["email"]},
+    )
+    unknown_response = await client.post(
+        "/api/auth/forgot-password",
+        json={"email": "missing-user@example.com"},
+    )
+
+    assert known_response.status_code == 200
+    assert unknown_response.status_code == 200
+    assert known_response.json() == {
+        "detail": "If an account exists for that email, a reset link has been sent."
+    }
+    assert unknown_response.json() == {
+        "detail": "If an account exists for that email, a reset link has been sent."
+    }
+    assert len(_mock_email_service.messages) == 1
+
+    user = await db_session.scalar(select(User).where(User.email == credentials["email"]))
+    assert user is not None
+    reset_tokens = (
+        await db_session.scalars(
+            select(PasswordResetToken).where(PasswordResetToken.user_id == user.id)
+        )
+    ).all()
+    assert len(reset_tokens) == 1
+
+
+async def test_forgot_password_rate_limit_is_scoped_per_email(
+    client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(app.state.limiter, "enabled", True)
+    monkeypatch.setenv("AUTH_FORGOT_PASSWORD_RATE_LIMIT", "3/hour")
+    get_settings.cache_clear()
+
+    first_user = _credentials()
+    second_user = _credentials()
+    assert (await client.post("/api/auth/register", json=first_user)).status_code == 201
+    assert (await client.post("/api/auth/register", json=second_user)).status_code == 201
+
+    for _ in range(3):
+        response = await client.post(
+            "/api/auth/forgot-password",
+            json={"email": first_user["email"]},
+        )
+        assert response.status_code == 200
+
+    blocked_response = await client.post(
+        "/api/auth/forgot-password",
+        json={"email": first_user["email"]},
+    )
+    second_email_response = await client.post(
+        "/api/auth/forgot-password",
+        json={"email": second_user["email"]},
+    )
+
+    assert blocked_response.status_code == 429
+    assert second_email_response.status_code == 200
+
+
+async def test_reset_password_updates_hash_marks_token_used_and_revokes_refresh_tokens(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    _mock_email_service: _MockEmailService,
+) -> None:
+    credentials = _credentials()
+    register_response = await client.post("/api/auth/register", json=credentials)
+    assert register_response.status_code == 201
+    login_response = await client.post("/api/auth/login", json=credentials)
+    assert login_response.status_code == 200
+
+    forgot_response = await client.post(
+        "/api/auth/forgot-password",
+        json={"email": credentials["email"]},
+    )
+    assert forgot_response.status_code == 200
+    assert len(_mock_email_service.messages) == 1
+    raw_token = _extract_reset_token(_mock_email_service.messages[0])
+
+    reset_response = await client.post(
+        "/api/auth/reset-password",
+        json={"token": raw_token, "new_password": "NewStrongPass123!"},
+    )
+    assert reset_response.status_code == 200
+    assert reset_response.json() == {"detail": "Password has been reset."}
+
+    user = await db_session.scalar(select(User).where(User.email == credentials["email"]))
+    assert user is not None
+    assert verify_password("NewStrongPass123!", user.password_hash)
+
+    reset_token_row = await db_session.scalar(
+        select(PasswordResetToken).where(PasswordResetToken.token_hash == hash_token(raw_token))
+    )
+    assert reset_token_row is not None
+    assert reset_token_row.used_at is not None
+
+    refresh_tokens = (
+        await db_session.scalars(select(RefreshToken).where(RefreshToken.user_id == user.id))
+    ).all()
+    assert refresh_tokens
+    assert all(token_row.revoked_at is not None for token_row in refresh_tokens)
+
+    old_password_login = await client.post("/api/auth/login", json=credentials)
+    new_password_login = await client.post(
+        "/api/auth/login",
+        json={"email": credentials["email"], "password": "NewStrongPass123!"},
+    )
+    assert old_password_login.status_code == 401
+    assert new_password_login.status_code == 200
+
+
+async def test_reset_password_rejects_invalid_expired_or_used_token(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    _mock_email_service: _MockEmailService,
+) -> None:
+    credentials = _credentials()
+    register_response = await client.post("/api/auth/register", json=credentials)
+    assert register_response.status_code == 201
+
+    invalid_response = await client.post(
+        "/api/auth/reset-password",
+        json={"token": "invalid-token", "new_password": "NewStrongPass123!"},
+    )
+    assert invalid_response.status_code == 400
+    assert invalid_response.json() == {"detail": "Invalid or expired token"}
+
+    forgot_response = await client.post(
+        "/api/auth/forgot-password",
+        json={"email": credentials["email"]},
+    )
+    assert forgot_response.status_code == 200
+    raw_token = _extract_reset_token(_mock_email_service.messages[-1])
+
+    first_reset = await client.post(
+        "/api/auth/reset-password",
+        json={"token": raw_token, "new_password": "NewStrongPass123!"},
+    )
+    second_reset = await client.post(
+        "/api/auth/reset-password",
+        json={"token": raw_token, "new_password": "AnotherStrongPass123!"},
+    )
+    assert first_reset.status_code == 200
+    assert second_reset.status_code == 400
+    assert second_reset.json() == {"detail": "Invalid or expired token"}
+
+    second_credentials = _credentials()
+    second_register = await client.post("/api/auth/register", json=second_credentials)
+    assert second_register.status_code == 201
+    second_forgot = await client.post(
+        "/api/auth/forgot-password",
+        json={"email": second_credentials["email"]},
+    )
+    assert second_forgot.status_code == 200
+    expired_token = _extract_reset_token(_mock_email_service.messages[-1])
+
+    expired_row = await db_session.scalar(
+        select(PasswordResetToken).where(PasswordResetToken.token_hash == hash_token(expired_token))
+    )
+    assert expired_row is not None
+    expired_row.expires_at = expired_row.created_at - timedelta(minutes=1)
+    await db_session.flush()
+
+    expired_response = await client.post(
+        "/api/auth/reset-password",
+        json={"token": expired_token, "new_password": "FreshStrongPass123!"},
+    )
+    assert expired_response.status_code == 400
+    assert expired_response.json() == {"detail": "Invalid or expired token"}
 
 
 async def test_refresh_rejects_missing_csrf_header(client: AsyncClient) -> None:
@@ -609,3 +810,10 @@ def _cookie_header(set_cookie_values: list[str], cookie_name: str) -> str:
         if value.startswith(f"{cookie_name}="):
             return value
     raise AssertionError(f"Cookie {cookie_name} not found in set-cookie headers")
+
+
+def _extract_reset_token(message: EmailMessage) -> str:
+    match = re.search(r"token=([^&\s]+)", message.text_content)
+    if match is None:
+        raise AssertionError("reset token not found in email text body")
+    return match.group(1)

--- a/backend/app/features/auth/tests/test_auth_service.py
+++ b/backend/app/features/auth/tests/test_auth_service.py
@@ -38,6 +38,26 @@ class _IntegrityErrorRepository:
     ) -> object:
         return object()
 
+    async def create_reset_token(
+        self,
+        *,
+        user_id: object,
+        token_hash: str,
+        expires_at: object,
+    ) -> object:
+        return object()
+
+    async def get_valid_reset_token(
+        self,
+        *,
+        token_hash: str,
+        now: object,
+    ) -> object | None:
+        return None
+
+    async def mark_reset_token_used(self, *, token_id: object, used_at: object) -> None:
+        return None
+
     async def consume_and_rotate_refresh_token(
         self,
         *,
@@ -50,6 +70,9 @@ class _IntegrityErrorRepository:
         raise NotImplementedError()
 
     async def revoke_refresh_token(self, *, token_hash: str, revoked_at: object) -> None:
+        return None
+
+    async def revoke_all_user_tokens(self, *, user_id: object, revoked_at: object) -> None:
         return None
 
 

--- a/backend/app/features/auth/tests/test_registry.py
+++ b/backend/app/features/auth/tests/test_registry.py
@@ -14,3 +14,4 @@ def test_feature_registry_import_loads_auth_models() -> None:
     assert "job_records" in Base.metadata.tables
     assert "users" in Base.metadata.tables
     assert "refresh_tokens" in Base.metadata.tables
+    assert "password_reset_tokens" in Base.metadata.tables

--- a/backend/app/shared/dependencies.py
+++ b/backend/app/shared/dependencies.py
@@ -111,9 +111,15 @@ def get_idempotency_store() -> IdempotencyStore:
 
 def get_auth_service(
     db: Annotated[AsyncSession, Depends(get_db)],
+    email_service: Annotated[EmailService, Depends(get_email_service)],
 ) -> AuthService:
     """Build a request-scoped auth service wired to the DB session."""
-    return AuthService(repository=AuthRepository(db))
+    settings = get_settings()
+    return AuthService(
+        repository=AuthRepository(db),
+        email_service=email_service,
+        frontend_url=settings.frontend_url,
+    )
 
 
 def get_profile_service(

--- a/backend/app/templates/password_reset_email.html
+++ b/backend/app/templates/password_reset_email.html
@@ -1,0 +1,52 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Password reset</title>
+  </head>
+  <body style="margin:0;padding:24px;background:#f6f7fb;font-family:Arial,sans-serif;color:#111827;">
+    <table role="presentation" width="100%" cellspacing="0" cellpadding="0">
+      <tr>
+        <td align="center">
+          <table
+            role="presentation"
+            width="100%"
+            style="max-width:560px;background:#ffffff;border:1px solid #e5e7eb;border-radius:12px;padding:28px;"
+            cellspacing="0"
+            cellpadding="0"
+          >
+            <tr>
+              <td style="font-size:22px;font-weight:700;padding-bottom:10px;">Reset your password</td>
+            </tr>
+            <tr>
+              <td style="font-size:15px;line-height:1.6;padding-bottom:18px;">
+                We received a request to reset your Stima password. Use the button below to set a new one.
+              </td>
+            </tr>
+            <tr>
+              <td style="padding-bottom:18px;">
+                <a
+                  href="{{ reset_link }}"
+                  style="display:inline-block;background:#111827;color:#ffffff;text-decoration:none;padding:12px 18px;border-radius:8px;font-weight:600;"
+                >
+                  Reset password
+                </a>
+              </td>
+            </tr>
+            <tr>
+              <td style="font-size:13px;line-height:1.5;color:#4b5563;padding-bottom:8px;">
+                This link expires in 1 hour.
+              </td>
+            </tr>
+            <tr>
+              <td style="font-size:13px;line-height:1.5;color:#6b7280;">
+                If you did not request this, you can safely ignore this email.
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -196,6 +196,8 @@ Internal analytics access:
 |---|---|---|---|---|---|---|
 | `/register` | POST | 3/hr | no | no | `{ email, password }` | `201 { user: { id, email, is_active, is_onboarded, timezone } }` |
 | `/login` | POST | 5/min | no | no | `{ email, password }` | `200 { user: { id, email, is_active, is_onboarded, timezone }, csrf_token }` + sets cookies |
+| `/forgot-password` | POST | 3/hr (per email) | no | no | `{ email }` | `200 { detail }` (same response for known/unknown emails) |
+| `/reset-password` | POST | — | no | no | `{ token, new_password }` | `200 { detail }` on success, `400 { detail: "Invalid or expired token" }` for invalid/expired/used tokens |
 | `/refresh` | POST | 10/min | yes | cookie | — | `200 { user: { id, email, is_active, is_onboarded, timezone }, csrf_token }` + rotates cookies |
 | `/logout` | POST | 10/min | yes | cookie | — | `204` + clears cookies |
 | `/me` | GET | — | no | cookie | — | `200 { id, email, is_active, is_onboarded, timezone }` |


### PR DESCRIPTION
## Summary
- add password reset token persistence with a new password_reset_tokens migration/model
- add forgot-password and reset-password auth endpoints with per-email forgot-password rate limiting
- hash and store reset tokens, enforce one-time/expiry validation, update password hash, and revoke all refresh tokens on successful reset
- send password reset email through existing Resend integration with a new HTML template
- add backend tests for enumeration resistance, per-email throttling, token lifecycle, and token-family revocation behavior

## Verification
- make backend-verify

Closes #301