### PR TITLE
Extract quote extraction append lifecycle slice

### DIFF
--- a/backend/app/features/quotes/extraction_append/__init__.py
+++ b/backend/app/features/quotes/extraction_append/__init__.py
@@ -1,0 +1,5 @@
+"""Quote extraction append lifecycle slice."""
+
+from app.features.quotes.extraction_append.service import QuoteExtractionAppendService
+
+__all__ = ["QuoteExtractionAppendService"]

--- a/backend/app/features/quotes/extraction_append/service.py
+++ b/backend/app/features/quotes/extraction_append/service.py
@@ -1,0 +1,231 @@
+"""Quote extraction append lifecycle service."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Awaitable, Callable, Sequence
+from typing import Protocol
+from uuid import UUID
+
+from app.features.quotes.errors import QuoteServiceError
+from app.features.quotes.extraction_outcomes import classify_extraction_result
+from app.features.quotes.models import Document, QuoteStatus
+from app.features.quotes.schemas import ExtractionResult, LineItemDraft
+from app.shared.pricing import (
+    PricingValidationError,
+    derive_document_subtotal_from_line_items,
+    document_field_float_or_none,
+    resolve_document_subtotal_for_edit,
+    validate_document_pricing_input,
+)
+
+_APPENDABLE_QUOTE_STATUSES = frozenset(
+    {
+        QuoteStatus.DRAFT,
+        QuoteStatus.READY,
+        QuoteStatus.SHARED,
+        QuoteStatus.VIEWED,
+        QuoteStatus.APPROVED,
+        QuoteStatus.DECLINED,
+    }
+)
+_APPEND_UNAVAILABLE_DETAIL = "This quote can no longer be edited."
+_APPEND_TRANSCRIPT_SEPARATOR_PATTERN = re.compile(r"(?:^|\n\n)Added later(?: \(\d+\))?:\n")
+_APPEND_TRANSCRIPT_BULLET_PREFIXES = ("- ", "* ")
+
+
+class QuoteExtractionAppendRepositoryProtocol(Protocol):
+    """Repository behavior required by extraction append lifecycle orchestration."""
+
+    async def get_by_id(self, quote_id: UUID, user_id: UUID) -> Document | None: ...
+
+    async def append_extraction(
+        self,
+        *,
+        document: Document,
+        transcript: str,
+        total_amount: float | None,
+        line_items: list[LineItemDraft],
+        extraction_tier: str | None = None,
+        extraction_degraded_reason_code: str | None = None,
+    ) -> Document: ...
+
+    async def invalidate_pdf_artifact(self, document: Document) -> str | None: ...
+
+    async def commit(self) -> None: ...
+
+    async def refresh(self, document: Document) -> Document: ...
+
+
+class QuoteExtractionAppendService:
+    """Own extraction append lifecycle behavior for existing quotes."""
+
+    def __init__(
+        self,
+        *,
+        repository: QuoteExtractionAppendRepositoryProtocol,
+        delete_obsolete_artifact: Callable[[str | None], Awaitable[None]],
+    ) -> None:
+        self._repository = repository
+        self._delete_obsolete_artifact = delete_obsolete_artifact
+
+    async def ensure_quote_appendable(
+        self,
+        *,
+        user_id: UUID,
+        quote_id: UUID,
+    ) -> Document:
+        """Return one owned quote that can accept append extraction updates."""
+        quote = await self._repository.get_by_id(quote_id, user_id)
+        if quote is None:
+            raise QuoteServiceError(detail="Not found", status_code=404)
+        if quote.status not in _APPENDABLE_QUOTE_STATUSES:
+            raise QuoteServiceError(detail=_APPEND_UNAVAILABLE_DETAIL, status_code=409)
+        return quote
+
+    async def append_extraction_to_quote(
+        self,
+        *,
+        user_id: UUID,
+        quote_id: UUID,
+        extraction_result: ExtractionResult,
+        commit: bool = True,
+    ) -> tuple[Document, ExtractionResult]:
+        """Append extraction output and commit cleanup only when `commit=True`."""
+        quote = await self.ensure_quote_appendable(user_id=user_id, quote_id=quote_id)
+        appended_line_items = [
+            LineItemDraft(
+                description=item.description,
+                details=item.details,
+                price=item.price,
+            )
+            for item in extraction_result.line_items
+        ]
+        merged_line_items = [
+            *[
+                LineItemDraft(
+                    description=line_item.description,
+                    details=line_item.details,
+                    price=document_field_float_or_none(line_item.price),
+                )
+                for line_item in quote.line_items
+            ],
+            *appended_line_items,
+        ]
+        line_items_define_subtotal, derived_line_item_subtotal = (
+            derive_document_subtotal_from_line_items(merged_line_items)
+        )
+        current_subtotal = resolve_document_subtotal_for_edit(
+            total_amount=quote.total_amount,
+            discount_type=quote.discount_type,
+            discount_value=quote.discount_value,
+            tax_rate=quote.tax_rate,
+            deposit_amount=quote.deposit_amount,
+            line_items=merged_line_items,
+        )
+        validated_pricing = _validate_document_pricing_for_append(
+            total_amount=(
+                derived_line_item_subtotal if line_items_define_subtotal else current_subtotal
+            ),
+            line_items=merged_line_items,
+            discount_type=quote.discount_type,
+            discount_value=document_field_float_or_none(quote.discount_value),
+            tax_rate=document_field_float_or_none(quote.tax_rate),
+            deposit_amount=document_field_float_or_none(quote.deposit_amount),
+        )
+
+        next_transcript = _merge_append_transcript(
+            current_transcript=quote.transcript,
+            appended_transcript=extraction_result.transcript,
+        )
+        extraction_metadata = classify_extraction_result(extraction_result)
+        updated_quote = await self._repository.append_extraction(
+            document=quote,
+            transcript=next_transcript,
+            total_amount=document_field_float_or_none(validated_pricing.total_amount),
+            line_items=appended_line_items,
+            extraction_tier=extraction_metadata.tier,
+            extraction_degraded_reason_code=extraction_metadata.degraded_reason_code,
+        )
+        obsolete_artifact_path = await self._repository.invalidate_pdf_artifact(updated_quote)
+        if not commit:
+            return updated_quote, extraction_result
+
+        await self._repository.commit()
+        await self._delete_obsolete_artifact(obsolete_artifact_path)
+        return await self._repository.refresh(updated_quote), extraction_result
+
+
+def _validate_document_pricing_for_append(
+    *,
+    total_amount: float | None,
+    line_items: Sequence[object] | None,
+    discount_type: str | None,
+    discount_value: float | None,
+    tax_rate: float | None,
+    deposit_amount: float | None,
+):
+    try:
+        return validate_document_pricing_input(
+            total_amount=total_amount,
+            line_items=line_items,
+            discount_type=discount_type,
+            discount_value=discount_value,
+            tax_rate=tax_rate,
+            deposit_amount=deposit_amount,
+        )
+    except PricingValidationError as exc:
+        raise QuoteServiceError(detail=str(exc), status_code=422) from exc
+
+
+def _merge_append_transcript(*, current_transcript: str, appended_transcript: str) -> str:
+    normalized_current = current_transcript.rstrip()
+    appended_entries = _extract_append_entries(appended_transcript)
+
+    if not normalized_current:
+        if not appended_entries:
+            return ""
+        return "Added later:\n" + "\n".join(f"- {entry}" for entry in appended_entries)
+
+    base_transcript, existing_entries = _split_transcript_and_append_entries(normalized_current)
+    merged_entries = [*existing_entries, *appended_entries]
+    if not merged_entries:
+        return base_transcript
+
+    append_section = "Added later:\n" + "\n".join(f"- {entry}" for entry in merged_entries)
+    if not base_transcript:
+        return append_section
+    return f"{base_transcript}\n\n{append_section}"
+
+
+def _split_transcript_and_append_entries(current_transcript: str) -> tuple[str, list[str]]:
+    matches = list(_APPEND_TRANSCRIPT_SEPARATOR_PATTERN.finditer(current_transcript))
+    if not matches:
+        return current_transcript, []
+
+    base_transcript = current_transcript[: matches[0].start()].rstrip()
+    entries: list[str] = []
+    for index, match in enumerate(matches):
+        body_start = match.end()
+        body_end = (
+            matches[index + 1].start() if index + 1 < len(matches) else len(current_transcript)
+        )
+        section_body = current_transcript[body_start:body_end]
+        entries.extend(_extract_append_entries(section_body))
+
+    return base_transcript, entries
+
+
+def _extract_append_entries(transcript: str) -> list[str]:
+    entries: list[str] = []
+    for raw_line in transcript.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        for prefix in _APPEND_TRANSCRIPT_BULLET_PREFIXES:
+            if line.startswith(prefix):
+                line = line[len(prefix) :].strip()
+                break
+        if line:
+            entries.append(line)
+    return entries

--- a/backend/app/features/quotes/service.py
+++ b/backend/app/features/quotes/service.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-import re
 from collections.abc import Sequence
 from datetime import datetime
 from typing import Literal, Protocol, cast
@@ -18,6 +17,7 @@ from app.features.jobs.models import JobRecord
 from app.features.jobs.service import JobService
 from app.features.quotes.deletion import QuoteDeletionService
 from app.features.quotes.errors import QuoteServiceError
+from app.features.quotes.extraction_append import QuoteExtractionAppendService
 from app.features.quotes.extraction_outcomes import classify_extraction_result
 from app.features.quotes.models import Document, QuoteStatus
 from app.features.quotes.mutation import QuoteMutationService
@@ -41,28 +41,13 @@ from app.integrations.storage import StorageServiceProtocol
 from app.shared.event_logger import log_event
 from app.shared.pricing import (
     PricingValidationError,
-    derive_document_subtotal_from_line_items,
     document_field_float_or_none,
-    resolve_document_subtotal_for_edit,
     validate_document_pricing_input,
 )
 
 LOGGER = logging.getLogger(__name__)
 _TERMINAL_QUOTE_STATUSES = frozenset({QuoteStatus.APPROVED, QuoteStatus.DECLINED})
 _CUSTOMER_ASSIGNMENT_REQUIRED_DETAIL = "Assign a customer before continuing."
-_APPENDABLE_QUOTE_STATUSES = frozenset(
-    {
-        QuoteStatus.DRAFT,
-        QuoteStatus.READY,
-        QuoteStatus.SHARED,
-        QuoteStatus.VIEWED,
-        QuoteStatus.APPROVED,
-        QuoteStatus.DECLINED,
-    }
-)
-_APPEND_UNAVAILABLE_DETAIL = "This quote can no longer be edited."
-_APPEND_TRANSCRIPT_SEPARATOR_PATTERN = re.compile(r"(?:^|\n\n)Added later(?: \(\d+\))?:\n")
-_APPEND_TRANSCRIPT_BULLET_PREFIXES = ("- ", "* ")
 
 
 class QuoteRepositoryProtocol(Protocol):
@@ -225,6 +210,10 @@ class QuoteService:
             repository=repository,
             delete_obsolete_artifact=self._delete_obsolete_artifact,
             ensure_quote_customer_assigned=ensure_quote_customer_assigned,
+        )
+        self._extraction_append_service = QuoteExtractionAppendService(
+            repository=repository,
+            delete_obsolete_artifact=self._delete_obsolete_artifact,
         )
         self._deletion_service = QuoteDeletionService(repository=repository)
         self._outcome_service = QuoteOutcomeService(repository=repository)
@@ -401,12 +390,10 @@ class QuoteService:
         quote_id: UUID,
     ) -> Document:
         """Return one owned quote that can accept append extraction updates."""
-        quote = await self._repository.get_by_id(quote_id, user_id)
-        if quote is None:
-            raise QuoteServiceError(detail="Not found", status_code=404)
-        if quote.status not in _APPENDABLE_QUOTE_STATUSES:
-            raise QuoteServiceError(detail=_APPEND_UNAVAILABLE_DETAIL, status_code=409)
-        return quote
+        return await self._extraction_append_service.ensure_quote_appendable(
+            user_id=user_id,
+            quote_id=quote_id,
+        )
 
     async def append_extraction_to_quote(
         self,
@@ -416,69 +403,13 @@ class QuoteService:
         extraction_result: ExtractionResult,
         commit: bool = True,
     ) -> tuple[Document, ExtractionResult]:
-        """Append extraction output onto an existing persisted quote."""
-        quote = await self.ensure_quote_appendable(user_id=user_id, quote_id=quote_id)
-        appended_line_items = [
-            LineItemDraft(
-                description=item.description,
-                details=item.details,
-                price=item.price,
-            )
-            for item in extraction_result.line_items
-        ]
-        merged_line_items = [
-            *[
-                LineItemDraft(
-                    description=line_item.description,
-                    details=line_item.details,
-                    price=document_field_float_or_none(line_item.price),
-                )
-                for line_item in quote.line_items
-            ],
-            *appended_line_items,
-        ]
-        line_items_define_subtotal, derived_line_item_subtotal = (
-            derive_document_subtotal_from_line_items(merged_line_items)
+        """Delegate append extraction lifecycle behavior to the append slice."""
+        return await self._extraction_append_service.append_extraction_to_quote(
+            user_id=user_id,
+            quote_id=quote_id,
+            extraction_result=extraction_result,
+            commit=commit,
         )
-        current_subtotal = resolve_document_subtotal_for_edit(
-            total_amount=quote.total_amount,
-            discount_type=quote.discount_type,
-            discount_value=quote.discount_value,
-            tax_rate=quote.tax_rate,
-            deposit_amount=quote.deposit_amount,
-            line_items=merged_line_items,
-        )
-        validated_pricing = _validate_document_pricing_for_quote(
-            total_amount=(
-                derived_line_item_subtotal if line_items_define_subtotal else current_subtotal
-            ),
-            line_items=merged_line_items,
-            discount_type=quote.discount_type,
-            discount_value=document_field_float_or_none(quote.discount_value),
-            tax_rate=document_field_float_or_none(quote.tax_rate),
-            deposit_amount=document_field_float_or_none(quote.deposit_amount),
-        )
-
-        next_transcript = _merge_append_transcript(
-            current_transcript=quote.transcript,
-            appended_transcript=extraction_result.transcript,
-        )
-        extraction_metadata = classify_extraction_result(extraction_result)
-        updated_quote = await self._repository.append_extraction(
-            document=quote,
-            transcript=next_transcript,
-            total_amount=document_field_float_or_none(validated_pricing.total_amount),
-            line_items=appended_line_items,
-            extraction_tier=extraction_metadata.tier,
-            extraction_degraded_reason_code=extraction_metadata.degraded_reason_code,
-        )
-        obsolete_artifact_path = await self._repository.invalidate_pdf_artifact(updated_quote)
-        if not commit:
-            return updated_quote, extraction_result
-
-        await self._repository.commit()
-        await self._delete_obsolete_artifact(obsolete_artifact_path)
-        return await self._repository.refresh(updated_quote), extraction_result
 
     async def list_quotes(
         self,
@@ -694,56 +625,3 @@ def _validate_document_pricing_for_quote(
         )
     except PricingValidationError as exc:
         raise QuoteServiceError(detail=str(exc), status_code=422) from exc
-
-
-def _merge_append_transcript(*, current_transcript: str, appended_transcript: str) -> str:
-    normalized_current = current_transcript.rstrip()
-    appended_entries = _extract_append_entries(appended_transcript)
-
-    if not normalized_current:
-        if not appended_entries:
-            return ""
-        return "Added later:\n" + "\n".join(f"- {entry}" for entry in appended_entries)
-
-    base_transcript, existing_entries = _split_transcript_and_append_entries(normalized_current)
-    merged_entries = [*existing_entries, *appended_entries]
-    if not merged_entries:
-        return base_transcript
-
-    append_section = "Added later:\n" + "\n".join(f"- {entry}" for entry in merged_entries)
-    if not base_transcript:
-        return append_section
-    return f"{base_transcript}\n\n{append_section}"
-
-
-def _split_transcript_and_append_entries(current_transcript: str) -> tuple[str, list[str]]:
-    matches = list(_APPEND_TRANSCRIPT_SEPARATOR_PATTERN.finditer(current_transcript))
-    if not matches:
-        return current_transcript, []
-
-    base_transcript = current_transcript[: matches[0].start()].rstrip()
-    entries: list[str] = []
-    for index, match in enumerate(matches):
-        body_start = match.end()
-        body_end = (
-            matches[index + 1].start() if index + 1 < len(matches) else len(current_transcript)
-        )
-        section_body = current_transcript[body_start:body_end]
-        entries.extend(_extract_append_entries(section_body))
-
-    return base_transcript, entries
-
-
-def _extract_append_entries(transcript: str) -> list[str]:
-    entries: list[str] = []
-    for raw_line in transcript.splitlines():
-        line = raw_line.strip()
-        if not line:
-            continue
-        for prefix in _APPEND_TRANSCRIPT_BULLET_PREFIXES:
-            if line.startswith(prefix):
-                line = line[len(prefix) :].strip()
-                break
-        if line:
-            entries.append(line)
-    return entries

--- a/backend/app/features/quotes/tests/test_quotes.py
+++ b/backend/app/features/quotes/tests/test_quotes.py
@@ -3365,6 +3365,46 @@ async def test_append_extraction_sync_appends_line_items_and_merges_transcript_e
     assert "Added later (2):" not in payload["transcript"]
 
 
+async def test_append_extraction_sync_cleans_obsolete_pdf_artifact_after_commit(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    deleted_paths: list[str] = []
+
+    def _capture_delete(self, object_path: str) -> None:  # noqa: ANN001
+        del self
+        deleted_paths.append(object_path)
+
+    monkeypatch.setattr(_MockStorageService, "delete", _capture_delete)
+
+    csrf_token = await _register_and_login(client, _credentials())
+    customer_id = await _create_customer(client, csrf_token)
+    quote = await _create_quote(client, csrf_token, customer_id)
+    quote_id = UUID(quote["id"])
+    app.state.arq_pool = None
+
+    persisted_quote = await db_session.get(Document, quote_id)
+    assert persisted_quote is not None
+    initial_revision = persisted_quote.pdf_artifact_revision
+    persisted_quote.pdf_artifact_path = "quotes/obsolete-artifact.pdf"
+    await db_session.commit()
+
+    append_response = await client.post(
+        f"/api/quotes/{quote_id}/append-extraction",
+        files=[("notes", (None, "append artifact cleanup"))],
+        headers={"X-CSRF-Token": csrf_token},
+    )
+
+    assert append_response.status_code == 200
+    assert deleted_paths == ["quotes/obsolete-artifact.pdf"]
+
+    refreshed_quote = await db_session.get(Document, quote_id)
+    assert refreshed_quote is not None
+    assert refreshed_quote.pdf_artifact_path is None
+    assert refreshed_quote.pdf_artifact_revision == initial_revision + 1
+
+
 async def test_append_extraction_enqueues_async_job_for_owned_quote(
     client: AsyncClient,
     db_session: AsyncSession,


### PR DESCRIPTION
## Summary
- extract quote append lifecycle behavior into `quotes/extraction_append/QuoteExtractionAppendService`
- keep `QuoteService` as the public facade and delegate `ensure_quote_appendable` + `append_extraction_to_quote` with unchanged signatures
- preserve sync (`commit=True`) and worker (`commit=False`) append semantics, including transcript merge, pricing validation, degraded extraction metadata, artifact invalidation, and obsolete artifact cleanup timing
- add a focused parity test that asserts sync append cleans obsolete PDF artifact paths after commit

## Verification
- `cd /home/odys/stima/backend && .venv/bin/pytest -q app/features/quotes/tests/test_quotes.py::test_append_extraction_sync_appends_line_items_and_merges_transcript_entries app/features/quotes/tests/test_quotes.py::test_append_extraction_sync_cleans_obsolete_pdf_artifact_after_commit app/features/quotes/tests/test_quotes.py::test_append_extraction_sync_retryable_failure_uses_degraded_append_semantics app/features/quotes/tests/test_quotes.py::test_append_extraction_sync_normalizes_legacy_numbered_transcript_sections app/features/quotes/tests/test_quotes.py::test_append_extraction_sync_merges_from_append_only_baseline_without_duplicate_headers app/features/quotes/tests/test_quotes.py::test_append_extraction_enqueues_async_job_for_owned_quote app/features/quotes/tests/test_quotes.py::test_append_extraction_rejects_when_async_job_limit_is_exhausted app/features/quotes/tests/test_quotes.py::test_append_extraction_async_worker_updates_existing_quote app/features/quotes/tests/test_quotes.py::test_append_extraction_returns_404_for_quotes_owned_by_other_users app/features/quotes/tests/test_quotes.py::test_append_extraction_worker_provider_failure_keeps_quote_unchanged` (10 passed before external interruption)
- `cd /home/odys/stima/backend && .venv/bin/pytest -q app/features/quotes/tests/test_quotes.py::test_append_extraction_sync_persistence_failure_keeps_quote_unchanged app/features/quotes/tests/test_quotes.py::test_append_extraction_requires_authentication app/features/quotes/tests/test_quotes.py::test_append_extraction_requires_csrf` (3 passed)
- `cd /home/odys/stima && make backend-verify` (pass)

Closes #350
