### PR TITLE
Add Start Blank manual quote draft path

### DIFF
--- a/backend/app/features/quotes/api.py
+++ b/backend/app/features/quotes/api.py
@@ -43,6 +43,7 @@ from app.features.quotes.schemas import (
     ExtractionResult,
     LineItemResponse,
     LinkedInvoiceResponse,
+    ManualDraftCreateRequest,
     PdfArtifactResponse,
     PersistedExtractionResponse,
     PublicDocumentResponse,
@@ -183,6 +184,41 @@ async def create_quote(
         quote = await quote_service.create_quote(user, payload)
     except QuoteServiceError as exc:
         raise HTTPException(status_code=exc.status_code, detail=exc.detail) from exc
+    return QuoteResponse.model_validate(quote)
+
+
+@router.post(
+    "/manual-draft",
+    response_model=QuoteResponse,
+    status_code=status.HTTP_201_CREATED,
+    dependencies=[Depends(require_csrf)],
+)
+async def create_manual_draft(
+    payload: ManualDraftCreateRequest,
+    user: Annotated[User, Depends(get_current_user)],
+    quote_service: Annotated[QuoteService, Depends(get_quote_service)],
+) -> QuoteResponse:
+    """Create a blank manual draft quote for the authenticated user."""
+    try:
+        quote = await quote_service.create_manual_draft(
+            user_id=user.id,
+            customer_id=payload.customer_id,
+        )
+    except QuoteServiceError as exc:
+        raise HTTPException(status_code=exc.status_code, detail=exc.detail) from exc
+
+    log_event(
+        "quote.created",
+        user_id=user.id,
+        quote_id=quote.id,
+        customer_id=quote.customer_id,
+    )
+    log_event(
+        "manual_draft_created",
+        user_id=user.id,
+        quote_id=quote.id,
+        customer_id=quote.customer_id,
+    )
     return QuoteResponse.model_validate(quote)
 
 

--- a/backend/app/features/quotes/schemas.py
+++ b/backend/app/features/quotes/schemas.py
@@ -74,6 +74,12 @@ class ConvertNotesRequest(BaseModel):
     notes: str = Field(min_length=1, max_length=NOTE_INPUT_MAX_CHARS)
 
 
+class ManualDraftCreateRequest(BaseModel):
+    """Request payload for creating a manual quote draft without extraction."""
+
+    customer_id: UUID | None = None
+
+
 class QuoteCreateRequest(BaseModel):
     """Request payload for creating a quote from a draft."""
 

--- a/backend/app/features/quotes/service.py
+++ b/backend/app/features/quotes/service.py
@@ -376,6 +376,53 @@ class QuoteService:
             ) from exc
         return quote
 
+    async def create_manual_draft(
+        self,
+        *,
+        user_id: UUID,
+        customer_id: UUID | None,
+    ) -> Document:
+        """Persist one blank draft quote without running extraction."""
+        await self.ensure_customer_exists_for_user(
+            user_id=user_id,
+            customer_id=customer_id,
+        )
+        try:
+            quote = await _create_quote_document(
+                self,
+                user_id=user_id,
+                customer_id=customer_id,
+                title=None,
+                transcript="",
+                line_items=[],
+                total_amount=None,
+                tax_rate=None,
+                discount_type=None,
+                discount_value=None,
+                deposit_amount=None,
+                notes=None,
+                source_type="text",
+            )
+        except QuoteServiceError:
+            raise
+        except Exception as exc:  # noqa: BLE001
+            await self._repository.rollback()
+            raise QuoteServiceError(
+                detail="Unable to save manual draft right now. Please try again.",
+                status_code=503,
+            ) from exc
+
+        try:
+            await self._repository.commit()
+        except Exception as exc:  # noqa: BLE001
+            await self._repository.rollback()
+            raise QuoteServiceError(
+                detail="Unable to save manual draft right now. Please try again.",
+                status_code=503,
+            ) from exc
+
+        return quote
+
     async def ensure_quote_appendable(
         self,
         *,

--- a/backend/app/features/quotes/tests/test_quotes.py
+++ b/backend/app/features/quotes/tests/test_quotes.py
@@ -521,6 +521,96 @@ async def test_create_quote_returns_404_for_nonexistent_customer(
     assert response.json() == {"detail": "Not found"}
 
 
+async def test_create_manual_draft_without_customer_persists_empty_draft_and_logs_manual_event(
+    client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    emitted_events: list[dict[str, str]] = []
+
+    def _capture(message: str) -> None:
+        emitted_events.append(json.loads(message))
+
+    monkeypatch.setattr(event_logger._EVENT_LOGGER, "info", _capture)  # noqa: SLF001
+
+    csrf_token = await _register_and_login(client, _credentials())
+
+    response = await client.post(
+        "/api/quotes/manual-draft",
+        json={},
+        headers={"X-CSRF-Token": csrf_token},
+    )
+
+    assert response.status_code == 201
+    payload = response.json()
+    assert payload["customer_id"] is None
+    assert payload["title"] is None
+    assert payload["status"] == "draft"
+    assert payload["source_type"] == "text"
+    assert payload["transcript"] == ""
+    assert payload["line_items"] == []
+    assert payload["total_amount"] is None
+
+    detail_response = await client.get(f"/api/quotes/{payload['id']}")
+    assert detail_response.status_code == 200
+    detail_payload = detail_response.json()
+    assert detail_payload["extraction_tier"] is None
+    assert detail_payload["extraction_degraded_reason_code"] is None
+
+    quote_event_names = [
+        event["event"] for event in emitted_events if event.get("quote_id") == payload["id"]
+    ]
+    assert "manual_draft_created" in quote_event_names
+    assert "draft_generated" not in quote_event_names
+
+
+async def test_create_manual_draft_with_owned_customer_assigns_customer(
+    client: AsyncClient,
+) -> None:
+    csrf_token = await _register_and_login(client, _credentials())
+    customer_id = await _create_customer(client, csrf_token)
+
+    response = await client.post(
+        "/api/quotes/manual-draft",
+        json={"customer_id": customer_id},
+        headers={"X-CSRF-Token": csrf_token},
+    )
+
+    assert response.status_code == 201
+    payload = response.json()
+    assert payload["customer_id"] == customer_id
+    assert payload["line_items"] == []
+    assert payload["transcript"] == ""
+
+
+async def test_create_manual_draft_rejects_missing_or_foreign_customer(
+    client: AsyncClient,
+) -> None:
+    csrf_token = await _register_and_login(client, _credentials())
+    first_user_customer_id = await _create_customer(client, csrf_token)
+
+    missing_customer_response = await client.post(
+        "/api/quotes/manual-draft",
+        json={"customer_id": str(uuid4())},
+        headers={"X-CSRF-Token": csrf_token},
+    )
+    assert missing_customer_response.status_code == 404
+    assert missing_customer_response.json() == {"detail": "Not found"}
+
+    second_user_credentials = _credentials()
+    second_user_credentials["email"] = "manual-draft-second-user@example.com"
+    second_user_csrf_token = await _register_and_login(
+        client,
+        second_user_credentials,
+    )
+    foreign_customer_response = await client.post(
+        "/api/quotes/manual-draft",
+        json={"customer_id": first_user_customer_id},
+        headers={"X-CSRF-Token": second_user_csrf_token},
+    )
+    assert foreign_customer_response.status_code == 404
+    assert foreign_customer_response.json() == {"detail": "Not found"}
+
+
 async def test_create_quote_allows_empty_line_items_and_returns_empty_list(
     client: AsyncClient,
 ) -> None:
@@ -4062,6 +4152,7 @@ async def test_convert_notes_rejects_when_concurrency_limit_is_exhausted(
         ("get", "/api/quotes", None),
         ("get", "/api/quotes/00000000-0000-0000-0000-000000000000", None),
         ("post", "/api/quotes/convert-notes", {"notes": "notes"}),
+        ("post", "/api/quotes/manual-draft", {}),
         (
             "post",
             "/api/quotes",

--- a/frontend/src/features/quotes/components/CaptureInputPanel.tsx
+++ b/frontend/src/features/quotes/components/CaptureInputPanel.tsx
@@ -17,6 +17,8 @@ interface CaptureInputPanelProps {
   isSupported: boolean;
   onStartRecording: () => void;
   onStopRecording: () => void;
+  onStartBlank?: () => void;
+  isStartBlankDisabled?: boolean;
 }
 
 export function CaptureInputPanel({
@@ -31,6 +33,8 @@ export function CaptureInputPanel({
   isSupported,
   onStartRecording,
   onStopRecording,
+  onStartBlank,
+  isStartBlankDisabled = false,
 }: CaptureInputPanelProps): React.ReactElement {
   return (
     <>
@@ -105,6 +109,16 @@ export function CaptureInputPanel({
           placeholder="Add any typed details here..."
           className="w-full resize-none rounded-lg bg-surface-container-high px-4 py-3 font-body text-sm text-on-surface placeholder:text-outline transition-all focus:bg-surface-container-lowest focus:ring-2 focus:ring-primary/30 focus:outline-none"
         />
+        {onStartBlank ? (
+          <button
+            type="button"
+            className="mt-3 cursor-pointer text-sm text-primary underline decoration-primary/60 underline-offset-4 transition-colors hover:text-primary/80 disabled:cursor-not-allowed disabled:text-outline"
+            onClick={onStartBlank}
+            disabled={isStartBlankDisabled}
+          >
+            Or start with a blank document
+          </button>
+        ) : null}
       </section>
 
       {isRecording ? (

--- a/frontend/src/features/quotes/components/CaptureScreen.tsx
+++ b/frontend/src/features/quotes/components/CaptureScreen.tsx
@@ -66,6 +66,7 @@ export function CaptureScreen(): React.ReactElement {
     null,
   );
   const [error, setError] = useState<string | null>(null);
+  const [isStartingBlank, setIsStartingBlank] = useState(false);
   const isExtracting = extractionStage !== null;
   const hasClips = clips.length > 0;
   const hasNotes = notes.trim().length > 0;
@@ -245,7 +246,30 @@ export function CaptureScreen(): React.ReactElement {
       }
     }
   }
-
+  async function onStartBlank(): Promise<void> {
+    clearActionErrors();
+    setIsStartingBlank(true);
+    try {
+      const manualDraft = await quoteService.createManualDraft({ customerId });
+      if (!isMountedRef.current) {
+        return;
+      }
+      navigate(`/documents/${manualDraft.id}/edit`);
+    } catch (startBlankError) {
+      if (!isMountedRef.current) {
+        return;
+      }
+      const message =
+        startBlankError instanceof Error
+          ? startBlankError.message
+          : "Unable to start a blank draft";
+      setError(message);
+    } finally {
+      if (isMountedRef.current) {
+        setIsStartingBlank(false);
+      }
+    }
+  }
   async function pollExtractionJob(
     jobId: string,
     sourceType: QuoteSourceType,
@@ -287,7 +311,6 @@ export function CaptureScreen(): React.ReactElement {
       if (pollCount === EXTRACTION_MAX_POLLS - 1) {
         break;
       }
-
       await new Promise((resolve) => {
         window.setTimeout(resolve, EXTRACTION_POLL_INTERVAL_MS);
       });
@@ -304,7 +327,6 @@ export function CaptureScreen(): React.ReactElement {
   function hasUnsavedWork(): boolean {
     return clips.length > 0 || notes.trim().length > 0;
   }
-
   function requestExit(target: string): void {
     if (hasUnsavedWork()) {
       setPendingExitTarget(target);
@@ -363,6 +385,16 @@ export function CaptureScreen(): React.ReactElement {
               void startRecording();
             }}
             onStopRecording={stopRecording}
+            onStartBlank={
+              isAppendMode
+                ? undefined
+                : () => {
+                    void onStartBlank();
+                  }
+            }
+            isStartBlankDisabled={
+              isExtracting || isRecording || isStartingBlank
+            }
           />
         </div>
       </section>

--- a/frontend/src/features/quotes/components/CaptureScreen.tsx
+++ b/frontend/src/features/quotes/components/CaptureScreen.tsx
@@ -22,10 +22,7 @@ import {
 } from "@/features/quotes/utils/reviewConfidenceNotes";
 import { useVoiceCapture } from "@/features/quotes/hooks/useVoiceCapture";
 import { quoteService } from "@/features/quotes/services/quoteService";
-import type {
-  ExtractionResult,
-  QuoteSourceType,
-} from "@/features/quotes/types/quote.types";
+import type { ExtractionResult, QuoteSourceType } from "@/features/quotes/types/quote.types";
 import { Button } from "@/shared/components/Button";
 import { ConfirmModal } from "@/shared/components/ConfirmModal";
 import { ScreenFooter } from "@/shared/components/ScreenFooter";
@@ -33,10 +30,9 @@ import { Toast } from "@/shared/components/Toast";
 import { WorkflowScreenHeader } from "@/shared/components/WorkflowScreenHeader";
 import { jobService } from "@/shared/lib/jobService";
 import { formatByteLimit } from "@/shared/lib/formatters";
-import {
-  MAX_AUDIO_CLIPS_PER_REQUEST,
-  MAX_AUDIO_TOTAL_BYTES,
-} from "@/shared/lib/inputLimits";
+import { MAX_AUDIO_CLIPS_PER_REQUEST, MAX_AUDIO_TOTAL_BYTES } from "@/shared/lib/inputLimits";
+
+const START_BLANK_GUARD_TARGET = "__start_blank__";
 
 export function CaptureScreen(): React.ReactElement {
   const navigate = useNavigate();
@@ -62,9 +58,7 @@ export function CaptureScreen(): React.ReactElement {
 
   const [notes, setNotes] = useState("");
   const [extractionStage, setExtractionStage] = useState<string | null>(null);
-  const [pendingExitTarget, setPendingExitTarget] = useState<string | null>(
-    null,
-  );
+  const [pendingExitTarget, setPendingExitTarget] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [isStartingBlank, setIsStartingBlank] = useState(false);
   const isExtracting = extractionStage !== null;
@@ -344,6 +338,14 @@ export function CaptureScreen(): React.ReactElement {
     requestExit(HOME_ROUTE);
   }
 
+  function onStartBlankClick(): void {
+    if (hasUnsavedWork()) {
+      setPendingExitTarget(START_BLANK_GUARD_TARGET);
+      return;
+    }
+    void onStartBlank();
+  }
+
   const displayedError = error ?? voiceError;
   const hasReachedClipLimit = clips.length >= MAX_AUDIO_CLIPS_PER_REQUEST;
   const canExtract = (hasClips || hasNotes) && !isExtracting && !isRecording;
@@ -385,16 +387,8 @@ export function CaptureScreen(): React.ReactElement {
               void startRecording();
             }}
             onStopRecording={stopRecording}
-            onStartBlank={
-              isAppendMode
-                ? undefined
-                : () => {
-                    void onStartBlank();
-                  }
-            }
-            isStartBlankDisabled={
-              isExtracting || isRecording || isStartingBlank
-            }
+            onStartBlank={isAppendMode ? undefined : onStartBlankClick}
+            isStartBlankDisabled={isExtracting || isRecording || isStartingBlank}
           />
         </div>
       </section>
@@ -439,6 +433,10 @@ export function CaptureScreen(): React.ReactElement {
           onConfirm={() => {
             const nextTarget = pendingExitTarget;
             setPendingExitTarget(null);
+            if (nextTarget === START_BLANK_GUARD_TARGET) {
+              void onStartBlank();
+              return;
+            }
             navigate(nextTarget, { replace: true });
           }}
           onCancel={() => setPendingExitTarget(null)}

--- a/frontend/src/features/quotes/services/quoteService.ts
+++ b/frontend/src/features/quotes/services/quoteService.ts
@@ -123,6 +123,13 @@ async function appendExtraction(
   return submitExtraction(`/api/quotes/${quoteId}/append-extraction`, params);
 }
 
+function createManualDraft(params?: { customerId?: string }): Promise<Quote> {
+  return request<Quote>("/api/quotes/manual-draft", {
+    method: "POST",
+    body: params?.customerId ? { customer_id: params.customerId } : {},
+  });
+}
+
 function createQuote(data: QuoteCreateRequest): Promise<Quote> {
   return request<Quote>("/api/quotes", {
     method: "POST",
@@ -197,6 +204,7 @@ function convertToInvoice(id: string): Promise<Invoice> {
 export const quoteService = {
   extract,
   appendExtraction,
+  createManualDraft,
   convertNotes,
   captureAudio,
   createQuote,

--- a/frontend/src/features/quotes/tests/CaptureScreen.test.tsx
+++ b/frontend/src/features/quotes/tests/CaptureScreen.test.tsx
@@ -442,6 +442,37 @@ describe("CaptureScreen", () => {
     expect(navigateMock).toHaveBeenCalledWith("/documents/quote-manual-1/edit");
   });
 
+  it("guards Start Blank with confirmation when unsaved notes and clips exist", async () => {
+    mockVoiceCapture({ clips: [clipFixture] });
+    renderScreen();
+
+    fireEvent.change(screen.getByLabelText(/written description/i), {
+      target: { value: "Install sod in backyard" },
+    });
+    fireEvent.click(
+      screen.getByRole("button", { name: "Or start with a blank document" }),
+    );
+
+    expect(screen.getByRole("dialog", { name: "Leave this screen?" })).toBeInTheDocument();
+    expect(mockedQuoteService.createManualDraft).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole("button", { name: "Stay" }));
+    expect(screen.queryByRole("dialog", { name: "Leave this screen?" })).not.toBeInTheDocument();
+    expect(mockedQuoteService.createManualDraft).not.toHaveBeenCalled();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Or start with a blank document" }),
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Leave" }));
+
+    await waitFor(() => {
+      expect(mockedQuoteService.createManualDraft).toHaveBeenCalledWith({
+        customerId: "cust-1",
+      });
+    });
+    expect(navigateMock).toHaveBeenCalledWith("/documents/quote-manual-1/edit");
+  });
+
   it("starts a blank draft without customer context and routes to edit", async () => {
     mockedQuoteService.createManualDraft.mockResolvedValueOnce({
       id: "quote-manual-home",

--- a/frontend/src/features/quotes/tests/CaptureScreen.test.tsx
+++ b/frontend/src/features/quotes/tests/CaptureScreen.test.tsx
@@ -45,6 +45,7 @@ vi.mock("@/features/quotes/services/quoteService", () => ({
   quoteService: {
     extract: vi.fn(),
     appendExtraction: vi.fn(),
+    createManualDraft: vi.fn(),
     convertNotes: vi.fn(),
     captureAudio: vi.fn(),
     createQuote: vi.fn(),
@@ -160,6 +161,26 @@ beforeEach(() => {
   mockVoiceCapture();
   mockedQuoteService.extract.mockResolvedValue({ type: "sync", quoteId: "quote-1", result: extractionFixture });
   mockedQuoteService.appendExtraction.mockReset();
+  mockedQuoteService.createManualDraft.mockResolvedValue({
+    id: "quote-manual-1",
+    customer_id: "cust-1",
+    doc_number: "Q-099",
+    title: null,
+    status: "draft",
+    source_type: "text",
+    transcript: "",
+    total_amount: null,
+    tax_rate: null,
+    discount_type: null,
+    discount_value: null,
+    deposit_amount: null,
+    notes: null,
+    shared_at: null,
+    share_token: null,
+    line_items: [],
+    created_at: "2026-03-20T00:00:00.000Z",
+    updated_at: "2026-03-20T00:00:00.000Z",
+  });
   mockedJobService.getJobStatus.mockReset();
   useParamsMock.mockReturnValue({ customerId: "cust-1" });
 });
@@ -201,6 +222,26 @@ describe("CaptureScreen", () => {
     );
     expect(
       screen.queryByText(`${notesValue.length}/${NOTE_INPUT_MAX_CHARS}`),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows Start Blank affordance in new capture mode", () => {
+    renderScreen();
+
+    expect(
+      screen.getByRole("button", { name: "Or start with a blank document" }),
+    ).toBeInTheDocument();
+  });
+
+  it("hides Start Blank affordance in append mode", () => {
+    renderScreen({
+      pathname: "/quotes/quote-1/review/append-capture",
+      customerId: null,
+      quoteId: "quote-1",
+    });
+
+    expect(
+      screen.queryByRole("button", { name: "Or start with a blank document" }),
     ).not.toBeInTheDocument();
   });
 
@@ -384,6 +425,56 @@ describe("CaptureScreen", () => {
       }),
     );
     expect(mockedQuoteService.createQuote).not.toHaveBeenCalled();
+  });
+
+  it("starts a blank draft with customer context and routes to edit", async () => {
+    renderScreen();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Or start with a blank document" }),
+    );
+
+    await waitFor(() => {
+      expect(mockedQuoteService.createManualDraft).toHaveBeenCalledWith({
+        customerId: "cust-1",
+      });
+    });
+    expect(navigateMock).toHaveBeenCalledWith("/documents/quote-manual-1/edit");
+  });
+
+  it("starts a blank draft without customer context and routes to edit", async () => {
+    mockedQuoteService.createManualDraft.mockResolvedValueOnce({
+      id: "quote-manual-home",
+      customer_id: null,
+      doc_number: "Q-100",
+      title: null,
+      status: "draft",
+      source_type: "text",
+      transcript: "",
+      total_amount: null,
+      tax_rate: null,
+      discount_type: null,
+      discount_value: null,
+      deposit_amount: null,
+      notes: null,
+      shared_at: null,
+      share_token: null,
+      line_items: [],
+      created_at: "2026-03-20T00:00:00.000Z",
+      updated_at: "2026-03-20T00:00:00.000Z",
+    });
+    renderScreen({ pathname: "/quotes/capture", customerId: null });
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Or start with a blank document" }),
+    );
+
+    await waitFor(() => {
+      expect(mockedQuoteService.createManualDraft).toHaveBeenCalledWith({
+        customerId: undefined,
+      });
+    });
+    expect(navigateMock).toHaveBeenCalledWith("/documents/quote-manual-home/edit");
   });
 
   it("submits append extraction from review, requests draft reseed, and replaces prior confidence notes", async () => {

--- a/frontend/src/features/quotes/tests/quoteService.extract.test.ts
+++ b/frontend/src/features/quotes/tests/quoteService.extract.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { quoteService } from "@/features/quotes/services/quoteService";
-import { requestWithMetadata } from "@/shared/lib/http";
+import { request, requestWithMetadata } from "@/shared/lib/http";
 
 vi.mock("@/shared/lib/http", () => ({
   request: vi.fn(),
@@ -10,10 +10,12 @@ vi.mock("@/shared/lib/http", () => ({
 }));
 
 const mockedRequestWithMetadata = vi.mocked(requestWithMetadata);
+const mockedRequest = vi.mocked(request);
 
 describe("quoteService.extract", () => {
   afterEach(() => {
     mockedRequestWithMetadata.mockReset();
+    mockedRequest.mockReset();
   });
 
   it("builds multipart form data with clips and trimmed notes for async extraction", async () => {
@@ -137,5 +139,31 @@ describe("quoteService.extract", () => {
     const formData = options?.body as FormData;
     expect(formData.get("notes")).toBe("add one more item");
     expect(formData.get("customer_id")).toBeNull();
+  });
+
+  it("creates manual draft with customer payload when customerId is provided", async () => {
+    mockedRequest.mockResolvedValue({
+      id: "quote-manual-1",
+    });
+
+    await quoteService.createManualDraft({ customerId: "cust-1" });
+
+    const [path, options] = mockedRequest.mock.calls[0] ?? [];
+    expect(path).toBe("/api/quotes/manual-draft");
+    expect(options?.method).toBe("POST");
+    expect(options?.body).toEqual({ customer_id: "cust-1" });
+  });
+
+  it("creates manual draft with empty payload when customerId is omitted", async () => {
+    mockedRequest.mockResolvedValue({
+      id: "quote-manual-2",
+    });
+
+    await quoteService.createManualDraft();
+
+    const [path, options] = mockedRequest.mock.calls[0] ?? [];
+    expect(path).toBe("/api/quotes/manual-draft");
+    expect(options?.method).toBe("POST");
+    expect(options?.body).toEqual({});
   });
 });

--- a/frontend/src/shared/tests/mocks/handlers.ts
+++ b/frontend/src/shared/tests/mocks/handlers.ts
@@ -250,6 +250,36 @@ export const handlers = [
     );
   }),
 
+  http.post("/api/quotes/manual-draft", async ({ request }) => {
+    const csrfError = requireCsrf(request);
+    if (csrfError) return csrfError;
+
+    const body = (await request.json()) as { customer_id?: string };
+    return HttpResponse.json(
+      {
+        id: "quote-manual-1",
+        customer_id: body.customer_id ?? null,
+        doc_number: "Q-003",
+        title: null,
+        status: "draft",
+        source_type: "text",
+        transcript: "",
+        total_amount: null,
+        tax_rate: null,
+        discount_type: null,
+        discount_value: null,
+        deposit_amount: null,
+        notes: null,
+        shared_at: null,
+        share_token: null,
+        line_items: [],
+        created_at: "2026-03-20T00:00:00.000Z",
+        updated_at: "2026-03-20T00:00:00.000Z",
+      },
+      { status: 201 },
+    );
+  }),
+
   http.post("/api/quotes/capture-audio", ({ request }) => {
     const csrfError = requireCsrf(request);
     if (csrfError) return csrfError;


### PR DESCRIPTION
## Summary
- add `POST /api/quotes/manual-draft` for creating blank manual drafts with optional owned customer assignment
- emit `manual_draft_created` on manual draft creation and avoid extraction analytics on this path
- add CaptureScreen Start Blank affordance that creates a manual draft and routes to `/documents/{id}/edit`
- add backend and frontend tests covering manual-draft behavior, customer ownership validation, and Start Blank navigation

## Verification
- make backend-verify
- make frontend-verify

Closes #307
