### PR TITLE
Add backend doc_type switching guards for quote/invoice PATCH

### DIFF
--- a/backend/app/features/invoices/api.py
+++ b/backend/app/features/invoices/api.py
@@ -95,6 +95,7 @@ async def get_invoice(
     return InvoiceDetailResponse(
         id=invoice.id,
         customer_id=invoice.customer_id,
+        doc_type="invoice",
         doc_number=invoice.doc_number,
         title=invoice.title,
         status=invoice.status,  # type: ignore[arg-type]

--- a/backend/app/features/invoices/schemas.py
+++ b/backend/app/features/invoices/schemas.py
@@ -124,6 +124,7 @@ class InvoiceUpdateRequest(BaseModel):
     deposit_amount: float | None = None
     notes: str | None = Field(default=None, max_length=DOCUMENT_NOTES_MAX_CHARS)
     due_date: date | None = None
+    doc_type: Literal["quote", "invoice"] | None = None
 
     _normalize_title = field_validator("title", mode="before")(_normalize_optional_title)
 
@@ -134,4 +135,6 @@ class InvoiceUpdateRequest(BaseModel):
             raise ValueError("line_items cannot be null")
         if "due_date" in self.model_fields_set and self.due_date is None:
             raise ValueError("due_date cannot be null")
+        if "doc_type" in self.model_fields_set and self.doc_type is None:
+            raise ValueError("doc_type cannot be null")
         return self

--- a/backend/app/features/invoices/schemas.py
+++ b/backend/app/features/invoices/schemas.py
@@ -57,6 +57,7 @@ class InvoiceResponse(BaseModel):
 
     id: UUID
     customer_id: UUID
+    doc_type: str
     doc_number: str
     title: str | None
     status: Literal["draft", "ready", "sent", "paid", "void"]
@@ -83,6 +84,7 @@ class InvoiceListItemResponse(BaseModel):
     id: UUID
     customer_id: UUID
     customer_name: str
+    doc_type: Literal["invoice"] = "invoice"
     doc_number: str
     title: str | None
     status: Literal["draft", "ready", "sent", "paid", "void"]

--- a/backend/app/features/invoices/service.py
+++ b/backend/app/features/invoices/service.py
@@ -75,6 +75,11 @@ _INVOICE_OUTCOME_MUTABLE_STATUSES = frozenset(
         QuoteStatus.VOID,
     }
 )
+_DOC_TYPE_CHANGEABLE_STATUSES = frozenset({QuoteStatus.DRAFT, QuoteStatus.READY})
+_DOC_TYPE_CHANGE_STATUS_BLOCKED_DETAIL = (
+    "Document type can only be changed in draft or ready status."
+)
+_DOC_TYPE_CHANGE_SHARED_BLOCKED_DETAIL = "Document type cannot be changed after sharing."
 _PDF_JOB_NAME = "jobs.pdf"
 _PDF_QUEUE_FAILURE_DETAIL = "Unable to start PDF generation right now. Please try again."
 
@@ -187,6 +192,8 @@ class InvoiceRepositoryProtocol(Protocol):
     async def invalidate_pdf_artifact(self, invoice: Document) -> str | None: ...
 
     async def mark_ready_if_draft(self, *, invoice_id: UUID, user_id: UUID) -> None: ...
+
+    async def get_next_doc_sequence_for_type(self, *, user_id: UUID, doc_type: str) -> int: ...
 
     async def commit(self) -> None: ...
 
@@ -386,6 +393,18 @@ class InvoiceService:
                 detail="Invoice cannot be edited",
                 status_code=409,
             )
+        requested_doc_type = (
+            data.doc_type
+            if "doc_type" in data.model_fields_set
+            else getattr(invoice, "doc_type", "invoice")
+        )
+        if requested_doc_type is None:
+            raise QuoteServiceError(detail="doc_type cannot be null", status_code=422)
+        doc_type_changed_to_quote = await self._apply_doc_type_transition(
+            user_id=user_id,
+            invoice=invoice,
+            requested_doc_type=requested_doc_type,
+        )
 
         next_line_items = (
             data.line_items if "line_items" in data.model_fields_set else invoice.line_items
@@ -437,20 +456,31 @@ class InvoiceService:
                 else document_field_float_or_none(invoice.deposit_amount)
             ),
         )
