### PR TITLE
Task #316: add extraction quality eval suite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help verify backend-verify frontend-verify db-verify template-verify extraction-live extraction-eval
+.PHONY: help verify backend-verify frontend-verify db-verify template-verify extraction-live extraction-eval extraction-quality
 
 help: ## Show available targets
 	@grep -E '^[a-zA-Z_-]+:.*##' $(MAKEFILE_LIST) | awk -F ':.*## ' '{printf "  %-20s %s\n", $$1, $$2}'
@@ -17,7 +17,7 @@ backend-verify: ## Run backend lint, type checks, security scan, and tests
 		.venv/bin/ruff format --check . && \
 		.venv/bin/mypy . --cache-dir .mypy_cache && \
 		.venv/bin/bandit -r app/ -x app/core/tests,app/features/auth/tests,app/features/customers/tests,app/features/profile/tests,app/features/quotes/tests,app/shared/tests && \
-		.venv/bin/pytest -v -m "not live and not extraction_eval" -o cache_dir=.pytest_cache
+		.venv/bin/pytest -v -m "not live and not extraction_eval and not extraction_quality" -o cache_dir=.pytest_cache
 
 frontend-verify: ## Run frontend type checks, lint, tests, and build
 	@if [ "$(SKIP_FILE_SIZE_CHECK)" != "1" ]; then bash scripts/check_file_sizes.sh --scope frontend; fi
@@ -46,3 +46,7 @@ extraction-eval: ## Run manual extraction eval harness (offline by default, set 
 		echo "Running optional live extraction probes (requires ANTHROPIC_API_KEY in backend/.env)"; \
 		cd backend && .venv/bin/pytest app/features/quotes/tests/test_extraction_live.py -m live -s -v -o cache_dir=.pytest_cache; \
 	fi
+
+extraction-quality: ## Run extraction quality eval against real API (requires ANTHROPIC_API_KEY)
+	@test -x backend/.venv/bin/pytest || (echo "Missing backend/.venv. Run: cd backend && python3 -m venv .venv && .venv/bin/pip install -r requirements.txt" && exit 1)
+	@cd backend && .venv/bin/pytest app/features/quotes/tests/test_extraction_quality.py -m extraction_quality -s -v -o cache_dir=.pytest_cache

