### PR TITLE
Task #336: quote share thin-facade Phase 1A owner lifecycle

### DIFF
--- a/backend/app/features/quotes/errors.py
+++ b/backend/app/features/quotes/errors.py
@@ -1,0 +1,12 @@
+"""Quote-domain shared errors."""
+
+from __future__ import annotations
+
+
+class QuoteServiceError(Exception):
+    """Quote-domain exception mapped to an HTTP status code."""
+
+    def __init__(self, *, detail: str, status_code: int) -> None:
+        super().__init__(detail)
+        self.detail = detail
+        self.status_code = status_code

--- a/backend/app/features/quotes/service.py
+++ b/backend/app/features/quotes/service.py
@@ -9,16 +9,16 @@ import re
 from collections.abc import Sequence
 from datetime import UTC, date, datetime, timedelta
 from typing import Literal, Protocol, cast
-from uuid import UUID, uuid4
+from uuid import UUID
 
 from arq.connections import ArqRedis
 from sqlalchemy import inspect as sa_inspect
 from sqlalchemy.exc import IntegrityError
 
-from app.core.config import get_settings
 from app.features.auth.models import User
 from app.features.jobs.models import JobRecord, JobStatus, JobType
 from app.features.jobs.service import JobService
+from app.features.quotes.errors import QuoteServiceError
 from app.features.quotes.extraction_outcomes import classify_extraction_result
 from app.features.quotes.models import Document, QuoteStatus
 from app.features.quotes.repository import (
@@ -34,6 +34,8 @@ from app.features.quotes.schemas import (
     QuoteCreateRequest,
     QuoteUpdateRequest,
 )
+from app.features.quotes.share import QuoteShareService
+from app.features.quotes.share.tokens import _share_token_has_expired
 from app.integrations.pdf import PdfRenderError
 from app.integrations.storage import StorageNotFoundError, StorageServiceProtocol
 from app.shared.event_logger import log_event
@@ -72,13 +74,6 @@ _QUOTE_OUTCOME_ELIGIBLE_STATUSES = (
     QuoteStatus.APPROVED,
     QuoteStatus.DECLINED,
 )
-_POST_SHARE_NON_REGRESSION_STATUSES = frozenset(
-    {
-        QuoteStatus.VIEWED,
-        QuoteStatus.APPROVED,
-        QuoteStatus.DECLINED,
-    }
-)
 _CUSTOMER_ASSIGNMENT_REQUIRED_DETAIL = "Assign a customer before continuing."
 _CUSTOMER_CLEAR_BLOCKED_DETAIL = "Customer cannot be cleared from a quote."
 _CUSTOMER_CHANGE_BLOCKED_DETAIL = "Customer cannot be changed after sharing or invoice conversion."
@@ -101,15 +96,6 @@ _APPENDABLE_QUOTE_STATUSES = frozenset(
 _APPEND_UNAVAILABLE_DETAIL = "This quote can no longer be edited."
 _APPEND_TRANSCRIPT_SEPARATOR_PATTERN = re.compile(r"(?:^|\n\n)Added later(?: \(\d+\))?:\n")
 _APPEND_TRANSCRIPT_BULLET_PREFIXES = ("- ", "* ")
-
-
-class QuoteServiceError(Exception):
-    """Quote-domain exception mapped to an HTTP status code."""
-
-    def __init__(self, *, detail: str, status_code: int) -> None:
-        super().__init__(detail)
-        self.detail = detail
-        self.status_code = status_code
 
 
 class QuoteRepositoryProtocol(Protocol):
@@ -257,6 +243,10 @@ class QuoteService:
         self._repository = repository
         self._pdf = pdf_integration
         self._storage_service = storage_service
+        self._share_service = QuoteShareService(
+            repository=repository,
+            ensure_quote_customer_assigned=ensure_quote_customer_assigned,
+        )
 
     async def create_quote(self, user: User, data: QuoteCreateRequest) -> Document:
         """Create a user-owned quote and retry once on sequence collisions."""
@@ -969,43 +959,13 @@ class QuoteService:
         *,
         regenerate: bool = False,
     ) -> Document:
-        """Set share token/timestamp and transition quote status to shared."""
+        """Delegate owner-facing share lifecycle behavior to the share slice."""
         user_id = _resolve_user_id(user)
-        quote = await self._repository.get_by_id(quote_id, user_id)
-        if quote is None:
-            raise QuoteServiceError(detail="Not found", status_code=404)
-        ensure_quote_customer_assigned(quote)
-        now = _utcnow()
-        should_refresh_token = (
-            regenerate
-            or quote.share_token is None
-            or quote.share_token_revoked_at is not None
-            or _share_token_has_expired(quote.share_token_expires_at, now)
-        )
-        if quote.status in _POST_SHARE_NON_REGRESSION_STATUSES and not should_refresh_token:
-            return quote
-
-        if should_refresh_token:
-            quote.share_token = str(uuid4())
-            quote.share_token_created_at = now
-            quote.share_token_expires_at = _build_share_token_expiry(now)
-            quote.share_token_revoked_at = None
-
-        if quote.status not in _POST_SHARE_NON_REGRESSION_STATUSES:
-            quote.shared_at = now
-            quote.status = QuoteStatus.SHARED
-        elif quote.shared_at is None:
-            quote.shared_at = now
-
-        await self._repository.commit()
-        refreshed_quote = await self._repository.refresh(quote)
-        log_event(
-            "quote_shared",
+        return await self._share_service.share_quote(
             user_id=user_id,
-            quote_id=refreshed_quote.id,
-            customer_id=refreshed_quote.customer_id,
+            quote_id=quote_id,
+            regenerate=regenerate,
         )
-        return refreshed_quote
 
     async def _apply_doc_type_transition(
         self,
@@ -1065,16 +1025,12 @@ class QuoteService:
         return True
 
     async def revoke_public_share(self, user: User, quote_id: UUID) -> None:
-        """Revoke the currently active public share token for one quote."""
+        """Delegate owner-facing share revocation behavior to the share slice."""
         user_id = _resolve_user_id(user)
-        quote = await self._repository.get_by_id(quote_id, user_id)
-        if quote is None:
-            raise QuoteServiceError(detail="Not found", status_code=404)
-        if quote.share_token is None or quote.share_token_revoked_at is not None:
-            return
-
-        quote.share_token_revoked_at = _utcnow()
-        await self._repository.commit()
+        await self._share_service.revoke_public_share(
+            user_id=user_id,
+            quote_id=quote_id,
+        )
 
     async def mark_quote_outcome(
         self,
@@ -1262,14 +1218,6 @@ def _build_default_invoice_due_date() -> date:
 def build_doc_number(*, doc_type: str, sequence: int) -> str:
     prefix = "I" if doc_type == "invoice" else "Q"
     return f"{prefix}-{sequence:03d}"
-
-
-def _build_share_token_expiry(created_at: datetime) -> datetime:
-    return created_at + timedelta(days=get_settings().public_share_link_expire_days)
-
-
-def _share_token_has_expired(expires_at: datetime | None, now: datetime) -> bool:
-    return expires_at is not None and expires_at < now
 
 
 def _build_public_share_denial_rate_limit_key(

--- a/backend/app/features/quotes/share/__init__.py
+++ b/backend/app/features/quotes/share/__init__.py
@@ -1,0 +1,5 @@
+"""Quote share slice package."""
+
+from app.features.quotes.share.service import QuoteShareService
+
+__all__ = ["QuoteShareService"]

--- a/backend/app/features/quotes/share/service.py
+++ b/backend/app/features/quotes/share/service.py
@@ -1,0 +1,107 @@
+"""Owner-facing quote share lifecycle service."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from datetime import UTC, datetime
+from typing import Protocol
+from uuid import UUID, uuid4
+
+from app.features.quotes.errors import QuoteServiceError
+from app.features.quotes.models import Document, QuoteStatus
+from app.features.quotes.share.tokens import (
+    _build_share_token_expiry,
+    _share_token_has_expired,
+)
+from app.shared.event_logger import log_event
+
+_POST_SHARE_NON_REGRESSION_STATUSES = frozenset(
+    {
+        QuoteStatus.VIEWED,
+        QuoteStatus.APPROVED,
+        QuoteStatus.DECLINED,
+    }
+)
+
+
+class QuoteShareRepositoryProtocol(Protocol):
+    """Repository behavior required by the quote share slice."""
+
+    async def get_by_id(self, quote_id: UUID, user_id: UUID) -> Document | None: ...
+
+    async def commit(self) -> None: ...
+
+    async def refresh(self, document: Document) -> Document: ...
+
+
+class QuoteShareService:
+    """Own owner-facing quote share and revoke behavior."""
+
+    def __init__(
+        self,
+        *,
+        repository: QuoteShareRepositoryProtocol,
+        ensure_quote_customer_assigned: Callable[[Document], None],
+    ) -> None:
+        self._repository = repository
+        self._ensure_quote_customer_assigned = ensure_quote_customer_assigned
+
+    async def share_quote(
+        self,
+        *,
+        user_id: UUID,
+        quote_id: UUID,
+        regenerate: bool = False,
+    ) -> Document:
+        """Set share token/timestamp and transition quote status to shared."""
+        quote = await self._repository.get_by_id(quote_id, user_id)
+        if quote is None:
+            raise QuoteServiceError(detail="Not found", status_code=404)
+
+        self._ensure_quote_customer_assigned(quote)
+        now = _utcnow()
+        should_refresh_token = (
+            regenerate
+            or quote.share_token is None
+            or quote.share_token_revoked_at is not None
+            or _share_token_has_expired(quote.share_token_expires_at, now)
+        )
+        if quote.status in _POST_SHARE_NON_REGRESSION_STATUSES and not should_refresh_token:
+            return quote
+
+        if should_refresh_token:
+            quote.share_token = str(uuid4())
+            quote.share_token_created_at = now
+            quote.share_token_expires_at = _build_share_token_expiry(now)
+            quote.share_token_revoked_at = None
+
+        if quote.status not in _POST_SHARE_NON_REGRESSION_STATUSES:
+            quote.shared_at = now
+            quote.status = QuoteStatus.SHARED
+        elif quote.shared_at is None:
+            quote.shared_at = now
+
+        await self._repository.commit()
+        refreshed_quote = await self._repository.refresh(quote)
+        log_event(
+            "quote_shared",
+            user_id=user_id,
+            quote_id=refreshed_quote.id,
+            customer_id=refreshed_quote.customer_id,
+        )
+        return refreshed_quote
+
+    async def revoke_public_share(self, *, user_id: UUID, quote_id: UUID) -> None:
+        """Revoke the currently active public share token for one quote."""
+        quote = await self._repository.get_by_id(quote_id, user_id)
+        if quote is None:
+            raise QuoteServiceError(detail="Not found", status_code=404)
+        if quote.share_token is None or quote.share_token_revoked_at is not None:
+            return
+
+        quote.share_token_revoked_at = _utcnow()
+        await self._repository.commit()
+
+
+def _utcnow() -> datetime:
+    return datetime.now(UTC)

--- a/backend/app/features/quotes/share/tokens.py
+++ b/backend/app/features/quotes/share/tokens.py
@@ -1,0 +1,15 @@
+"""Token lifecycle helpers for quote share links."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+from app.core.config import get_settings
+
+
+def _build_share_token_expiry(created_at: datetime) -> datetime:
+    return created_at + timedelta(days=get_settings().public_share_link_expire_days)
+
+
+def _share_token_has_expired(expires_at: datetime | None, now: datetime) -> bool:
+    return expires_at is not None and expires_at < now

--- a/backend/app/features/quotes/tests/test_pdf.py
+++ b/backend/app/features/quotes/tests/test_pdf.py
@@ -1213,6 +1213,75 @@ async def test_public_quote_endpoint_returns_json_and_marks_first_view_once(
     assert emitted_events[0]["customer_id"] == customer_id
 
 
+async def test_revoke_share_is_idempotent_when_quote_has_no_token(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    csrf_token = await _register_and_login(client, _credentials())
+    customer_id = await _create_customer(client, csrf_token)
+    quote = await _create_quote(client, csrf_token, customer_id)
+
+    revoke_response = await client.delete(
+        f"/api/quotes/{quote['id']}/share",
+        headers={"X-CSRF-Token": csrf_token},
+    )
+    assert revoke_response.status_code == 204
+
+    detail_response = await client.get(f"/api/quotes/{quote['id']}")
+    assert detail_response.status_code == 200
+    assert detail_response.json()["share_token"] is None
+    assert detail_response.json()["has_active_share"] is False
+
+    quote_row = await db_session.scalar(select(Document).where(Document.id == UUID(quote["id"])))
+    assert quote_row is not None
+    assert quote_row.share_token is None
+    assert quote_row.share_token_revoked_at is None
+
+
+async def test_revoke_share_is_idempotent_when_quote_token_already_revoked(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    csrf_token = await _register_and_login(client, _credentials())
+    customer_id = await _create_customer(client, csrf_token)
+    quote = await _create_quote(client, csrf_token, customer_id)
+
+    share_response = await client.post(
+        f"/api/quotes/{quote['id']}/share",
+        headers={"X-CSRF-Token": csrf_token},
+    )
+    assert share_response.status_code == 200
+
+    first_revoke_response = await client.delete(
+        f"/api/quotes/{quote['id']}/share",
+        headers={"X-CSRF-Token": csrf_token},
+    )
+    assert first_revoke_response.status_code == 204
+
+    first_quote_row = await db_session.scalar(
+        select(Document).where(Document.id == UUID(quote["id"]))
+    )
+    assert first_quote_row is not None
+    first_revoked_at = first_quote_row.share_token_revoked_at
+    assert first_revoked_at is not None
+
+    second_revoke_response = await client.delete(
+        f"/api/quotes/{quote['id']}/share",
+        headers={"X-CSRF-Token": csrf_token},
+    )
+    assert second_revoke_response.status_code == 204
+
+    detail_response = await client.get(f"/api/quotes/{quote['id']}")
+    assert detail_response.status_code == 200
+    assert detail_response.json()["has_active_share"] is False
+
+    second_quote_row = await db_session.scalar(
+        select(Document).where(Document.id == UUID(quote["id"]))
+    )
+    assert second_quote_row is not None
+    assert second_quote_row.share_token_revoked_at == first_revoked_at
+
+
 async def test_revoked_public_quote_token_returns_generic_404(
     client: AsyncClient,
     db_session: AsyncSession,


### PR DESCRIPTION
## Summary
- extract owner-facing quote share/revoke lifecycle into `backend/app/features/quotes/share/` via `QuoteShareService`
- move `QuoteServiceError` to `backend/app/features/quotes/errors.py` while preserving imports from `app.features.quotes.service`
- move share token expiry helpers into `backend/app/features/quotes/share/tokens.py`
- keep `QuoteService` constructor/signatures stable and keep public-access orchestration in `QuoteService`
- add revoke idempotency API tests for no-token and already-revoked token paths

## Verification
- `cd backend && .venv/bin/pytest app/features/quotes/tests/test_pdf.py::test_share_sets_status_token_and_timestamp app/features/quotes/tests/test_pdf.py::test_share_reuses_existing_token_and_updates_timestamp app/features/quotes/tests/test_pdf.py::test_share_does_not_regress_viewed_or_finalized_quotes app/features/quotes/tests/test_pdf.py::test_share_quote_returns_404_for_nonexistent_quote app/features/quotes/tests/test_pdf.py::test_revoked_public_quote_token_returns_generic_404 app/features/quotes/tests/test_pdf.py::test_regenerate_quote_share_invalidates_old_token app/features/quotes/tests/test_pdf.py::test_revoke_share_is_idempotent_when_quote_has_no_token app/features/quotes/tests/test_pdf.py::test_revoke_share_is_idempotent_when_quote_token_already_revoked app/features/quotes/tests/test_quotes.py::test_quotes_support_unassigned_drafts_and_customer_assignment_guards`
- `make backend-verify`

Closes #336