-        rendered_fields_changed = _invoice_render_inputs_changed(
-            invoice=invoice,
-            update_fields=data.model_fields_set,
-            next_line_items=next_line_items,
-            next_total_amount=document_field_float_or_none(current_pricing.total_amount),
-            next_tax_rate=document_field_float_or_none(current_pricing.tax_rate),
-            next_discount_type=current_pricing.discount_type,
-            next_discount_value=document_field_float_or_none(current_pricing.discount_value),
-            next_deposit_amount=document_field_float_or_none(current_pricing.deposit_amount),
-            next_title=data.title if "title" in data.model_fields_set else invoice.title,
-            next_notes=data.notes if "notes" in data.model_fields_set else invoice.notes,
-            next_due_date=(
-                data.due_date if "due_date" in data.model_fields_set else invoice.due_date
-            ),
+        rendered_fields_changed = (
+            _invoice_render_inputs_changed(
+                invoice=invoice,
+                update_fields=data.model_fields_set,
+                next_line_items=next_line_items,
+                next_total_amount=document_field_float_or_none(current_pricing.total_amount),
+                next_tax_rate=document_field_float_or_none(current_pricing.tax_rate),
+                next_discount_type=current_pricing.discount_type,
+                next_discount_value=document_field_float_or_none(current_pricing.discount_value),
+                next_deposit_amount=document_field_float_or_none(current_pricing.deposit_amount),
+                next_title=data.title if "title" in data.model_fields_set else invoice.title,
+                next_notes=data.notes if "notes" in data.model_fields_set else invoice.notes,
+                next_due_date=(
+                    None
+                    if doc_type_changed_to_quote
+                    else (
+                        data.due_date if "due_date" in data.model_fields_set else invoice.due_date
+                    )
+                ),
+            )
+            or doc_type_changed_to_quote
+        )
+
+        should_update_due_date = (
+            "due_date" in data.model_fields_set and not doc_type_changed_to_quote
         )
 
         updated_invoice = await self._invoice_repository.update(
@@ -481,8 +511,8 @@ class InvoiceService:
             update_notes="notes" in data.model_fields_set,
             line_items=data.line_items,
             replace_line_items="line_items" in data.model_fields_set,
-            due_date=data.due_date,
-            update_due_date="due_date" in data.model_fields_set,
+            due_date=None if doc_type_changed_to_quote else data.due_date,
+            update_due_date=should_update_due_date,
         )
         obsolete_artifact_path = None
         if rendered_fields_changed:
@@ -492,6 +522,47 @@ class InvoiceService:
         await self._invoice_repository.commit()
         await self._delete_obsolete_artifact(obsolete_artifact_path)
         return await self._invoice_repository.refresh(updated_invoice)
+
+    async def _apply_doc_type_transition(
+        self,
+        *,
+        user_id: UUID,
+        invoice: Document,
+        requested_doc_type: str,
+    ) -> bool:
+        current_doc_type = getattr(invoice, "doc_type", "invoice")
+        if requested_doc_type == current_doc_type:
+            return False
+        if requested_doc_type != "quote":
+            raise QuoteServiceError(
+                detail="Unsupported document type transition",
+                status_code=409,
+            )
+        if invoice.share_token is not None:
+            raise QuoteServiceError(
+                detail=_DOC_TYPE_CHANGE_SHARED_BLOCKED_DETAIL,
+                status_code=409,
+            )
+        if invoice.status not in _DOC_TYPE_CHANGEABLE_STATUSES:
+            raise QuoteServiceError(
+                detail=_DOC_TYPE_CHANGE_STATUS_BLOCKED_DETAIL,
+                status_code=409,
+            )
+        if invoice.source_document_id is not None:
+            raise QuoteServiceError(
+                detail="Invoices created from quotes cannot be converted to quotes.",
+                status_code=409,
+            )
+
+        next_sequence = await self._invoice_repository.get_next_doc_sequence_for_type(
+            user_id=user_id,
+            doc_type="quote",
+        )
+        invoice.doc_type = "quote"
+        invoice.doc_sequence = next_sequence
+        invoice.doc_number = _build_doc_number(doc_type="quote", sequence=next_sequence)
+        invoice.due_date = None
+        return True
 
     async def start_pdf_generation(
         self,
@@ -847,6 +918,11 @@ def _resolve_user_id(user: User) -> UUID:
 
 def _utcnow() -> datetime:
     return datetime.now(UTC)
+
+
+def _build_doc_number(*, doc_type: str, sequence: int) -> str:
+    prefix = "I" if doc_type == "invoice" else "Q"
+    return f"{prefix}-{sequence:03d}"
 
 
 def _build_share_token_expiry(created_at: datetime) -> datetime:

--- a/backend/app/features/invoices/service.py
+++ b/backend/app/features/invoices/service.py
@@ -484,54 +484,7 @@ class InvoiceService:
             "due_date" in data.model_fields_set and not doc_type_changed_to_quote
         )
 
-        if doc_type_changed_to_quote:
-            try:
-                updated_invoice = await self._invoice_repository.update(
-                    invoice=invoice,
-                    title=data.title,
-                    update_title="title" in data.model_fields_set,
-                    total_amount=document_field_float_or_none(current_pricing.total_amount),
-                    update_total_amount="total_amount" in data.model_fields_set
-                    or ("line_items" in data.model_fields_set and line_items_define_subtotal)
-                    or "discount_type" in data.model_fields_set
-                    or "discount_value" in data.model_fields_set
-                    or "tax_rate" in data.model_fields_set,
-                    tax_rate=document_field_float_or_none(current_pricing.tax_rate),
-                    update_tax_rate="tax_rate" in data.model_fields_set,
-                    discount_type=current_pricing.discount_type,
-                    update_discount_type=(
-                        "discount_type" in data.model_fields_set
-                        or (
-                            "discount_value" in data.model_fields_set
-                            and current_pricing.discount_type is None
-                        )
-                    ),
-                    discount_value=document_field_float_or_none(current_pricing.discount_value),
-                    update_discount_value="discount_value" in data.model_fields_set,
-                    deposit_amount=document_field_float_or_none(current_pricing.deposit_amount),
-                    update_deposit_amount="deposit_amount" in data.model_fields_set,
-                    notes=data.notes,
-                    update_notes="notes" in data.model_fields_set,
-                    line_items=data.line_items,
-                    replace_line_items="line_items" in data.model_fields_set,
-                    due_date=None if doc_type_changed_to_quote else data.due_date,
-                    update_due_date=should_update_due_date,
-                )
-                obsolete_artifact_path = None
-                if rendered_fields_changed:
-                    obsolete_artifact_path = await self._invoice_repository.invalidate_pdf_artifact(
-                        updated_invoice
-                    )
-                await self._invoice_repository.commit()
-            except IntegrityError as exc:
-                if _is_doc_sequence_collision(exc):
-                    await self._invoice_repository.rollback()
-                    raise QuoteServiceError(
-                        detail="Document type change failed, please retry.",
-                        status_code=409,
-                    ) from exc
-                raise
-        else:
+        try:
             updated_invoice = await self._invoice_repository.update(
                 invoice=invoice,
                 title=data.title,
@@ -569,6 +522,14 @@ class InvoiceService:
                     updated_invoice
                 )
             await self._invoice_repository.commit()
+        except IntegrityError as exc:
+            await self._invoice_repository.rollback()
+            if doc_type_changed_to_quote and _is_doc_sequence_collision(exc):
+                raise QuoteServiceError(
+                    detail="Document type change failed, please retry.",
+                    status_code=409,
+                ) from exc
+            raise
 
         await self._delete_obsolete_artifact(obsolete_artifact_path)
         return await self._invoice_repository.refresh(updated_invoice)

--- a/backend/app/features/invoices/service.py
+++ b/backend/app/features/invoices/service.py
@@ -38,6 +38,7 @@ from app.features.quotes.schemas import LineItemDraft
 from app.features.quotes.service import (
     QuoteRepositoryProtocol,
     QuoteServiceError,
+    build_doc_number,
     ensure_quote_customer_assigned,
 )
 from app.integrations.pdf import PdfRenderError
@@ -483,43 +484,92 @@ class InvoiceService:
             "due_date" in data.model_fields_set and not doc_type_changed_to_quote
         )
 
