### PR TITLE
Task 13: skeleton loading states

### DIFF
--- a/frontend/src/features/customers/components/CustomerDetailLoadingSkeleton.tsx
+++ b/frontend/src/features/customers/components/CustomerDetailLoadingSkeleton.tsx
@@ -1,0 +1,25 @@
+import { SkeletonBlock } from "@/shared/components/SkeletonBlock";
+
+export function CustomerDetailLoadingSkeleton(): React.ReactElement {
+  return (
+    <>
+      <section className="rounded-xl bg-surface-container-lowest p-4 ghost-shadow">
+        <div className="space-y-3">
+          <SkeletonBlock width="45%" height="1rem" />
+          <SkeletonBlock width="72%" height="1rem" />
+          <SkeletonBlock width="68%" height="1rem" />
+        </div>
+      </section>
+      <section className="rounded-xl bg-surface-container-low p-3">
+        <div className="mb-3 flex items-center justify-between gap-3">
+          <SkeletonBlock width="48%" height="2.25rem" borderRadius="9999px" />
+          <SkeletonBlock width="20%" height="0.875rem" />
+        </div>
+        <div className="space-y-3">
+          <SkeletonBlock width="100%" height="4.25rem" />
+          <SkeletonBlock width="100%" height="4.25rem" />
+        </div>
+      </section>
+    </>
+  );
+}

--- a/frontend/src/features/customers/components/CustomerDetailScreen.tsx
+++ b/frontend/src/features/customers/components/CustomerDetailScreen.tsx
@@ -4,6 +4,7 @@ import { useNavigate, useParams } from "react-router-dom";
 import { useAuth } from "@/features/auth/hooks/useAuth";
 import { CustomerDeleteConfirmModal } from "@/features/customers/components/CustomerDeleteConfirmModal";
 import { CustomerInfoForm } from "@/features/customers/components/CustomerInfoForm";
+import { CustomerDetailLoadingSkeleton } from "@/features/customers/components/CustomerDetailLoadingSkeleton";
 import { InvoiceHistoryList } from "@/features/customers/components/InvoiceHistoryList";
 import { QuoteHistoryList } from "@/features/customers/components/QuoteHistoryList";
 import { customerService } from "@/features/customers/services/customerService";