--- a/backend/app/features/quotes/tests/fixtures/extraction_quality_cases.py
+++ b/backend/app/features/quotes/tests/fixtures/extraction_quality_cases.py
@@ -1,0 +1,297 @@
+"""Ground truth fixtures for extraction quality eval runs."""
+
+from __future__ import annotations
+
+from app.features.quotes.tests.fixtures.transcripts import TRANSCRIPTS
+from app.features.quotes.tests.scoring.extraction_scorer import (
+    ExpectedLineItem,
+    ExtractionQualityCase,
+)
+
+_Q03_SINGLE_ITEM_JOB = "Power wash the driveway. 400 flat."
+_Q04_QUANTITY_MATH = (
+    "Deliver and spread 5 yards of brown mulch across the front beds. "
+    "Mulch is 45 per yard, delivery is a flat 35."
+)
+_Q05_MIXED_SERVICES_AND_MATERIALS = (
+    "Replace the cracked driveway section near the garage, about 800 for the concrete and labor, "
+    "then reseal the whole driveway for 1300. Also need to fix the mailbox post, probably around "
+    "75 for materials and install."
+)
+_Q06_MID_SENTENCE_CORRECTION = (
+    "So we need to power wash the deck, that's 275, and then stain it which was going to be 350 "
+    "but actually let's do 325 for the stain since we already have the sealer. And clean the "
+    "gutters for 150, wait no, 175."
+)
+_Q07_ITEM_DESCRIBED_IN_PARTS = (
+    "Trim the hedges along the back fence - they're about 40 feet of hedge, so that's 200, and "
+    "also edge along the driveway for 85 dollars."
+)
+_Q08_VERBOSE_WITH_FILLER = (
+    "Um, okay so like, we need five yards of brown mulch, uh, edge the front beds, and maybe add "
+    "two hostas by the walkway. The mulch part was around 120 I think. The edging is probably 75 "
+    "and the hostas should be like 40 for both."
+)
+_Q10_TAX_AND_DISCOUNT = (
+    "Weekly lawn maintenance package: mow, edge, and blow for 45 per visit. Annual contract "
+    "discount of 10 percent. Sales tax is 6.5 percent."
+)
+_Q11_VERY_SHORT = "Mow lawn 50"
+_Q12_EXTENDED_MULTI_ITEM = (
+    "Okay so we need a full exterior refresh on the Johnson property. First power wash the siding "
+    "and driveway, that's gonna run about 350 total for both. Then we need to repaint the trim on "
+    "the second floor, I'm figuring 475 for materials and labor. The back deck needs to be sanded "
+    "and resealed, that's 280. We also need to fix two sections of fence that came down in the "
+    "storm - about 120 per section so 240 there. And then clean out all the gutters including the "
+    "second story ones, that's 195. Total on everything should come to 1540."
+)
+_Q13_DUPLICATE_DETECTION = (
+    "Clean gutters for 150. Also clean the gutters on the back side, that's another 150. And check "
+    "the downspouts for 75."
+)
+_Q14_IMPLICIT_SPLIT = (
+    "The front yard needs new sod. We'll need about 500 square feet of Bermuda sod, delivered and "
+    "installed. Installation is 2 per square foot and the sod itself is 1.50 per square foot, plus "
+    "a 75 delivery charge."
+)
+_Q15_LANDSCAPE_JARGON = (
+    "Do a full spring cleanup - dethatch, aerate, and overseed the lawn at 250, prune the "
+    "ornamentals at 175, and apply pre-emergent for 95. Then come back in six weeks for a "
+    "fertilizer app at 65."
+)
+
+
+QUALITY_CASES: tuple[ExtractionQualityCase, ...] = (
+    ExtractionQualityCase(
+        name="Q01_multi_item_exact_prices",
+        transcript=TRANSCRIPTS["clean_with_total"],
+        expected_line_items=(
+            ExpectedLineItem(description="Rear garage floodlights", price=360),
+            ExpectedLineItem(description="Porch switch replacement", price=75),
+        ),
+        expected_total=435,
+        category="services",
+        difficulty="easy",
+        human_notes="Baseline clear transcript with explicit per-item prices and total.",
+    ),
+    ExtractionQualityCase(
+        name="Q02_multi_item_no_prices",
+        transcript=TRANSCRIPTS["clean_no_prices"],
+        expected_line_items=(
+            ExpectedLineItem(description="Trim shrubs", price=None),
+            ExpectedLineItem(description="Edge front flower beds", price=None),
+            ExpectedLineItem(description="Bag leaves from side yard", price=None),
+        ),
+        expected_total=None,
+        expect_prices=False,
+        expect_total=False,
+        category="services",
+        difficulty="easy",
+        human_notes="No explicit pricing should keep extracted prices and total as null.",
+    ),
+    ExtractionQualityCase(
+        name="Q03_single_item_job",
+        transcript=_Q03_SINGLE_ITEM_JOB,
+        expected_line_items=(ExpectedLineItem(description="Power wash driveway", price=400),),
+        expected_total=400,
+        category="services",
+        difficulty="easy",
+        human_notes="Single-item extraction should remain compact with exact pricing.",
+    ),
+    ExtractionQualityCase(
+        name="Q04_quantities_in_description",
+        transcript=_Q04_QUANTITY_MATH,
+        expected_line_items=(
+            ExpectedLineItem(description="Brown mulch", details="5 yards", price=225),
+            ExpectedLineItem(description="Delivery", price=35),
+        ),
+        expected_total=260,
+        category="materials",
+        difficulty="easy",
+        human_notes="Checks quantity math and preservation of quantity context.",
+    ),
+    ExtractionQualityCase(
+        name="Q05_mixed_services_materials",
+        transcript=_Q05_MIXED_SERVICES_AND_MATERIALS,
+        expected_line_items=(
+            ExpectedLineItem(description="Driveway section repair", price=800),
+            ExpectedLineItem(description="Driveway reseal", price=1300),
+            ExpectedLineItem(description="Mailbox post fix", price=75),
+        ),
+        expected_total=2175,
+        category="mixed",
+        difficulty="medium",
+        human_notes="Service and material phrasing is mixed within sentences.",
+    ),
+    ExtractionQualityCase(
+        name="Q06_mid_sentence_correction",
+        transcript=_Q06_MID_SENTENCE_CORRECTION,
+        expected_line_items=(
+            ExpectedLineItem(description="Power wash deck", price=275),
+            ExpectedLineItem(description="Stain deck", price=325),
+            ExpectedLineItem(description="Clean gutters", price=175),
+        ),
+        expected_total=775,
+        category="correction",
+        difficulty="medium",
+        human_notes="Uses corrected prices and ignores superseded earlier values.",
+    ),
+    ExtractionQualityCase(
+        name="Q07_item_described_in_two_parts",
+        transcript=_Q07_ITEM_DESCRIBED_IN_PARTS,
+        expected_line_items=(
+            ExpectedLineItem(
+                description="Trim hedges along back fence", details="40 feet", price=200
+            ),
+            ExpectedLineItem(description="Edge driveway", price=85),
+        ),
+        expected_total=285,
+        category="services",
+        difficulty="medium",
+        human_notes="Length detail should land as details rather than a separate line item.",
+    ),
+    ExtractionQualityCase(
+        name="Q08_verbose_with_filler_words",
+        transcript=_Q08_VERBOSE_WITH_FILLER,
+        expected_line_items=(
+            ExpectedLineItem(description="Brown mulch", price=120),
+            ExpectedLineItem(description="Edge front beds", price=75),
+            ExpectedLineItem(description="Add two hostas", price=40),
+        ),
+        expected_total=235,
+        category="services",
+        difficulty="medium",
+        human_notes="Filler words and hedging should not degrade extraction structure.",
+    ),
+    ExtractionQualityCase(
+        name="Q09_total_only_transcript",
+        transcript=TRANSCRIPTS["total_only"],
+        expected_line_items=(
+            ExpectedLineItem(
+                description="Driveway repair and reseal",
+                price=None,
+                price_tolerance_pct=0.15,
+            ),
+        ),
+        expected_total=2100,
+        expected_line_item_count_min=1,
+        expected_line_item_count_max=3,
+        expect_prices=False,
+        category="services",
+        difficulty="medium",
+        human_notes="Total is explicit, but per-item pricing should remain unspecified.",
+    ),
+    ExtractionQualityCase(
+        name="Q10_tax_and_discount_language",
+        transcript=_Q10_TAX_AND_DISCOUNT,
+        expected_line_items=(
+            ExpectedLineItem(
+                description="Weekly lawn maintenance package",
+                price=45,
+                price_tolerance_pct=0.15,
+            ),
+        ),
+        expected_total=None,
+        expect_total=False,
+        confidence_note_substrings=("discount", "tax"),
+        category="tax_discount",
+        difficulty="medium",
+        human_notes="Discount and tax should appear as confidence notes, not line-item math.",
+    ),
+    ExtractionQualityCase(
+        name="Q11_very_short_transcript",
+        transcript=_Q11_VERY_SHORT,
+        expected_line_items=(ExpectedLineItem(description="Mow lawn", price=50),),
+        expected_total=50,
+        category="services",
+        difficulty="hard",
+        human_notes="Minimal transcript still needs one correct item and total.",
+    ),
+    ExtractionQualityCase(
+        name="Q12_extended_multi_item_transcript",
+        transcript=_Q12_EXTENDED_MULTI_ITEM,
+        expected_line_items=(
+            ExpectedLineItem(
+                description="Power wash siding and driveway", price=350, price_tolerance_pct=0.10
+            ),
+            ExpectedLineItem(
+                description="Repaint second floor trim", price=475, price_tolerance_pct=0.10
+            ),
+            ExpectedLineItem(
+                description="Sand and reseal back deck", price=280, price_tolerance_pct=0.10
+            ),
+            ExpectedLineItem(
+                description="Fix fence sections",
+                details="two sections",
+                price=240,
+                price_tolerance_pct=0.10,
+            ),
+            ExpectedLineItem(
+                description="Clean gutters including second story",
+                price=195,
+                price_tolerance_pct=0.10,
+            ),
+        ),
+        expected_total=1540,
+        category="long_transcript",
+        difficulty="hard",
+        cost_tier="high",
+        human_notes="Longest expensive run; skipped in cheap iteration with SKIP_HIGH_COST.",
+    ),
+    ExtractionQualityCase(
+        name="Q13_duplicate_detection",
+        transcript=_Q13_DUPLICATE_DETECTION,
+        expected_line_items=(
+            ExpectedLineItem(
+                description="Clean gutters",
+                price=150,
+                expected_flagged=True,
+                expected_flag_reason_substring="duplicate",
+            ),
+            ExpectedLineItem(
+                description="Clean gutters back side",
+                price=150,
+                expected_flagged=True,
+                expected_flag_reason_substring="duplicate",
+            ),
+            ExpectedLineItem(description="Check downspouts", price=75),
+        ),
+        expected_total=375,
+        category="services",
+        difficulty="hard",
+        human_notes="Duplicate-like entries should still extract with duplicate flags.",
+    ),
+    ExtractionQualityCase(
+        name="Q14_item_split_across_sentences",
+        transcript=_Q14_IMPLICIT_SPLIT,
+        expected_line_items=(
+            ExpectedLineItem(description="Sod installation", price=1000, price_tolerance_pct=0.15),
+            ExpectedLineItem(
+                description="Bermuda sod material", price=750, price_tolerance_pct=0.15
+            ),
+            ExpectedLineItem(description="Delivery", price=75, price_tolerance_pct=0.15),
+        ),
+        expected_total=1825,
+        category="materials",
+        difficulty="hard",
+        human_notes="Canonical split keeps labor/material separate while allowing tolerance.",
+    ),
+    ExtractionQualityCase(
+        name="Q15_landscape_jargon_future_followup",
+        transcript=_Q15_LANDSCAPE_JARGON,
+        expected_line_items=(
+            ExpectedLineItem(description="Dethatch aerate overseed lawn", price=250),
+            ExpectedLineItem(description="Prune ornamentals", price=175),
+            ExpectedLineItem(description="Apply pre-emergent", price=95),
+            ExpectedLineItem(
+                description="Fertilizer application in six weeks",
+                price=65,
+                must_match=False,
+            ),
+        ),
+        expected_total=585,
+        category="landscape",
+        difficulty="hard",
+        human_notes="Future follow-up line item is optional bonus due possible exclusion behavior.",
+    ),
+)