-        updated_invoice = await self._invoice_repository.update(
-            invoice=invoice,
-            title=data.title,
-            update_title="title" in data.model_fields_set,
-            total_amount=document_field_float_or_none(current_pricing.total_amount),
-            update_total_amount="total_amount" in data.model_fields_set
-            or ("line_items" in data.model_fields_set and line_items_define_subtotal)
-            or "discount_type" in data.model_fields_set
-            or "discount_value" in data.model_fields_set
-            or "tax_rate" in data.model_fields_set,
-            tax_rate=document_field_float_or_none(current_pricing.tax_rate),
-            update_tax_rate="tax_rate" in data.model_fields_set,
-            discount_type=current_pricing.discount_type,
-            update_discount_type=(
-                "discount_type" in data.model_fields_set
-                or (
-                    "discount_value" in data.model_fields_set
-                    and current_pricing.discount_type is None
+        if doc_type_changed_to_quote:
+            try:
+                updated_invoice = await self._invoice_repository.update(
+                    invoice=invoice,
+                    title=data.title,
+                    update_title="title" in data.model_fields_set,
+                    total_amount=document_field_float_or_none(current_pricing.total_amount),
+                    update_total_amount="total_amount" in data.model_fields_set
+                    or ("line_items" in data.model_fields_set and line_items_define_subtotal)
+                    or "discount_type" in data.model_fields_set
+                    or "discount_value" in data.model_fields_set
+                    or "tax_rate" in data.model_fields_set,
+                    tax_rate=document_field_float_or_none(current_pricing.tax_rate),
+                    update_tax_rate="tax_rate" in data.model_fields_set,
+                    discount_type=current_pricing.discount_type,
+                    update_discount_type=(
+                        "discount_type" in data.model_fields_set
+                        or (
+                            "discount_value" in data.model_fields_set
+                            and current_pricing.discount_type is None
+                        )
+                    ),
+                    discount_value=document_field_float_or_none(current_pricing.discount_value),
+                    update_discount_value="discount_value" in data.model_fields_set,
+                    deposit_amount=document_field_float_or_none(current_pricing.deposit_amount),
+                    update_deposit_amount="deposit_amount" in data.model_fields_set,
+                    notes=data.notes,
+                    update_notes="notes" in data.model_fields_set,
+                    line_items=data.line_items,
+                    replace_line_items="line_items" in data.model_fields_set,
+                    due_date=None if doc_type_changed_to_quote else data.due_date,
+                    update_due_date=should_update_due_date,
                 )
-            ),
-            discount_value=document_field_float_or_none(current_pricing.discount_value),
-            update_discount_value="discount_value" in data.model_fields_set,
-            deposit_amount=document_field_float_or_none(current_pricing.deposit_amount),
-            update_deposit_amount="deposit_amount" in data.model_fields_set,
-            notes=data.notes,
-            update_notes="notes" in data.model_fields_set,
-            line_items=data.line_items,
-            replace_line_items="line_items" in data.model_fields_set,
-            due_date=None if doc_type_changed_to_quote else data.due_date,
-            update_due_date=should_update_due_date,
-        )
-        obsolete_artifact_path = None
-        if rendered_fields_changed:
-            obsolete_artifact_path = await self._invoice_repository.invalidate_pdf_artifact(
-                updated_invoice
+                obsolete_artifact_path = None
+                if rendered_fields_changed:
+                    obsolete_artifact_path = await self._invoice_repository.invalidate_pdf_artifact(
+                        updated_invoice
+                    )
+                await self._invoice_repository.commit()
+            except IntegrityError as exc:
+                if _is_doc_sequence_collision(exc):
+                    await self._invoice_repository.rollback()
+                    raise QuoteServiceError(
+                        detail="Document type change failed, please retry.",
+                        status_code=409,
+                    ) from exc
+                raise
+        else:
+            updated_invoice = await self._invoice_repository.update(
+                invoice=invoice,
+                title=data.title,
+                update_title="title" in data.model_fields_set,
+                total_amount=document_field_float_or_none(current_pricing.total_amount),
+                update_total_amount="total_amount" in data.model_fields_set
+                or ("line_items" in data.model_fields_set and line_items_define_subtotal)
+                or "discount_type" in data.model_fields_set
+                or "discount_value" in data.model_fields_set
+                or "tax_rate" in data.model_fields_set,
+                tax_rate=document_field_float_or_none(current_pricing.tax_rate),
+                update_tax_rate="tax_rate" in data.model_fields_set,
+                discount_type=current_pricing.discount_type,
+                update_discount_type=(
+                    "discount_type" in data.model_fields_set
+                    or (
+                        "discount_value" in data.model_fields_set
+                        and current_pricing.discount_type is None
+                    )
+                ),
+                discount_value=document_field_float_or_none(current_pricing.discount_value),
+                update_discount_value="discount_value" in data.model_fields_set,
+                deposit_amount=document_field_float_or_none(current_pricing.deposit_amount),
+                update_deposit_amount="deposit_amount" in data.model_fields_set,
+                notes=data.notes,
+                update_notes="notes" in data.model_fields_set,
+                line_items=data.line_items,
+                replace_line_items="line_items" in data.model_fields_set,
+                due_date=None if doc_type_changed_to_quote else data.due_date,
+                update_due_date=should_update_due_date,
             )
-        await self._invoice_repository.commit()
+            obsolete_artifact_path = None
+            if rendered_fields_changed:
+                obsolete_artifact_path = await self._invoice_repository.invalidate_pdf_artifact(
+                    updated_invoice
+                )
+            await self._invoice_repository.commit()
+
         await self._delete_obsolete_artifact(obsolete_artifact_path)
         return await self._invoice_repository.refresh(updated_invoice)
 
@@ -560,7 +610,7 @@ class InvoiceService:
         )
         invoice.doc_type = "quote"
         invoice.doc_sequence = next_sequence
-        invoice.doc_number = _build_doc_number(doc_type="quote", sequence=next_sequence)
+        invoice.doc_number = build_doc_number(doc_type="quote", sequence=next_sequence)
         invoice.due_date = None
         return True
 
@@ -918,11 +968,6 @@ def _resolve_user_id(user: User) -> UUID:
 
 def _utcnow() -> datetime:
     return datetime.now(UTC)
-
-
-def _build_doc_number(*, doc_type: str, sequence: int) -> str:
-    prefix = "I" if doc_type == "invoice" else "Q"
-    return f"{prefix}-{sequence:03d}"
 
 
 def _build_share_token_expiry(created_at: datetime) -> datetime:

--- a/backend/app/features/invoices/tests/test_service.py
+++ b/backend/app/features/invoices/tests/test_service.py
@@ -114,6 +114,11 @@ class _RetryingInvoiceRepository:
         del user_id
         return None
 
+    async def get_next_doc_sequence_for_type(self, *, user_id, doc_type):  # noqa: ANN001
+        del user_id
+        del doc_type
+        return 1
+
     async def commit(self) -> None:
         self.commit_calls += 1
 
@@ -241,6 +246,11 @@ class _DirectInvoiceCollisionRepository:
         del invoice_id
         del user_id
         return None
+
+    async def get_next_doc_sequence_for_type(self, *, user_id, doc_type):  # noqa: ANN001
+        del user_id
+        del doc_type
+        return 1
 
     async def commit(self) -> None:
         self.commit_calls += 1
@@ -374,6 +384,11 @@ class _UpdatingInvoiceRepository:
 
     async def refresh(self, invoice):  # noqa: ANN001
         return invoice
+
+    async def get_next_doc_sequence_for_type(self, *, user_id, doc_type):  # noqa: ANN001
+        del user_id
+        del doc_type
+        return 1
 
 
 async def test_update_invoice_empty_patch_preserves_existing_pdf_artifact() -> None:

--- a/backend/app/features/quotes/api.py
+++ b/backend/app/features/quotes/api.py
@@ -482,6 +482,7 @@ async def get_quote(
     return QuoteDetailResponse(
         id=quote.id,
         customer_id=quote.customer_id,
+        doc_type="quote",
         doc_number=quote.doc_number,
         title=quote.title,
         status=cast(str, quote.status),

--- a/backend/app/features/quotes/schemas.py
+++ b/backend/app/features/quotes/schemas.py
@@ -115,6 +115,8 @@ class QuoteUpdateRequest(BaseModel):
     discount_value: float | None = None
     deposit_amount: float | None = None
     notes: str | None = Field(default=None, max_length=DOCUMENT_NOTES_MAX_CHARS)
+    doc_type: Literal["quote", "invoice"] | None = None
+    due_date: date | None = None
 
     _normalize_title = field_validator("title", mode="before")(_normalize_optional_title)
 
@@ -125,6 +127,10 @@ class QuoteUpdateRequest(BaseModel):
             raise ValueError("line_items cannot be null")
         if "transcript" in self.model_fields_set and self.transcript is None:
             raise ValueError("transcript cannot be null")
+        if "doc_type" in self.model_fields_set and self.doc_type is None:
+            raise ValueError("doc_type cannot be null")
+        if "due_date" in self.model_fields_set and self.due_date is None:
+            raise ValueError("due_date cannot be null")
         return self
 
 

--- a/backend/app/features/quotes/schemas.py
+++ b/backend/app/features/quotes/schemas.py
@@ -164,6 +164,7 @@ class QuoteListItemResponse(BaseModel):
     id: UUID
     customer_id: UUID | None
     customer_name: str | None
+    doc_type: Literal["quote"] = "quote"
     doc_number: str
     title: str | None
     status: str
@@ -181,6 +182,7 @@ class QuoteResponse(BaseModel):
 
     id: UUID
     customer_id: UUID | None
+    doc_type: str
     doc_number: str
     title: str | None
     status: str

--- a/backend/app/features/quotes/service.py
+++ b/backend/app/features/quotes/service.py
@@ -7,7 +7,7 @@ import base64
 import logging
 import re
 from collections.abc import Sequence
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, date, datetime, timedelta
 from typing import Literal, Protocol, cast
 from uuid import UUID, uuid4
 
@@ -82,7 +82,12 @@ _POST_SHARE_NON_REGRESSION_STATUSES = frozenset(
 _CUSTOMER_ASSIGNMENT_REQUIRED_DETAIL = "Assign a customer before continuing."
 _CUSTOMER_CLEAR_BLOCKED_DETAIL = "Customer cannot be cleared from a quote."
 _CUSTOMER_CHANGE_BLOCKED_DETAIL = "Customer cannot be changed after sharing or invoice conversion."
+_DOC_TYPE_CHANGE_STATUS_BLOCKED_DETAIL = (
+    "Document type can only be changed in draft or ready status."
+)
+_DOC_TYPE_CHANGE_SHARED_BLOCKED_DETAIL = "Document type cannot be changed after sharing."
 _CUSTOMER_REASSIGNABLE_STATUSES = frozenset({QuoteStatus.DRAFT, QuoteStatus.READY})
+_DOC_TYPE_CHANGEABLE_STATUSES = frozenset({QuoteStatus.DRAFT, QuoteStatus.READY})
 _APPENDABLE_QUOTE_STATUSES = frozenset(
     {
         QuoteStatus.DRAFT,
@@ -128,6 +133,8 @@ class QuoteRepositoryProtocol(Protocol):
         source_document_id: UUID,
         user_id: UUID,
     ) -> bool: ...
+
+    async def get_next_doc_sequence_for_type(self, *, user_id: UUID, doc_type: str) -> int: ...
 
     async def get_render_context(
         self, quote_id: UUID, user_id: UUID
@@ -491,6 +498,7 @@ class QuoteService:
         quote = await self._repository.get_by_id(quote_id, user_id)
         if quote is None:
             raise QuoteServiceError(detail="Not found", status_code=404)
+        has_linked_invoice: bool | None = None
         next_customer_id = quote.customer_id
         if "customer_id" in data.model_fields_set:
             has_linked_invoice = await self._repository.has_linked_invoice(
@@ -503,6 +511,20 @@ class QuoteService:
                 requested_customer_id=data.customer_id,
                 has_linked_invoice=has_linked_invoice,
             )
+        requested_doc_type = (
+            data.doc_type
+            if "doc_type" in data.model_fields_set
+            else getattr(quote, "doc_type", "quote")
+        )
+        if requested_doc_type is None:
+            raise QuoteServiceError(detail="doc_type cannot be null", status_code=422)
+        doc_type_changed = await self._apply_doc_type_transition(
+            user_id=user_id,
+            quote=quote,
+            requested_doc_type=requested_doc_type,
+            requested_due_date=(data.due_date if "due_date" in data.model_fields_set else None),
+            has_linked_invoice=has_linked_invoice,
+        )
 
         next_line_items = (
             data.line_items if "line_items" in data.model_fields_set else quote.line_items
@@ -554,18 +576,21 @@ class QuoteService:
                 else document_field_float_or_none(quote.deposit_amount)
             ),
         )
-        rendered_fields_changed = _quote_render_inputs_changed(
-            quote=quote,
-            update_fields=data.model_fields_set,
-            next_customer_id=next_customer_id,
-            next_line_items=next_line_items,
-            next_total_amount=document_field_float_or_none(current_pricing.total_amount),
-            next_tax_rate=document_field_float_or_none(current_pricing.tax_rate),
-            next_discount_type=current_pricing.discount_type,
-            next_discount_value=document_field_float_or_none(current_pricing.discount_value),
-            next_deposit_amount=document_field_float_or_none(current_pricing.deposit_amount),
-            next_title=data.title if "title" in data.model_fields_set else quote.title,
-            next_notes=data.notes if "notes" in data.model_fields_set else quote.notes,
+        rendered_fields_changed = (
+            _quote_render_inputs_changed(
+                quote=quote,
+                update_fields=data.model_fields_set,
+                next_customer_id=next_customer_id,
+                next_line_items=next_line_items,
+                next_total_amount=document_field_float_or_none(current_pricing.total_amount),
+                next_tax_rate=document_field_float_or_none(current_pricing.tax_rate),
+                next_discount_type=current_pricing.discount_type,
+                next_discount_value=document_field_float_or_none(current_pricing.discount_value),
+                next_deposit_amount=document_field_float_or_none(current_pricing.deposit_amount),
+                next_title=data.title if "title" in data.model_fields_set else quote.title,
+                next_notes=data.notes if "notes" in data.model_fields_set else quote.notes,
+            )
+            or doc_type_changed
         )
 
         updated_quote = await self._repository.update(
@@ -846,7 +871,6 @@ class QuoteService:
             LOGGER.warning("Failed to delete invalidated quote PDF artifact", exc_info=True)
 
     def _log_public_quote_viewed(self, transition: QuoteViewTransition) -> None:
-        """Emit the first public quote view event."""
         log_event(
             "quote_viewed",
             user_id=transition.user_id,
@@ -923,6 +947,61 @@ class QuoteService:
             customer_id=refreshed_quote.customer_id,
         )
         return refreshed_quote
+
+    async def _apply_doc_type_transition(
+        self,
+        *,
+        user_id: UUID,
+        quote: Document,
+        requested_doc_type: str,
+        requested_due_date: date | None,
+        has_linked_invoice: bool | None,
+    ) -> bool:
+        current_doc_type = getattr(quote, "doc_type", "quote")
+        if requested_doc_type == current_doc_type:
+            return False
+        if requested_doc_type != "invoice":
+            raise QuoteServiceError(
+                detail="Unsupported document type transition",
+                status_code=409,
+            )
+        if quote.share_token is not None:
+            raise QuoteServiceError(
+                detail=_DOC_TYPE_CHANGE_SHARED_BLOCKED_DETAIL,
+                status_code=409,
+            )
+        if quote.status not in _DOC_TYPE_CHANGEABLE_STATUSES:
+            raise QuoteServiceError(
+                detail=_DOC_TYPE_CHANGE_STATUS_BLOCKED_DETAIL,
+                status_code=409,
+            )
+
+        linked_invoice = has_linked_invoice
+        if linked_invoice is None:
+            linked_invoice = await self._repository.has_linked_invoice(
+                source_document_id=quote.id,
+                user_id=user_id,
+            )
+        if linked_invoice:
+            raise QuoteServiceError(
+                detail="An invoice already exists for this quote",
+                status_code=409,
+            )
+
+        ensure_quote_customer_assigned(quote)
+        next_sequence = await self._repository.get_next_doc_sequence_for_type(
+            user_id=user_id,
+            doc_type="invoice",
+        )
+        quote.doc_type = "invoice"
+        quote.doc_sequence = next_sequence
+        quote.doc_number = _build_doc_number(doc_type="invoice", sequence=next_sequence)
+        quote.due_date = (
+            requested_due_date
+            if requested_due_date is not None
+            else _build_default_invoice_due_date()
+        )
+        return True
 
     async def revoke_public_share(self, user: User, quote_id: UUID) -> None:
         """Revoke the currently active public share token for one quote."""
@@ -1113,6 +1192,15 @@ def _is_doc_sequence_collision(exc: IntegrityError) -> bool:
 
 def _utcnow() -> datetime:
     return datetime.now(UTC)
+
+
+def _build_default_invoice_due_date() -> date:
+    return _utcnow().date() + timedelta(days=30)
+
+
+def _build_doc_number(*, doc_type: str, sequence: int) -> str:
+    prefix = "I" if doc_type == "invoice" else "Q"
+    return f"{prefix}-{sequence:03d}"
 
 
 def _build_share_token_expiry(created_at: datetime) -> datetime:

--- a/backend/app/features/quotes/service.py
+++ b/backend/app/features/quotes/service.py
@@ -593,56 +593,7 @@ class QuoteService:
             or doc_type_changed
         )
 
-        if doc_type_changed:
-            try:
-                updated_quote = await self._repository.update(
-                    document=quote,
-                    customer_id=next_customer_id,
-                    update_customer_id="customer_id" in data.model_fields_set,
-                    title=data.title,
-                    update_title="title" in data.model_fields_set,
-                    transcript=data.transcript,
-                    update_transcript="transcript" in data.model_fields_set,
-                    total_amount=document_field_float_or_none(current_pricing.total_amount),
-                    update_total_amount="total_amount" in data.model_fields_set
-                    or ("line_items" in data.model_fields_set and line_items_define_subtotal)
-                    or "discount_type" in data.model_fields_set
-                    or "discount_value" in data.model_fields_set
-                    or "tax_rate" in data.model_fields_set,
-                    tax_rate=document_field_float_or_none(current_pricing.tax_rate),
-                    update_tax_rate="tax_rate" in data.model_fields_set,
-                    discount_type=current_pricing.discount_type,
-                    update_discount_type=(
-                        "discount_type" in data.model_fields_set
-                        or (
-                            "discount_value" in data.model_fields_set
-                            and current_pricing.discount_type is None
-                        )
-                    ),
-                    discount_value=document_field_float_or_none(current_pricing.discount_value),
-                    update_discount_value="discount_value" in data.model_fields_set,
-                    deposit_amount=document_field_float_or_none(current_pricing.deposit_amount),
-                    update_deposit_amount="deposit_amount" in data.model_fields_set,
-                    notes=data.notes,
-                    update_notes="notes" in data.model_fields_set,
-                    line_items=data.line_items,
-                    replace_line_items="line_items" in data.model_fields_set,
-                )
-                obsolete_artifact_path = None
-                if rendered_fields_changed:
-                    obsolete_artifact_path = await self._repository.invalidate_pdf_artifact(
-                        updated_quote
-                    )
-                await self._repository.commit()
-            except IntegrityError as exc:
-                if _is_doc_sequence_collision(exc):
-                    await self._repository.rollback()
-                    raise QuoteServiceError(
-                        detail="Document type change failed, please retry.",
-                        status_code=409,
-                    ) from exc
-                raise
-        else:
+        try:
             updated_quote = await self._repository.update(
                 document=quote,
                 customer_id=next_customer_id,
@@ -682,6 +633,14 @@ class QuoteService:
                     updated_quote
                 )
             await self._repository.commit()
+        except IntegrityError as exc:
+            await self._repository.rollback()
+            if doc_type_changed and _is_doc_sequence_collision(exc):
+                raise QuoteServiceError(
+                    detail="Document type change failed, please retry.",
+                    status_code=409,
+                ) from exc
+            raise
 
         await self._delete_obsolete_artifact(obsolete_artifact_path)
         log_event(

--- a/backend/app/features/quotes/service.py
+++ b/backend/app/features/quotes/service.py
@@ -593,43 +593,96 @@ class QuoteService:
             or doc_type_changed
         )
 
-        updated_quote = await self._repository.update(
-            document=quote,
-            customer_id=next_customer_id,
-            update_customer_id="customer_id" in data.model_fields_set,
-            title=data.title,
-            update_title="title" in data.model_fields_set,
-            transcript=data.transcript,
-            update_transcript="transcript" in data.model_fields_set,
-            total_amount=document_field_float_or_none(current_pricing.total_amount),
-            update_total_amount="total_amount" in data.model_fields_set
-            or ("line_items" in data.model_fields_set and line_items_define_subtotal)
-            or "discount_type" in data.model_fields_set
-            or "discount_value" in data.model_fields_set
-            or "tax_rate" in data.model_fields_set,
-            tax_rate=document_field_float_or_none(current_pricing.tax_rate),
-            update_tax_rate="tax_rate" in data.model_fields_set,
-            discount_type=current_pricing.discount_type,
-            update_discount_type=(
-                "discount_type" in data.model_fields_set
-                or (
-                    "discount_value" in data.model_fields_set
-                    and current_pricing.discount_type is None
+        if doc_type_changed:
+            try:
+                updated_quote = await self._repository.update(
+                    document=quote,
+                    customer_id=next_customer_id,
+                    update_customer_id="customer_id" in data.model_fields_set,
+                    title=data.title,
+                    update_title="title" in data.model_fields_set,
+                    transcript=data.transcript,
+                    update_transcript="transcript" in data.model_fields_set,
+                    total_amount=document_field_float_or_none(current_pricing.total_amount),
+                    update_total_amount="total_amount" in data.model_fields_set
+                    or ("line_items" in data.model_fields_set and line_items_define_subtotal)
+                    or "discount_type" in data.model_fields_set
+                    or "discount_value" in data.model_fields_set
+                    or "tax_rate" in data.model_fields_set,
+                    tax_rate=document_field_float_or_none(current_pricing.tax_rate),
+                    update_tax_rate="tax_rate" in data.model_fields_set,
+                    discount_type=current_pricing.discount_type,
+                    update_discount_type=(
+                        "discount_type" in data.model_fields_set
+                        or (
+                            "discount_value" in data.model_fields_set
+                            and current_pricing.discount_type is None
+                        )
+                    ),
+                    discount_value=document_field_float_or_none(current_pricing.discount_value),
+                    update_discount_value="discount_value" in data.model_fields_set,
+                    deposit_amount=document_field_float_or_none(current_pricing.deposit_amount),
+                    update_deposit_amount="deposit_amount" in data.model_fields_set,
+                    notes=data.notes,
+                    update_notes="notes" in data.model_fields_set,
+                    line_items=data.line_items,
+                    replace_line_items="line_items" in data.model_fields_set,
                 )
-            ),
-            discount_value=document_field_float_or_none(current_pricing.discount_value),
-            update_discount_value="discount_value" in data.model_fields_set,
-            deposit_amount=document_field_float_or_none(current_pricing.deposit_amount),
-            update_deposit_amount="deposit_amount" in data.model_fields_set,
-            notes=data.notes,
-            update_notes="notes" in data.model_fields_set,
-            line_items=data.line_items,
-            replace_line_items="line_items" in data.model_fields_set,
-        )
-        obsolete_artifact_path = None
-        if rendered_fields_changed:
-            obsolete_artifact_path = await self._repository.invalidate_pdf_artifact(updated_quote)
-        await self._repository.commit()
+                obsolete_artifact_path = None
+                if rendered_fields_changed:
+                    obsolete_artifact_path = await self._repository.invalidate_pdf_artifact(
+                        updated_quote
+                    )
+                await self._repository.commit()
+            except IntegrityError as exc:
+                if _is_doc_sequence_collision(exc):
+                    await self._repository.rollback()
+                    raise QuoteServiceError(
+                        detail="Document type change failed, please retry.",
+                        status_code=409,
+                    ) from exc
+                raise
+        else:
+            updated_quote = await self._repository.update(
+                document=quote,
+                customer_id=next_customer_id,
+                update_customer_id="customer_id" in data.model_fields_set,
+                title=data.title,
+                update_title="title" in data.model_fields_set,
+                transcript=data.transcript,
+                update_transcript="transcript" in data.model_fields_set,
+                total_amount=document_field_float_or_none(current_pricing.total_amount),
+                update_total_amount="total_amount" in data.model_fields_set
+                or ("line_items" in data.model_fields_set and line_items_define_subtotal)
+                or "discount_type" in data.model_fields_set
+                or "discount_value" in data.model_fields_set
+                or "tax_rate" in data.model_fields_set,
+                tax_rate=document_field_float_or_none(current_pricing.tax_rate),
+                update_tax_rate="tax_rate" in data.model_fields_set,
+                discount_type=current_pricing.discount_type,
+                update_discount_type=(
+                    "discount_type" in data.model_fields_set
+                    or (
+                        "discount_value" in data.model_fields_set
+                        and current_pricing.discount_type is None
+                    )
+                ),
+                discount_value=document_field_float_or_none(current_pricing.discount_value),
+                update_discount_value="discount_value" in data.model_fields_set,
+                deposit_amount=document_field_float_or_none(current_pricing.deposit_amount),
+                update_deposit_amount="deposit_amount" in data.model_fields_set,
+                notes=data.notes,
+                update_notes="notes" in data.model_fields_set,
+                line_items=data.line_items,
+                replace_line_items="line_items" in data.model_fields_set,
+            )
+            obsolete_artifact_path = None
+            if rendered_fields_changed:
+                obsolete_artifact_path = await self._repository.invalidate_pdf_artifact(
+                    updated_quote
+                )
+            await self._repository.commit()
+
         await self._delete_obsolete_artifact(obsolete_artifact_path)
         log_event(
             "quote.updated",
@@ -995,7 +1048,7 @@ class QuoteService:
         )
         quote.doc_type = "invoice"
         quote.doc_sequence = next_sequence
-        quote.doc_number = _build_doc_number(doc_type="invoice", sequence=next_sequence)
+        quote.doc_number = build_doc_number(doc_type="invoice", sequence=next_sequence)
         quote.due_date = (
             requested_due_date
             if requested_due_date is not None
@@ -1198,7 +1251,7 @@ def _build_default_invoice_due_date() -> date:
     return _utcnow().date() + timedelta(days=30)
 
 
-def _build_doc_number(*, doc_type: str, sequence: int) -> str:
+def build_doc_number(*, doc_type: str, sequence: int) -> str:
     prefix = "I" if doc_type == "invoice" else "Q"
     return f"{prefix}-{sequence:03d}"
 

--- a/backend/app/features/quotes/tests/test_quotes.py
+++ b/backend/app/features/quotes/tests/test_quotes.py
@@ -419,6 +419,7 @@ async def test_quote_crud_happy_path_with_ordering_and_line_item_replacement(
         "id",
         "customer_id",
         "customer_name",
+        "doc_type",
         "doc_number",
         "title",
         "status",
@@ -2723,6 +2724,7 @@ async def test_list_quotes_can_filter_by_customer_id(client: AsyncClient) -> Non
             "id": quote_b["id"],
             "customer_id": customer_id_b,
             "customer_name": "Customer B",
+            "doc_type": "quote",
             "doc_number": "Q-002",
             "title": None,
             "status": "draft",
@@ -4789,6 +4791,7 @@ async def test_mark_quote_outcome_updates_status_and_persists_event_log(
     assert set(payload) == {
         "id",
         "customer_id",
+        "doc_type",
         "doc_number",
         "title",
         "status",
@@ -5143,6 +5146,30 @@ async def test_patch_quote_doc_type_after_share_returns_409(client: AsyncClient)
     assert response.json() == {"detail": "Document type cannot be changed after sharing."}
 
 
+async def test_patch_quote_doc_type_to_invoice_rejects_non_changeable_status_without_share_token(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    csrf_token = await _register_and_login(client, _credentials())
+    customer_id = await _create_customer(client, csrf_token)
+    quote = await _create_quote(client, csrf_token, customer_id)
+    quote_id = quote["id"]
+
+    await _set_quote_status(db_session, quote_id, QuoteStatus.READY)
+    await _set_quote_status(db_session, quote_id, QuoteStatus.APPROVED)
+
+    response = await client.patch(
+        f"/api/quotes/{quote_id}",
+        json={"doc_type": "invoice"},
+        headers={"X-CSRF-Token": csrf_token},
+    )
+
+    assert response.status_code == 409
+    assert response.json() == {
+        "detail": "Document type can only be changed in draft or ready status."
+    }
+
+
 async def test_patch_customerless_quote_doc_type_to_invoice_returns_409(
     client: AsyncClient,
     db_session: AsyncSession,
@@ -5436,6 +5463,7 @@ async def test_list_invoices_returns_direct_and_quote_derived_summaries_newest_f
             "id": direct_invoice["id"],
             "customer_id": direct_customer_id,
             "customer_name": "Direct Customer",
+            "doc_type": "invoice",
             "doc_number": "I-002",
             "title": "Direct invoice",
             "status": "draft",
@@ -5448,6 +5476,7 @@ async def test_list_invoices_returns_direct_and_quote_derived_summaries_newest_f
             "id": linked_invoice["id"],
             "customer_id": quote_customer_id,
             "customer_name": "Quote Customer",
+            "doc_type": "invoice",
             "doc_number": "I-001",
             "title": None,
             "status": "draft",
@@ -5489,6 +5518,7 @@ async def test_list_invoices_can_filter_by_customer_id(client: AsyncClient) -> N
             "id": invoice_b["id"],
             "customer_id": customer_id_b,
             "customer_name": "Customer B",
+            "doc_type": "invoice",
             "doc_number": "I-002",
             "title": "Invoice for B",
             "status": "draft",
@@ -5603,6 +5633,38 @@ async def test_patch_invoice_doc_type_after_share_returns_409(client: AsyncClien
 
     assert response.status_code == 409
     assert response.json() == {"detail": "Document type cannot be changed after sharing."}
+
+
+async def test_patch_invoice_doc_type_to_quote_rejects_non_changeable_status_without_share_token(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    csrf_token = await _register_and_login(client, _credentials())
+    customer_id = await _create_customer(client, csrf_token)
+    direct_invoice = await _create_direct_invoice(
+        client,
+        csrf_token,
+        customer_id,
+        title="Direct invoice",
+        transcript="direct invoice transcript",
+        total_amount=220,
+    )
+    invoice_id = direct_invoice["id"]
+    assert isinstance(invoice_id, str)
+
+    await _set_invoice_status(db_session, invoice_id, QuoteStatus.READY)
+    await _set_invoice_status(db_session, invoice_id, QuoteStatus.SENT)
+
+    response = await client.patch(
+        f"/api/invoices/{invoice_id}",
+        json={"doc_type": "quote"},
+        headers={"X-CSRF-Token": csrf_token},
+    )
+
+    assert response.status_code == 409
+    assert response.json() == {
+        "detail": "Document type can only be changed in draft or ready status."
+    }
 
 
 async def test_patch_invoice_doc_type_to_quote_rejects_linked_source_invoice(

--- a/backend/app/features/quotes/tests/test_quotes.py
+++ b/backend/app/features/quotes/tests/test_quotes.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import json
 from collections.abc import Iterator, Sequence
-from datetime import date
+from datetime import UTC, date, datetime, timedelta
 from types import SimpleNamespace
 from typing import Annotated, TypedDict, cast
 from uuid import UUID, uuid4
@@ -5069,6 +5069,137 @@ async def test_convert_quote_to_invoice_creates_linked_invoice_and_keeps_quote_l
     assert invoice_count == 1
 
 
+@pytest.mark.parametrize("starting_status", [QuoteStatus.DRAFT, QuoteStatus.READY])
+async def test_patch_quote_doc_type_to_invoice_regenerates_number_and_sets_default_due_date(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    starting_status: QuoteStatus,
+) -> None:
+    csrf_token = await _register_and_login(client, _credentials())
+    customer_id = await _create_customer(client, csrf_token)
+    quote = await _create_quote(client, csrf_token, customer_id)
+    quote_id = quote["id"]
+
+    if starting_status is QuoteStatus.READY:
+        await _set_quote_status(db_session, quote_id, QuoteStatus.READY)
+
+    response = await client.patch(
+        f"/api/quotes/{quote_id}",
+        json={"doc_type": "invoice"},
+        headers={"X-CSRF-Token": csrf_token},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["doc_number"].startswith("I-")
+
+    invoice_detail_response = await client.get(f"/api/invoices/{quote_id}")
+    assert invoice_detail_response.status_code == 200
+    invoice_detail = invoice_detail_response.json()
+    assert invoice_detail["doc_number"].startswith("I-")
+    assert invoice_detail["due_date"] == (datetime.now(UTC).date() + timedelta(days=30)).isoformat()
+
+
+async def test_patch_quote_doc_type_to_invoice_accepts_explicit_due_date(
+    client: AsyncClient,
+) -> None:
+    csrf_token = await _register_and_login(client, _credentials())
+    customer_id = await _create_customer(client, csrf_token)
+    quote = await _create_quote(client, csrf_token, customer_id)
+    quote_id = quote["id"]
+
+    response = await client.patch(
+        f"/api/quotes/{quote_id}",
+        json={"doc_type": "invoice", "due_date": "2026-05-20"},
+        headers={"X-CSRF-Token": csrf_token},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["doc_number"].startswith("I-")
+
+    invoice_detail_response = await client.get(f"/api/invoices/{quote_id}")
+    assert invoice_detail_response.status_code == 200
+    assert invoice_detail_response.json()["due_date"] == "2026-05-20"
+
+
+async def test_patch_quote_doc_type_after_share_returns_409(client: AsyncClient) -> None:
+    csrf_token = await _register_and_login(client, _credentials())
+    customer_id = await _create_customer(client, csrf_token)
+    quote = await _create_quote(client, csrf_token, customer_id)
+
+    share_response = await client.post(
+        f"/api/quotes/{quote['id']}/share",
+        headers={"X-CSRF-Token": csrf_token},
+    )
+    assert share_response.status_code == 200
+
+    response = await client.patch(
+        f"/api/quotes/{quote['id']}",
+        json={"doc_type": "invoice"},
+        headers={"X-CSRF-Token": csrf_token},
+    )
+
+    assert response.status_code == 409
+    assert response.json() == {"detail": "Document type cannot be changed after sharing."}
+
+
+async def test_patch_customerless_quote_doc_type_to_invoice_returns_409(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    credentials = _credentials()
+    csrf_token = await _register_and_login(client, credentials)
+    user = await _get_user_by_email(db_session, credentials["email"])
+    repository = QuoteRepository(db_session)
+    unassigned_quote = await repository.create(
+        user_id=user.id,
+        customer_id=None,
+        title=None,
+        transcript="unassigned quote",
+        line_items=[],
+        total_amount=None,
+        tax_rate=None,
+        discount_type=None,
+        discount_value=None,
+        deposit_amount=None,
+        notes=None,
+        source_type="text",
+    )
+    await repository.commit()
+
+    response = await client.patch(
+        f"/api/quotes/{unassigned_quote.id}",
+        json={"doc_type": "invoice"},
+        headers={"X-CSRF-Token": csrf_token},
+    )
+
+    assert response.status_code == 409
+    assert response.json() == {"detail": "Assign a customer before continuing."}
+
+
+async def test_patch_quote_doc_type_to_invoice_rejects_existing_linked_invoice(
+    client: AsyncClient,
+) -> None:
+    csrf_token = await _register_and_login(client, _credentials())
+    customer_id = await _create_customer(client, csrf_token)
+    quote = await _create_quote(client, csrf_token, customer_id)
+
+    convert_response = await client.post(
+        f"/api/quotes/{quote['id']}/convert-to-invoice",
+        headers={"X-CSRF-Token": csrf_token},
+    )
+    assert convert_response.status_code == 201
+
+    response = await client.patch(
+        f"/api/quotes/{quote['id']}",
+        json={"doc_type": "invoice"},
+        headers={"X-CSRF-Token": csrf_token},
+    )
+
+    assert response.status_code == 409
+    assert response.json() == {"detail": "An invoice already exists for this quote"}
+
+
 async def test_optional_pricing_persists_on_quotes_public_payloads_and_converted_invoices(
     client: AsyncClient,
     db_session: AsyncSession,
@@ -5384,6 +5515,7 @@ async def test_invoice_patch_preserves_omitted_fields_and_ready_status_for_direc
         total_amount=220,
     )
     invoice_id = direct_invoice["id"]
+    assert isinstance(invoice_id, str)
 
     await _set_invoice_status(db_session, invoice_id, QuoteStatus.READY)
 
@@ -5402,6 +5534,101 @@ async def test_invoice_patch_preserves_omitted_fields_and_ready_status_for_direc
     assert patched_invoice["line_items"] == direct_invoice["line_items"]
     assert patched_invoice["share_token"] is None
     assert patched_invoice["shared_at"] is None
+
+
+@pytest.mark.parametrize("starting_status", [QuoteStatus.DRAFT, QuoteStatus.READY])
+async def test_patch_invoice_doc_type_to_quote_regenerates_number_and_clears_due_date(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    starting_status: QuoteStatus,
+) -> None:
+    csrf_token = await _register_and_login(client, _credentials())
+    customer_id = await _create_customer(client, csrf_token)
+    direct_invoice = await _create_direct_invoice(
+        client,
+        csrf_token,
+        customer_id,
+        title="Direct invoice",
+        transcript="direct invoice transcript",
+        total_amount=220,
+    )
+    invoice_id = direct_invoice["id"]
+    assert isinstance(invoice_id, str)
+
+    if starting_status is QuoteStatus.READY:
+        await _set_invoice_status(db_session, invoice_id, QuoteStatus.READY)
+
+    response = await client.patch(
+        f"/api/invoices/{invoice_id}",
+        json={"doc_type": "quote"},
+        headers={"X-CSRF-Token": csrf_token},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["doc_number"].startswith("Q-")
+
+    stored_document = await db_session.scalar(
+        select(Document).where(Document.id == UUID(invoice_id))
+    )
+    assert stored_document is not None
+    assert stored_document.doc_type == "quote"
+    assert stored_document.due_date is None
+
+
+async def test_patch_invoice_doc_type_after_share_returns_409(client: AsyncClient) -> None:
+    csrf_token = await _register_and_login(client, _credentials())
+    customer_id = await _create_customer(client, csrf_token)
+    direct_invoice = await _create_direct_invoice(
+        client,
+        csrf_token,
+        customer_id,
+        title="Direct invoice",
+        transcript="direct invoice transcript",
+        total_amount=220,
+    )
+    invoice_id = direct_invoice["id"]
+
+    share_response = await client.post(
+        f"/api/invoices/{invoice_id}/share",
+        headers={"X-CSRF-Token": csrf_token},
+    )
+    assert share_response.status_code == 200
+
+    response = await client.patch(
+        f"/api/invoices/{invoice_id}",
+        json={"doc_type": "quote"},
+        headers={"X-CSRF-Token": csrf_token},
+    )
+
+    assert response.status_code == 409
+    assert response.json() == {"detail": "Document type cannot be changed after sharing."}
+
+
+async def test_patch_invoice_doc_type_to_quote_rejects_linked_source_invoice(
+    client: AsyncClient,
+) -> None:
+    csrf_token = await _register_and_login(client, _credentials())
+    customer_id = await _create_customer(client, csrf_token)
+    quote = await _create_quote(client, csrf_token, customer_id)
+
+    convert_response = await client.post(
+        f"/api/quotes/{quote['id']}/convert-to-invoice",
+        headers={"X-CSRF-Token": csrf_token},
+    )
+    assert convert_response.status_code == 201
+    invoice_id = convert_response.json()["id"]
+
+    response = await client.patch(
+        f"/api/invoices/{invoice_id}",
+        json={"doc_type": "quote"},
+        headers={"X-CSRF-Token": csrf_token},
+    )
+
+    assert response.status_code == 409
+    assert response.json() == {
+        "detail": "Invoices created from quotes cannot be converted to quotes."
+    }
 
 
 async def test_invoice_patch_rejects_invalid_optional_pricing_without_partial_write(

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -400,13 +400,13 @@ Public landing-page rules:
 - `source_document_id`
 
 `QuoteDetailResponse` fields:
-- Standard `Quote` fields, including `id`, nullable `customer_id`, `doc_number`, `title`, `status`, `source_type`, `transcript`, `total_amount`, `tax_rate`, `discount_type`, `discount_value`, `deposit_amount`, `notes`, `shared_at`, `share_token`, `line_items`, `created_at`, and `updated_at`
+- Standard `Quote` fields, including `id`, nullable `customer_id`, `doc_type`, `doc_number`, `title`, `status`, `source_type`, `transcript`, `total_amount`, `tax_rate`, `discount_type`, `discount_value`, `deposit_amount`, `notes`, `shared_at`, `share_token`, `line_items`, `created_at`, and `updated_at`
 - Customer display fields: nullable `customer_name`, `customer_email`, `customer_phone`
 - Helper flags: `requires_customer_assignment`, `can_reassign_customer`
 - `linked_invoice`: `{ id, doc_number, status, due_date, total_amount, created_at } | null`
 
 `InvoiceDetail` fields:
-- Standard invoice fields: `id`, `customer_id`, `doc_number`, `title`, `status`, `total_amount`, `tax_rate`, `discount_type`, `discount_value`, `deposit_amount`, `notes`, `due_date`, `shared_at`, `share_token`, `source_document_id`, `line_items`, `created_at`, and `updated_at`
+- Standard invoice fields: `id`, `customer_id`, `doc_type`, `doc_number`, `title`, `status`, `total_amount`, `tax_rate`, `discount_type`, `discount_value`, `deposit_amount`, `notes`, `due_date`, `shared_at`, `share_token`, `source_document_id`, `line_items`, `created_at`, and `updated_at`
 - `source_quote_number` (`null` for direct invoices with no parent quote)
 - `customer`: `{ id, name, email, phone }`
 


### PR DESCRIPTION
## Summary
- add optional doc_type to quote and invoice PATCH schemas (plus quote PATCH due_date for quote->invoice transitions)
- implement guarded doc_type transitions in quote and invoice services
- enforce state/share/link invariants, regenerate doc numbers with Q-/I- prefixes, and normalize due dates on successful transitions
- add API tests covering success and conflict paths from Task #305 acceptance criteria

## Verification
- make backend-verify

Closes #305