### PR TITLE
Add frontend forgot/reset password flow

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,8 +7,10 @@ import {
   useParams,
 } from "react-router-dom";
 
+import { ForgotPasswordPage } from "@/features/auth/components/ForgotPasswordPage";
 import { LoginForm } from "@/features/auth/components/LoginForm";
 import { RegisterForm } from "@/features/auth/components/RegisterForm";
+import { ResetPasswordPage } from "@/features/auth/components/ResetPasswordPage";
 import { useAuth } from "@/features/auth/hooks/useAuth";
 import { CustomerCreateScreen } from "@/features/customers/components/CustomerCreateScreen";
 import { CustomerDetailScreen } from "@/features/customers/components/CustomerDetailScreen";
@@ -96,6 +98,22 @@ export default function App(): React.ReactElement {
         element={
           <PublicRoute>
             <RegisterForm />
+          </PublicRoute>
+        }
+      />
+      <Route
+        path="/forgot-password"
+        element={
+          <PublicRoute>
+            <ForgotPasswordPage />
+          </PublicRoute>
+        }
+      />
+      <Route
+        path="/reset-password"
+        element={
+          <PublicRoute>
+            <ResetPasswordPage />
           </PublicRoute>
         }
       />

--- a/frontend/src/features/auth/components/ForgotPasswordPage.tsx
+++ b/frontend/src/features/auth/components/ForgotPasswordPage.tsx
@@ -1,28 +1,22 @@
 import { useState } from "react";
-import { Link, useLocation, useNavigate } from "react-router-dom";
-import type { Location } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 
-import { useAuth } from "@/features/auth/hooks/useAuth";
+import { authService } from "@/features/auth/services/authService";
 import { Button } from "@/shared/components/Button";
 import { Input } from "@/shared/components/Input";
-import { Toast } from "@/shared/components/Toast";
 
-interface LoginLocationState {
-  from?: Location;
+const FORGOT_PASSWORD_SUCCESS_MESSAGE =
+  "If an account exists with that email, you'll receive a reset link.";
+
+interface LoginFlashState {
   flashMessage?: string;
 }
 
-export function LoginForm(): React.ReactElement {
-  const { login } = useAuth();
+export function ForgotPasswordPage(): React.ReactElement {
   const navigate = useNavigate();
-  const location = useLocation();
   const [email, setEmail] = useState("");
-  const [password, setPassword] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
-  const [flashMessage, setFlashMessage] = useState(
-    (location.state as LoginLocationState | undefined)?.flashMessage ?? null,
-  );
 
   const onSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -30,11 +24,13 @@ export function LoginForm(): React.ReactElement {
     setIsSubmitting(true);
 
     try {
-      await login({ email, password });
-      const from = (location.state as LoginLocationState | undefined)?.from;
-      navigate(from?.pathname ?? "/", { replace: true });
+      await authService.forgotPassword(email);
+      navigate("/login", {
+        replace: true,
+        state: { flashMessage: FORGOT_PASSWORD_SUCCESS_MESSAGE } satisfies LoginFlashState,
+      });
     } catch (submitError) {
-      const message = submitError instanceof Error ? submitError.message : "Login failed";
+      const message = submitError instanceof Error ? submitError.message : "Unable to send reset link";
       setError(message);
     } finally {
       setIsSubmitting(false);
@@ -45,28 +41,20 @@ export function LoginForm(): React.ReactElement {
     <main className="screen-radial-backdrop flex min-h-screen flex-col items-center justify-center px-4 py-8">
       <h1 className="mb-8 font-headline text-3xl font-bold text-primary">Stima</h1>
       <section className="w-full max-w-sm rounded-xl bg-surface-container-lowest p-6 ghost-shadow">
-        <h2 className="mb-6 font-headline text-2xl font-bold text-on-surface">Welcome Back</h2>
+        <h2 className="mb-2 font-headline text-2xl font-bold text-on-surface">Forgot password?</h2>
+        <p className="mb-6 text-sm text-on-surface-variant">
+          Enter your email and we&apos;ll send a reset link if your account exists.
+        </p>
+
         <form className="flex flex-col gap-4" onSubmit={onSubmit}>
           <Input
             id="email"
             label="Email"
             type="email"
+            required
             value={email}
             onChange={(event) => setEmail(event.target.value)}
           />
-          <Input
-            id="password"
-            label="Password"
-            type="password"
-            value={password}
-            onChange={(event) => setPassword(event.target.value)}
-          />
-
-          <p className="-mt-1 text-right text-sm text-on-surface-variant">
-            <Link to="/forgot-password" className="font-semibold text-primary">
-              Forgot password?
-            </Link>
-          </p>
 
           {error ? (
             <div role="alert" className="rounded-lg border-l-4 border-error bg-error-container p-4">
@@ -75,18 +63,16 @@ export function LoginForm(): React.ReactElement {
           ) : null}
 
           <Button type="submit" isLoading={isSubmitting} className="w-full">
-            Sign In →
+            Send Reset Link
           </Button>
         </form>
 
         <p className="mt-6 text-sm text-on-surface-variant">
-          Don&apos;t have an account?{" "}
-          <Link to="/register" className="font-semibold text-primary">
-            Register
+          <Link to="/login" className="font-semibold text-primary">
+            Back to Login
           </Link>
         </p>
       </section>
-      <Toast message={flashMessage} onDismiss={() => setFlashMessage(null)} />
     </main>
   );
 }

--- a/frontend/src/features/auth/components/ResetPasswordPage.tsx
+++ b/frontend/src/features/auth/components/ResetPasswordPage.tsx
@@ -1,0 +1,127 @@
+import { useMemo, useState } from "react";
+import { Link, useNavigate, useSearchParams } from "react-router-dom";
+
+import { authService } from "@/features/auth/services/authService";
+import { Button } from "@/shared/components/Button";
+import { Input } from "@/shared/components/Input";
+import { isHttpRequestError } from "@/shared/lib/http";
+
+const RESET_PASSWORD_SUCCESS_MESSAGE = "Password reset successful. Please sign in.";
+const BAD_TOKEN_MESSAGE = "This reset link is invalid or expired. Request a new reset link.";
+
+interface LoginFlashState {
+  flashMessage?: string;
+}
+
+export function ResetPasswordPage(): React.ReactElement {
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const [newPassword, setNewPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [isBadToken, setIsBadToken] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const token = useMemo(() => searchParams.get("token")?.trim() ?? "", [searchParams]);
+  const isMissingToken = token.length === 0;
+
+  const onSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    if (isMissingToken) {
+      setIsBadToken(true);
+      setError(null);
+      return;
+    }
+
+    if (newPassword !== confirmPassword) {
+      setError("Passwords do not match");
+      return;
+    }
+
+    setError(null);
+    setIsBadToken(false);
+    setIsSubmitting(true);
+
+    try {
+      await authService.resetPassword(token, newPassword);
+      navigate("/login", {
+        replace: true,
+        state: { flashMessage: RESET_PASSWORD_SUCCESS_MESSAGE } satisfies LoginFlashState,
+      });
+    } catch (submitError) {
+      if (
+        isHttpRequestError(submitError) &&
+        submitError.status === 400 &&
+        submitError.message === "Invalid or expired token"
+      ) {
+        setIsBadToken(true);
+        return;
+      }
+
+      const message = submitError instanceof Error ? submitError.message : "Unable to reset password";
+      setError(message);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const shouldShowBadTokenState = isBadToken || isMissingToken;
+
+  return (
+    <main className="screen-radial-backdrop flex min-h-screen flex-col items-center justify-center px-4 py-8">
+      <h1 className="mb-8 font-headline text-3xl font-bold text-primary">Stima</h1>
+      <section className="w-full max-w-sm rounded-xl bg-surface-container-lowest p-6 ghost-shadow">
+        <h2 className="mb-6 font-headline text-2xl font-bold text-on-surface">Reset password</h2>
+
+        {shouldShowBadTokenState ? (
+          <div className="space-y-4">
+            <div role="alert" className="rounded-lg border-l-4 border-error bg-error-container p-4">
+              <p className="text-sm font-medium text-error">{BAD_TOKEN_MESSAGE}</p>
+            </div>
+            <p className="text-sm text-on-surface-variant">
+              <Link to="/forgot-password" className="font-semibold text-primary">
+                Back to forgot password
+              </Link>
+            </p>
+          </div>
+        ) : (
+          <form className="flex flex-col gap-4" onSubmit={onSubmit}>
+            <Input
+              id="new-password"
+              label="New Password"
+              type="password"
+              required
+              value={newPassword}
+              onChange={(event) => setNewPassword(event.target.value)}
+            />
+            <Input
+              id="confirm-password"
+              label="Confirm Password"
+              type="password"
+              required
+              value={confirmPassword}
+              onChange={(event) => setConfirmPassword(event.target.value)}
+            />
+
+            {error ? (
+              <div role="alert" className="rounded-lg border-l-4 border-error bg-error-container p-4">
+                <p className="text-sm font-medium text-error">{error}</p>
+              </div>
+            ) : null}
+
+            <Button type="submit" isLoading={isSubmitting} className="w-full">
+              Reset Password
+            </Button>
+          </form>
+        )}
+
+        <p className="mt-6 text-sm text-on-surface-variant">
+          <Link to="/login" className="font-semibold text-primary">
+            Back to Login
+          </Link>
+        </p>
+      </section>
+    </main>
+  );
+}

--- a/frontend/src/features/auth/services/authService.ts
+++ b/frontend/src/features/auth/services/authService.ts
@@ -7,6 +7,10 @@ import type {
 } from "@/features/auth/types/auth.types";
 import { clearCsrfToken, request, setCsrfToken } from "@/shared/lib/http";
 
+interface AuthMessageResponse {
+  detail: string;
+}
+
 async function login(credentials: LoginRequest): Promise<void> {
   const response = await request<AuthResponse>("/api/auth/login", {
     method: "POST",
@@ -35,9 +39,30 @@ function me(): Promise<User> {
   return request<User>("/api/auth/me");
 }
 
+async function forgotPassword(email: string): Promise<void> {
+  await request<AuthMessageResponse>("/api/auth/forgot-password", {
+    method: "POST",
+    body: { email },
+    skipRefresh: true,
+  });
+}
+
+async function resetPassword(token: string, newPassword: string): Promise<void> {
+  await request<AuthMessageResponse>("/api/auth/reset-password", {
+    method: "POST",
+    body: {
+      token,
+      new_password: newPassword,
+    },
+    skipRefresh: true,
+  });
+}
+
 export const authService = {
   login,
   register,
   logout,
   me,
+  forgotPassword,
+  resetPassword,
 };

--- a/frontend/src/features/auth/tests/App.routes.test.tsx
+++ b/frontend/src/features/auth/tests/App.routes.test.tsx
@@ -141,6 +141,22 @@ describe("App routes", () => {
     expect(await screen.findByRole("heading", { name: /capture the job first/i })).toBeInTheDocument();
   });
 
+  it("renders forgot-password for unauthenticated users", async () => {
+    mockedAuthService.me.mockRejectedValueOnce(new Error("Not authenticated"));
+
+    renderApp("/forgot-password");
+
+    expect(await screen.findByRole("heading", { name: /forgot password\?/i })).toBeInTheDocument();
+  });
+
+  it("renders reset-password for unauthenticated users", async () => {
+    mockedAuthService.me.mockRejectedValueOnce(new Error("Not authenticated"));
+
+    renderApp("/reset-password?token=sample-token");
+
+    expect(await screen.findByRole("heading", { name: /reset password/i })).toBeInTheDocument();
+  });
+
   it("preserves the protected route in login state so users return after sign-in", async () => {
     mockedAuthService.me.mockRejectedValueOnce(new Error("Not authenticated"));
 

--- a/frontend/src/features/auth/tests/ForgotPasswordPage.test.tsx
+++ b/frontend/src/features/auth/tests/ForgotPasswordPage.test.tsx
@@ -1,0 +1,70 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { ForgotPasswordPage } from "@/features/auth/components/ForgotPasswordPage";
+import { authService } from "@/features/auth/services/authService";
+
+vi.mock("@/features/auth/services/authService", () => ({
+  authService: {
+    login: vi.fn(),
+    register: vi.fn(),
+    logout: vi.fn(),
+    me: vi.fn(),
+    forgotPassword: vi.fn(),
+    resetPassword: vi.fn(),
+  },
+}));
+
+const mockedAuthService = vi.mocked(authService);
+
+function LoginFlashProbe(): React.ReactElement {
+  const location = useLocation();
+  const flashMessage =
+    (location.state as { flashMessage?: string } | undefined)?.flashMessage ?? "";
+
+  return <p>{flashMessage}</p>;
+}
+
+function renderForgotPassword() {
+  return render(
+    <MemoryRouter initialEntries={["/forgot-password"]}>
+      <Routes>
+        <Route path="/forgot-password" element={<ForgotPasswordPage />} />
+        <Route path="/login" element={<LoginFlashProbe />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("ForgotPasswordPage", () => {
+  it("submits email and redirects to login with generic success message", async () => {
+    mockedAuthService.forgotPassword.mockResolvedValueOnce();
+
+    renderForgotPassword();
+
+    fireEvent.change(await screen.findByLabelText(/email/i), {
+      target: { value: "user@example.com" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /send reset link/i }));
+
+    await waitFor(() => {
+      expect(mockedAuthService.forgotPassword).toHaveBeenCalledWith("user@example.com");
+    });
+
+    expect(
+      await screen.findByText("If an account exists with that email, you'll receive a reset link."),
+    ).toBeInTheDocument();
+  });
+
+  it("renders back-to-login link", async () => {
+    renderForgotPassword();
+
+    const link = await screen.findByRole("link", { name: /back to login/i });
+    expect(link).toHaveAttribute("href", "/login");
+  });
+});

--- a/frontend/src/features/auth/tests/LoginForm.test.tsx
+++ b/frontend/src/features/auth/tests/LoginForm.test.tsx
@@ -124,4 +124,17 @@ describe("LoginForm", () => {
     const forgotPasswordLink = await screen.findByRole("link", { name: /forgot password\?/i });
     expect(forgotPasswordLink).toHaveAttribute("href", "/forgot-password");
   });
+
+  it("renders a success toast when flashMessage exists in location state", async () => {
+    mockedAuthService.me.mockRejectedValueOnce(new Error("Not authenticated"));
+
+    renderLogin({
+      pathname: "/login",
+      state: { flashMessage: "Password reset successful. Please sign in." },
+    });
+
+    expect(
+      await screen.findByText("Password reset successful. Please sign in."),
+    ).toBeInTheDocument();
+  });
 });

--- a/frontend/src/features/auth/tests/LoginForm.test.tsx
+++ b/frontend/src/features/auth/tests/LoginForm.test.tsx
@@ -115,4 +115,13 @@ describe("LoginForm", () => {
 
     expect(await screen.findByRole("alert")).toHaveTextContent("Invalid credentials");
   });
+
+  it("shows forgot-password link", async () => {
+    mockedAuthService.me.mockRejectedValueOnce(new Error("Not authenticated"));
+
+    renderLogin();
+
+    const forgotPasswordLink = await screen.findByRole("link", { name: /forgot password\?/i });
+    expect(forgotPasswordLink).toHaveAttribute("href", "/forgot-password");
+  });
 });

--- a/frontend/src/features/auth/tests/ResetPasswordPage.test.tsx
+++ b/frontend/src/features/auth/tests/ResetPasswordPage.test.tsx
@@ -1,0 +1,94 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { ResetPasswordPage } from "@/features/auth/components/ResetPasswordPage";
+import { authService } from "@/features/auth/services/authService";
+import { HttpRequestError } from "@/shared/lib/http";
+
+vi.mock("@/features/auth/services/authService", () => ({
+  authService: {
+    login: vi.fn(),
+    register: vi.fn(),
+    logout: vi.fn(),
+    me: vi.fn(),
+    forgotPassword: vi.fn(),
+    resetPassword: vi.fn(),
+  },
+}));
+
+const mockedAuthService = vi.mocked(authService);
+
+function LoginFlashProbe(): React.ReactElement {
+  const location = useLocation();
+  const flashMessage =
+    (location.state as { flashMessage?: string } | undefined)?.flashMessage ?? "";
+
+  return <p>{flashMessage}</p>;
+}
+
+function renderResetPassword(initialEntry = "/reset-password?token=token-123") {
+  return render(
+    <MemoryRouter initialEntries={[initialEntry]}>
+      <Routes>
+        <Route path="/reset-password" element={<ResetPasswordPage />} />
+        <Route path="/login" element={<LoginFlashProbe />} />
+        <Route path="/forgot-password" element={<div>Forgot Password Route</div>} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("ResetPasswordPage", () => {
+  it("submits token and new password then redirects to login with success message", async () => {
+    mockedAuthService.resetPassword.mockResolvedValueOnce();
+
+    renderResetPassword();
+
+    fireEvent.change(await screen.findByLabelText(/new password/i), {
+      target: { value: "NewStrongPass123!" },
+    });
+    fireEvent.change(await screen.findByLabelText(/confirm password/i), {
+      target: { value: "NewStrongPass123!" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /reset password/i }));
+
+    await waitFor(() => {
+      expect(mockedAuthService.resetPassword).toHaveBeenCalledWith(
+        "token-123",
+        "NewStrongPass123!",
+      );
+    });
+
+    expect(await screen.findByText("Password reset successful. Please sign in.")).toBeInTheDocument();
+  });
+
+  it("shows invalid-token state and forgot-password link when reset token is rejected", async () => {
+    mockedAuthService.resetPassword.mockRejectedValueOnce(
+      new HttpRequestError("Invalid or expired token", 400, {
+        detail: "Invalid or expired token",
+      }),
+    );
+
+    renderResetPassword();
+
+    fireEvent.change(await screen.findByLabelText(/new password/i), {
+      target: { value: "NewStrongPass123!" },
+    });
+    fireEvent.change(await screen.findByLabelText(/confirm password/i), {
+      target: { value: "NewStrongPass123!" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /reset password/i }));
+
+    expect(
+      await screen.findByText("This reset link is invalid or expired. Request a new reset link."),
+    ).toBeInTheDocument();
+
+    const forgotPasswordLink = screen.getByRole("link", { name: /back to forgot password/i });
+    expect(forgotPasswordLink).toHaveAttribute("href", "/forgot-password");
+  });
+});

--- a/frontend/src/features/auth/tests/authService.integration.test.ts
+++ b/frontend/src/features/auth/tests/authService.integration.test.ts
@@ -46,6 +46,39 @@ describe("authService integration (MSW)", () => {
     expect(capturedBody).toEqual({ email: "new@example.com", password: "s3cret" });
   });
 
+  it("forgotPassword sends the expected email payload", async () => {
+    let capturedBody: { email: string } | null = null;
+
+    server.use(
+      http.post("/api/auth/forgot-password", async ({ request: req }) => {
+        capturedBody = (await req.json()) as { email: string };
+        return HttpResponse.json(
+          { detail: "If an account exists for that email, a reset link has been sent." },
+          { status: 200 },
+        );
+      }),
+    );
+
+    await authService.forgotPassword("missing@example.com");
+
+    expect(capturedBody).toEqual({ email: "missing@example.com" });
+  });
+
+  it("resetPassword sends token and new password payload", async () => {
+    let capturedBody: { token: string; new_password: string } | null = null;
+
+    server.use(
+      http.post("/api/auth/reset-password", async ({ request: req }) => {
+        capturedBody = (await req.json()) as { token: string; new_password: string };
+        return HttpResponse.json({ detail: "Password has been reset." }, { status: 200 });
+      }),
+    );
+
+    await authService.resetPassword("token-123", "NewStrongPass123!");
+
+    expect(capturedBody).toEqual({ token: "token-123", new_password: "NewStrongPass123!" });
+  });
+
   it("logout clears CSRF so next mutating request has no token", async () => {
     await authService.login({ email: "a@b.com", password: "pass" });
     await authService.logout();

--- a/frontend/src/shared/tests/mocks/handlers.ts
+++ b/frontend/src/shared/tests/mocks/handlers.ts
@@ -43,6 +43,20 @@ export const handlers = [
     );
   }),
 
+  http.post("/api/auth/forgot-password", () => {
+    return HttpResponse.json(
+      { detail: "If an account exists for that email, a reset link has been sent." },
+      { status: 200 },
+    );
+  }),
+
+  http.post("/api/auth/reset-password", () => {
+    return HttpResponse.json(
+      { detail: "Password has been reset." },
+      { status: 200 },
+    );
+  }),
+
   http.post("/api/auth/refresh", ({ request }) => {
     const csrfError = requireCsrf(request);
     if (csrfError) return csrfError;


### PR DESCRIPTION
## Summary
- add public forgot-password and reset-password pages with form handling and navigation back to login
- add auth service methods for forgot-password and reset-password API calls
- add reset invalid/expired token error state with forgot-password recovery link
- add login form forgot-password link and login success toast handoff for reset/forgot redirects
- add frontend tests and MSW handlers for new routes and auth service behavior

## Verification
- make frontend-verify

Closes #302