--- a/backend/app/features/quotes/tests/scoring/__init__.py
+++ b/backend/app/features/quotes/tests/scoring/__init__.py
@@ -1,0 +1,1 @@
+"""Scoring helpers for quote extraction test suites."""

--- a/backend/app/features/quotes/tests/scoring/extraction_scorer.py
+++ b/backend/app/features/quotes/tests/scoring/extraction_scorer.py
@@ -1,0 +1,433 @@
+"""Scoring utilities for manual extraction quality evaluation runs."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass
+from difflib import SequenceMatcher
+from math import isclose
+from typing import Any, Literal
+
+from app.features.quotes.schemas import ExtractionResult, LineItemExtracted
+from app.integrations.extraction import ExtractionCallMetadata
+
+_DESCRIPTION_MATCH_THRESHOLD = 0.4
+_WHITESPACE_PATTERN = re.compile(r"\s+")
+
+
+@dataclass(frozen=True, slots=True)
+class ExpectedLineItem:
+    """Ground truth definition for one expected extraction line item."""
+
+    description: str
+    price: float | None = None
+    details: str | None = None
+    must_match: bool = True
+    expected_flagged: bool = False
+    expected_flag_reason_substring: str | None = None
+    price_tolerance_pct: float = 0.05
+
+
+@dataclass(frozen=True, slots=True)
+class ExtractionQualityCase:
+    """Ground truth case for extraction quality measurement."""
+
+    name: str
+    transcript: str
+    expected_line_items: tuple[ExpectedLineItem, ...]
+    expected_total: float | None = None
+    expected_total_tolerance_pct: float = 0.05
+    expected_line_item_count_min: int | None = None
+    expected_line_item_count_max: int | None = None
+    expect_prices: bool = True
+    expect_total: bool = True
+    confidence_note_substrings: tuple[str, ...] = ()
+    category: str = "general"
+    difficulty: Literal["easy", "medium", "hard"] = "medium"
+    cost_tier: Literal["standard", "high"] = "standard"
+    human_notes: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class ItemMatchResult:
+    """Scored match result for one expected line item."""
+
+    expected: ExpectedLineItem
+    matched: bool
+    description_score: float
+    price_score: float
+    details_score: float | None
+    flag_score: float | None
+
+
+@dataclass(frozen=True, slots=True)
+class CaseScore:
+    """Per-case extraction quality score and supporting metrics."""
+
+    name: str
+    category: str
+    difficulty: str
+    item_scores: tuple[ItemMatchResult, ...]
+    total_score: float
+    confidence_note_score: float | None
+    precision: float
+    recall: float
+    extras_count: int
+    missing_count: int
+    overall: float
+
+
+def _normalize_text(value: str) -> str:
+    return _WHITESPACE_PATTERN.sub(" ", value).strip().casefold()
+
+
+def _description_similarity(left: str, right: str) -> float:
+    left_norm = _normalize_text(left)
+    right_norm = _normalize_text(right)
+    if not left_norm or not right_norm:
+        return 0.0
+    return SequenceMatcher(a=left_norm, b=right_norm).ratio()
+
+
+def _average(values: Iterable[float], *, default: float) -> float:
+    values_list = list(values)
+    if not values_list:
+        return default
+    return sum(values_list) / len(values_list)
+
+
+def _clamp(value: float, *, lower: float = 0.0, upper: float = 1.0) -> float:
+    return max(lower, min(upper, value))
+
+
+def _is_same_order_of_magnitude(expected: float, actual: float) -> bool:
+    if expected == 0:
+        return actual == 0
+    ratio = abs(actual) / abs(expected)
+    return 0.1 <= ratio <= 10.0
+
+
+def _score_price(
+    expected_price: float | None, actual_price: float | None, tolerance_pct: float
+) -> float:
+    if expected_price is None:
+        return 1.0 if actual_price is None else 0.0
+
+    if actual_price is None:
+        return 0.5
+
+    if isclose(expected_price, actual_price, abs_tol=0.01):
+        return 1.0
+
+    tolerance = abs(expected_price) * max(tolerance_pct, 0.0)
+    if abs(actual_price - expected_price) <= tolerance:
+        return 0.75
+
+    if _is_same_order_of_magnitude(expected_price, actual_price):
+        return 0.25
+    return 0.0
+
+
+def _score_details(
+    expected_details: str | None, actual_details: str | None, *, matched: bool
+) -> float | None:
+    if expected_details is None:
+        return None
+    if not matched:
+        return 0.0
+    if actual_details is None or not actual_details.strip():
+        return 0.5
+
+    expected_norm = _normalize_text(expected_details)
+    actual_norm = _normalize_text(actual_details)
+    return 1.0 if expected_norm in actual_norm else 0.0
+
+
+def _score_flag(
+    expected: ExpectedLineItem, actual: LineItemExtracted | None, *, matched: bool
+) -> float | None:
+    if not expected.expected_flagged:
+        return None
+    if not matched or actual is None:
+        return 0.0
+    if not actual.flagged:
+        return 0.0
+
+    if expected.expected_flag_reason_substring is None:
+        return 1.0
+
+    flag_reason = actual.flag_reason or ""
+    expected_fragment = expected.expected_flag_reason_substring.casefold()
+    return 1.0 if expected_fragment in flag_reason.casefold() else 0.0
+
+
+def _best_candidate_index(
+    expected: ExpectedLineItem,
+    actual: Sequence[LineItemExtracted],
+    consumed_indices: set[int],
+) -> tuple[int, float] | None:
+    best_index: int | None = None
+    best_score = 0.0
+
+    for index, item in enumerate(actual):
+        if index in consumed_indices:
+            continue
+        similarity = _description_similarity(expected.description, item.description)
+        if similarity < _DESCRIPTION_MATCH_THRESHOLD:
+            continue
+        if similarity > best_score:
+            best_index = index
+            best_score = similarity
+
+    if best_index is None:
+        return None
+    return best_index, best_score
+
+
+def match_line_items(
+    expected: Sequence[ExpectedLineItem],
+    actual: Sequence[LineItemExtracted],
+) -> list[ItemMatchResult]:
+    """Greedy one-to-one assignment of expected items to output line items."""
+
+    prioritized_indices = sorted(
+        range(len(expected)),
+        key=lambda index: (0 if expected[index].must_match else 1, index),
+    )
+    consumed_indices: set[int] = set()
+    results_by_index: list[ItemMatchResult | None] = [None] * len(expected)
+
+    for expected_index in prioritized_indices:
+        expected_item = expected[expected_index]
+        candidate = _best_candidate_index(expected_item, actual, consumed_indices)
+
+        if candidate is None:
+            results_by_index[expected_index] = ItemMatchResult(
+                expected=expected_item,
+                matched=False,
+                description_score=0.0,
+                price_score=0.0,
+                details_score=_score_details(expected_item.details, None, matched=False),
+                flag_score=_score_flag(expected_item, None, matched=False),
+            )
+            continue
+
+        actual_index, description_score = candidate
+        consumed_indices.add(actual_index)
+        actual_item = actual[actual_index]
+        results_by_index[expected_index] = ItemMatchResult(
+            expected=expected_item,
+            matched=True,
+            description_score=description_score,
+            price_score=_score_price(
+                expected_item.price,
+                actual_item.price,
+                expected_item.price_tolerance_pct,
+            ),
+            details_score=_score_details(
+                expected_item.details,
+                actual_item.details,
+                matched=True,
+            ),
+            flag_score=_score_flag(expected_item, actual_item, matched=True),
+        )
+
+    return [result for result in results_by_index if result is not None]
+
+
+def _score_total(
+    expected_total: float | None, actual_total: float | None, tolerance_pct: float
+) -> float:
+    if expected_total is None:
+        return 1.0 if actual_total is None else 0.0
+    if actual_total is None:
+        return 0.0
+    if isclose(expected_total, actual_total, abs_tol=0.01):
+        return 1.0
+
+    tolerance = abs(expected_total) * max(tolerance_pct, 0.0)
+    distance = abs(actual_total - expected_total)
+    if distance <= tolerance:
+        return 0.9
+    if distance <= (2 * tolerance):
+        return 0.3
+    return 0.0
+
+
+def _score_confidence_notes(expected: Sequence[str], actual_notes: Sequence[str]) -> float | None:
+    if not expected:
+        return None
+
+    folded_notes = [note.casefold() for note in actual_notes]
+    found_count = 0
+    for fragment in expected:
+        folded_fragment = fragment.casefold()
+        if any(folded_fragment in note for note in folded_notes):
+            found_count += 1
+
+    return found_count / len(expected)
+
+
+def _description_recall(item_scores: Sequence[ItemMatchResult]) -> float:
+    must_match_items = [
+        score.description_score for score in item_scores if score.expected.must_match
+    ]
+    return _average(must_match_items, default=1.0)
+
+
+def _price_accuracy(item_scores: Sequence[ItemMatchResult]) -> float:
+    priced_items = [score.price_score for score in item_scores if score.expected.price is not None]
+    return _average(priced_items, default=1.0)
+
+
+def _details_accuracy(item_scores: Sequence[ItemMatchResult]) -> float:
+    details_items = [
+        score.details_score
+        for score in item_scores
+        if score.expected.details is not None and score.details_score is not None
+    ]
+    return _average((float(value) for value in details_items), default=1.0)
+
+
+def score_case(
+    case: ExtractionQualityCase,
+    result: ExtractionResult,
+    metadata: ExtractionCallMetadata | None = None,
+) -> CaseScore:
+    """Score one extraction result against a quality case ground truth."""
+
+    _ = metadata  # Reserved for future scoring dimensions tied to call metadata.
+
+    item_scores = tuple(match_line_items(case.expected_line_items, result.line_items))
+
+    matched_count = sum(1 for score in item_scores if score.matched)
+    extras_count = max(len(result.line_items) - matched_count, 0)
+
+    required_item_scores = [score for score in item_scores if score.expected.must_match]
+    missing_count = sum(1 for score in required_item_scores if not score.matched)
+
+    true_positives = matched_count
+    false_positives = extras_count
+    precision_denominator = true_positives + false_positives
+    precision = true_positives / precision_denominator if precision_denominator else 1.0
+
+    required_total = len(required_item_scores)
+    recall = (required_total - missing_count) / required_total if required_total else 1.0
+
+    description_recall = _description_recall(item_scores)
+    price_accuracy = _price_accuracy(item_scores)
+    details_accuracy = _details_accuracy(item_scores)
+    total_score = _score_total(case.expected_total, result.total, case.expected_total_tolerance_pct)
+    extras_penalty = min(extras_count / max(len(case.expected_line_items), 1), 1.0)
+
+    overall = _clamp(
+        (0.40 * description_recall)
+        + (0.25 * price_accuracy)
+        + (0.15 * total_score)
+        + (0.10 * details_accuracy)
+        + (0.10 * (1.0 - extras_penalty))
+    )
+
+    confidence_note_score = _score_confidence_notes(
+        case.confidence_note_substrings,
+        result.confidence_notes,
+    )
+
+    return CaseScore(
+        name=case.name,
+        category=case.category,
+        difficulty=case.difficulty,
+        item_scores=item_scores,
+        total_score=total_score,
+        confidence_note_score=confidence_note_score,
+        precision=precision,
+        recall=recall,
+        extras_count=extras_count,
+        missing_count=missing_count,
+        overall=overall,
+    )
+
+
+def aggregate_scores(scores: Sequence[CaseScore]) -> dict[str, Any]:
+    """Compute overall, category, and difficulty score aggregates."""
+
+    if not scores:
+        return {
+            "overall": 0.0,
+            "count": 0,
+            "by_category": {},
+            "by_difficulty": {},
+        }
+
+    def _group_average(
+        values: Sequence[CaseScore], field: str
+    ) -> dict[str, dict[str, float | int]]:
+        grouped: dict[str, list[float]] = {}
+        for score in values:
+            group = getattr(score, field)
+            grouped.setdefault(group, []).append(score.overall)
+        return {
+            group: {"average": sum(group_scores) / len(group_scores), "count": len(group_scores)}
+            for group, group_scores in grouped.items()
+        }
+
+    return {
+        "overall": sum(score.overall for score in scores) / len(scores),
+        "count": len(scores),
+        "by_category": _group_average(scores, "category"),
+        "by_difficulty": _group_average(scores, "difficulty"),
+    }
+
+
+def format_report(cases: Sequence[ExtractionQualityCase], scores: Sequence[CaseScore]) -> str:
+    """Build a concise human-readable report for quality eval runs."""
+
+    score_by_name = {score.name: score for score in scores}
+    lines: list[str] = ["=== EXTRACTION QUALITY REPORT ==="]
+
+    for case in cases:
+        score = score_by_name.get(case.name)
+        if score is None:
+            continue
+
+        matched_count = sum(1 for item_score in score.item_scores if item_score.matched)
+        expected_count = len(case.expected_line_items)
+        description_recall = _description_recall(score.item_scores)
+        price_accuracy = _price_accuracy(score.item_scores)
+        details_items_exist = any(item.expected.details is not None for item in score.item_scores)
+        details_accuracy = _details_accuracy(score.item_scores) if details_items_exist else None
+
+        lines.append(f"[{case.name}] {case.difficulty}/{case.category}")
+        lines.append(
+            f"  Items: {matched_count}/{expected_count} matched, {score.extras_count} extras"
+        )
+        details_label = f"{details_accuracy:.2f}" if details_accuracy is not None else "n/a"
+        lines.append(
+            "  Description: "
+            f"{description_recall:.2f}  Price: {price_accuracy:.2f}  "
+            f"Details: {details_label}  Total: {score.total_score:.2f}"
+        )
+        if score.confidence_note_score is not None:
+            lines.append(f"  Confidence notes: {score.confidence_note_score:.2f}")
+        lines.append(f"  Overall: {score.overall:.2f}")
+
+    summary = aggregate_scores(scores)
+    lines.append("=== EXTRACTION QUALITY SUMMARY ===")
+    lines.append(f"Overall: {summary['overall']:.2f}")
+    lines.append("By category:")
+    for category in sorted(summary["by_category"].keys()):
+        category_summary = summary["by_category"][category]
+        lines.append(
+            f"  {category}: {category_summary['average']:.2f} ({category_summary['count']} cases)"
+        )
+    lines.append("By difficulty:")
+    for difficulty in sorted(summary["by_difficulty"].keys()):
+        difficulty_summary = summary["by_difficulty"][difficulty]
+        lines.append(
+            "  "
+            f"{difficulty}: {difficulty_summary['average']:.2f} "
+            f"({difficulty_summary['count']} cases)"
+        )
+
+    return "\n".join(lines)

--- a/backend/app/features/quotes/tests/test_extraction_quality.py
+++ b/backend/app/features/quotes/tests/test_extraction_quality.py
@@ -1,0 +1,98 @@
+"""Manual extraction quality eval suite against the real extraction provider."""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from app.core.config import get_settings
+from app.features.quotes.tests.fixtures.extraction_quality_cases import QUALITY_CASES
+from app.features.quotes.tests.scoring.extraction_scorer import (
+    ExtractionQualityCase,
+    aggregate_scores,
+    format_report,
+    score_case,
+)
+from app.integrations.extraction import ExtractionCallMetadata, ExtractionIntegration
+
+_SETTINGS = get_settings()
+
+pytestmark = [
+    pytest.mark.asyncio,
+    pytest.mark.extraction_quality,
+    pytest.mark.skipif(
+        not _SETTINGS.anthropic_api_key.strip(),
+        reason="Extraction quality tests require ANTHROPIC_API_KEY in backend/.env",
+    ),
+]
+
+
+def _build_integration() -> ExtractionIntegration:
+    return ExtractionIntegration(
+        api_key=_SETTINGS.anthropic_api_key,
+        model=_SETTINGS.extraction_model,
+        fallback_model=_SETTINGS.extraction_fallback_model,
+        primary_prompt_variant=_SETTINGS.extraction_primary_prompt_variant,
+        fallback_prompt_variant=_SETTINGS.extraction_fallback_prompt_variant,
+    )
+
+
+def _skip_high_cost_enabled() -> bool:
+    raw_value = os.environ.get("SKIP_HIGH_COST")
+    if raw_value is None:
+        return False
+    return raw_value.strip().casefold() not in {"", "0", "false", "no"}
+
+
+def _selected_cases() -> tuple[ExtractionQualityCase, ...]:
+    if not _skip_high_cost_enabled():
+        return QUALITY_CASES
+    return tuple(case for case in QUALITY_CASES if case.cost_tier != "high")
+
+
+def _format_token_usage(metadata: ExtractionCallMetadata | None) -> str:
+    if metadata is None or metadata.token_usage is None:
+        return "token_usage=None"
+
+    usage = ", ".join(f"{key}={value}" for key, value in sorted(metadata.token_usage.items()))
+    model_id = metadata.model_id or "unknown"
+    return f"token_usage=({usage}) tier={metadata.invocation_tier} model={model_id}"
+
+
+async def test_extraction_quality_suite() -> None:
+    selected_cases = _selected_cases()
+
+    assert len(QUALITY_CASES) == 15
+    assert selected_cases
+    if _skip_high_cost_enabled():
+        assert not any(case.name.startswith("Q12") for case in selected_cases)
+
+    integration = _build_integration()
+    scores = []
+
+    for case in selected_cases:
+        result = await integration.extract(case.transcript)
+        metadata = integration.pop_last_call_metadata()
+
+        case_score = score_case(case, result, metadata=metadata)
+        scores.append(case_score)
+
+        print(f"[{case.name}] {case.difficulty}/{case.category}")
+        print(f"  {_format_token_usage(metadata)}")
+        print(
+            "  "
+            f"overall={case_score.overall:.2f} "
+            f"precision={case_score.precision:.2f} "
+            f"recall={case_score.recall:.2f}"
+        )
+
+        assert 0.0 <= case_score.overall <= 1.0
+        assert 0.0 <= case_score.total_score <= 1.0
+
+    print(format_report(selected_cases, scores))
+    aggregate = aggregate_scores(scores)
+    print(f"Selected cases: {len(selected_cases)} / {len(QUALITY_CASES)}")
+    print(f"Aggregate overall: {aggregate['overall']:.2f}")
+
+    assert 0.0 <= aggregate["overall"] <= 1.0

--- a/backend/app/features/quotes/tests/test_extraction_quality.py
+++ b/backend/app/features/quotes/tests/test_extraction_quality.py
@@ -75,6 +75,12 @@ async def test_extraction_quality_suite() -> None:
         result = await integration.extract(case.transcript)
         metadata = integration.pop_last_call_metadata()
 
+        line_item_count = len(result.line_items)
+        if case.expected_line_item_count_min is not None:
+            assert line_item_count >= case.expected_line_item_count_min
+        if case.expected_line_item_count_max is not None:
+            assert line_item_count <= case.expected_line_item_count_max
+
         case_score = score_case(case, result, metadata=metadata)
         scores.append(case_score)
 

--- a/backend/app/features/quotes/tests/test_extraction_scorer.py
+++ b/backend/app/features/quotes/tests/test_extraction_scorer.py
@@ -1,0 +1,221 @@
+"""Offline unit tests for extraction quality scoring utilities."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.features.quotes.schemas import ExtractionResult, LineItemExtracted
+from app.features.quotes.tests.scoring import extraction_scorer as scorer_module
+from app.features.quotes.tests.scoring.extraction_scorer import (
+    CaseScore,
+    ExpectedLineItem,
+    ExtractionQualityCase,
+    _score_price,
+    _score_total,
+    aggregate_scores,
+    format_report,
+    match_line_items,
+    score_case,
+)
+
+
+def _item(
+    description: str,
+    *,
+    price: float | None = None,
+    details: str | None = None,
+    flagged: bool = False,
+    flag_reason: str | None = None,
+) -> LineItemExtracted:
+    return LineItemExtracted(
+        description=description,
+        price=price,
+        details=details,
+        flagged=flagged,
+        flag_reason=flag_reason,
+    )
+
+
+def _result(
+    line_items: list[LineItemExtracted],
+    *,
+    total: float | None = None,
+    confidence_notes: list[str] | None = None,
+) -> ExtractionResult:
+    return ExtractionResult(
+        transcript="unit test transcript",
+        line_items=line_items,
+        total=total,
+        confidence_notes=confidence_notes or [],
+    )
+
+
+def test_match_line_items_enforces_one_to_one_consumption() -> None:
+    expected = (
+        ExpectedLineItem(description="clean gutters"),
+        ExpectedLineItem(description="clean gutters back side"),
+    )
+    actual = [_item("clean gutters")]
+
+    matches = match_line_items(expected, actual)
+
+    assert len(matches) == 2
+    assert sum(1 for match in matches if match.matched) == 1
+
+
+def test_score_case_zero_division_guards_no_must_match_items() -> None:
+    case = ExtractionQualityCase(
+        name="no_must_match",
+        transcript="optional only",
+        expected_line_items=(
+            ExpectedLineItem(description="optional service", must_match=False),
+        ),
+        expected_total=None,
+    )
+
+    score = score_case(case, _result([]))
+
+    assert score.recall == 1.0
+    assert score.missing_count == 0
+
+
+def test_score_case_zero_division_guards_no_priced_or_details_items() -> None:
+    case = ExtractionQualityCase(
+        name="no_price_no_details",
+        transcript="trim shrubs",
+        expected_line_items=(
+            ExpectedLineItem(description="trim shrubs", price=None, details=None),
+        ),
+        expected_total=None,
+    )
+
+    score = score_case(case, _result([_item("trim shrubs")]))
+
+    assert score.overall == pytest.approx(1.0)
+    assert score.total_score == pytest.approx(1.0)
+
+
+def test_score_case_clamps_overall_upper_bound(monkeypatch: pytest.MonkeyPatch) -> None:
+    case = ExtractionQualityCase(
+        name="clamp_upper",
+        transcript="x",
+        expected_line_items=(ExpectedLineItem(description="x"),),
+    )
+    result = _result([_item("x")])
+
+    monkeypatch.setattr(scorer_module, "_description_recall", lambda _: 5.0)
+    monkeypatch.setattr(scorer_module, "_price_accuracy", lambda _: 5.0)
+    monkeypatch.setattr(scorer_module, "_details_accuracy", lambda _: 5.0)
+    monkeypatch.setattr(scorer_module, "_score_total", lambda *_args: 5.0)
+
+    score = score_case(case, result)
+
+    assert score.overall == 1.0
+
+
+def test_score_case_clamps_overall_lower_bound(monkeypatch: pytest.MonkeyPatch) -> None:
+    case = ExtractionQualityCase(
+        name="clamp_lower",
+        transcript="x",
+        expected_line_items=(ExpectedLineItem(description="x"),),
+    )
+    result = _result([_item("x")])
+
+    monkeypatch.setattr(scorer_module, "_description_recall", lambda _: -5.0)
+    monkeypatch.setattr(scorer_module, "_price_accuracy", lambda _: -5.0)
+    monkeypatch.setattr(scorer_module, "_details_accuracy", lambda _: -5.0)
+    monkeypatch.setattr(scorer_module, "_score_total", lambda *_args: -5.0)
+
+    score = score_case(case, result)
+
+    assert score.overall == 0.0
+
+
+def test_score_price_tier_bands() -> None:
+    assert _score_price(None, None, 0.05) == 1.0
+    assert _score_price(100.0, None, 0.05) == 0.5
+    assert _score_price(100.0, 100.0, 0.05) == 1.0
+    assert _score_price(100.0, 104.0, 0.05) == 0.75
+    assert _score_price(100.0, 130.0, 0.05) == 0.25
+    assert _score_price(100.0, 2000.0, 0.05) == 0.0
+
+
+def test_score_total_tolerance_bands() -> None:
+    assert _score_total(None, None, 0.05) == 1.0
+    assert _score_total(None, 10.0, 0.05) == 0.0
+    assert _score_total(100.0, 100.0, 0.05) == 1.0
+    assert _score_total(100.0, 104.0, 0.05) == 0.9
+    assert _score_total(100.0, 108.0, 0.05) == 0.3
+    assert _score_total(100.0, 111.0, 0.05) == 0.0
+
+
+def test_aggregate_scores_groups_by_category_and_difficulty() -> None:
+    scores = (
+        CaseScore(
+            name="a",
+            category="services",
+            difficulty="easy",
+            item_scores=(),
+            total_score=1.0,
+            confidence_note_score=None,
+            precision=1.0,
+            recall=1.0,
+            extras_count=0,
+            missing_count=0,
+            overall=0.8,
+        ),
+        CaseScore(
+            name="b",
+            category="services",
+            difficulty="hard",
+            item_scores=(),
+            total_score=1.0,
+            confidence_note_score=None,
+            precision=1.0,
+            recall=1.0,
+            extras_count=0,
+            missing_count=0,
+            overall=0.6,
+        ),
+        CaseScore(
+            name="c",
+            category="materials",
+            difficulty="easy",
+            item_scores=(),
+            total_score=1.0,
+            confidence_note_score=None,
+            precision=1.0,
+            recall=1.0,
+            extras_count=0,
+            missing_count=0,
+            overall=1.0,
+        ),
+    )
+
+    aggregate = aggregate_scores(scores)
+
+    assert aggregate["overall"] == pytest.approx((0.8 + 0.6 + 1.0) / 3)
+    assert aggregate["by_category"]["services"]["average"] == pytest.approx(0.7)
+    assert aggregate["by_category"]["services"]["count"] == 2
+    assert aggregate["by_difficulty"]["easy"]["average"] == pytest.approx(0.9)
+    assert aggregate["by_difficulty"]["easy"]["count"] == 2
+
+
+def test_format_report_includes_case_lines_and_summary() -> None:
+    case = ExtractionQualityCase(
+        name="report_case",
+        transcript="trim shrubs for 50",
+        expected_line_items=(ExpectedLineItem(description="trim shrubs", price=50),),
+        expected_total=50,
+        category="services",
+        difficulty="easy",
+    )
+    score = score_case(case, _result([_item("trim shrubs", price=50)], total=50))
+
+    report = format_report((case,), (score,))
+
+    assert "=== EXTRACTION QUALITY REPORT ===" in report
+    assert "[report_case] easy/services" in report
+    assert "=== EXTRACTION QUALITY SUMMARY ===" in report
+    assert "By category:" in report
+    assert "By difficulty:" in report

