### PR TITLE
Task 341: extract quote PDF artifact lifecycle slice

### DIFF
--- a/backend/app/features/quotes/pdf_artifacts/__init__.py
+++ b/backend/app/features/quotes/pdf_artifacts/__init__.py
@@ -1,0 +1,5 @@
+"""Quote authenticated PDF artifact lifecycle slice."""
+
+from app.features.quotes.pdf_artifacts.service import QuotePdfArtifactService
+
+__all__ = ["QuotePdfArtifactService"]

--- a/backend/app/features/quotes/pdf_artifacts/service.py
+++ b/backend/app/features/quotes/pdf_artifacts/service.py
@@ -1,0 +1,156 @@
+"""Quote authenticated PDF artifact lifecycle coordination."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Callable
+from typing import Protocol
+from uuid import UUID
+
+from arq.connections import ArqRedis
+
+from app.features.jobs.models import JobRecord, JobStatus, JobType
+from app.features.jobs.service import JobService
+from app.features.quotes.errors import QuoteServiceError
+from app.features.quotes.models import Document
+from app.integrations.storage import StorageNotFoundError, StorageServiceProtocol
+from app.shared.pdf_artifacts import PDF_ARTIFACT_NOT_READY_DETAIL
+
+LOGGER = logging.getLogger(__name__)
+_PDF_JOB_NAME = "jobs.pdf"
+_PDF_QUEUE_FAILURE_DETAIL = "Unable to start PDF generation right now. Please try again."
+
+
+class QuotePdfArtifactRepositoryProtocol(Protocol):
+    """Repository behavior required by the quote PDF artifact slice."""
+
+    async def get_by_id(self, quote_id: UUID, user_id: UUID) -> Document | None: ...
+
+    async def commit(self) -> None: ...
+
+
+class QuotePdfArtifactService:
+    """Own authenticated quote PDF artifact generation and retrieval behavior."""
+
+    def __init__(
+        self,
+        *,
+        repository: QuotePdfArtifactRepositoryProtocol,
+        storage_service: StorageServiceProtocol,
+        ensure_quote_customer_assigned: Callable[[Document], None],
+    ) -> None:
+        self._repository = repository
+        self._storage_service = storage_service
+        self._ensure_quote_customer_assigned = ensure_quote_customer_assigned
+
+    async def start_pdf_generation(
+        self,
+        *,
+        user_id: UUID,
+        quote_id: UUID,
+        job_service: JobService,
+        arq_pool: ArqRedis | None,
+    ) -> JobRecord:
+        """Create or reuse a durable quote PDF job for the current artifact revision."""
+        quote = await self._repository.get_by_id(quote_id, user_id)
+        if quote is None:
+            raise QuoteServiceError(detail="Not found", status_code=404)
+        self._ensure_quote_customer_assigned(quote)
+
+        existing_job = await self._get_reusable_pdf_job(
+            job_service=job_service,
+            user_id=user_id,
+            document=quote,
+        )
+        if existing_job is not None:
+            return existing_job
+
+        attach_job_to_document = quote.pdf_artifact_path is None
+        job = await job_service.create_job(
+            user_id=user_id,
+            job_type=JobType.PDF,
+            document_id=quote.id,
+            document_revision=quote.pdf_artifact_revision,
+        )
+        if attach_job_to_document:
+            quote.pdf_artifact_job_id = job.id
+
+        try:
+            if arq_pool is None:
+                raise RuntimeError("ARQ pool is not available")
+            queued_job = await arq_pool.enqueue_job(
+                _PDF_JOB_NAME,
+                str(job.id),
+                _job_id=str(job.id),
+            )
+            if queued_job is None:
+                raise RuntimeError("ARQ did not accept the PDF job")
+        except Exception as exc:
+            LOGGER.warning("Failed to enqueue quote PDF job %s", job.id, exc_info=True)
+            if attach_job_to_document:
+                quote.pdf_artifact_job_id = None
+            await job_service.mark_enqueue_failed(job.id, job_type=JobType.PDF)
+            await self._repository.commit()
+            raise QuoteServiceError(detail=_PDF_QUEUE_FAILURE_DETAIL, status_code=503) from exc
+
+        await self._repository.commit()
+        return job
+
+    async def get_pdf_artifact(self, *, user_id: UUID, quote_id: UUID) -> tuple[str, bytes]:
+        """Return one persisted quote PDF artifact or a stable not-ready error."""
+        quote = await self._repository.get_by_id(quote_id, user_id)
+        if quote is None:
+            raise QuoteServiceError(detail="Not found", status_code=404)
+        if quote.pdf_artifact_path is None:
+            raise QuoteServiceError(detail=PDF_ARTIFACT_NOT_READY_DETAIL, status_code=409)
+
+        try:
+            pdf_bytes = await asyncio.to_thread(
+                self._storage_service.fetch_bytes,
+                quote.pdf_artifact_path,
+            )
+        except StorageNotFoundError as exc:
+            quote.pdf_artifact_path = None
+            quote.pdf_artifact_job_id = None
+            # Keep the artifact revision unchanged here: storage-loss recovery should
+            # regenerate and overwrite the same revision path, while true content
+            # invalidation paths are the only flows that bump revision.
+            await self._repository.commit()
+            raise QuoteServiceError(detail=PDF_ARTIFACT_NOT_READY_DETAIL, status_code=409) from exc
+        except Exception as exc:  # noqa: BLE001
+            raise QuoteServiceError(detail="Unable to load PDF artifact", status_code=500) from exc
+
+        return quote.doc_number, pdf_bytes
+
+    async def delete_obsolete_artifact(self, object_path: str | None) -> None:
+        """Best-effort cleanup for obsolete quote PDF artifact storage objects."""
+        if object_path is None:
+            return
+        try:
+            await asyncio.to_thread(self._storage_service.delete, object_path)
+        except Exception:  # noqa: BLE001
+            LOGGER.warning("Failed to delete invalidated quote PDF artifact", exc_info=True)
+
+    async def _get_reusable_pdf_job(
+        self,
+        *,
+        job_service: JobService,
+        user_id: UUID,
+        document: Document,
+    ) -> JobRecord | None:
+        if document.pdf_artifact_job_id is None:
+            return None
+
+        job = await job_service.get_job_for_user(
+            job_id=document.pdf_artifact_job_id,
+            user_id=user_id,
+        )
+        if (
+            job is None
+            or job.job_type != JobType.PDF
+            or job.document_revision != document.pdf_artifact_revision
+            or job.status not in {JobStatus.PENDING, JobStatus.RUNNING}
+        ):
+            return None
+        return job

--- a/backend/app/features/quotes/service.py
+++ b/backend/app/features/quotes/service.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 import logging
 import re
 from collections.abc import Sequence
@@ -15,11 +14,12 @@ from sqlalchemy import inspect as sa_inspect
 from sqlalchemy.exc import IntegrityError
 
 from app.features.auth.models import User
-from app.features.jobs.models import JobRecord, JobStatus, JobType
+from app.features.jobs.models import JobRecord
 from app.features.jobs.service import JobService
 from app.features.quotes.errors import QuoteServiceError
 from app.features.quotes.extraction_outcomes import classify_extraction_result
 from app.features.quotes.models import Document, QuoteStatus
+from app.features.quotes.pdf_artifacts import QuotePdfArtifactService
 from app.features.quotes.repository import (
     PublicShareRecord,
     QuoteDetailRow,
@@ -34,9 +34,8 @@ from app.features.quotes.schemas import (
     QuoteUpdateRequest,
 )
 from app.features.quotes.share import QuoteShareService
-from app.integrations.storage import StorageNotFoundError, StorageServiceProtocol
+from app.integrations.storage import StorageServiceProtocol
 from app.shared.event_logger import log_event
-from app.shared.pdf_artifacts import PDF_ARTIFACT_NOT_READY_DETAIL
 from app.shared.pricing import (
     PricingValidationError,
     derive_document_subtotal_from_line_items,
@@ -46,8 +45,6 @@ from app.shared.pricing import (
 )
 
 LOGGER = logging.getLogger(__name__)
-_PDF_JOB_NAME = "jobs.pdf"
-_PDF_QUEUE_FAILURE_DETAIL = "Unable to start PDF generation right now. Please try again."
 _NON_DELETABLE_QUOTE_STATUSES = frozenset(
     {
         QuoteStatus.SHARED,
@@ -237,6 +234,11 @@ class QuoteService:
         self._share_service = QuoteShareService(
             repository=repository,
             pdf_integration=pdf_integration,
+            storage_service=storage_service,
+            ensure_quote_customer_assigned=ensure_quote_customer_assigned,
+        )
+        self._pdf_artifact_service = QuotePdfArtifactService(
+            repository=repository,
             storage_service=storage_service,
             ensure_quote_customer_assigned=ensure_quote_customer_assigned,
         )
@@ -712,73 +714,19 @@ class QuoteService:
     ) -> JobRecord:
         """Create or reuse a durable quote PDF job for the current artifact revision."""
         user_id = _resolve_user_id(user)
-        quote = await self._repository.get_by_id(quote_id, user_id)
-        if quote is None:
-            raise QuoteServiceError(detail="Not found", status_code=404)
-        ensure_quote_customer_assigned(quote)
-
-        existing_job = await self._get_reusable_pdf_job(
+        return await self._pdf_artifact_service.start_pdf_generation(
+            user_id=user_id,
+            quote_id=quote_id,
             job_service=job_service,
-            user_id=user_id,
-            document=quote,
+            arq_pool=arq_pool,
         )
-        if existing_job is not None:
-            return existing_job
-
-        attach_job_to_document = quote.pdf_artifact_path is None
-        job = await job_service.create_job(
-            user_id=user_id,
-            job_type=JobType.PDF,
-            document_id=quote.id,
-            document_revision=quote.pdf_artifact_revision,
-        )
-        if attach_job_to_document:
-            quote.pdf_artifact_job_id = job.id
-
-        try:
-            if arq_pool is None:
-                raise RuntimeError("ARQ pool is not available")
-            queued_job = await arq_pool.enqueue_job(
-                _PDF_JOB_NAME,
-                str(job.id),
-                _job_id=str(job.id),
-            )
-            if queued_job is None:
-                raise RuntimeError("ARQ did not accept the PDF job")
-        except Exception as exc:
-            LOGGER.warning("Failed to enqueue quote PDF job %s", job.id, exc_info=True)
-            if attach_job_to_document:
-                quote.pdf_artifact_job_id = None
-            await job_service.mark_enqueue_failed(job.id, job_type=JobType.PDF)
-            await self._repository.commit()
-            raise QuoteServiceError(detail=_PDF_QUEUE_FAILURE_DETAIL, status_code=503) from exc
-
-        await self._repository.commit()
-        return job
 
     async def get_pdf_artifact(self, user: User, quote_id: UUID) -> tuple[str, bytes]:
         """Return one persisted quote PDF artifact or a stable not-ready error."""
-        quote = await self.get_quote(user, quote_id)
-        if quote.pdf_artifact_path is None:
-            raise QuoteServiceError(detail=PDF_ARTIFACT_NOT_READY_DETAIL, status_code=409)
-
-        try:
-            pdf_bytes = await asyncio.to_thread(
-                self._storage_service.fetch_bytes,
-                quote.pdf_artifact_path,
-            )
-        except StorageNotFoundError as exc:
-            quote.pdf_artifact_path = None
-            quote.pdf_artifact_job_id = None
-            # Keep the artifact revision unchanged here: storage-loss recovery should
-            # regenerate and overwrite the same revision path, while true content
-            # invalidation paths are the only flows that bump revision.
-            await self._repository.commit()
-            raise QuoteServiceError(detail=PDF_ARTIFACT_NOT_READY_DETAIL, status_code=409) from exc
-        except Exception as exc:  # noqa: BLE001
-            raise QuoteServiceError(detail="Unable to load PDF artifact", status_code=500) from exc
-
-        return quote.doc_number, pdf_bytes
+        return await self._pdf_artifact_service.get_pdf_artifact(
+            user_id=_resolve_user_id(user),
+            quote_id=quote_id,
+        )
 
     async def generate_shared_pdf(self, share_token: str) -> tuple[str, bytes]:
         """Render and return a publicly shared quote PDF by token."""
@@ -792,36 +740,8 @@ class QuoteService:
         """Return public logo bytes/content type for one shared quote token."""
         return await self._share_service.get_public_logo(share_token)
 
-    async def _get_reusable_pdf_job(
-        self,
-        *,
-        job_service: JobService,
-        user_id: UUID,
-        document: Document,
-    ) -> JobRecord | None:
-        if document.pdf_artifact_job_id is None:
-            return None
-
-        job = await job_service.get_job_for_user(
-            job_id=document.pdf_artifact_job_id,
-            user_id=user_id,
-        )
-        if (
-            job is None
-            or job.job_type != JobType.PDF
-            or job.document_revision != document.pdf_artifact_revision
-            or job.status not in {JobStatus.PENDING, JobStatus.RUNNING}
-        ):
-            return None
-        return job
-
     async def _delete_obsolete_artifact(self, object_path: str | None) -> None:
-        if object_path is None:
-            return
-        try:
-            await asyncio.to_thread(self._storage_service.delete, object_path)
-        except Exception:  # noqa: BLE001
-            LOGGER.warning("Failed to delete invalidated quote PDF artifact", exc_info=True)
+        await self._pdf_artifact_service.delete_obsolete_artifact(object_path)
 
     async def share_quote(
         self,

--- a/backend/app/features/quotes/tests/test_pdf.py
+++ b/backend/app/features/quotes/tests/test_pdf.py
@@ -330,6 +330,64 @@ async def test_generate_pdf_reuses_persisted_artifact_without_rerendering(
     assert artifact_response.content == b"PDF for Q-001"
 
 
+async def test_get_pdf_artifact_resets_missing_storage_artifact_and_keeps_revision(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    _arq_pool_dependency: _MockArqPool,
+    _storage_service_dependency: _FakeStorageService,
+    _override_quote_service_dependency: _ConfigurablePdfIntegration,
+) -> None:
+    csrf_token = await _register_and_login(client, _credentials())
+    customer_id = await _create_customer(client, csrf_token)
+    quote = await _create_quote(client, csrf_token, customer_id)
+
+    initial_job = await _generate_ready_quote_pdf(
+        client,
+        db_session,
+        csrf_token=csrf_token,
+        quote_id=quote["id"],
+        pdf_integration=_override_quote_service_dependency,
+        storage_service=_storage_service_dependency,
+    )
+
+    stored_quote = await db_session.scalar(select(Document).where(Document.id == UUID(quote["id"])))
+    assert stored_quote is not None
+    assert stored_quote.pdf_artifact_path is not None
+    stored_revision = stored_quote.pdf_artifact_revision
+
+    _storage_service_dependency.delete(stored_quote.pdf_artifact_path)
+
+    artifact_response = await client.get(f"/api/quotes/{quote['id']}/pdf")
+    assert artifact_response.status_code == 409
+    assert artifact_response.json() == {"detail": PDF_ARTIFACT_NOT_READY_DETAIL}
+
+    db_session.expire_all()
+    recovered_quote = await db_session.scalar(
+        select(Document).where(Document.id == UUID(quote["id"]))
+    )
+    assert recovered_quote is not None
+    assert recovered_quote.pdf_artifact_path is None
+    assert recovered_quote.pdf_artifact_job_id is None
+    assert recovered_quote.pdf_artifact_revision == stored_revision
+
+    detail_response = await client.get(f"/api/quotes/{quote['id']}")
+    assert detail_response.status_code == 200
+    assert detail_response.json()["pdf_artifact"] == {
+        "status": "missing",
+        "job_id": None,
+        "download_url": None,
+        "terminal_error": None,
+    }
+
+    next_job_response = await client.post(
+        f"/api/quotes/{quote['id']}/pdf",
+        headers={"X-CSRF-Token": csrf_token},
+    )
+    next_job = _assert_async_pdf_job_response(next_job_response, document_id=quote["id"])
+    assert next_job["document_revision"] == stored_revision
+    assert initial_job["document_revision"] == stored_revision
+
+
 async def test_generate_pdf_reuses_existing_pending_job_instead_of_enqueuing_duplicate(
     client: AsyncClient,
     _arq_pool_dependency: _MockArqPool,


### PR DESCRIPTION
## Summary
- extract authenticated quote PDF artifact lifecycle behavior into a dedicated slice at backend/app/features/quotes/pdf_artifacts
- keep QuoteService as the stable facade while delegating start_pdf_generation and get_pdf_artifact to QuotePdfArtifactService
- move reusable pending job lookup and obsolete artifact storage cleanup behavior under the new slice coordinator
- add authenticated storage-loss recovery coverage to verify artifact field reset and revision stability

## Verification
- cd /home/odys/stima/backend && .venv/bin/pytest app/features/quotes/tests/test_pdf.py::test_generate_pdf_returns_pdf_and_sets_ready app/features/quotes/tests/test_pdf.py::test_generate_pdf_reuses_persisted_artifact_without_rerendering app/features/quotes/tests/test_pdf.py::test_get_pdf_artifact_resets_missing_storage_artifact_and_keeps_revision app/features/quotes/tests/test_pdf.py::test_generate_pdf_reuses_existing_pending_job_instead_of_enqueuing_duplicate app/features/quotes/tests/test_pdf.py::test_generate_pdf_does_not_downgrade_shared_quote app/features/quotes/tests/test_pdf.py::test_generate_pdf_does_not_downgrade_post_share_quote_statuses app/features/quotes/tests/test_pdf.py::test_generate_pdf_returns_404_for_nonexistent_quote app/features/quotes/tests/test_pdf.py::test_generate_pdf_returns_422_when_render_fails app/features/quotes/tests/test_pdf.py::test_generate_pdf_rejects_documents_that_exceed_render_limits app/features/quotes/tests/test_service.py::test_update_quote_with_unchanged_rendered_values_preserves_pdf_artifact
- cd /home/odys/stima/backend && .venv/bin/pytest app/features/quotes/tests/test_pdf.py::test_patch_quote_rendered_fields_invalidates_ready_pdf_artifact_and_bumps_revision
- cd /home/odys/stima && make backend-verify

Closes #341
