### PR TITLE
Task #317: add extraction eval pipeline invariant cases

### DIFF
--- a/backend/app/features/quotes/tests/fixtures/extraction_eval_cases.py
+++ b/backend/app/features/quotes/tests/fixtures/extraction_eval_cases.py
@@ -255,8 +255,7 @@ EXTRACTION_EVAL_CASES: tuple[ExtractionEvalCase, ...] = (
     ExtractionEvalCase(
         name="total_mismatch_transcript",
         transcript=(
-            "Paint fence for 150 and replace gate latch for 100. "
-            "Customer says total should be 225."
+            "Paint fence for 150 and replace gate latch for 100. Customer says total should be 225."
         ),
         provider_events=(
             {
@@ -298,9 +297,7 @@ EXTRACTION_EVAL_CASES: tuple[ExtractionEvalCase, ...] = (
     ),
     ExtractionEvalCase(
         name="duplicate_line_items_in_transcript",
-        transcript=(
-            "Clean gutters for 150, also clean the gutters on the back for 150."
-        ),
+        transcript=("Clean gutters for 150, also clean the gutters on the back for 150."),
         provider_events=(
             {
                 "type": "tool_use",

--- a/backend/app/features/quotes/tests/fixtures/extraction_eval_cases.py
+++ b/backend/app/features/quotes/tests/fixtures/extraction_eval_cases.py
@@ -32,6 +32,8 @@ class ExtractionEvalCase:
     expect_line_item_count_min: int | None = None
     expect_line_item_count_max: int | None = None
     expect_confidence_note_substrings: tuple[str, ...] = ()
+    expect_all_line_items_flagged: bool | None = None
+    expect_flag_reason_substrings: tuple[str, ...] = ()
     expect_repair_attempted: bool | None = None
     expect_repair_outcome: (
         Literal[
@@ -249,5 +251,120 @@ EXTRACTION_EVAL_CASES: tuple[ExtractionEvalCase, ...] = (
         expect_repair_attempted=False,
         expect_repair_outcome="not_attempted",
         human_notes="Boundary probe at/above semantic transcript + word thresholds.",
+    ),
+    ExtractionEvalCase(
+        name="total_mismatch_transcript",
+        transcript=(
+            "Paint fence for 150 and replace gate latch for 100. "
+            "Customer says total should be 225."
+        ),
+        provider_events=(
+            {
+                "type": "tool_use",
+                "input": {
+                    "transcript": (
+                        "Paint fence for 150 and replace gate latch for 100. "
+                        "Customer says total should be 225."
+                    ),
+                    "line_items": [
+                        {
+                            "description": "Paint fence",
+                            "details": None,
+                            "price": 150,
+                        },
+                        {
+                            "description": "Replace gate latch",
+                            "details": None,
+                            "price": 100,
+                        },
+                    ],
+                    "total": 225,
+                    "confidence_notes": [
+                        "Stated total does not match line item sum; review total before sending."
+                    ],
+                },
+            },
+        ),
+        expected_models=("primary-model",),
+        expected_invocation_tier="primary",
+        expect_total_matches_priced_sum=True,
+        expect_extraction_tier="primary",
+        expect_line_item_count_min=2,
+        expect_line_item_count_max=2,
+        expect_confidence_note_substrings=("does not match line item sum",),
+        expect_repair_attempted=False,
+        expect_repair_outcome="not_attempted",
+        human_notes="Total mismatch should recalculate or provide explicit mismatch guidance.",
+    ),
+    ExtractionEvalCase(
+        name="duplicate_line_items_in_transcript",
+        transcript=(
+            "Clean gutters for 150, also clean the gutters on the back for 150."
+        ),
+        provider_events=(
+            {
+                "type": "tool_use",
+                "input": {
+                    "transcript": (
+                        "Clean gutters for 150, also clean the gutters on the back for 150."
+                    ),
+                    "line_items": [
+                        {
+                            "description": "Clean gutters",
+                            "details": "Front",
+                            "price": 150,
+                        },
+                        {
+                            "description": "Clean gutters",
+                            "details": "Back",
+                            "price": 150,
+                        },
+                    ],
+                    "total": 300,
+                    "confidence_notes": [],
+                },
+            },
+        ),
+        expected_models=("primary-model",),
+        expected_invocation_tier="primary",
+        expect_total_matches_priced_sum=True,
+        expect_extraction_tier="primary",
+        expect_line_item_count_min=2,
+        expect_line_item_count_max=2,
+        expect_all_line_items_flagged=True,
+        expect_flag_reason_substrings=("duplicate",),
+        expect_repair_attempted=False,
+        expect_repair_outcome="not_attempted",
+        human_notes="Duplicate post-validation semantic flagging should mark both entries.",
+    ),
+    ExtractionEvalCase(
+        name="very_short_transcript",
+        transcript="Mow lawn 50",
+        provider_events=(
+            {
+                "type": "tool_use",
+                "input": {
+                    "transcript": "Mow lawn 50",
+                    "line_items": [
+                        {
+                            "description": "Mow lawn",
+                            "details": None,
+                            "price": 50,
+                        }
+                    ],
+                    "total": 50,
+                    "confidence_notes": [],
+                },
+            },
+        ),
+        expected_models=("primary-model",),
+        expected_invocation_tier="primary",
+        expect_total_matches_priced_sum=True,
+        expect_extraction_tier="primary",
+        expect_line_item_count_min=1,
+        expect_line_item_count_max=1,
+        expect_repair_attempted=False,
+        expect_repair_outcome="not_attempted",
+        human_notes="Very short transcripts should not trip empty-items semantic degradation.",
     ),
 )

--- a/backend/app/features/quotes/tests/test_extraction_eval.py
+++ b/backend/app/features/quotes/tests/test_extraction_eval.py
@@ -18,7 +18,11 @@ from app.features.quotes.tests.fixtures.extraction_eval_cases import (
     EXTRACTION_EVAL_CASES,
     ExtractionEvalCase,
 )
-from app.integrations.extraction import ExtractionCallMetadata, ExtractionIntegration
+from app.integrations.extraction import (
+    ExtractionCallMetadata,
+    ExtractionError,
+    ExtractionIntegration,
+)
 from app.shared.input_limits import (
     CONFIDENCE_NOTES_MAX_ITEMS,
     DOCUMENT_LINE_ITEMS_MAX_ITEMS,
@@ -85,7 +89,15 @@ def _assert_extraction_invariants(
     if expect_total_matches_priced_sum and result.total is not None:
         priced_items = [item.price for item in result.line_items if item.price is not None]
         assert priced_items
-        assert sum(priced_items) == pytest.approx(result.total)
+        priced_sum = sum(priced_items)
+        if priced_sum != pytest.approx(result.total):
+            assert any(
+                any(
+                    token in note.casefold()
+                    for token in ("mismatch", "does not match", "doesn't match", "line item sum")
+                )
+                for note in result.confidence_notes
+            )
 
 
 def _assert_extraction_quality(
@@ -109,6 +121,17 @@ def _assert_extraction_quality(
     for substring in case.expect_confidence_note_substrings:
         normalized_substring = substring.casefold()
         assert any(normalized_substring in note.casefold() for note in result.confidence_notes)
+
+    if case.expect_all_line_items_flagged is not None:
+        assert result.line_items
+        assert all(item.flagged is case.expect_all_line_items_flagged for item in result.line_items)
+    if case.expect_flag_reason_substrings:
+        assert result.line_items
+        for item in result.line_items:
+            assert item.flag_reason is not None
+            normalized_flag_reason = item.flag_reason.casefold()
+            for substring in case.expect_flag_reason_substrings:
+                assert substring.casefold() in normalized_flag_reason
 
     if case.expect_repair_attempted is not None:
         assert metadata.repair_attempted == case.expect_repair_attempted
@@ -168,3 +191,15 @@ async def test_extraction_eval_invariants(case: ExtractionEvalCase) -> None:
     assert metadata is not None
     assert metadata.invocation_tier == case.expected_invocation_tier
     _assert_extraction_quality(case, result, metadata=metadata)
+
+
+async def test_empty_transcript_raises_extraction_error() -> None:
+    integration = ExtractionIntegration(
+        api_key="",
+        model="primary-model",
+        fallback_model="fallback-model",
+        max_attempts=1,
+    )
+
+    with pytest.raises(ExtractionError, match="notes cannot be empty"):
+        await integration.extract("")


### PR DESCRIPTION
## Summary
- add three new extraction eval fixture cases for pipeline invariants: total mismatch, duplicate line items, and very short transcript
- extend eval harness assertions to validate duplicate flag propagation and allow total mismatch when confidence notes explicitly indicate the mismatch
- add standalone extraction eval test asserting `ExtractionIntegration.extract("")` raises `ExtractionError`

## Verification
- `make extraction-eval`

Closes #317
