### PR TITLE
Task 304: add paid/void invoice outcomes on frontend

### DIFF
--- a/frontend/src/features/invoices/components/InvoiceDetailScreen.tsx
+++ b/frontend/src/features/invoices/components/InvoiceDetailScreen.tsx
@@ -1,6 +1,7 @@
 import { useNavigate, useParams } from "react-router-dom";
 import { useInvoiceDetailActions } from "@/features/invoices/hooks/useInvoiceDetailActions";
 import { useInvoiceDetail } from "@/features/invoices/hooks/useInvoiceDetail";
+import { buildInvoiceOutcomeOverflowItems } from "@/features/invoices/components/invoiceDetail.helpers";
 import { isInvoiceEditableStatus } from "@/features/invoices/utils/invoiceStatus";
 import { QuoteDetailsCard } from "@/features/quotes/components/QuoteDetailsCard";
 import { QuoteLineItemsSection } from "@/features/quotes/components/QuoteLineItemsSection";
@@ -19,6 +20,7 @@ import {
   documentActionUtilityButtonClassName,
 } from "@/shared/components/DocumentActionSurface";
 import { FeedbackMessage } from "@/shared/components/FeedbackMessage";
+import { OverflowMenu } from "@/shared/components/OverflowMenu";
 import { ScreenHeader } from "@/shared/components/ScreenHeader";
 import { StatusBadge } from "@/shared/components/StatusBadge";
 import { formatDate } from "@/shared/lib/formatters";
