### PR TITLE
Extract quote delete lifecycle slice

### DIFF
--- a/backend/app/features/quotes/deletion/__init__.py
+++ b/backend/app/features/quotes/deletion/__init__.py
@@ -1,0 +1,5 @@
+"""Quote deletion lifecycle slice."""
+
+from app.features.quotes.deletion.service import QuoteDeletionService
+
+__all__ = ["QuoteDeletionService"]

--- a/backend/app/features/quotes/deletion/service.py
+++ b/backend/app/features/quotes/deletion/service.py
@@ -1,0 +1,56 @@
+"""Quote deletion lifecycle orchestration."""
+
+from __future__ import annotations
+
+from typing import Protocol
+from uuid import UUID
+
+from app.features.quotes.errors import QuoteServiceError
+from app.features.quotes.models import Document, QuoteStatus
+from app.shared.event_logger import log_event
+
+_NON_DELETABLE_QUOTE_STATUSES = frozenset(
+    {
+        QuoteStatus.SHARED,
+        QuoteStatus.VIEWED,
+        QuoteStatus.APPROVED,
+        QuoteStatus.DECLINED,
+    }
+)
+
+
+class QuoteDeletionRepositoryProtocol(Protocol):
+    """Structural protocol for quote-deletion persistence behavior."""
+
+    async def get_by_id(self, quote_id: UUID, user_id: UUID) -> Document | None: ...
+
+    async def delete(self, document_id: UUID) -> None: ...
+
+    async def commit(self) -> None: ...
+
+
+class QuoteDeletionService:
+    """Delete one owned quote and emit the deletion event after commit."""
+
+    def __init__(self, *, repository: QuoteDeletionRepositoryProtocol) -> None:
+        self._repository = repository
+
+    async def delete_quote(self, *, user_id: UUID, quote_id: UUID) -> None:
+        """Hard-delete an owned quote when its status allows deletion."""
+        quote = await self._repository.get_by_id(quote_id, user_id)
+        if quote is None:
+            raise QuoteServiceError(detail="Not found", status_code=404)
+        if quote.status in _NON_DELETABLE_QUOTE_STATUSES:
+            raise QuoteServiceError(
+                detail="Shared quotes cannot be deleted",
+                status_code=409,
+            )
+
+        await self._repository.delete(quote_id)
+        await self._repository.commit()
+        log_event(
+            "quote.deleted",
+            user_id=user_id,
+            quote_id=quote.id,
+            customer_id=quote.customer_id,
+        )

--- a/backend/app/features/quotes/service.py
+++ b/backend/app/features/quotes/service.py
@@ -16,6 +16,7 @@ from sqlalchemy.exc import IntegrityError
 from app.features.auth.models import User
 from app.features.jobs.models import JobRecord
 from app.features.jobs.service import JobService
+from app.features.quotes.deletion import QuoteDeletionService
 from app.features.quotes.errors import QuoteServiceError
 from app.features.quotes.extraction_outcomes import classify_extraction_result
 from app.features.quotes.models import Document, QuoteStatus
@@ -46,14 +47,6 @@ from app.shared.pricing import (
 )
 
 LOGGER = logging.getLogger(__name__)
-_NON_DELETABLE_QUOTE_STATUSES = frozenset(
-    {
-        QuoteStatus.SHARED,
-        QuoteStatus.VIEWED,
-        QuoteStatus.APPROVED,
-        QuoteStatus.DECLINED,
-    }
-)
 _TERMINAL_QUOTE_STATUSES = frozenset({QuoteStatus.APPROVED, QuoteStatus.DECLINED})
 _QUOTE_OUTCOME_ELIGIBLE_STATUSES = (
     QuoteStatus.DRAFT,
@@ -240,6 +233,7 @@ class QuoteService:
             delete_obsolete_artifact=self._delete_obsolete_artifact,
             ensure_quote_customer_assigned=ensure_quote_customer_assigned,
         )
+        self._deletion_service = QuoteDeletionService(repository=repository)
 
     async def create_quote(self, user: User, data: QuoteCreateRequest) -> Document:
         """Create a user-owned quote and retry once on sequence collisions."""
@@ -531,24 +525,10 @@ class QuoteService:
         )
 
     async def delete_quote(self, user: User, quote_id: UUID) -> None:
-        """Delete a user-owned quote unless it has already been shared."""
-        user_id = _resolve_user_id(user)
-        quote = await self._repository.get_by_id(quote_id, user_id)
-        if quote is None:
-            raise QuoteServiceError(detail="Not found", status_code=404)
-        if quote.status in _NON_DELETABLE_QUOTE_STATUSES:
-            raise QuoteServiceError(
-                detail="Shared quotes cannot be deleted",
-                status_code=409,
-            )
-
-        await self._repository.delete(quote_id)
-        await self._repository.commit()
-        log_event(
-            "quote.deleted",
-            user_id=user_id,
-            quote_id=quote.id,
-            customer_id=quote.customer_id,
+        """Delegate owner-facing quote deletion to the deletion lifecycle slice."""
+        await self._deletion_service.delete_quote(
+            user_id=_resolve_user_id(user),
+            quote_id=quote_id,
         )
 
     async def start_pdf_generation(


### PR DESCRIPTION
## Summary
- extract quote deletion orchestration into a dedicated deletion lifecycle slice
- keep QuoteService as the stable facade and delegate delete behavior after resolving user_id
- preserve delete guards, commit timing, and quote.deleted event logging semantics

## Verification
- cd /home/odys/stima/backend && .venv/bin/pytest -q app/features/quotes/tests/test_quotes.py::test_delete_quote_returns_204_for_owned_draft_and_ready_quotes_and_cascades app/features/quotes/tests/test_quotes.py::test_delete_quote_returns_404_for_missing_quote app/features/quotes/tests/test_quotes.py::test_delete_quote_returns_404_for_different_users_quote app/features/quotes/tests/test_quotes.py::test_delete_shared_quote_returns_409 app/features/quotes/tests/test_quotes.py::test_delete_non_editable_quote_statuses_return_409
- cd /home/odys/stima/backend && .venv/bin/pytest -q app/features/quotes/tests/test_quotes.py::test_business_events_are_logged_for_quote_customer_and_extraction_flows
- cd /home/odys/stima && make backend-verify

Closes #346
