### PR TITLE
Extract quote outcome lifecycle slice

### DIFF
--- a/backend/app/features/quotes/outcomes/__init__.py
+++ b/backend/app/features/quotes/outcomes/__init__.py
@@ -1,0 +1,5 @@
+"""Quote outcome lifecycle slice."""
+
+from app.features.quotes.outcomes.service import QuoteOutcomeService
+
+__all__ = ["QuoteOutcomeService"]

--- a/backend/app/features/quotes/outcomes/service.py
+++ b/backend/app/features/quotes/outcomes/service.py
@@ -1,0 +1,89 @@
+"""Quote outcome lifecycle orchestration."""
+
+from __future__ import annotations
+
+from typing import Literal, Protocol
+from uuid import UUID
+
+from app.features.quotes.errors import QuoteServiceError
+from app.features.quotes.models import Document, QuoteStatus
+from app.shared.event_logger import log_event
+
+_QUOTE_OUTCOME_ELIGIBLE_STATUSES = (
+    QuoteStatus.DRAFT,
+    QuoteStatus.READY,
+    QuoteStatus.SHARED,
+    QuoteStatus.VIEWED,
+    QuoteStatus.APPROVED,
+    QuoteStatus.DECLINED,
+)
+
+
+class QuoteOutcomeRepositoryProtocol(Protocol):
+    """Repository behavior required by quote outcome lifecycle orchestration."""
+
+    async def get_by_id(self, quote_id: UUID, user_id: UUID) -> Document | None: ...
+
+    async def set_quote_outcome(
+        self,
+        *,
+        quote_id: UUID,
+        user_id: UUID,
+        status: QuoteStatus,
+        allowed_current_statuses: tuple[QuoteStatus, ...],
+    ) -> Document | None: ...
+
+    async def commit(self) -> None: ...
+
+    async def refresh(self, document: Document) -> Document: ...
+
+
+class QuoteOutcomeService:
+    """Record quote outcomes with idempotency and atomic race fallback semantics."""
+
+    def __init__(self, *, repository: QuoteOutcomeRepositoryProtocol) -> None:
+        self._repository = repository
+
+    async def mark_quote_outcome(
+        self,
+        *,
+        user_id: UUID,
+        quote_id: UUID,
+        outcome: Literal["approved", "declined"],
+    ) -> Document:
+        """Persist one approved/declined transition and emit the matching outcome event."""
+        quote = await self._repository.get_by_id(quote_id, user_id)
+        if quote is None:
+            raise QuoteServiceError(detail="Not found", status_code=404)
+
+        next_status = QuoteStatus.APPROVED if outcome == "approved" else QuoteStatus.DECLINED
+        if quote.status == next_status:
+            return quote
+
+        event_name = "quote_approved" if outcome == "approved" else "quote_marked_lost"
+        updated_quote = await self._repository.set_quote_outcome(
+            quote_id=quote_id,
+            user_id=user_id,
+            status=next_status,
+            allowed_current_statuses=tuple(
+                status for status in _QUOTE_OUTCOME_ELIGIBLE_STATUSES if status != next_status
+            ),
+        )
+        if updated_quote is None:
+            current_quote = await self._repository.get_by_id(quote_id, user_id)
+            if current_quote is not None and current_quote.status == next_status:
+                return current_quote
+            raise QuoteServiceError(
+                detail="Unable to update quote outcome",
+                status_code=409,
+            )
+
+        await self._repository.commit()
+        refreshed_quote = await self._repository.refresh(updated_quote)
+        log_event(
+            event_name,
+            user_id=user_id,
+            quote_id=refreshed_quote.id,
+            customer_id=refreshed_quote.customer_id,
+        )
+        return refreshed_quote

--- a/backend/app/features/quotes/service.py
+++ b/backend/app/features/quotes/service.py
@@ -21,6 +21,7 @@ from app.features.quotes.errors import QuoteServiceError
 from app.features.quotes.extraction_outcomes import classify_extraction_result
 from app.features.quotes.models import Document, QuoteStatus
 from app.features.quotes.mutation import QuoteMutationService
