### PR TITLE
Task 9: update customer detail document entry CTA

### DIFF
--- a/frontend/src/features/customers/components/CustomerDetailScreen.tsx
+++ b/frontend/src/features/customers/components/CustomerDetailScreen.tsx
@@ -286,7 +286,7 @@ export function CustomerDetailScreen(): React.ReactElement {
                         state: createCaptureLocationState(`/customers/${customer.id}`),
                       })}
                     >
-                      Create Quote
+                      Create Document
                     </Button>
                     <button
                       type="button"

--- a/frontend/src/features/customers/tests/CustomerDetailScreen.test.tsx
+++ b/frontend/src/features/customers/tests/CustomerDetailScreen.test.tsx
@@ -326,7 +326,7 @@ describe("CustomerDetailScreen", () => {
     renderScreen();
     await screen.findByText("Q-001");
 
-    fireEvent.click(screen.getByRole("button", { name: /create quote/i }));
+    fireEvent.click(screen.getByRole("button", { name: /create document/i }));
 
     expect(navigateMock).toHaveBeenCalledWith("/quotes/capture/cust-1", {
       state: { launchOrigin: "/customers/cust-1" },


### PR DESCRIPTION
## Summary
- update customer detail primary action copy from "Create Quote" to "Create Document"
- keep customer-prefilled navigation target unchanged (`/quotes/capture/:customerId`)
- keep FAB behavior unchanged (still routes to `/quotes/capture`)

## Verification
- make frontend-verify

Closes #308