@@ -282,9 +283,9 @@ export function CustomerDetailScreen(): React.ReactElement {
 
       <section className="mx-auto w-full max-w-3xl space-y-4 px-4 pt-20">
         {isLoading ? (
-          <p role="status" className="text-sm text-on-surface-variant">
-            Loading customer...
-          </p>
+          <div role="status" aria-label="Loading customer" className="space-y-4">
+            <CustomerDetailLoadingSkeleton />
+          </div>
         ) : null}
 
         {loadError ? (

--- a/frontend/src/features/customers/components/InvoiceHistoryList.tsx
+++ b/frontend/src/features/customers/components/InvoiceHistoryList.tsx
@@ -1,6 +1,7 @@
 import type { InvoiceListItem } from "@/features/invoices/types/invoice.types";
 import { StatusBadge } from "@/shared/components/StatusBadge";
 import { FeedbackMessage } from "@/shared/components/FeedbackMessage";
+import { SkeletonBlock } from "@/shared/components/SkeletonBlock";
 import { formatCurrency, formatDate } from "@/shared/lib/formatters";
 
 interface InvoiceHistoryListProps {
@@ -36,9 +37,20 @@ export function InvoiceHistoryList({
       ) : null}
 
       {isLoading ? (
-        <p role="status" className="rounded-lg bg-surface-container-lowest p-4 text-sm text-outline ghost-shadow">
-          Loading invoices...
-        </p>
+        <div role="status" aria-label="Loading invoices" className="space-y-3 rounded-xl bg-surface-container-low p-3">
+          {Array.from({ length: 3 }).map((_, index) => (
+            <div key={`invoice-history-skeleton-${index}`} className="rounded-xl bg-surface-container-lowest p-4 ghost-shadow">
+              <div className="flex items-baseline justify-between gap-3">
+                <SkeletonBlock width="42%" height="1rem" />
+                <SkeletonBlock width="26%" height="1rem" />
+              </div>
+              <div className="mt-2 flex items-center justify-between gap-3">
+                <SkeletonBlock width="58%" height="0.875rem" />
+                <SkeletonBlock width="24%" height="1.5rem" borderRadius="9999px" />
+              </div>
+            </div>
+          ))}
+        </div>
       ) : null}
 
       {!isLoading && loadError ? <FeedbackMessage variant="error">{loadError}</FeedbackMessage> : null}

--- a/frontend/src/features/customers/tests/CustomerDetailScreen.test.tsx
+++ b/frontend/src/features/customers/tests/CustomerDetailScreen.test.tsx
@@ -204,7 +204,7 @@ describe("CustomerDetailScreen", () => {
 
     renderScreen();
 
-    expect(screen.getByRole("status")).toHaveTextContent("Loading customer...");
+    expect(screen.getByRole("status", { name: /loading customer/i })).toBeInTheDocument();
   });
 
   it("shows error when customer fetch fails", async () => {
@@ -407,7 +407,7 @@ describe("CustomerDetailScreen", () => {
     expect(
       await screen.findByRole("heading", { level: 1, name: "Alice Johnson" }),
     ).toBeInTheDocument();
-    expect(screen.getByRole("status")).toHaveTextContent("Loading invoices...");
+    expect(screen.getByRole("status", { name: /loading invoices/i })).toBeInTheDocument();
   });
 
   it("renders quote history empty state when customer has no quotes", async () => {

--- a/frontend/src/features/invoices/components/InvoiceDetailScreen.tsx
+++ b/frontend/src/features/invoices/components/InvoiceDetailScreen.tsx
@@ -9,6 +9,7 @@ import { QuoteLineItemsSection } from "@/features/quotes/components/QuoteLineIte
 import { BottomNav } from "@/shared/components/BottomNav";
 import { Button } from "@/shared/components/Button";
 import { ConfirmModal } from "@/shared/components/ConfirmModal";
+import { DetailPageSkeleton } from "@/shared/components/DetailPageSkeleton";
 import {
   DocumentActionError,
   DocumentActionHint,
@@ -157,9 +158,9 @@ export function InvoiceDetailScreen(): React.ReactElement {
 
       <section className="mx-auto w-full max-w-3xl">
         {isLoadingInvoice ? (
-          <p role="status" className="mt-4 px-4 text-sm text-on-surface-variant">
-            Loading invoice...
-          </p>
+          <div role="status" aria-label="Loading invoice" className="mt-4 px-4">
+            <DetailPageSkeleton />
+          </div>
         ) : null}
 
         {loadError ? (

--- a/frontend/src/features/quotes/components/QuoteList.tsx
+++ b/frontend/src/features/quotes/components/QuoteList.tsx
@@ -7,6 +7,7 @@ import type { InvoiceListItem } from "@/features/invoices/types/invoice.types";
 import { quoteService } from "@/features/quotes/services/quoteService";
 import type { QuoteListItem } from "@/features/quotes/types/quote.types";
 import { BottomNav } from "@/shared/components/BottomNav";
+import { DocumentCardSkeleton } from "@/shared/components/DocumentCardSkeleton";
 import { FeedbackMessage } from "@/shared/components/FeedbackMessage";
 import { Input } from "@/shared/components/Input";
 import { ScreenHeader } from "@/shared/components/ScreenHeader";
@@ -375,9 +376,15 @@ export function QuoteList(): React.ReactElement {
         </div>
 
         {isLoading ? (
-          <p role="status" className="px-4 text-sm text-on-surface-variant">
-            {documentMode === "quotes" ? "Loading quotes..." : "Loading invoices..."}
-          </p>
+          <div
+            role="status"
+            aria-label={documentMode === "quotes" ? "Loading quotes" : "Loading invoices"}
+            className="space-y-3 px-4"
+          >
+            {Array.from({ length: 4 }).map((_, index) => (
+              <DocumentCardSkeleton key={`${documentMode}-skeleton-${index}`} />
+            ))}
+          </div>
         ) : null}
 
         {loadError ? (

--- a/frontend/src/features/quotes/components/QuotePreview.tsx
+++ b/frontend/src/features/quotes/components/QuotePreview.tsx
@@ -21,6 +21,7 @@ import { useQuoteInvoiceConversion } from "@/features/quotes/hooks/useQuoteInvoi
 import { useQuoteOutcomeActions } from "@/features/quotes/hooks/useQuoteOutcomeActions";
 import { isQuoteEditableStatus } from "@/features/quotes/utils/quoteStatus";
 import { BottomNav } from "@/shared/components/BottomNav";
+import { DetailPageSkeleton } from "@/shared/components/DetailPageSkeleton";
 import { FeedbackMessage } from "@/shared/components/FeedbackMessage";
 import { ScreenHeader } from "@/shared/components/ScreenHeader";
 import { canNavigateBack } from "@/shared/lib/navigation";
@@ -177,7 +178,11 @@ export function QuotePreview(): React.ReactElement {
       />
 
       <section className="mx-auto w-full max-w-3xl">
-        {isLoadingQuote ? <p role="status" className="mt-4 px-4 text-sm text-on-surface-variant">Loading quote...</p> : null}
+        {isLoadingQuote ? (
+          <div role="status" aria-label="Loading quote" className="mt-4 px-4">
+            <DetailPageSkeleton />
+          </div>
+        ) : null}
 
         {loadError ? (
           <div className="mx-4 mt-4">

--- a/frontend/src/features/quotes/tests/QuoteList.test.tsx
+++ b/frontend/src/features/quotes/tests/QuoteList.test.tsx
@@ -532,11 +532,11 @@ describe("QuoteList", () => {
     renderScreen();
 
     expect(screen.queryByText(/active\s*·\s*\d+\s*pending/i)).not.toBeInTheDocument();
-    expect(screen.getByRole("status")).toHaveTextContent("Loading quotes...");
+    expect(screen.getByRole("status", { name: /loading quotes/i })).toBeInTheDocument();
 
     resolveQuotes?.([makeQuoteListItem()]);
     await waitFor(() => {
-      expect(screen.queryByText("Loading quotes...")).not.toBeInTheDocument();
+      expect(screen.queryByRole("status", { name: /loading quotes/i })).not.toBeInTheDocument();
     });
     expect(screen.getByText("0 active · 1 pending")).toBeInTheDocument();
   });

--- a/frontend/src/features/quotes/tests/QuotePreview.test.tsx
+++ b/frontend/src/features/quotes/tests/QuotePreview.test.tsx
@@ -717,7 +717,7 @@ describe("QuotePreview", () => {
 
     renderScreen();
 
-    expect(screen.getByRole("status")).toHaveTextContent("Loading quote...");
+    expect(screen.getByRole("status", { name: /loading quote/i })).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /generate pdf/i })).not.toBeInTheDocument();
   });
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -264,6 +264,27 @@
   font-variation-settings: "FILL" 0, "wght" 400, "GRAD" 0, "opsz" 24;
 }
 
+@keyframes shimmer {
+  0% {
+    background-position: 200% 0;
+  }
+
+  100% {
+    background-position: -200% 0;
+  }
+}
+
+.animate-shimmer {
+  background-image: linear-gradient(
+    90deg,
+    var(--color-surface-container-highest) 0%,
+    var(--color-surface-container-high) 50%,
+    var(--color-surface-container-highest) 100%
+  );
+  background-size: 200% 100%;
+  animation: shimmer 1.5s linear infinite;
+}
+
 body {
   margin: 0;
   background-color: var(--color-background);

--- a/frontend/src/shared/components/DetailPageSkeleton.tsx
+++ b/frontend/src/shared/components/DetailPageSkeleton.tsx
@@ -1,0 +1,25 @@
+import { SkeletonBlock } from "@/shared/components/SkeletonBlock";
+
+interface DetailPageSkeletonProps {
+  className?: string;
+}
+
+export function DetailPageSkeleton({ className }: DetailPageSkeletonProps): React.ReactElement {
+  return (
+    <div className={`space-y-4 ${className ?? ""}`.trim()}>
+      <div className="rounded-xl bg-surface-container-lowest p-4 ghost-shadow">
+        <div className="flex items-center justify-between gap-3">
+          <SkeletonBlock width="48%" height="1.5rem" />
+          <SkeletonBlock width="28%" height="1.5rem" borderRadius="9999px" />
+        </div>
+        <SkeletonBlock className="mt-3" width="36%" height="0.875rem" />
+      </div>
+
+      <div className="space-y-3 rounded-xl bg-surface-container-low p-4">
+        <SkeletonBlock width="100%" height="4.5rem" />
+        <SkeletonBlock width="100%" height="4.5rem" />
+        <SkeletonBlock width="100%" height="4.5rem" />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/shared/components/DocumentCardSkeleton.tsx
+++ b/frontend/src/shared/components/DocumentCardSkeleton.tsx
@@ -1,0 +1,19 @@
+import { SkeletonBlock } from "@/shared/components/SkeletonBlock";
+
+export function DocumentCardSkeleton(): React.ReactElement {
+  return (
+    <div className="w-full rounded-xl bg-surface-container-lowest p-4 ghost-shadow">
+      <div className="flex items-baseline justify-between gap-3">
+        <SkeletonBlock width="52%" height="1rem" />
+        <SkeletonBlock width="26%" height="1rem" />
+      </div>
+      <div className="mt-3 space-y-2">
+        <SkeletonBlock width="64%" height="0.875rem" />
+        <div className="flex items-center justify-between gap-3">
+          <SkeletonBlock width="44%" height="0.875rem" />
+          <SkeletonBlock width="30%" height="1.5rem" borderRadius="9999px" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/shared/components/SkeletonBlock.tsx
+++ b/frontend/src/shared/components/SkeletonBlock.tsx
@@ -1,0 +1,25 @@
+interface SkeletonBlockProps {
+  width?: string | number;
+  height?: string | number;
+  borderRadius?: string | number;
+  className?: string;
+}
+
+export function SkeletonBlock({
+  width = "100%",
+  height = "1rem",
+  borderRadius = "0.5rem",
+  className,
+}: SkeletonBlockProps): React.ReactElement {
+  return (
+    <div
+      aria-hidden="true"
+      className={`animate-shimmer bg-surface-container-highest ${className ?? ""}`.trim()}
+      style={{
+        width,
+        height,
+        borderRadius,
+      }}
+    />
+  );
+}


### PR DESCRIPTION
## Summary
- add shared skeleton primitives: `SkeletonBlock`, `DocumentCardSkeleton`, and `DetailPageSkeleton`
- replace loading text with skeleton states in Quote list/invoice tab, quote preview, invoice detail, and customer detail screens
- replace customer invoice-history loading text with skeleton placeholders
- update affected frontend tests to assert labeled loading status regions
- add a shared shimmer animation utility in `frontend/src/index.css`

## Verification
- make frontend-verify

Closes #311