+from app.features.quotes.outcomes import QuoteOutcomeService
 from app.features.quotes.pdf_artifacts import QuotePdfArtifactService
 from app.features.quotes.repository import (
     PublicShareRecord,
@@ -48,14 +49,6 @@ from app.shared.pricing import (
 
 LOGGER = logging.getLogger(__name__)
 _TERMINAL_QUOTE_STATUSES = frozenset({QuoteStatus.APPROVED, QuoteStatus.DECLINED})
-_QUOTE_OUTCOME_ELIGIBLE_STATUSES = (
-    QuoteStatus.DRAFT,
-    QuoteStatus.READY,
-    QuoteStatus.SHARED,
-    QuoteStatus.VIEWED,
-    QuoteStatus.APPROVED,
-    QuoteStatus.DECLINED,
-)
 _CUSTOMER_ASSIGNMENT_REQUIRED_DETAIL = "Assign a customer before continuing."
 _APPENDABLE_QUOTE_STATUSES = frozenset(
     {
@@ -234,6 +227,7 @@ class QuoteService:
             ensure_quote_customer_assigned=ensure_quote_customer_assigned,
         )
         self._deletion_service = QuoteDeletionService(repository=repository)
+        self._outcome_service = QuoteOutcomeService(repository=repository)
 
     async def create_quote(self, user: User, data: QuoteCreateRequest) -> Document:
         """Create a user-owned quote and retry once on sequence collisions."""
@@ -599,42 +593,12 @@ class QuoteService:
         quote_id: UUID,
         outcome: Literal["approved", "declined"],
     ) -> Document:
-        """Record a contractor-controlled quote outcome without changing share state."""
-        user_id = _resolve_user_id(user)
-        quote = await self._repository.get_by_id(quote_id, user_id)
-        if quote is None:
-            raise QuoteServiceError(detail="Not found", status_code=404)
-        next_status = QuoteStatus.APPROVED if outcome == "approved" else QuoteStatus.DECLINED
-        if quote.status == next_status:
-            return quote
-
-        event_name = "quote_approved" if outcome == "approved" else "quote_marked_lost"
-        updated_quote = await self._repository.set_quote_outcome(
+        """Delegate quote outcome lifecycle behavior to the outcome slice."""
+        return await self._outcome_service.mark_quote_outcome(
+            user_id=_resolve_user_id(user),
             quote_id=quote_id,
-            user_id=user_id,
-            status=next_status,
-            allowed_current_statuses=tuple(
-                status for status in _QUOTE_OUTCOME_ELIGIBLE_STATUSES if status != next_status
-            ),
+            outcome=outcome,
         )
-        if updated_quote is None:
-            current_quote = await self._repository.get_by_id(quote_id, user_id)
-            if current_quote is not None and current_quote.status == next_status:
-                return current_quote
-            raise QuoteServiceError(
-                detail="Unable to update quote outcome",
-                status_code=409,
-            )
-
-        await self._repository.commit()
-        refreshed_quote = await self._repository.refresh(updated_quote)
-        log_event(
-            event_name,
-            user_id=user_id,
-            quote_id=refreshed_quote.id,
-            customer_id=refreshed_quote.customer_id,
-        )
-        return refreshed_quote
 
 
 async def _create_quote_document(

--- a/backend/app/features/quotes/tests/test_quotes.py
+++ b/backend/app/features/quotes/tests/test_quotes.py
@@ -4422,6 +4422,37 @@ async def test_patch_quote_returns_404_for_different_users_quote(
     assert response.json() == {"detail": "Not found"}
 
 
+async def test_mark_won_quote_returns_404_for_different_users_quote(
+    client: AsyncClient,
+) -> None:
+    csrf_token_user_a = await _register_and_login(client, _credentials())
+    customer_id_user_a = await _create_customer(client, csrf_token_user_a)
+
+    create_response = await client.post(
+        "/api/quotes",
+        json={
+            "customer_id": customer_id_user_a,
+            "transcript": "quote transcript",
+            "line_items": [{"description": "line item", "details": None, "price": 55}],
+            "total_amount": 55,
+            "notes": None,
+            "source_type": "text",
+        },
+        headers={"X-CSRF-Token": csrf_token_user_a},
+    )
+    assert create_response.status_code == 201
+    quote_id = create_response.json()["id"]
+
+    csrf_token_user_b = await _register_and_login(client, _credentials())
+    response = await client.post(
+        f"/api/quotes/{quote_id}/mark-won",
+        headers={"X-CSRF-Token": csrf_token_user_b},
+    )
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Not found"}
+
+
 @pytest.mark.parametrize("make_ready", [False, True], ids=["draft", "ready"])
 async def test_delete_quote_returns_204_for_owned_draft_and_ready_quotes_and_cascades(
     client: AsyncClient,


### PR DESCRIPTION
## Summary
- extract quote outcome orchestration into a new outcomes slice: `QuoteOutcomeService`
- keep `QuoteService.mark_quote_outcome(...)` as the public facade and delegate after resolving `user_id`
- preserve outcome transition, idempotency, atomic race fallback, and event timing behavior
- add API coverage for foreign quote access on `POST /api/quotes/{quote_id}/mark-won` returning `404`

## Verification
- cd backend && .venv/bin/pytest app/features/quotes/tests/test_quotes.py::test_mark_quote_outcome_updates_status_and_persists_event_log app/features/quotes/tests/test_quotes.py::test_mark_quote_outcome_is_idempotent_when_reapplying_same_terminal_status app/features/quotes/tests/test_quotes.py::test_mark_quote_outcome_returns_409_when_atomic_write_loses_race app/features/quotes/tests/test_quotes.py::test_mark_won_quote_requires_csrf app/features/quotes/tests/test_quotes.py::test_mark_lost_quote_requires_csrf app/features/quotes/tests/test_quotes.py::test_mark_won_quote_returns_404_for_different_users_quote
- make backend-verify

Closes #347