--- a/backend/app/features/quotes/tests/test_extraction_scorer.py
+++ b/backend/app/features/quotes/tests/test_extraction_scorer.py
@@ -67,9 +67,7 @@ def test_score_case_zero_division_guards_no_must_match_items() -> None:
     case = ExtractionQualityCase(
         name="no_must_match",
         transcript="optional only",
-        expected_line_items=(
-            ExpectedLineItem(description="optional service", must_match=False),
-        ),
+        expected_line_items=(ExpectedLineItem(description="optional service", must_match=False),),
         expected_total=None,
     )
 

--- a/backend/pytest.ini
+++ b/backend/pytest.ini
@@ -6,3 +6,4 @@ addopts = -v --tb=short
 markers =
     live: Tests that call real external APIs (excluded from CI)
     extraction_eval: Manual extraction eval harness checks (manual-only, excluded from backend-verify)
+    extraction_quality: Extraction quality eval (real API, manual only, excluded from backend-verify)


### PR DESCRIPTION
## Summary
- add extraction quality scoring module with greedy one-to-one matching and weighted per-case scoring
- add 15 quality ground-truth cases (Q01-Q15) and a live quality runner with token usage reporting
- add extraction_quality pytest marker and Makefile extraction-quality target
- exclude extraction_quality from backend-verify marker selection

## Verification
- cd backend && .venv/bin/ruff check app/features/quotes/tests/scoring/extraction_scorer.py app/features/quotes/tests/fixtures/extraction_quality_cases.py app/features/quotes/tests/test_extraction_quality.py
- cd backend && .venv/bin/mypy app/features/quotes/tests/scoring/extraction_scorer.py app/features/quotes/tests/fixtures/extraction_quality_cases.py app/features/quotes/tests/test_extraction_quality.py
- cd backend && .venv/bin/pytest app/features/quotes/tests/ -m extraction_eval -v -o cache_dir=.pytest_cache
- cd backend && SKIP_HIGH_COST=1 .venv/bin/pytest app/features/quotes/tests/test_extraction_quality.py -m extraction_quality -v -o cache_dir=.pytest_cache
- SKIP_HIGH_COST=1 make extraction-quality
- make extraction-eval
- make backend-verify

Closes #316
