### PR TITLE
Add paid/void invoice outcome transitions

### DIFF
--- a/backend/alembic/versions/20260410_0022_add_invoice_paid_void_statuses.py
+++ b/backend/alembic/versions/20260410_0022_add_invoice_paid_void_statuses.py
@@ -1,0 +1,73 @@
+"""Add paid and void invoice statuses.
+
+Revision ID: 20260410_0022
+Revises: 20260410_0021
+Create Date: 2026-04-10
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "20260410_0022"
+down_revision: str | None = "20260410_0021"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_STATUS_CONSTRAINT = "quote_status"
+_EXPANDED_STATUSES = (
+    "draft",
+    "ready",
+    "shared",
+    "viewed",
+    "approved",
+    "declined",
+    "sent",
+    "paid",
+    "void",
+)
+_PREVIOUS_STATUSES = (
+    "draft",
+    "ready",
+    "shared",
+    "viewed",
+    "approved",
+    "declined",
+    "sent",
+)
+
+
+def upgrade() -> None:
+    op.drop_constraint(_STATUS_CONSTRAINT, "documents", type_="check")
+    op.create_check_constraint(
+        _STATUS_CONSTRAINT,
+        "documents",
+        _build_status_check(_EXPANDED_STATUSES),
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        sa.text(
+            """
+            UPDATE documents
+            SET status = 'sent'
+            WHERE status IN ('paid', 'void')
+            """
+        )
+    )
+    op.drop_constraint(_STATUS_CONSTRAINT, "documents", type_="check")
+    op.create_check_constraint(
+        _STATUS_CONSTRAINT,
+        "documents",
+        _build_status_check(_PREVIOUS_STATUSES),
+    )
+
+
+def _build_status_check(statuses: Sequence[str]) -> str:
+    quoted_statuses = ", ".join(f"'{status}'" for status in statuses)
+    return f"status IN ({quoted_statuses})"

--- a/backend/app/features/invoices/api.py
+++ b/backend/app/features/invoices/api.py
@@ -152,6 +152,42 @@ async def update_invoice(
 
 
 @router.post(
+    "/{invoice_id}/mark-paid",
+    response_model=InvoiceResponse,
+    dependencies=[Depends(require_csrf)],
+)
+async def mark_invoice_paid(
+    invoice_id: UUID,
+    user: Annotated[User, Depends(get_current_user)],
+    invoice_service: Annotated[InvoiceService, Depends(get_invoice_service)],
+) -> InvoiceResponse:
+    """Mark one invoice as paid when it has already reached a sent/outcome state."""
+    try:
+        invoice = await invoice_service.mark_invoice_paid(user, invoice_id)
+    except QuoteServiceError as exc:
+        raise HTTPException(status_code=exc.status_code, detail=exc.detail) from exc
+    return InvoiceResponse.model_validate(invoice)
+
+
+@router.post(
+    "/{invoice_id}/mark-void",
+    response_model=InvoiceResponse,
+    dependencies=[Depends(require_csrf)],
+)
+async def mark_invoice_void(
+    invoice_id: UUID,
+    user: Annotated[User, Depends(get_current_user)],
+    invoice_service: Annotated[InvoiceService, Depends(get_invoice_service)],
+) -> InvoiceResponse:
+    """Mark one invoice as void when it has already reached a sent/outcome state."""
+    try:
+        invoice = await invoice_service.mark_invoice_voided(user, invoice_id)
+    except QuoteServiceError as exc:
+        raise HTTPException(status_code=exc.status_code, detail=exc.detail) from exc
+    return InvoiceResponse.model_validate(invoice)
+
+
+@router.post(
     "/{invoice_id}/pdf",
     response_model=JobRecordResponse,
     status_code=status.HTTP_202_ACCEPTED,

--- a/backend/app/features/invoices/repository.py
+++ b/backend/app/features/invoices/repository.py
@@ -33,7 +33,11 @@ from app.shared.pricing import (
 )
 
 _INVOICE_DOC_TYPE = "invoice"
-_SENT_INVOICE_STATUS = QuoteStatus.SENT
+_PUBLIC_INVOICE_STATUSES = (
+    QuoteStatus.SENT,
+    QuoteStatus.PAID,
+    QuoteStatus.VOID,
+)
 
 
 @dataclass(slots=True)
@@ -366,7 +370,7 @@ class InvoiceRepository:
         self,
         share_token: str,
     ) -> QuoteRenderContext | None:
-        """Return PDF render context for a sent invoice share token."""
+        """Return PDF render context for an active invoice share token."""
         result = await self._session.execute(
             select(Document, Customer, User)
             .join(Customer, Customer.id == Document.customer_id)
@@ -374,7 +378,7 @@ class InvoiceRepository:
             .where(
                 Document.share_token == share_token,
                 Document.doc_type == _INVOICE_DOC_TYPE,
-                Document.status == _SENT_INVOICE_STATUS,
+                Document.status.in_(_PUBLIC_INVOICE_STATUSES),
             )
             .options(selectinload(Document.line_items))
         )
@@ -424,13 +428,13 @@ class InvoiceRepository:
         *,
         viewed_at: datetime,
     ) -> InvoiceFirstViewTransition | None:
-        """Set the invoice first-view timestamp exactly once for a sent share token."""
+        """Set the invoice first-view timestamp exactly once for an active token."""
         row = await self._session.execute(
             update(Document)
             .where(
                 Document.share_token == share_token,
                 Document.doc_type == _INVOICE_DOC_TYPE,
-                Document.status == _SENT_INVOICE_STATUS,
+                Document.status.in_(_PUBLIC_INVOICE_STATUSES),
                 Document.invoice_first_viewed_at.is_(None),
             )
             .values(

--- a/backend/app/features/invoices/schemas.py
+++ b/backend/app/features/invoices/schemas.py
@@ -59,7 +59,7 @@ class InvoiceResponse(BaseModel):
     customer_id: UUID
     doc_number: str
     title: str | None
-    status: Literal["draft", "ready", "sent"]
+    status: Literal["draft", "ready", "sent", "paid", "void"]
     total_amount: float | None
     tax_rate: float | None
     discount_type: DiscountType | None
@@ -85,7 +85,7 @@ class InvoiceListItemResponse(BaseModel):
     customer_name: str
     doc_number: str
     title: str | None
-    status: Literal["draft", "ready", "sent"]
+    status: Literal["draft", "ready", "sent", "paid", "void"]
     total_amount: float | None
     due_date: date | None
     created_at: datetime

--- a/backend/app/features/invoices/service.py
+++ b/backend/app/features/invoices/service.py
@@ -59,7 +59,22 @@ from app.shared.pricing import (
 )
 
 LOGGER = logging.getLogger(__name__)
-_EDITABLE_INVOICE_STATUSES = frozenset({QuoteStatus.DRAFT, QuoteStatus.READY, QuoteStatus.SENT})
+_EDITABLE_INVOICE_STATUSES = frozenset(
+    {
+        QuoteStatus.DRAFT,
+        QuoteStatus.READY,
+        QuoteStatus.SENT,
+        QuoteStatus.PAID,
+        QuoteStatus.VOID,
+    }
+)
+_INVOICE_OUTCOME_MUTABLE_STATUSES = frozenset(
+    {
+        QuoteStatus.SENT,
+        QuoteStatus.PAID,
+        QuoteStatus.VOID,
+    }
+)
 _PDF_JOB_NAME = "jobs.pdf"
 _PDF_QUEUE_FAILURE_DETAIL = "Unable to start PDF generation right now. Please try again."
 
@@ -335,6 +350,26 @@ class InvoiceService:
             raise QuoteServiceError(detail="Not found", status_code=404)
         return row
 
+    async def mark_invoice_paid(self, user: User, invoice_id: UUID) -> Document:
+        """Mark one invoice as paid without changing share/access capabilities."""
+        return await self._mark_invoice_outcome(
+            user,
+            invoice_id,
+            next_status=QuoteStatus.PAID,
+            event_name="invoice_paid",
+            action_label="paid",
+        )
+
+    async def mark_invoice_voided(self, user: User, invoice_id: UUID) -> Document:
+        """Mark one invoice as void without changing share/access capabilities."""
+        return await self._mark_invoice_outcome(
+            user,
+            invoice_id,
+            next_status=QuoteStatus.VOID,
+            event_name="invoice_voided",
+            action_label="void",
+        )
+
     async def update_invoice(
         self,
         user: User,
@@ -545,7 +580,7 @@ class InvoiceService:
         *,
         regenerate: bool = False,
     ) -> Document:
-        """Create/reuse a share token and transition the invoice to sent."""
+        """Create/reuse a share token without regressing paid/void outcome labels."""
         user_id = _resolve_user_id(user)
         invoice = await self._invoice_repository.get_by_id(invoice_id, user_id)
         if invoice is None:
@@ -557,7 +592,7 @@ class InvoiceService:
             or invoice.share_token_revoked_at is not None
             or _share_token_has_expired(invoice.share_token_expires_at, now)
         )
-        if invoice.status == QuoteStatus.SENT and not should_refresh_token:
+        if invoice.status in _INVOICE_OUTCOME_MUTABLE_STATUSES and not should_refresh_token:
             return invoice
 
         if should_refresh_token:
@@ -566,8 +601,11 @@ class InvoiceService:
             invoice.share_token_expires_at = _build_share_token_expiry(now)
             invoice.share_token_revoked_at = None
 
-        invoice.shared_at = now
-        invoice.status = QuoteStatus.SENT
+        if invoice.status not in _INVOICE_OUTCOME_MUTABLE_STATUSES:
+            invoice.shared_at = now
+            invoice.status = QuoteStatus.SENT
+        elif invoice.shared_at is None:
+            invoice.shared_at = now
         await self._invoice_repository.commit()
         return await self._invoice_repository.refresh(invoice)
 
@@ -584,7 +622,7 @@ class InvoiceService:
         await self._invoice_repository.commit()
 
     async def generate_shared_pdf(self, share_token: str) -> tuple[str, bytes]:
-        """Render and return a sent invoice PDF by share token."""
+        """Render and return one shared invoice PDF by share token."""
         context = await self._get_public_invoice_context(share_token)
         await self._attach_logo_data_uri(context)
 
@@ -697,6 +735,38 @@ class InvoiceService:
         ):
             return None
         return job
+
+    async def _mark_invoice_outcome(
+        self,
+        user: User,
+        invoice_id: UUID,
+        *,
+        next_status: QuoteStatus,
+        event_name: str,
+        action_label: str,
+    ) -> Document:
+        user_id = _resolve_user_id(user)
+        invoice = await self._invoice_repository.get_by_id(invoice_id, user_id)
+        if invoice is None:
+            raise QuoteServiceError(detail="Not found", status_code=404)
+        if invoice.status == next_status:
+            return invoice
+        if invoice.status not in _INVOICE_OUTCOME_MUTABLE_STATUSES:
+            raise QuoteServiceError(
+                detail=f"Only sent, paid, or void invoices can be marked {action_label}.",
+                status_code=409,
+            )
+
+        invoice.status = next_status
+        await self._invoice_repository.commit()
+        refreshed_invoice = await self._invoice_repository.refresh(invoice)
+        log_event(
+            event_name,
+            user_id=user_id,
+            invoice_id=refreshed_invoice.id,
+            customer_id=refreshed_invoice.customer_id,
+        )
+        return refreshed_invoice
 
     def _log_public_share_denied(
         self,

--- a/backend/app/features/quotes/models.py
+++ b/backend/app/features/quotes/models.py
@@ -23,6 +23,8 @@ class DocumentStatus(StrEnum):
     APPROVED = "approved"
     DECLINED = "declined"
     SENT = "sent"
+    PAID = "paid"
+    VOID = "void"
 
 
 QuoteStatus = DocumentStatus

--- a/backend/app/features/quotes/tests/test_quotes.py
+++ b/backend/app/features/quotes/tests/test_quotes.py
@@ -5736,6 +5736,213 @@ async def test_convert_quote_to_invoice_rejects_duplicates_and_patch_preserves_s
 
 
 @pytest.mark.parametrize(
+    ("starting_status", "endpoint", "expected_status", "expected_event"),
+    [
+        (QuoteStatus.SENT, "mark-paid", "paid", "invoice_paid"),
+        (QuoteStatus.VOID, "mark-paid", "paid", "invoice_paid"),
+        (QuoteStatus.SENT, "mark-void", "void", "invoice_voided"),
+        (QuoteStatus.PAID, "mark-void", "void", "invoice_voided"),
+    ],
+)
+async def test_mark_invoice_outcome_transitions_status_and_emits_event_once(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+    starting_status: QuoteStatus,
+    endpoint: str,
+    expected_status: str,
+    expected_event: str,
+) -> None:
+    emitted_events: list[dict[str, str]] = []
+
+    def _capture(message: str) -> None:
+        emitted_events.append(json.loads(message))
+
+    monkeypatch.setattr(event_logger._EVENT_LOGGER, "info", _capture)  # noqa: SLF001
+    csrf_token = await _register_and_login(client, _credentials())
+    customer_id = await _create_customer(client, csrf_token)
+    invoice = await _create_direct_invoice(
+        client,
+        csrf_token,
+        customer_id,
+        title="Invoice",
+        transcript="invoice transcript",
+        total_amount=120,
+    )
+    invoice_id = invoice["id"]
+
+    share_response = await client.post(
+        f"/api/invoices/{invoice_id}/share",
+        headers={"X-CSRF-Token": csrf_token},
+    )
+    assert share_response.status_code == 200
+    if starting_status is not QuoteStatus.SENT:
+        await _set_invoice_status(db_session, invoice_id, starting_status)
+
+    response = await client.post(
+        f"/api/invoices/{invoice_id}/{endpoint}",
+        headers={"X-CSRF-Token": csrf_token},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["status"] == expected_status
+
+    detail_response = await client.get(f"/api/invoices/{invoice_id}")
+    assert detail_response.status_code == 200
+    assert detail_response.json()["status"] == expected_status
+
+    invoice_events = [
+        payload["event"] for payload in emitted_events if payload.get("invoice_id") == invoice_id
+    ]
+    assert invoice_events[-1:] == [expected_event]
+
+
+@pytest.mark.parametrize(
+    ("starting_status", "endpoint", "expected_status", "expected_event"),
+    [
+        (QuoteStatus.PAID, "mark-paid", "paid", "invoice_paid"),
+        (QuoteStatus.VOID, "mark-void", "void", "invoice_voided"),
+    ],
+)
+async def test_mark_invoice_outcome_is_idempotent_without_duplicate_event(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+    starting_status: QuoteStatus,
+    endpoint: str,
+    expected_status: str,
+    expected_event: str,
+) -> None:
+    emitted_events: list[dict[str, str]] = []
+
+    def _capture(message: str) -> None:
+        emitted_events.append(json.loads(message))
+
+    monkeypatch.setattr(event_logger._EVENT_LOGGER, "info", _capture)  # noqa: SLF001
+    csrf_token = await _register_and_login(client, _credentials())
+    customer_id = await _create_customer(client, csrf_token)
+    invoice = await _create_direct_invoice(
+        client,
+        csrf_token,
+        customer_id,
+        title="Invoice",
+        transcript="invoice transcript",
+        total_amount=120,
+    )
+    invoice_id = invoice["id"]
+
+    share_response = await client.post(
+        f"/api/invoices/{invoice_id}/share",
+        headers={"X-CSRF-Token": csrf_token},
+    )
+    assert share_response.status_code == 200
+    await _set_invoice_status(db_session, invoice_id, starting_status)
+
+    response = await client.post(
+        f"/api/invoices/{invoice_id}/{endpoint}",
+        headers={"X-CSRF-Token": csrf_token},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["status"] == expected_status
+
+    matching_events = [
+        payload
+        for payload in emitted_events
+        if payload.get("invoice_id") == invoice_id and payload.get("event") == expected_event
+    ]
+    assert matching_events == []
+
+
+@pytest.mark.parametrize("starting_status", [QuoteStatus.DRAFT, QuoteStatus.READY])
+@pytest.mark.parametrize("endpoint", ["mark-paid", "mark-void"])
+async def test_mark_invoice_outcome_returns_409_for_draft_or_ready_invoices(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    starting_status: QuoteStatus,
+    endpoint: str,
+) -> None:
+    csrf_token = await _register_and_login(client, _credentials())
+    customer_id = await _create_customer(client, csrf_token)
+    invoice = await _create_direct_invoice(
+        client,
+        csrf_token,
+        customer_id,
+        title="Invoice",
+        transcript="invoice transcript",
+        total_amount=120,
+    )
+    invoice_id = invoice["id"]
+
+    if starting_status is QuoteStatus.READY:
+        await _set_invoice_status(db_session, invoice_id, QuoteStatus.READY)
+
+    response = await client.post(
+        f"/api/invoices/{invoice_id}/{endpoint}",
+        headers={"X-CSRF-Token": csrf_token},
+    )
+
+    assert response.status_code == 409
+
+
+@pytest.mark.parametrize(
+    ("endpoint", "expected_status"),
+    [("mark-paid", "paid"), ("mark-void", "void")],
+)
+async def test_invoice_outcome_labels_remain_editable_shareable_and_public(
+    client: AsyncClient,
+    endpoint: str,
+    expected_status: str,
+) -> None:
+    csrf_token = await _register_and_login(client, _credentials())
+    customer_id = await _create_customer(client, csrf_token)
+    invoice = await _create_direct_invoice(
+        client,
+        csrf_token,
+        customer_id,
+        title="Invoice",
+        transcript="invoice transcript",
+        total_amount=120,
+    )
+    invoice_id = invoice["id"]
+
+    share_response = await client.post(
+        f"/api/invoices/{invoice_id}/share",
+        headers={"X-CSRF-Token": csrf_token},
+    )
+    assert share_response.status_code == 200
+    original_share_token = share_response.json()["share_token"]
+
+    outcome_response = await client.post(
+        f"/api/invoices/{invoice_id}/{endpoint}",
+        headers={"X-CSRF-Token": csrf_token},
+    )
+    assert outcome_response.status_code == 200
+    assert outcome_response.json()["status"] == expected_status
+
+    patch_response = await client.patch(
+        f"/api/invoices/{invoice_id}",
+        json={"notes": "Updated after outcome"},
+        headers={"X-CSRF-Token": csrf_token},
+    )
+    assert patch_response.status_code == 200
+    assert patch_response.json()["status"] == expected_status
+    assert patch_response.json()["notes"] == "Updated after outcome"
+
+    reshare_response = await client.post(
+        f"/api/invoices/{invoice_id}/share",
+        headers={"X-CSRF-Token": csrf_token},
+    )
+    assert reshare_response.status_code == 200
+    assert reshare_response.json()["status"] == expected_status
+    assert reshare_response.json()["share_token"] == original_share_token
+
+    public_response = await client.get(f"/api/public/doc/{original_share_token}")
+    assert public_response.status_code == 200
+    assert public_response.json()["doc_type"] == "invoice"
+
+
+@pytest.mark.parametrize(
     ("method", "path_suffix", "payload"),
     [
         ("get", "", None),

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -111,7 +111,7 @@ Runbooks:
 | doc_number | String(20) | stored display ID, format `Q-001` or `I-001` |
 | title | String(120) | nullable optional document label shown in detail views and PDFs |
 | source_document_id | UUID (self-FK → documents.id) | nullable, `ON DELETE SET NULL`; invoice rows use this for immutable quote lineage |
-| status | String(20) | `draft \| ready \| shared \| viewed \| approved \| declined \| sent` with DB check constraint; `sent` is invoice-only |
+| status | String(20) | `draft \| ready \| shared \| viewed \| approved \| declined \| sent \| paid \| void` with DB check constraint; `sent`, `paid`, and `void` are invoice-only |
 | source_type | String(20) | `"text"` or `"voice"` based on capture mode |
 | transcript | Text | stored source transcript/notes inherited from capture flow |
 | total_amount | Numeric(10,2) | nullable, user-editable |
@@ -178,6 +178,8 @@ Pilot event set:
 - `email_sent`
 - `invoice_created`
 - `invoice_viewed`
+- `invoice_paid`
+- `invoice_voided`
 
 These underscore names are the canonical quote-flow vocabulary for pilot instrumentation; dot-notation events such as `quote.created`, `quote.updated`, `quote.deleted`, and `customer.created` remain separate operational logs outside the pilot analytics scope.
 
@@ -312,6 +314,8 @@ Quote extraction guardrails:
 | `/invoices/{id}/pdf` | POST | yes | cookie | — | `200` raw PDF bytes; preview transitions `draft -> ready` |
 | `/invoices/{id}/share` | POST | yes | cookie | `regenerate?` (bool query, default `false`) | `200 Invoice`; creates/reuses the active `share_token`, regenerates when requested or when the existing token is expired/revoked, and transitions invoice to `sent` |
 | `/invoices/{id}/share` | DELETE | yes | cookie | — | `204`; revokes the current invoice share token without leaking token state publicly |
+| `/invoices/{id}/mark-paid` | POST | yes | cookie | — | `200 Invoice` with `status: "paid"`; idempotent when already `paid`; `404 { detail: "Not found" }` or `409` when invoice is `draft` or `ready` |
+| `/invoices/{id}/mark-void` | POST | yes | cookie | — | `200 Invoice` with `status: "void"`; idempotent when already `void`; `404 { detail: "Not found" }` or `409` when invoice is `draft` or `ready` |
 | `/invoices/{id}/send-email` | POST | yes | cookie | header `Idempotency-Key` required | `202 JobRecordResponse` after ensuring the invoice is shared, creating a durable `email` job row, and enqueueing worker delivery; replayed same-key responses return the same `202` payload with `Idempotency-Replayed: true`; `400` when the idempotency header is missing, `404` when invoice is missing/not owned, `409` when still `draft`, when the same key is reused for a different invoice, or when the same key is already in progress, `422` when customer email is missing/invalid, `429` when resent within 5 minutes, or `503 { detail: "Unable to start email delivery right now. Please try again." }` when enqueue fails after job creation |
 
 ### Public document landing endpoints
@@ -327,11 +331,11 @@ Public landing-page rules:
 - transactional quote emails reuse that same `/doc/{share_token}` landing page as the primary CTA and include `/share/{share_token}` as the secondary "Download PDF" link
 - the public JSON contract is a discriminated union keyed by `doc_type`:
   - quote variant: `doc_type = "quote"`, `status` in `shared | viewed | approved | declined`
-  - invoice variant: `doc_type = "invoice"`, `status = "sent"`, includes `due_date`
+  - invoice variant: `doc_type = "invoice"`, `status = "sent"` (always "sent" on the public page regardless of paid/void outcome labels), includes `due_date`
 - first public load of a `shared` quote transitions it to `viewed` and logs exactly one `quote_viewed` event
 - repeat public loads of `viewed`, `approved`, and `declined` quotes are read-only and do not create duplicate `quote_viewed` events
-- first public load of a `sent` invoice sets `invoice_first_viewed_at`, logs exactly one `invoice_viewed` event, and does not mutate invoice status
-- repeat public loads of a `sent` invoice are read-only and do not create duplicate `invoice_viewed` events
+- first public load of a `sent`, `paid`, or `void` invoice sets `invoice_first_viewed_at`, logs exactly one `invoice_viewed` event, and does not mutate invoice status
+- repeat public loads of a `sent`, `paid`, or `void` invoice are read-only and do not create duplicate `invoice_viewed` events
 - revoked, expired, and unknown tokens all return the same external `404`; internal logs retain the reason code for revoked/expired cases
 - public JSON, logo, and PDF responses are IP-keyed rate-limited and return `429` on limit exhaustion
 - public JSON, logo, and PDF responses send `X-Robots-Tag: noindex`
@@ -415,13 +419,13 @@ Invoice rules:
 - direct invoices use `source_document_id = null` and `source_quote_number = null`
 - quote-to-invoice conversion now rejects unassigned quotes before any invoice write is attempted
 - quote conversion is one-to-one; duplicate conversions are blocked by service guard plus the DB partial unique index
-- invoice lifecycle is `draft -> ready -> sent`
+- invoice lifecycle is `draft -> ready -> sent`; `paid` and `void` are terminal outcome labels that can be applied to any `sent`, `paid`, or `void` invoice
 - if `title` is present, blank or whitespace-only values are normalized to `null`
 - if `title`, `total_amount`, `notes`, or `due_date` are omitted, the existing persisted values are preserved
 - if `line_items` is present, existing rows are fully replaced; if omitted, existing rows are preserved
 - editing preserves the persisted invoice status plus any existing `share_token` / `shared_at` values
-- editing a `ready` invoice keeps it in `ready`; editing a `sent` invoice keeps it in `sent`
-- invoice public landing pages share the same `/doc/{share_token}` route shell as quotes, but render invoice-specific fields (`due_date`, `status = sent`) without quote-only terminal-state messaging
+- editing a `ready` invoice keeps it in `ready`; editing a `sent`, `paid`, or `void` invoice keeps its status unchanged
+- invoice public landing pages share the same `/doc/{share_token}` route shell as quotes, but render invoice-specific fields (`due_date`, `status = sent`) without quote-only terminal-state messaging; paid/void invoices remain publicly accessible and also render `status = sent` on the public page
 
 ### Error format
 ```json


### PR DESCRIPTION
## Summary
- add paid/void invoice statuses to document status enum and DB check constraint
- add mark-paid and mark-void invoice endpoints with idempotent service transitions and event emission on actual status changes only
- keep paid/void invoices editable and preserve outcome labels across share/public-token flows
- widen invoice response status unions and add backend tests for transitions, idempotency, 409 guards, and paid/void capability continuity

## Verification
- make backend-verify

Closes #303