### PR TITLE
Task #339: quote share thin-facade phase 1B public access lifecycle

### DIFF
--- a/backend/app/features/quotes/service.py
+++ b/backend/app/features/quotes/service.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-import base64
 import logging
 import re
 from collections.abc import Sequence
@@ -35,16 +34,8 @@ from app.features.quotes.schemas import (
     QuoteUpdateRequest,
 )
 from app.features.quotes.share import QuoteShareService
-from app.features.quotes.share.tokens import _share_token_has_expired
-from app.integrations.pdf import PdfRenderError
 from app.integrations.storage import StorageNotFoundError, StorageServiceProtocol
 from app.shared.event_logger import log_event
-from app.shared.image_signatures import detect_image_content_type
-from app.shared.observability import (
-    current_request_context,
-    hash_token_reference,
-    log_security_event,
-)
 from app.shared.pdf_artifacts import PDF_ARTIFACT_NOT_READY_DETAIL
 from app.shared.pricing import (
     PricingValidationError,
@@ -245,6 +236,8 @@ class QuoteService:
         self._storage_service = storage_service
         self._share_service = QuoteShareService(
             repository=repository,
+            pdf_integration=pdf_integration,
+            storage_service=storage_service,
             ensure_quote_customer_assigned=ensure_quote_customer_assigned,
         )
 
@@ -789,104 +782,15 @@ class QuoteService:
 
     async def generate_shared_pdf(self, share_token: str) -> tuple[str, bytes]:
         """Render and return a publicly shared quote PDF by token."""
-        context = await self._get_public_quote_context(share_token)
-        await self._attach_logo_data_uri(context)
-
-        try:
-            pdf_bytes = await asyncio.to_thread(self._pdf.render, context)
-        except PdfRenderError as exc:
-            raise QuoteServiceError(detail=str(exc), status_code=422) from exc
-
-        await self._mark_public_quote_viewed_once(context, share_token)
-        return context.doc_number, pdf_bytes
+        return await self._share_service.generate_shared_pdf(share_token)
 
     async def get_public_quote(self, share_token: str) -> QuoteRenderContext:
         """Return public quote data and apply the first shared->viewed transition once."""
-        context = await self._get_public_quote_context(share_token)
-        await self._mark_public_quote_viewed_once(context, share_token)
-        return context
+        return await self._share_service.get_public_quote(share_token)
 
     async def get_public_logo(self, share_token: str) -> tuple[bytes, str]:
         """Return public logo bytes/content type for one shared quote token."""
-        context = await self._get_public_quote_context(share_token)
-        if context.logo_path is None:
-            raise QuoteServiceError(detail="Logo not found", status_code=404)
-
-        try:
-            logo_bytes = await asyncio.to_thread(
-                self._storage_service.fetch_bytes,
-                context.logo_path,
-            )
-        except StorageNotFoundError as exc:
-            raise QuoteServiceError(detail="Logo not found", status_code=404) from exc
-        except Exception as exc:  # noqa: BLE001
-            raise QuoteServiceError(detail="Unable to load logo", status_code=500) from exc
-
-        content_type = detect_image_content_type(logo_bytes)
-        if content_type is None:
-            raise QuoteServiceError(detail="Unable to load logo", status_code=500)
-
-        return logo_bytes, content_type
-
-    async def _get_public_quote_context(self, share_token: str) -> QuoteRenderContext:
-        """Load public quote context for a share token or raise a 404."""
-        now = _utcnow()
-        share_record = await self._repository.get_public_share_record(share_token)
-        if share_record is None:
-            raise QuoteServiceError(detail="Not found", status_code=404)
-        if share_record.share_token_revoked_at is not None:
-            self._log_public_share_denied(
-                share_record,
-                share_token=share_token,
-                reason_code="revoked",
-            )
-            raise QuoteServiceError(detail="Not found", status_code=404)
-        if _share_token_has_expired(share_record.share_token_expires_at, now):
-            self._log_public_share_denied(
-                share_record,
-                share_token=share_token,
-                reason_code="expired",
-            )
-            raise QuoteServiceError(detail="Not found", status_code=404)
-
-        context = await self._repository.get_render_context_by_share_token(share_token)
-        if context is None:
-            raise QuoteServiceError(detail="Not found", status_code=404)
-        return context
-
-    async def _mark_public_quote_viewed_once(
-        self,
-        context: QuoteRenderContext,
-        share_token: str,
-    ) -> None:
-        """Advance a shared public quote to viewed and log the first successful access."""
-        accessed_at = _utcnow()
-        if context.status != QuoteStatus.SHARED.value:
-            await self._repository.touch_last_public_accessed_at_by_share_token(
-                share_token,
-                accessed_at=accessed_at,
-            )
-            await self._repository.commit()
-            return
-
-        transition = await self._repository.transition_to_viewed_by_share_token(
-            share_token,
-            accessed_at=accessed_at,
-        )
-        if transition is not None:
-            await self._repository.commit()
-            self._log_public_quote_viewed(transition)
-            context.status = QuoteStatus.VIEWED.value
-            return
-
-        await self._repository.touch_last_public_accessed_at_by_share_token(
-            share_token,
-            accessed_at=accessed_at,
-        )
-        await self._repository.commit()
-        refreshed_context = await self._repository.get_render_context_by_share_token(share_token)
-        if refreshed_context is not None:
-            context.status = refreshed_context.status
+        return await self._share_service.get_public_logo(share_token)
 
     async def _get_reusable_pdf_job(
         self,
@@ -918,39 +822,6 @@ class QuoteService:
             await asyncio.to_thread(self._storage_service.delete, object_path)
         except Exception:  # noqa: BLE001
             LOGGER.warning("Failed to delete invalidated quote PDF artifact", exc_info=True)
-
-    def _log_public_quote_viewed(self, transition: QuoteViewTransition) -> None:
-        log_event(
-            "quote_viewed",
-            user_id=transition.user_id,
-            quote_id=transition.quote_id,
-            customer_id=transition.customer_id,
-        )
-
-    def _log_public_share_denied(
-        self,
-        share_record: PublicShareRecord,
-        *,
-        share_token: str,
-        reason_code: Literal["revoked", "expired"],
-    ) -> None:
-        """Record the internal reason when a quote token is denied publicly."""
-        log_security_event(
-            "public_share.token_denied",
-            outcome="denied",
-            level=logging.WARNING,
-            status_code=404,
-            reason=reason_code,
-            token_ref=share_token,
-            rate_limit_key=_build_public_share_denial_rate_limit_key(
-                document_type="quote",
-                reason_code=reason_code,
-                share_token=share_token,
-            ),
-            rate_limit_seconds=60,
-            document_id=str(share_record.document_id),
-            document_type="quote",
-        )
 
     async def share_quote(
         self,
@@ -1110,34 +981,6 @@ class QuoteService:
 
         return requested_customer_id
 
-    async def _attach_logo_data_uri(self, context: QuoteRenderContext) -> None:
-        if context.logo_path is None:
-            context.logo_data_uri = None
-            return
-
-        try:
-            logo_bytes = await asyncio.to_thread(
-                self._storage_service.fetch_bytes,
-                context.logo_path,
-            )
-        except StorageNotFoundError:
-            LOGGER.warning("Quote logo missing in storage; omitting from PDF render")
-            context.logo_data_uri = None
-            return
-        except Exception:  # noqa: BLE001
-            LOGGER.warning("Failed to load quote logo for PDF render; omitting logo", exc_info=True)
-            context.logo_data_uri = None
-            return
-
-        content_type = detect_image_content_type(logo_bytes)
-        if content_type is None:
-            LOGGER.warning("Quote logo bytes were invalid; omitting from PDF render")
-            context.logo_data_uri = None
-            return
-
-        encoded_logo = base64.b64encode(logo_bytes).decode("ascii")
-        context.logo_data_uri = f"data:{content_type};base64,{encoded_logo}"
-
 
 async def _create_quote_document(
     service: QuoteService,
@@ -1218,21 +1061,6 @@ def _build_default_invoice_due_date() -> date:
 def build_doc_number(*, doc_type: str, sequence: int) -> str:
     prefix = "I" if doc_type == "invoice" else "Q"
     return f"{prefix}-{sequence:03d}"
-
-
-def _build_public_share_denial_rate_limit_key(
-    *,
-    document_type: str,
-    reason_code: str,
-    share_token: str,
-) -> str:
-    request_context = current_request_context()
-    source = (
-        request_context.client_ip_hash
-        if request_context is not None
-        else hash_token_reference(share_token)
-    )
-    return f"public-share:{document_type}:{reason_code}:{source}"
 
 
 def _validate_document_pricing_for_quote(

--- a/backend/app/features/quotes/share/public_access.py
+++ b/backend/app/features/quotes/share/public_access.py
@@ -1,0 +1,162 @@
+"""Public-access helpers for the quote share slice."""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import logging
+from collections.abc import Callable
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Literal, Protocol
+
+from app.features.quotes.errors import QuoteServiceError
+from app.features.quotes.models import QuoteStatus
+from app.features.quotes.repository import (
+    PublicShareRecord,
+    QuoteRenderContext,
+    QuoteViewTransition,
+)
+from app.features.quotes.share.tokens import _share_token_has_expired
+from app.integrations.storage import StorageNotFoundError, StorageServiceProtocol
+from app.shared.image_signatures import detect_image_content_type
+from app.shared.observability import current_request_context, hash_token_reference
+
+if TYPE_CHECKING:
+    from app.features.quotes.share.service import QuoteShareRepositoryProtocol
+
+
+class _LogPublicShareDenied(Protocol):
+    def __call__(
+        self,
+        share_record: PublicShareRecord,
+        *,
+        share_token: str,
+        reason_code: Literal["revoked", "expired"],
+    ) -> None: ...
+
+
+def _utcnow() -> datetime:
+    return datetime.now(UTC)
+
+
+async def _attach_logo_data_uri(
+    context: QuoteRenderContext,
+    *,
+    storage_service: StorageServiceProtocol,
+    logger: logging.Logger,
+    document_label: str,
+) -> None:
+    if context.logo_path is None:
+        context.logo_data_uri = None
+        return
+
+    try:
+        logo_bytes = await asyncio.to_thread(
+            storage_service.fetch_bytes,
+            context.logo_path,
+        )
+    except StorageNotFoundError:
+        logger.warning("%s logo missing in storage; omitting from PDF render", document_label)
+        context.logo_data_uri = None
+        return
+    except Exception:  # noqa: BLE001
+        logger.warning(
+            "Failed to load %s logo for PDF render; omitting logo",
+            document_label.lower(),
+            exc_info=True,
+        )
+        context.logo_data_uri = None
+        return
+
+    content_type = detect_image_content_type(logo_bytes)
+    if content_type is None:
+        logger.warning("%s logo bytes were invalid; omitting from PDF render", document_label)
+        context.logo_data_uri = None
+        return
+
+    encoded_logo = base64.b64encode(logo_bytes).decode("ascii")
+    context.logo_data_uri = f"data:{content_type};base64,{encoded_logo}"
+
+
+async def _get_public_quote_context(
+    *,
+    repository: QuoteShareRepositoryProtocol,
+    share_token: str,
+    log_public_share_denied: _LogPublicShareDenied,
+) -> QuoteRenderContext:
+    """Load public quote context for a share token or raise a 404."""
+    now = _utcnow()
+    share_record = await repository.get_public_share_record(share_token)
+    if share_record is None:
+        raise QuoteServiceError(detail="Not found", status_code=404)
+    if share_record.share_token_revoked_at is not None:
+        log_public_share_denied(
+            share_record,
+            share_token=share_token,
+            reason_code="revoked",
+        )
+        raise QuoteServiceError(detail="Not found", status_code=404)
+    if _share_token_has_expired(share_record.share_token_expires_at, now):
+        log_public_share_denied(
+            share_record,
+            share_token=share_token,
+            reason_code="expired",
+        )
+        raise QuoteServiceError(detail="Not found", status_code=404)
+
+    context = await repository.get_render_context_by_share_token(share_token)
+    if context is None:
+        raise QuoteServiceError(detail="Not found", status_code=404)
+    return context
+
+
+async def _mark_public_quote_viewed_once(
+    *,
+    repository: QuoteShareRepositoryProtocol,
+    context: QuoteRenderContext,
+    share_token: str,
+    log_public_quote_viewed: Callable[[QuoteViewTransition], None],
+) -> None:
+    """Advance shared quotes to viewed once; otherwise touch access timestamp."""
+    accessed_at = _utcnow()
+    if context.status != QuoteStatus.SHARED.value:
+        await repository.touch_last_public_accessed_at_by_share_token(
+            share_token,
+            accessed_at=accessed_at,
+        )
+        await repository.commit()
+        return
+
+    transition = await repository.transition_to_viewed_by_share_token(
+        share_token,
+        accessed_at=accessed_at,
+    )
+    if transition is not None:
+        await repository.commit()
+        log_public_quote_viewed(transition)
+        context.status = QuoteStatus.VIEWED.value
+        return
+
+    await repository.touch_last_public_accessed_at_by_share_token(
+        share_token,
+        accessed_at=accessed_at,
+    )
+    await repository.commit()
+    refreshed_context = await repository.get_render_context_by_share_token(share_token)
+    if refreshed_context is not None:
+        context.status = refreshed_context.status
+
+
+def _build_public_share_denial_rate_limit_key(
+    *,
+    document_type: str,
+    reason_code: str,
+    share_token: str,
+) -> str:
+    request_context = current_request_context()
+    source = (
+        request_context.client_ip_hash
+        if request_context is not None
+        else hash_token_reference(share_token)
+    )
+    return f"public-share:{document_type}:{reason_code}:{source}"

--- a/backend/app/features/quotes/share/service.py
+++ b/backend/app/features/quotes/share/service.py
@@ -1,19 +1,38 @@
-"""Owner-facing quote share lifecycle service."""
+"""Quote share lifecycle service for owner and public access behavior."""
 
 from __future__ import annotations
 
+import asyncio
+import logging
 from collections.abc import Callable
 from datetime import UTC, datetime
-from typing import Protocol
+from typing import Literal, Protocol
 from uuid import UUID, uuid4
 
 from app.features.quotes.errors import QuoteServiceError
 from app.features.quotes.models import Document, QuoteStatus
+from app.features.quotes.repository import (
+    PublicShareRecord,
+    QuoteRenderContext,
+    QuoteViewTransition,
+)
+from app.features.quotes.share.public_access import (
+    _attach_logo_data_uri,
+    _build_public_share_denial_rate_limit_key,
+    _get_public_quote_context,
+    _mark_public_quote_viewed_once,
+)
 from app.features.quotes.share.tokens import (
     _build_share_token_expiry,
     _share_token_has_expired,
 )
+from app.integrations.pdf import PdfRenderError
+from app.integrations.storage import StorageNotFoundError, StorageServiceProtocol
 from app.shared.event_logger import log_event
+from app.shared.image_signatures import detect_image_content_type
+from app.shared.observability import log_security_event
+
+LOGGER = logging.getLogger(__name__)
 
 _POST_SHARE_NON_REGRESSION_STATUSES = frozenset(
     {
@@ -29,21 +48,51 @@ class QuoteShareRepositoryProtocol(Protocol):
 
     async def get_by_id(self, quote_id: UUID, user_id: UUID) -> Document | None: ...
 
+    async def get_public_share_record(self, share_token: str) -> PublicShareRecord | None: ...
+
+    async def get_render_context_by_share_token(
+        self, share_token: str
+    ) -> QuoteRenderContext | None: ...
+
+    async def transition_to_viewed_by_share_token(
+        self,
+        share_token: str,
+        *,
+        accessed_at: datetime,
+    ) -> QuoteViewTransition | None: ...
+
+    async def touch_last_public_accessed_at_by_share_token(
+        self,
+        share_token: str,
+        *,
+        accessed_at: datetime,
+    ) -> None: ...
+
     async def commit(self) -> None: ...
 
     async def refresh(self, document: Document) -> Document: ...
 
 
+class QuoteSharePdfIntegrationProtocol(Protocol):
+    """PDF rendering dependency required for public quote share access."""
+
+    def render(self, context: QuoteRenderContext) -> bytes: ...
+
+
 class QuoteShareService:
-    """Own owner-facing quote share and revoke behavior."""
+    """Own owner-facing and public quote share lifecycle behavior."""
 
     def __init__(
         self,
         *,
         repository: QuoteShareRepositoryProtocol,
+        pdf_integration: QuoteSharePdfIntegrationProtocol,
+        storage_service: StorageServiceProtocol,
         ensure_quote_customer_assigned: Callable[[Document], None],
     ) -> None:
         self._repository = repository
+        self._pdf = pdf_integration
+        self._storage_service = storage_service
         self._ensure_quote_customer_assigned = ensure_quote_customer_assigned
 
     async def share_quote(
@@ -101,6 +150,107 @@ class QuoteShareService:
 
         quote.share_token_revoked_at = _utcnow()
         await self._repository.commit()
+
+    async def generate_shared_pdf(self, share_token: str) -> tuple[str, bytes]:
+        """Render and return a publicly shared quote PDF by token."""
+        context = await _get_public_quote_context(
+            repository=self._repository,
+            share_token=share_token,
+            log_public_share_denied=self._log_public_share_denied,
+        )
+        await _attach_logo_data_uri(
+            context,
+            storage_service=self._storage_service,
+            logger=LOGGER,
+            document_label="Quote",
+        )
+
+        try:
+            pdf_bytes = await asyncio.to_thread(self._pdf.render, context)
+        except PdfRenderError as exc:
+            raise QuoteServiceError(detail=str(exc), status_code=422) from exc
+
+        await _mark_public_quote_viewed_once(
+            repository=self._repository,
+            context=context,
+            share_token=share_token,
+            log_public_quote_viewed=self._log_public_quote_viewed,
+        )
+        return context.doc_number, pdf_bytes
+
+    async def get_public_quote(self, share_token: str) -> QuoteRenderContext:
+        """Return public quote data and apply the first shared->viewed transition once."""
+        context = await _get_public_quote_context(
+            repository=self._repository,
+            share_token=share_token,
+            log_public_share_denied=self._log_public_share_denied,
+        )
+        await _mark_public_quote_viewed_once(
+            repository=self._repository,
+            context=context,
+            share_token=share_token,
+            log_public_quote_viewed=self._log_public_quote_viewed,
+        )
+        return context
+
+    async def get_public_logo(self, share_token: str) -> tuple[bytes, str]:
+        """Return public logo bytes/content type for one shared quote token."""
+        context = await _get_public_quote_context(
+            repository=self._repository,
+            share_token=share_token,
+            log_public_share_denied=self._log_public_share_denied,
+        )
+        if context.logo_path is None:
+            raise QuoteServiceError(detail="Logo not found", status_code=404)
+
+        try:
+            logo_bytes = await asyncio.to_thread(
+                self._storage_service.fetch_bytes,
+                context.logo_path,
+            )
+        except StorageNotFoundError as exc:
+            raise QuoteServiceError(detail="Logo not found", status_code=404) from exc
+        except Exception as exc:  # noqa: BLE001
+            raise QuoteServiceError(detail="Unable to load logo", status_code=500) from exc
+
+        content_type = detect_image_content_type(logo_bytes)
+        if content_type is None:
+            raise QuoteServiceError(detail="Unable to load logo", status_code=500)
+
+        return logo_bytes, content_type
+
+    def _log_public_quote_viewed(self, transition: QuoteViewTransition) -> None:
+        log_event(
+            "quote_viewed",
+            user_id=transition.user_id,
+            quote_id=transition.quote_id,
+            customer_id=transition.customer_id,
+        )
+
+    def _log_public_share_denied(
+        self,
+        share_record: PublicShareRecord,
+        *,
+        share_token: str,
+        reason_code: Literal["revoked", "expired"],
+    ) -> None:
+        """Record the internal reason when a quote token is denied publicly."""
+        log_security_event(
+            "public_share.token_denied",
+            outcome="denied",
+            level=logging.WARNING,
+            status_code=404,
+            reason=reason_code,
+            token_ref=share_token,
+            rate_limit_key=_build_public_share_denial_rate_limit_key(
+                document_type="quote",
+                reason_code=reason_code,
+                share_token=share_token,
+            ),
+            rate_limit_seconds=60,
+            document_id=str(share_record.document_id),
+            document_type="quote",
+        )
 
 
 def _utcnow() -> datetime:

--- a/backend/app/features/quotes/tests/test_pdf.py
+++ b/backend/app/features/quotes/tests/test_pdf.py
@@ -1636,6 +1636,54 @@ async def test_public_quote_endpoint_returns_visible_terminal_statuses(
     assert response.json()["status"] == expected_message
 
 
+async def test_public_quote_access_touches_timestamp_for_already_visible_status(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    csrf_token = await _register_and_login(client, _credentials())
+    customer_id = await _create_customer(client, csrf_token)
+    quote = await _create_quote(client, csrf_token, customer_id)
+
+    share_response = await client.post(
+        f"/api/quotes/{quote['id']}/share",
+        headers={"X-CSRF-Token": csrf_token},
+    )
+    assert share_response.status_code == 200
+    share_token = share_response.json()["share_token"]
+
+    await _set_quote_status(db_session, quote["id"], QuoteStatus.APPROVED)
+    seeded_accessed_at = datetime.now(UTC) - timedelta(minutes=5)
+    quote_row = await db_session.scalar(select(Document).where(Document.id == UUID(quote["id"])))
+    assert quote_row is not None
+    quote_row.last_public_accessed_at = seeded_accessed_at
+    await db_session.commit()
+
+    client.cookies.clear()
+    json_response = await client.get(f"/api/public/doc/{share_token}")
+    assert json_response.status_code == 200
+    assert json_response.json()["status"] == "approved"
+
+    row_after_json = await db_session.scalar(
+        select(Document).where(Document.id == UUID(quote["id"]))
+    )
+    assert row_after_json is not None
+    assert row_after_json.status == QuoteStatus.APPROVED
+    assert row_after_json.last_public_accessed_at is not None
+    assert row_after_json.last_public_accessed_at > seeded_accessed_at
+    first_accessed_at = row_after_json.last_public_accessed_at
+
+    pdf_response = await client.get(f"/share/{share_token}")
+    assert pdf_response.status_code == 200
+
+    row_after_pdf = await db_session.scalar(
+        select(Document).where(Document.id == UUID(quote["id"]))
+    )
+    assert row_after_pdf is not None
+    assert row_after_pdf.status == QuoteStatus.APPROVED
+    assert row_after_pdf.last_public_accessed_at is not None
+    assert row_after_pdf.last_public_accessed_at > first_accessed_at
+
+
 async def test_public_logo_endpoint_returns_image_bytes(client: AsyncClient) -> None:
     csrf_token = await _register_and_login(client, _credentials())
     await _upload_logo(client, csrf_token)


### PR DESCRIPTION
## Summary
- move quote public-access lifecycle logic out of QuoteService into QuoteShareService
- add quote share public-access helper module at backend/app/features/quotes/share/public_access.py
- keep QuoteService as thin facade by delegating public quote JSON/PDF/logo flows to QuoteShareService
- add API-level coverage proving already-visible quote public access updates last_public_accessed_at across repeated JSON/PDF hits

## Verification
- cd backend && .venv/bin/pytest app/features/quotes/tests/test_pdf.py::test_public_share_endpoint_streams_pdf_without_auth app/features/quotes/tests/test_pdf.py::test_public_share_endpoint_marks_first_view_once app/features/quotes/tests/test_pdf.py::test_public_quote_endpoint_returns_json_and_marks_first_view_once app/features/quotes/tests/test_pdf.py::test_public_share_endpoint_returns_404_for_unknown_token app/features/quotes/tests/test_pdf.py::test_public_share_endpoint_returns_422_when_render_fails app/features/quotes/tests/test_pdf.py::test_revoked_public_quote_token_returns_generic_404 app/features/quotes/tests/test_pdf.py::test_revoked_public_quote_token_emits_structured_denial_log app/features/quotes/tests/test_pdf.py::test_expired_public_quote_token_returns_generic_404 app/features/quotes/tests/test_pdf.py::test_public_share_endpoint_includes_logo_data_uri_when_logo_exists app/features/quotes/tests/test_pdf.py::test_public_logo_endpoint_returns_image_bytes app/features/quotes/tests/test_pdf.py::test_public_logo_endpoint_returns_404_when_quote_has_no_logo app/features/quotes/tests/test_pdf.py::test_public_logo_endpoint_returns_404_when_logo_object_is_missing app/features/quotes/tests/test_pdf.py::test_public_logo_endpoint_returns_500_for_storage_failures app/features/quotes/tests/test_pdf.py::test_public_quote_endpoint_prefers_terminal_status_when_view_transition_races app/features/quotes/tests/test_pdf.py::test_public_quote_endpoint_returns_404_for_non_public_statuses app/features/quotes/tests/test_pdf.py::test_public_quote_endpoint_returns_visible_terminal_statuses app/features/quotes/tests/test_pdf.py::test_public_quote_access_touches_timestamp_for_already_visible_status
- cd /home/odys/stima && make backend-verify

Closes #339