@@ -43,13 +45,18 @@ export function InvoiceDetailScreen(): React.ReactElement {
     manualCopyUrl,
     showSendEmailConfirm,
     isSendingEmail,
+    isMarkingPaid,
+    isMarkingVoid,
     emailError,
     emailMessage,
+    outcomeError,
     setShowSendEmailConfirm,
     onGeneratePdf,
     onCopyLink,
     onRequestSendEmail,
     onConfirmSendEmail,
+    onMarkInvoicePaid,
+    onMarkInvoiceVoid,
   } = useInvoiceDetailActions({
     invoiceId: id,
     invoice,
@@ -63,12 +70,14 @@ export function InvoiceDetailScreen(): React.ReactElement {
   const canEdit = Boolean(invoice && id && isInvoiceEditableStatus(invoice.status));
   const emailActionLabel = invoice?.status === "ready"
     ? "Send Email"
-    : invoice?.status === "sent" ? "Resend Email" : null;
+    : invoice?.status === "sent" || invoice?.status === "paid" || invoice?.status === "void" ? "Resend Email" : null;
   const shouldRenderNotes = Boolean(invoice?.notes?.trim());
   const clientContact = invoice?.customer.phone?.trim()
     || invoice?.customer.email?.trim()
     || "No contact details";
   const isPdfBusy = isGeneratingPdf || invoice?.pdf_artifact.status === "pending";
+  const isOutcomeBusy = isMarkingPaid || isMarkingVoid;
+  const isBusy = isPdfBusy || isSharing || isSendingEmail || isOutcomeBusy;
   const resolvedPdfError = pdfError ?? (
     invoice?.pdf_artifact.status === "failed"
       ? "Invoice PDF failed. Please try again."
@@ -83,8 +92,33 @@ export function InvoiceDetailScreen(): React.ReactElement {
   const statusCopy = isPdfBusy
     ? "Generating PDF preview. This can take a few moments."
     : isSendingEmail ? "Sending invoice email..."
+    : isMarkingPaid ? "Recording invoice as paid..."
+    : isMarkingVoid ? "Recording invoice as void..."
     : isSharing ? "Copying share link..."
     : null;
+
+  const overflowItems = buildInvoiceOutcomeOverflowItems({
+    status: invoice?.status ?? null,
+    isBusy,
+    onMarkPaidRequest: () => {
+      void onMarkInvoicePaid();
+    },
+    onMarkVoidRequest: () => {
+      void onMarkInvoiceVoid();
+    },
+  });
+
+  const outcomeBanner = invoice?.status === "paid"
+    ? {
+      className: "mx-4 mt-4 rounded-lg border border-success/30 bg-success-container p-4 text-sm text-success",
+      message: "This invoice is marked as paid.",
+    }
+    : invoice?.status === "void"
+      ? {
+        className: "mx-4 mt-4 rounded-lg border border-outline/40 bg-surface-container-low p-4 text-sm text-on-surface-variant",
+        message: "This invoice is marked as void.",
+      }
+      : null;
 
   return (
     <main className="min-h-screen bg-background pb-24 pt-16">
@@ -105,6 +139,7 @@ export function InvoiceDetailScreen(): React.ReactElement {
                 <span className="material-symbols-outlined block text-[1.125rem] leading-none">edit</span>
               </button>
             ) : null}
+            <OverflowMenu items={overflowItems} />
           </div>
         ) : null}
       />
@@ -124,6 +159,12 @@ export function InvoiceDetailScreen(): React.ReactElement {
 
         {!isLoadingInvoice && !loadError && invoice ? (
           <>
+            {outcomeBanner ? (
+              <div className={outcomeBanner.className}>
+                {outcomeBanner.message}
+              </div>
+            ) : null}
+
             <QuoteDetailsCard
               documentLabel="INVOICE"
               totalAmount={invoice.total_amount}
@@ -205,7 +246,7 @@ export function InvoiceDetailScreen(): React.ReactElement {
                 <Button
                   type="button"
                   className={documentActionPrimaryButtonClassName}
-                  disabled={isSharing || isSendingEmail || isPdfBusy}
+                  disabled={isBusy}
                   onClick={() => {
                     void onGeneratePdf();
                   }}
@@ -220,7 +261,7 @@ export function InvoiceDetailScreen(): React.ReactElement {
                     <button
                       type="button"
                       className={documentActionUtilityButtonClassName}
-                      disabled={!hasCustomerEmail || isPdfBusy || isSharing || isSendingEmail}
+                      disabled={!hasCustomerEmail || isBusy}
                       onClick={() => onRequestSendEmail({ emailActionLabel, hasCustomerEmail, isPdfBusy })}
                     >
                       <span className="material-symbols-outlined text-base">mail</span>
@@ -231,7 +272,7 @@ export function InvoiceDetailScreen(): React.ReactElement {
                   <button
                     type="button"
                     className={documentActionUtilityButtonClassName}
-                    disabled={isSharing || isPdfBusy || isSendingEmail}
+                    disabled={isBusy}
                     onClick={() => {
                       void onCopyLink();
                     }}
@@ -253,6 +294,7 @@ export function InvoiceDetailScreen(): React.ReactElement {
                 <>
                   {resolvedPdfError ? <DocumentActionError>{resolvedPdfError}</DocumentActionError> : null}
                   {emailError ? <DocumentActionError>{emailError}</DocumentActionError> : null}
+                  {outcomeError ? <DocumentActionError>{outcomeError}</DocumentActionError> : null}
                   {shareError ? <DocumentActionError>{shareError}</DocumentActionError> : null}
                   {manualCopyUrl ? (
                     <DocumentActionManualCopyField url={manualCopyUrl} />

--- a/frontend/src/features/invoices/components/invoiceDetail.helpers.ts
+++ b/frontend/src/features/invoices/components/invoiceDetail.helpers.ts
@@ -1,4 +1,6 @@
 import type { Invoice, InvoiceDetail } from "@/features/invoices/types/invoice.types";
+import type { InvoiceStatus } from "@/features/invoices/types/invoice-status";
+import type { OverflowMenuItem } from "@/shared/components/OverflowMenu";
 
 export function mergeInvoiceDetailWithUpdate(
   currentInvoice: InvoiceDetail | null,
@@ -20,4 +22,61 @@ export function mergeInvoiceDetailWithUpdate(
     updated_at: updatedInvoice.updated_at,
     line_items: updatedInvoice.line_items,
   };
+}
+
+interface BuildInvoiceOutcomeOverflowItemsArgs {
+  status: InvoiceStatus | null;
+  isBusy: boolean;
+  onMarkPaidRequest: () => void;
+  onMarkVoidRequest: () => void;
+}
+
+export function buildInvoiceOutcomeOverflowItems({
+  status,
+  isBusy,
+  onMarkPaidRequest,
+  onMarkVoidRequest,
+}: BuildInvoiceOutcomeOverflowItemsArgs): OverflowMenuItem[] {
+  if (status === "sent") {
+    return [
+      {
+        label: "Mark as Paid",
+        icon: "check_circle",
+        disabled: isBusy,
+        onSelect: onMarkPaidRequest,
+      },
+      {
+        label: "Mark as Void",
+        icon: "cancel",
+        tone: "destructive",
+        disabled: isBusy,
+        onSelect: onMarkVoidRequest,
+      },
+    ];
+  }
+
+  if (status === "paid") {
+    return [
+      {
+        label: "Mark as Void",
+        icon: "cancel",
+        tone: "destructive",
+        disabled: isBusy,
+        onSelect: onMarkVoidRequest,
+      },
+    ];
+  }
+
+  if (status === "void") {
+    return [
+      {
+        label: "Mark as Paid",
+        icon: "check_circle",
+        disabled: isBusy,
+        onSelect: onMarkPaidRequest,
+      },
+    ];
+  }
+
+  return [];
 }

--- a/frontend/src/features/invoices/hooks/useInvoiceDetailActions.ts
+++ b/frontend/src/features/invoices/hooks/useInvoiceDetailActions.ts
@@ -24,8 +24,11 @@ interface UseInvoiceDetailActionsResult {
   manualCopyUrl: string | null;
   showSendEmailConfirm: boolean;
   isSendingEmail: boolean;
+  isMarkingPaid: boolean;
+  isMarkingVoid: boolean;
   emailError: string | null;
   emailMessage: string | null;
+  outcomeError: string | null;
   setShowSendEmailConfirm: Dispatch<SetStateAction<boolean>>;
   onGeneratePdf: () => Promise<void>;
   onCopyLink: () => Promise<void>;
@@ -35,6 +38,8 @@ interface UseInvoiceDetailActionsResult {
     isPdfBusy: boolean;
   }) => void;
   onConfirmSendEmail: () => Promise<void>;
+  onMarkInvoicePaid: () => Promise<void>;
+  onMarkInvoiceVoid: () => Promise<void>;
 }
 
 export function useInvoiceDetailActions({
@@ -51,8 +56,11 @@ export function useInvoiceDetailActions({
   const [manualCopyUrl, setManualCopyUrl] = useState<string | null>(null);
   const [showSendEmailConfirm, setShowSendEmailConfirm] = useState(false);
   const [isSendingEmail, setIsSendingEmail] = useState(false);
+  const [isMarkingPaid, setIsMarkingPaid] = useState(false);
+  const [isMarkingVoid, setIsMarkingVoid] = useState(false);
   const [emailError, setEmailError] = useState<string | null>(null);
   const [emailMessage, setEmailMessage] = useState<string | null>(null);
+  const [outcomeError, setOutcomeError] = useState<string | null>(null);
 
   usePendingPdfArtifactResume({
     artifact: invoice?.pdf_artifact,
@@ -83,6 +91,7 @@ export function useInvoiceDetailActions({
     setPdfError(null);
     setEmailError(null);
     setEmailMessage(null);
+    setOutcomeError(null);
     setShareError(null);
     setShareMessage(null);
     setManualCopyUrl(null);
@@ -113,6 +122,7 @@ export function useInvoiceDetailActions({
     const apiBase = import.meta.env.VITE_API_URL || window.location.origin;
     setEmailError(null);
     setEmailMessage(null);
+    setOutcomeError(null);
     setShareError(null);
     setShareMessage(null);
     setManualCopyUrl(null);
@@ -160,6 +170,7 @@ export function useInvoiceDetailActions({
 
     setEmailError(null);
     setEmailMessage(null);
+    setOutcomeError(null);
     setShowSendEmailConfirm(true);
   }
 
@@ -171,6 +182,7 @@ export function useInvoiceDetailActions({
     setShowSendEmailConfirm(false);
     setEmailError(null);
     setEmailMessage(null);
+    setOutcomeError(null);
     setShareError(null);
     setShareMessage(null);
     setManualCopyUrl(null);
@@ -196,6 +208,56 @@ export function useInvoiceDetailActions({
     }
   }
 
+  async function onMarkInvoicePaid(): Promise<void> {
+    if (!invoiceId) {
+      return;
+    }
+
+    setPdfError(null);
+    setEmailError(null);
+    setEmailMessage(null);
+    setOutcomeError(null);
+    setShareError(null);
+    setShareMessage(null);
+    setManualCopyUrl(null);
+    setIsMarkingPaid(true);
+
+    try {
+      const updatedInvoice = await invoiceService.markInvoicePaid(invoiceId);
+      applyInvoiceUpdate(updatedInvoice);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Unable to mark invoice as paid";
+      setOutcomeError(message);
+    } finally {
+      setIsMarkingPaid(false);
+    }
+  }
+
+  async function onMarkInvoiceVoid(): Promise<void> {
+    if (!invoiceId) {
+      return;
+    }
+
+    setPdfError(null);
+    setEmailError(null);
+    setEmailMessage(null);
+    setOutcomeError(null);
+    setShareError(null);
+    setShareMessage(null);
+    setManualCopyUrl(null);
+    setIsMarkingVoid(true);
+
+    try {
+      const updatedInvoice = await invoiceService.markInvoiceVoid(invoiceId);
+      applyInvoiceUpdate(updatedInvoice);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Unable to mark invoice as void";
+      setOutcomeError(message);
+    } finally {
+      setIsMarkingVoid(false);
+    }
+  }
+
   return {
     isGeneratingPdf,
     pdfError,
@@ -205,12 +267,17 @@ export function useInvoiceDetailActions({
     manualCopyUrl,
     showSendEmailConfirm,
     isSendingEmail,
+    isMarkingPaid,
+    isMarkingVoid,
     emailError,
     emailMessage,
+    outcomeError,
     setShowSendEmailConfirm,
     onGeneratePdf,
     onCopyLink,
     onRequestSendEmail,
     onConfirmSendEmail,
+    onMarkInvoicePaid,
+    onMarkInvoiceVoid,
   };
 }

--- a/frontend/src/features/invoices/services/invoiceService.ts
+++ b/frontend/src/features/invoices/services/invoiceService.ts
@@ -44,6 +44,18 @@ function shareInvoice(id: string): Promise<Invoice> {
   });
 }
 
+function markInvoicePaid(id: string): Promise<Invoice> {
+  return request<Invoice>(`/api/invoices/${id}/mark-paid`, {
+    method: "POST",
+  });
+}
+
+function markInvoiceVoid(id: string): Promise<Invoice> {
+  return request<Invoice>(`/api/invoices/${id}/mark-void`, {
+    method: "POST",
+  });
+}
+
 async function sendInvoiceEmail(id: string, idempotencyKey?: string): Promise<JobStatusResponse> {
   const response = await requestWithMetadata<JobStatusResponse>(`/api/invoices/${id}/send-email`, {
     method: "POST",
@@ -62,5 +74,7 @@ export const invoiceService = {
   updateInvoice,
   generatePdf,
   shareInvoice,
+  markInvoicePaid,
+  markInvoiceVoid,
   sendInvoiceEmail,
 };

--- a/frontend/src/features/invoices/tests/InvoiceDetailScreen.test.tsx
+++ b/frontend/src/features/invoices/tests/InvoiceDetailScreen.test.tsx
@@ -14,6 +14,8 @@ vi.mock("@/features/invoices/services/invoiceService", () => ({
     updateInvoice: vi.fn(),
     generatePdf: vi.fn(),
     shareInvoice: vi.fn(),
+    markInvoicePaid: vi.fn(),
+    markInvoiceVoid: vi.fn(),
     sendInvoiceEmail: vi.fn(),
   },
 }));
@@ -124,6 +126,10 @@ function renderScreen(path = "/invoices/invoice-1"): void {
   );
 }
 
+async function openOverflowMenu(): Promise<void> {
+  fireEvent.click(await screen.findByRole("button", { name: /more actions/i }));
+}
+
 beforeEach(() => {
   const pendingEmailJob: JobStatusResponse = {
     id: "job-email-invoice-1",
@@ -160,6 +166,22 @@ beforeEach(() => {
       share_token: "invoice-share-token-1",
       shared_at: "2026-03-20T00:15:00.000Z",
       updated_at: "2026-03-20T00:15:00.000Z",
+    }),
+  );
+  mockedInvoiceService.markInvoicePaid.mockResolvedValue(
+    makeInvoice({
+      status: "paid",
+      share_token: "invoice-share-token-1",
+      shared_at: "2026-03-20T00:15:00.000Z",
+      updated_at: "2026-03-20T00:20:00.000Z",
+    }),
+  );
+  mockedInvoiceService.markInvoiceVoid.mockResolvedValue(
+    makeInvoice({
+      status: "void",
+      share_token: "invoice-share-token-1",
+      shared_at: "2026-03-20T00:15:00.000Z",
+      updated_at: "2026-03-20T00:20:00.000Z",
     }),
   );
   mockedInvoiceService.sendInvoiceEmail.mockResolvedValue(pendingEmailJob);
@@ -249,6 +271,126 @@ describe("InvoiceDetailScreen", () => {
     renderScreen();
 
     expect(await screen.findByRole("button", { name: /resend email/i })).toBeInTheDocument();
+  });
+
+  it("shows both outcome actions in overflow for sent invoices", async () => {
+    mockedInvoiceService.getInvoice.mockResolvedValueOnce(
+      makeInvoiceDetail({
+        status: "sent",
+        share_token: "invoice-share-token-1",
+        shared_at: "2026-03-20T00:15:00.000Z",
+      }),
+    );
+
+    renderScreen();
+
+    await screen.findByRole("heading", { name: "Spring cleanup" });
+    await openOverflowMenu();
+
+    expect(screen.getByRole("menuitem", { name: /mark as paid/i })).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: /mark as void/i })).toBeInTheDocument();
+  });
+
+  it("shows paid banner and only Mark as Void in overflow for paid invoices", async () => {
+    mockedInvoiceService.getInvoice.mockResolvedValueOnce(
+      makeInvoiceDetail({
+        status: "paid",
+        share_token: "invoice-share-token-1",
+        shared_at: "2026-03-20T00:15:00.000Z",
+      }),
+    );
+
+    renderScreen();
+
+    expect(await screen.findByText("This invoice is marked as paid.")).toBeInTheDocument();
+    await openOverflowMenu();
+
+    expect(screen.queryByRole("menuitem", { name: /mark as paid/i })).not.toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: /mark as void/i })).toBeInTheDocument();
+  });
+
+  it("shows void banner and only Mark as Paid in overflow for void invoices", async () => {
+    mockedInvoiceService.getInvoice.mockResolvedValueOnce(
+      makeInvoiceDetail({
+        status: "void",
+        share_token: "invoice-share-token-1",
+        shared_at: "2026-03-20T00:15:00.000Z",
+      }),
+    );
+
+    renderScreen();
+
+    expect(await screen.findByText("This invoice is marked as void.")).toBeInTheDocument();
+    await openOverflowMenu();
+
+    expect(screen.getByRole("menuitem", { name: /mark as paid/i })).toBeInTheDocument();
+    expect(screen.queryByRole("menuitem", { name: /mark as void/i })).not.toBeInTheDocument();
+  });
+
+  it.each(["paid", "void"] as const)(
+    "keeps edit/share/pdf/email actions available for %s invoices",
+    async (status) => {
+      mockedInvoiceService.getInvoice.mockResolvedValueOnce(
+        makeInvoiceDetail({
+          status,
+          share_token: "invoice-share-token-1",
+          shared_at: "2026-03-20T00:15:00.000Z",
+          pdf_artifact: makePdfArtifact({
+            status: "ready",
+            download_url: "/api/invoices/invoice-1/pdf",
+          }),
+        }),
+      );
+
+      renderScreen();
+
+      expect(await screen.findByRole("button", { name: /edit invoice/i })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: /resend email/i })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: /copy link/i })).toBeInTheDocument();
+      expect(screen.getByRole("link", { name: /open pdf/i })).toBeInTheDocument();
+    },
+  );
+
+  it("marks a sent invoice as paid from overflow and updates visible state", async () => {
+    mockedInvoiceService.getInvoice.mockResolvedValueOnce(
+      makeInvoiceDetail({
+        status: "sent",
+        share_token: "invoice-share-token-1",
+        shared_at: "2026-03-20T00:15:00.000Z",
+      }),
+    );
+
+    renderScreen();
+
+    await openOverflowMenu();
+    fireEvent.click(screen.getByRole("menuitem", { name: /mark as paid/i }));
+
+    await waitFor(() => {
+      expect(mockedInvoiceService.markInvoicePaid).toHaveBeenCalledWith("invoice-1");
+    });
+
+    expect(await screen.findByText("This invoice is marked as paid.")).toBeInTheDocument();
+  });
+
+  it("marks a paid invoice as void from overflow and updates visible state", async () => {
+    mockedInvoiceService.getInvoice.mockResolvedValueOnce(
+      makeInvoiceDetail({
+        status: "paid",
+        share_token: "invoice-share-token-1",
+        shared_at: "2026-03-20T00:15:00.000Z",
+      }),
+    );
+
+    renderScreen();
+
+    await openOverflowMenu();
+    fireEvent.click(screen.getByRole("menuitem", { name: /mark as void/i }));
+
+    await waitFor(() => {
+      expect(mockedInvoiceService.markInvoiceVoid).toHaveBeenCalledWith("invoice-1");
+    });
+
+    expect(await screen.findByText("This invoice is marked as void.")).toBeInTheDocument();
   });
 
   it("hides the email action for draft invoices", async () => {

--- a/frontend/src/features/invoices/tests/invoiceService.integration.test.ts
+++ b/frontend/src/features/invoices/tests/invoiceService.integration.test.ts
@@ -272,6 +272,102 @@ describe("invoiceService integration (MSW)", () => {
     expect(invoice.share_token).toBe("invoice-share-token-1");
   });
 
+  it("markInvoicePaid sends CSRF and returns a paid invoice", async () => {
+    setCsrfToken("invoice-csrf-token");
+    let capturedCsrfHeader: string | null = null;
+
+    server.use(
+      http.post("/api/invoices/:id/mark-paid", ({ request, params }) => {
+        capturedCsrfHeader = request.headers.get("X-CSRF-Token");
+
+        return HttpResponse.json(
+          {
+            id: String(params.id),
+            customer_id: "cust-1",
+            doc_number: "I-001",
+            title: "Spring cleanup",
+            status: "paid",
+            total_amount: 120,
+            tax_rate: null,
+            discount_type: null,
+            discount_value: null,
+            deposit_amount: null,
+            notes: "Thanks for your business",
+            due_date: "2026-04-19",
+            shared_at: "2026-03-20T00:15:00.000Z",
+            share_token: "invoice-share-token-1",
+            source_document_id: "quote-1",
+            line_items: [
+              {
+                id: "line-1",
+                description: "Brown mulch",
+                details: "5 yards",
+                price: 120,
+                sort_order: 0,
+              },
+            ],
+            created_at: "2026-03-20T00:00:00.000Z",
+            updated_at: "2026-03-20T00:20:00.000Z",
+          },
+          { status: 200 },
+        );
+      }),
+    );
+
+    const invoice = await invoiceService.markInvoicePaid("invoice-1");
+
+    expect(capturedCsrfHeader).toBe("invoice-csrf-token");
+    expect(invoice.status).toBe("paid");
+  });
+
+  it("markInvoiceVoid sends CSRF and returns a void invoice", async () => {
+    setCsrfToken("invoice-csrf-token");
+    let capturedCsrfHeader: string | null = null;
+
+    server.use(
+      http.post("/api/invoices/:id/mark-void", ({ request, params }) => {
+        capturedCsrfHeader = request.headers.get("X-CSRF-Token");
+
+        return HttpResponse.json(
+          {
+            id: String(params.id),
+            customer_id: "cust-1",
+            doc_number: "I-001",
+            title: "Spring cleanup",
+            status: "void",
+            total_amount: 120,
+            tax_rate: null,
+            discount_type: null,
+            discount_value: null,
+            deposit_amount: null,
+            notes: "Thanks for your business",
+            due_date: "2026-04-19",
+            shared_at: "2026-03-20T00:15:00.000Z",
+            share_token: "invoice-share-token-1",
+            source_document_id: "quote-1",
+            line_items: [
+              {
+                id: "line-1",
+                description: "Brown mulch",
+                details: "5 yards",
+                price: 120,
+                sort_order: 0,
+              },
+            ],
+            created_at: "2026-03-20T00:00:00.000Z",
+            updated_at: "2026-03-20T00:20:00.000Z",
+          },
+          { status: 200 },
+        );
+      }),
+    );
+
+    const invoice = await invoiceService.markInvoiceVoid("invoice-1");
+
+    expect(capturedCsrfHeader).toBe("invoice-csrf-token");
+    expect(invoice.status).toBe("void");
+  });
+
   it("sendInvoiceEmail sends CSRF + Idempotency-Key and returns job metadata", async () => {
     setCsrfToken("invoice-csrf-token");
     let capturedCsrfHeader: string | null = null;

--- a/frontend/src/features/invoices/types/invoice-status.ts
+++ b/frontend/src/features/invoices/types/invoice-status.ts
@@ -1,1 +1,1 @@
-export type InvoiceStatus = "draft" | "ready" | "sent";
+export type InvoiceStatus = "draft" | "ready" | "sent" | "paid" | "void";

--- a/frontend/src/features/invoices/utils/invoiceStatus.ts
+++ b/frontend/src/features/invoices/utils/invoiceStatus.ts
@@ -1,6 +1,6 @@
 import type { InvoiceStatus } from "@/features/invoices/types/invoice-status";
 
-const EDITABLE_INVOICE_STATUSES = new Set<InvoiceStatus>(["draft", "ready", "sent"]);
+const EDITABLE_INVOICE_STATUSES = new Set<InvoiceStatus>(["draft", "ready", "sent", "paid", "void"]);
 
 export function isInvoiceEditableStatus(status: InvoiceStatus): boolean {
   return EDITABLE_INVOICE_STATUSES.has(status);

--- a/frontend/src/features/quotes/tests/QuoteList.test.tsx
+++ b/frontend/src/features/quotes/tests/QuoteList.test.tsx
@@ -331,6 +331,22 @@ describe("QuoteList", () => {
         created_at: "2026-03-21T00:00:00.000Z",
         source_document_id: "quote-2",
       }),
+      makeInvoiceListItem({
+        id: "invoice-3",
+        customer_id: "cust-3",
+        customer_name: "Carla Crew",
+        doc_number: "I-003",
+        status: "paid",
+        total_amount: 340,
+      }),
+      makeInvoiceListItem({
+        id: "invoice-4",
+        customer_id: "cust-4",
+        customer_name: "Diego Deck",
+        doc_number: "I-004",
+        status: "void",
+        total_amount: 95,
+      }),
     ]);
 
     renderScreen();
@@ -344,6 +360,8 @@ describe("QuoteList", () => {
     expect(screen.getByText("Bob Brown")).toBeInTheDocument();
     expect(screen.getByText(/I-002\s*·\s*Mar 21, 2026/)).toBeInTheDocument();
     expect(screen.getByText("Ready")).toBeInTheDocument();
+    expect(screen.getByText("Paid")).toBeInTheDocument();
+    expect(screen.getByText("Void")).toBeInTheDocument();
     expect(screen.getAllByText("$220.00")).toHaveLength(1);
     expect(screen.getByRole("region", { name: "PAST INVOICES" }).querySelector("p:empty")).toBeNull();
   });

--- a/frontend/src/shared/components/StatusBadge.test.tsx
+++ b/frontend/src/shared/components/StatusBadge.test.tsx
@@ -46,4 +46,16 @@ describe("StatusBadge", () => {
 
     expect(screen.getByText("Sent")).toHaveClass("bg-info-container", "text-info");
   });
+
+  it("renders paid variant styles", () => {
+    render(<StatusBadge variant="paid" />);
+
+    expect(screen.getByText("Paid")).toHaveClass("bg-success-container", "text-success");
+  });
+
+  it("renders void variant styles", () => {
+    render(<StatusBadge variant="void" />);
+
+    expect(screen.getByText("Void")).toHaveClass("bg-neutral-container", "text-on-surface-variant", "line-through");
+  });
 });

--- a/frontend/src/shared/components/StatusBadge.tsx
+++ b/frontend/src/shared/components/StatusBadge.tsx
@@ -1,5 +1,5 @@
 interface StatusBadgeProps {
-  variant: "draft" | "ready" | "shared" | "viewed" | "approved" | "declined" | "sent";
+  variant: "draft" | "ready" | "shared" | "viewed" | "approved" | "declined" | "sent" | "paid" | "void";
 }
 
 export const statusBadgeBaseClasses = "text-[0.6875rem] font-bold uppercase tracking-wide px-2.5 py-1 rounded-lg";
@@ -12,6 +12,8 @@ const styles = {
   approved: "bg-success-container text-success",
   declined: "bg-error-container text-error",
   sent: "bg-info-container text-info",
+  paid: "bg-success-container text-success",
+  void: "bg-neutral-container text-on-surface-variant line-through",
 } as const;
 
 const labels = {
@@ -22,6 +24,8 @@ const labels = {
   approved: "Approved",
   declined: "Declined",
   sent: "Sent",
+  paid: "Paid",
+  void: "Void",
 } as const;
 
 export function StatusBadge({ variant }: StatusBadgeProps): React.ReactElement {


### PR DESCRIPTION
## Summary
- add `paid` and `void` to invoice frontend status typing and editable-status handling
- extend shared status badges and invoice list coverage to render paid/void states
- add invoice service methods for `markInvoicePaid` and `markInvoiceVoid`
- add invoice detail overflow outcome actions + paid/void status banners while preserving existing edit/share/pdf/email actions
- add frontend tests for new status badges, invoice list rendering, service endpoints, and invoice detail outcome behavior

## Verification
- make frontend-verify
- cd frontend && ./node_modules/.bin/vitest run src/features/invoices/tests/InvoiceDetailScreen.test.tsx src/features/invoices/tests/invoiceService.integration.test.ts src/features/quotes/tests/QuoteList.test.tsx src/shared/components/StatusBadge.test.tsx

Closes #304