### PR TITLE
Task #352: extract quote creation/draft orchestration slice

### DIFF
--- a/backend/app/features/quotes/creation/__init__.py
+++ b/backend/app/features/quotes/creation/__init__.py
@@ -1,0 +1,5 @@
+"""Quote creation lifecycle slice exports."""
+
+from app.features.quotes.creation.service import QuoteCreationService
+
+__all__ = ["QuoteCreationService"]

--- a/backend/app/features/quotes/creation/service.py
+++ b/backend/app/features/quotes/creation/service.py
@@ -1,0 +1,293 @@
+"""Quote creation and draft persistence lifecycle service."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Literal, Protocol
+from uuid import UUID
+
+from sqlalchemy.exc import IntegrityError
+
+from app.features.quotes.errors import QuoteServiceError
+from app.features.quotes.extraction_outcomes import classify_extraction_result
+from app.features.quotes.models import Document
+from app.features.quotes.schemas import (
+    ExtractionResult,
+    LineItemDraft,
+    QuoteCreateRequest,
+)
+from app.shared.event_logger import log_event
+from app.shared.pricing import (
+    PricingValidationError,
+    document_field_float_or_none,
+    validate_document_pricing_input,
+)
+
+
+class QuoteCreationRepositoryProtocol(Protocol):
+    """Repository behavior required by quote creation orchestration."""
+
+    async def customer_exists_for_user(self, *, user_id: UUID, customer_id: UUID) -> bool: ...
+
+    async def create(
+        self,
+        *,
+        user_id: UUID,
+        customer_id: UUID | None,
+        title: str | None,
+        transcript: str,
+        line_items: list[LineItemDraft],
+        total_amount: float | None,
+        tax_rate: float | None,
+        discount_type: str | None,
+        discount_value: float | None,
+        deposit_amount: float | None,
+        notes: str | None,
+        source_type: str,
+        extraction_tier: str | None = None,
+        extraction_degraded_reason_code: str | None = None,
+    ) -> Document: ...
+
+    async def commit(self) -> None: ...
+
+    async def rollback(self) -> None: ...
+
+
+class QuoteCreationService:
+    """Own quote creation and draft persistence behavior."""
+
+    def __init__(self, *, repository: QuoteCreationRepositoryProtocol) -> None:
+        self._repository = repository
+
+    async def create_quote(self, *, user_id: UUID, data: QuoteCreateRequest) -> Document:
+        """Create a user-owned quote and retry once on sequence collisions."""
+        await self.ensure_customer_exists_for_user(
+            user_id=user_id,
+            customer_id=data.customer_id,
+        )
+
+        validated_pricing = _validate_document_pricing_for_quote(
+            total_amount=data.total_amount,
+            line_items=data.line_items,
+            discount_type=data.discount_type,
+            discount_value=data.discount_value,
+            tax_rate=data.tax_rate,
+            deposit_amount=data.deposit_amount,
+        )
+
+        quote = await self._create_quote_document(
+            user_id=user_id,
+            customer_id=data.customer_id,
+            title=data.title,
+            transcript=data.transcript,
+            line_items=data.line_items,
+            total_amount=document_field_float_or_none(validated_pricing.total_amount),
+            tax_rate=document_field_float_or_none(validated_pricing.tax_rate),
+            discount_type=validated_pricing.discount_type,
+            discount_value=document_field_float_or_none(validated_pricing.discount_value),
+            deposit_amount=document_field_float_or_none(validated_pricing.deposit_amount),
+            notes=data.notes,
+            source_type=data.source_type,
+        )
+        await self._repository.commit()
+        log_event(
+            "quote.created",
+            user_id=user_id,
+            quote_id=quote.id,
+            customer_id=quote.customer_id,
+        )
+        return quote
+
+    async def ensure_customer_exists_for_user(
+        self,
+        *,
+        user_id: UUID,
+        customer_id: UUID | None,
+    ) -> None:
+        """Reject missing or foreign customer ids when one is supplied."""
+        if customer_id is None:
+            return
+        customer_exists = await self._repository.customer_exists_for_user(
+            user_id=user_id,
+            customer_id=customer_id,
+        )
+        if not customer_exists:
+            raise QuoteServiceError(detail="Not found", status_code=404)
+
+    async def create_extracted_draft(
+        self,
+        *,
+        user_id: UUID,
+        customer_id: UUID | None,
+        extraction_result: ExtractionResult,
+        source_type: Literal["text", "voice"],
+        commit: bool = True,
+    ) -> Document:
+        """Persist one extraction result as a draft quote."""
+        await self.ensure_customer_exists_for_user(
+            user_id=user_id,
+            customer_id=customer_id,
+        )
+        extraction_metadata = classify_extraction_result(extraction_result)
+        try:
+            quote = await self._create_quote_document(
+                user_id=user_id,
+                customer_id=customer_id,
+                title=None,
+                transcript=extraction_result.transcript,
+                line_items=[
+                    LineItemDraft(
+                        description=item.description,
+                        details=item.details,
+                        price=item.price,
+                    )
+                    for item in extraction_result.line_items
+                ],
+                total_amount=extraction_result.total,
+                tax_rate=None,
+                discount_type=None,
+                discount_value=None,
+                deposit_amount=None,
+                notes=None,
+                source_type=source_type,
+                extraction_tier=extraction_metadata.tier,
+                extraction_degraded_reason_code=extraction_metadata.degraded_reason_code,
+            )
+        except QuoteServiceError:
+            raise
+        except Exception as exc:  # noqa: BLE001
+            await self._repository.rollback()
+            raise QuoteServiceError(
+                detail="Unable to save extracted draft right now. Please try again.",
+                status_code=503,
+            ) from exc
+        if not commit:
+            return quote
+
+        try:
+            await self._repository.commit()
+        except Exception as exc:  # noqa: BLE001
+            await self._repository.rollback()
+            raise QuoteServiceError(
+                detail="Unable to save extracted draft right now. Please try again.",
+                status_code=503,
+            ) from exc
+        return quote
+
+    async def create_manual_draft(
+        self,
+        *,
+        user_id: UUID,
+        customer_id: UUID | None,
+    ) -> Document:
+        """Persist one blank draft quote without running extraction."""
+        await self.ensure_customer_exists_for_user(
+            user_id=user_id,
+            customer_id=customer_id,
+        )
+        try:
+            quote = await self._create_quote_document(
+                user_id=user_id,
+                customer_id=customer_id,
+                title=None,
+                transcript="",
+                line_items=[],
+                total_amount=None,
+                tax_rate=None,
+                discount_type=None,
+                discount_value=None,
+                deposit_amount=None,
+                notes=None,
+                source_type="text",
+            )
+        except QuoteServiceError:
+            raise
+        except Exception as exc:  # noqa: BLE001
+            await self._repository.rollback()
+            raise QuoteServiceError(
+                detail="Unable to save manual draft right now. Please try again.",
+                status_code=503,
+            ) from exc
+
+        try:
+            await self._repository.commit()
+        except Exception as exc:  # noqa: BLE001
+            await self._repository.rollback()
+            raise QuoteServiceError(
+                detail="Unable to save manual draft right now. Please try again.",
+                status_code=503,
+            ) from exc
+
+        return quote
+
+    async def _create_quote_document(
+        self,
+        *,
+        user_id: UUID,
+        customer_id: UUID | None,
+        title: str | None,
+        transcript: str,
+        line_items: list[LineItemDraft],
+        total_amount: float | None,
+        tax_rate: float | None,
+        discount_type: str | None,
+        discount_value: float | None,
+        deposit_amount: float | None,
+        notes: str | None,
+        source_type: Literal["text", "voice"],
+        extraction_tier: str | None = None,
+        extraction_degraded_reason_code: str | None = None,
+    ) -> Document:
+        for attempt in range(2):
+            try:
+                return await self._repository.create(
+                    user_id=user_id,
+                    customer_id=customer_id,
+                    title=title,
+                    transcript=transcript,
+                    line_items=line_items,
+                    total_amount=total_amount,
+                    tax_rate=tax_rate,
+                    discount_type=discount_type,
+                    discount_value=discount_value,
+                    deposit_amount=deposit_amount,
+                    notes=notes,
+                    source_type=source_type,
+                    extraction_tier=extraction_tier,
+                    extraction_degraded_reason_code=extraction_degraded_reason_code,
+                )
+            except IntegrityError as exc:
+                await self._repository.rollback()
+                if attempt == 0 and _is_doc_sequence_collision(exc):
+                    continue
+                raise
+
+        raise QuoteServiceError(detail="Unable to create quote", status_code=409)
+
+
+def _is_doc_sequence_collision(exc: IntegrityError) -> bool:
+    """Return true when IntegrityError was caused by doc-sequence uniqueness collision."""
+    message = str(exc.orig)
+    return "uq_documents_user_type_sequence" in message
+
+
+def _validate_document_pricing_for_quote(
+    *,
+    total_amount: float | None,
+    line_items: Sequence[object] | None,
+    discount_type: str | None,
+    discount_value: float | None,
+    tax_rate: float | None,
+    deposit_amount: float | None,
+):
+    try:
+        return validate_document_pricing_input(
+            total_amount=total_amount,
+            line_items=line_items,
+            discount_type=discount_type,
+            discount_value=discount_value,
+            tax_rate=tax_rate,
+            deposit_amount=deposit_amount,
+        )
+    except PricingValidationError as exc:
+        raise QuoteServiceError(detail=str(exc), status_code=422) from exc

--- a/backend/app/features/quotes/service.py
+++ b/backend/app/features/quotes/service.py
@@ -3,22 +3,20 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Sequence
 from datetime import datetime
 from typing import Literal, Protocol, cast
 from uuid import UUID
 
 from arq.connections import ArqRedis
 from sqlalchemy import inspect as sa_inspect
-from sqlalchemy.exc import IntegrityError
 
 from app.features.auth.models import User
 from app.features.jobs.models import JobRecord
 from app.features.jobs.service import JobService
+from app.features.quotes.creation import QuoteCreationService
 from app.features.quotes.deletion import QuoteDeletionService
 from app.features.quotes.errors import QuoteServiceError
 from app.features.quotes.extraction_append import QuoteExtractionAppendService
-from app.features.quotes.extraction_outcomes import classify_extraction_result
 from app.features.quotes.models import Document, QuoteStatus
 from app.features.quotes.mutation import QuoteMutationService
 from app.features.quotes.outcomes import QuoteOutcomeService
@@ -38,12 +36,7 @@ from app.features.quotes.schemas import (
 )
 from app.features.quotes.share import QuoteShareService
 from app.integrations.storage import StorageServiceProtocol
-from app.shared.event_logger import log_event
-from app.shared.pricing import (
-    PricingValidationError,
-    document_field_float_or_none,
-    validate_document_pricing_input,
-)
+from app.shared.event_logger import log_event  # noqa: F401
 
 LOGGER = logging.getLogger(__name__)
 _TERMINAL_QUOTE_STATUSES = frozenset({QuoteStatus.APPROVED, QuoteStatus.DECLINED})
@@ -217,47 +210,14 @@ class QuoteService:
         )
         self._deletion_service = QuoteDeletionService(repository=repository)
         self._outcome_service = QuoteOutcomeService(repository=repository)
+        self._creation_service = QuoteCreationService(repository=repository)
 
     async def create_quote(self, user: User, data: QuoteCreateRequest) -> Document:
-        """Create a user-owned quote and retry once on sequence collisions."""
-        user_id = _resolve_user_id(user)
-        await self.ensure_customer_exists_for_user(
-            user_id=user_id,
-            customer_id=data.customer_id,
+        """Delegate quote creation orchestration to the creation lifecycle slice."""
+        return await self._creation_service.create_quote(
+            user_id=_resolve_user_id(user),
+            data=data,
         )
-
-        validated_pricing = _validate_document_pricing_for_quote(
-            total_amount=data.total_amount,
-            line_items=data.line_items,
-            discount_type=data.discount_type,
-            discount_value=data.discount_value,
-            tax_rate=data.tax_rate,
-            deposit_amount=data.deposit_amount,
-        )
-
-        quote = await _create_quote_document(
-            self,
-            user_id=user_id,
-            customer_id=data.customer_id,
-            title=data.title,
-            transcript=data.transcript,
-            line_items=data.line_items,
-            total_amount=document_field_float_or_none(validated_pricing.total_amount),
-            tax_rate=document_field_float_or_none(validated_pricing.tax_rate),
-            discount_type=validated_pricing.discount_type,
-            discount_value=document_field_float_or_none(validated_pricing.discount_value),
-            deposit_amount=document_field_float_or_none(validated_pricing.deposit_amount),
-            notes=data.notes,
-            source_type=data.source_type,
-        )
-        await self._repository.commit()
-        log_event(
-            "quote.created",
-            user_id=user_id,
-            quote_id=quote.id,
-            customer_id=quote.customer_id,
-        )
-        return quote
 
     async def ensure_customer_exists_for_user(
         self,
@@ -265,15 +225,11 @@ class QuoteService:
         user_id: UUID,
         customer_id: UUID | None,
     ) -> None:
-        """Reject missing or foreign customer ids when one is supplied."""
-        if customer_id is None:
-            return
-        customer_exists = await self._repository.customer_exists_for_user(
+        """Delegate customer ownership checks to the creation lifecycle slice."""
+        await self._creation_service.ensure_customer_exists_for_user(
             user_id=user_id,
             customer_id=customer_id,
         )
-        if not customer_exists:
-            raise QuoteServiceError(detail="Not found", status_code=404)
 
     async def create_extracted_draft(
         self,
@@ -284,57 +240,14 @@ class QuoteService:
         source_type: Literal["text", "voice"],
         commit: bool = True,
     ) -> Document:
-        """Persist one extraction result as a draft quote."""
-        await self.ensure_customer_exists_for_user(
+        """Delegate extracted-draft persistence to the creation lifecycle slice."""
+        return await self._creation_service.create_extracted_draft(
             user_id=user_id,
             customer_id=customer_id,
+            extraction_result=extraction_result,
+            source_type=source_type,
+            commit=commit,
         )
-        extraction_metadata = classify_extraction_result(extraction_result)
-        try:
-            quote = await _create_quote_document(
-                self,
-                user_id=user_id,
-                customer_id=customer_id,
-                title=None,
-                transcript=extraction_result.transcript,
-                line_items=[
-                    LineItemDraft(
-                        description=item.description,
-                        details=item.details,
-                        price=item.price,
-                    )
-                    for item in extraction_result.line_items
-                ],
-                total_amount=extraction_result.total,
-                tax_rate=None,
-                discount_type=None,
-                discount_value=None,
-                deposit_amount=None,
-                notes=None,
-                source_type=source_type,
-                extraction_tier=extraction_metadata.tier,
-                extraction_degraded_reason_code=extraction_metadata.degraded_reason_code,
-            )
-        except QuoteServiceError:
-            raise
-        except Exception as exc:  # noqa: BLE001
-            await self._repository.rollback()
-            raise QuoteServiceError(
-                detail="Unable to save extracted draft right now. Please try again.",
-                status_code=503,
-            ) from exc
-        if not commit:
-            return quote
-
-        try:
-            await self._repository.commit()
-        except Exception as exc:  # noqa: BLE001
-            await self._repository.rollback()
-            raise QuoteServiceError(
-                detail="Unable to save extracted draft right now. Please try again.",
-                status_code=503,
-            ) from exc
-        return quote
 
     async def create_manual_draft(
         self,
@@ -342,46 +255,11 @@ class QuoteService:
         user_id: UUID,
         customer_id: UUID | None,
     ) -> Document:
-        """Persist one blank draft quote without running extraction."""
-        await self.ensure_customer_exists_for_user(
+        """Delegate manual-draft persistence to the creation lifecycle slice."""
+        return await self._creation_service.create_manual_draft(
             user_id=user_id,
             customer_id=customer_id,
         )
-        try:
-            quote = await _create_quote_document(
-                self,
-                user_id=user_id,
-                customer_id=customer_id,
-                title=None,
-                transcript="",
-                line_items=[],
-                total_amount=None,
-                tax_rate=None,
-                discount_type=None,
-                discount_value=None,
-                deposit_amount=None,
-                notes=None,
-                source_type="text",
-            )
-        except QuoteServiceError:
-            raise
-        except Exception as exc:  # noqa: BLE001
-            await self._repository.rollback()
-            raise QuoteServiceError(
-                detail="Unable to save manual draft right now. Please try again.",
-                status_code=503,
-            ) from exc
-
-        try:
-            await self._repository.commit()
-        except Exception as exc:  # noqa: BLE001
-            await self._repository.rollback()
-            raise QuoteServiceError(
-                detail="Unable to save manual draft right now. Please try again.",
-                status_code=503,
-            ) from exc
-
-        return quote
 
     async def ensure_quote_appendable(
         self,
@@ -532,51 +410,6 @@ class QuoteService:
         )
 
 
-async def _create_quote_document(
-    service: QuoteService,
-    *,
-    user_id: UUID,
-    customer_id: UUID | None,
-    title: str | None,
-    transcript: str,
-    line_items: list[LineItemDraft],
-    total_amount: float | None,
-    tax_rate: float | None,
-    discount_type: str | None,
-    discount_value: float | None,
-    deposit_amount: float | None,
-    notes: str | None,
-    source_type: Literal["text", "voice"],
-    extraction_tier: str | None = None,
-    extraction_degraded_reason_code: str | None = None,
-) -> Document:
-    for attempt in range(2):
-        try:
-            return await service._repository.create(
-                user_id=user_id,
-                customer_id=customer_id,
-                title=title,
-                transcript=transcript,
-                line_items=line_items,
-                total_amount=total_amount,
-                tax_rate=tax_rate,
-                discount_type=discount_type,
-                discount_value=discount_value,
-                deposit_amount=deposit_amount,
-                notes=notes,
-                source_type=source_type,
-                extraction_tier=extraction_tier,
-                extraction_degraded_reason_code=extraction_degraded_reason_code,
-            )
-        except IntegrityError as exc:
-            await service._repository.rollback()
-            if attempt == 0 and _is_doc_sequence_collision(exc):
-                continue
-            raise
-
-    raise QuoteServiceError(detail="Unable to create quote", status_code=409)
-
-
 def _resolve_user_id(user: User) -> UUID:
     """Resolve user id without triggering async lazy loads on detached ORM instances."""
     identity = sa_inspect(user).identity
@@ -594,34 +427,6 @@ def ensure_quote_customer_assigned(quote: Document) -> None:
         )
 
 
-def _is_doc_sequence_collision(exc: IntegrityError) -> bool:
-    """Return true when IntegrityError was caused by doc-sequence uniqueness collision."""
-    message = str(exc.orig)
-    return "uq_documents_user_type_sequence" in message
-
-
 def build_doc_number(*, doc_type: str, sequence: int) -> str:
     prefix = "I" if doc_type == "invoice" else "Q"
     return f"{prefix}-{sequence:03d}"
-
-
-def _validate_document_pricing_for_quote(
-    *,
-    total_amount: float | None,
-    line_items: Sequence[object] | None,
-    discount_type: str | None,
-    discount_value: float | None,
-    tax_rate: float | None,
-    deposit_amount: float | None,
-):
-    try:
-        return validate_document_pricing_input(
-            total_amount=total_amount,
-            line_items=line_items,
-            discount_type=discount_type,
-            discount_value=discount_value,
-            tax_rate=tax_rate,
-            deposit_amount=deposit_amount,
-        )
-    except PricingValidationError as exc:
-        raise QuoteServiceError(detail=str(exc), status_code=422) from exc

--- a/backend/app/features/quotes/service.py
+++ b/backend/app/features/quotes/service.py
@@ -36,7 +36,6 @@ from app.features.quotes.schemas import (
 )
 from app.features.quotes.share import QuoteShareService
 from app.integrations.storage import StorageServiceProtocol
-from app.shared.event_logger import log_event  # noqa: F401
 
 LOGGER = logging.getLogger(__name__)
 _TERMINAL_QUOTE_STATUSES = frozenset({QuoteStatus.APPROVED, QuoteStatus.DECLINED})

--- a/backend/app/features/quotes/tests/test_creation_service.py
+++ b/backend/app/features/quotes/tests/test_creation_service.py
@@ -1,0 +1,122 @@
+"""Quote creation slice unit tests."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import cast
+from uuid import UUID, uuid4
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+
+from app.features.quotes.creation.service import (
+    QuoteCreationRepositoryProtocol,
+    QuoteCreationService,
+)
+from app.features.quotes.models import Document
+from app.features.quotes.schemas import (
+    ExtractionResult,
+    LineItemExtracted,
+    QuoteCreateRequest,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+class _CreationRepository:
+    def __init__(
+        self,
+        *,
+        customer_exists: bool = True,
+        sequence_collision_on_first_create: bool = False,
+    ) -> None:
+        self._customer_exists = customer_exists
+        self._sequence_collision_on_first_create = sequence_collision_on_first_create
+        self.create_calls = 0
+        self.rollback_calls = 0
+        self.commit_calls = 0
+
+    async def customer_exists_for_user(self, *, user_id: UUID, customer_id: UUID) -> bool:
+        del user_id
+        del customer_id
+        return self._customer_exists
+
+    async def create(self, **kwargs):  # noqa: ANN003, ANN201
+        self.create_calls += 1
+        if self._sequence_collision_on_first_create and self.create_calls == 1:
+            raise IntegrityError(
+                statement="INSERT INTO documents (...) VALUES (...)",
+                params={},
+                orig=Exception(
+                    "duplicate key value violates unique constraint "
+                    '"uq_documents_user_type_sequence"'
+                ),
+            )
+
+        return cast(
+            Document,
+            SimpleNamespace(
+                id=uuid4(),
+                customer_id=kwargs["customer_id"],
+                transcript=kwargs["transcript"],
+            ),
+        )
+
+    async def commit(self) -> None:
+        self.commit_calls += 1
+
+    async def rollback(self) -> None:
+        self.rollback_calls += 1
+
+
+async def test_create_quote_document_retries_on_sequence_collision() -> None:
+    repository = _CreationRepository(sequence_collision_on_first_create=True)
+    service = QuoteCreationService(
+        repository=cast(QuoteCreationRepositoryProtocol, repository),
+    )
+    request = QuoteCreateRequest(
+        customer_id=uuid4(),
+        transcript="quote transcript",
+        line_items=[],
+        total_amount=None,
+        notes="Draft quote",
+        source_type="text",
+    )
+
+    quote = await service.create_quote(user_id=uuid4(), data=request)
+
+    assert quote.id is not None  # nosec B101 - pytest assertion
+    assert repository.create_calls == 2  # nosec B101 - pytest assertion
+    assert repository.rollback_calls == 1  # nosec B101 - pytest assertion
+    assert repository.commit_calls == 1  # nosec B101 - pytest assertion
+
+
+async def test_create_extracted_draft_commit_false_skips_commit() -> None:
+    repository = _CreationRepository()
+    service = QuoteCreationService(
+        repository=cast(QuoteCreationRepositoryProtocol, repository),
+    )
+    extraction_result = ExtractionResult(
+        transcript="mulch the front beds",
+        line_items=[
+            LineItemExtracted(
+                description="Brown mulch",
+                details="5 yards",
+                price=120,
+            )
+        ],
+        total=120,
+        confidence_notes=[],
+    )
+
+    quote = await service.create_extracted_draft(
+        user_id=uuid4(),
+        customer_id=None,
+        extraction_result=extraction_result,
+        source_type="text",
+        commit=False,
+    )
+
+    assert quote.id is not None  # nosec B101 - pytest assertion
+    assert repository.create_calls == 1  # nosec B101 - pytest assertion
+    assert repository.commit_calls == 0  # nosec B101 - pytest assertion

--- a/backend/app/features/quotes/tests/test_quotes.py
+++ b/backend/app/features/quotes/tests/test_quotes.py
@@ -31,7 +31,11 @@ from app.features.quotes import email_delivery_service
 from app.features.quotes.extraction_service import ExtractionService
 from app.features.quotes.models import Document, LineItem, QuoteStatus
 from app.features.quotes.repository import QuoteRenderContext, QuoteRepository
-from app.features.quotes.schemas import ExtractionResult, LineItemDraft, LineItemExtracted
+from app.features.quotes.schemas import (
+    ExtractionResult,
+    LineItemDraft,
+    LineItemExtracted,
+)
 from app.features.quotes.service import QuoteService, QuoteServiceError
 from app.integrations.audio import AudioClip, AudioError
 from app.integrations.email import EmailConfigurationError, EmailMessage, EmailSendError
@@ -310,7 +314,9 @@ def _reset_rate_limiter() -> Iterator[None]:
 
 
 @pytest.fixture(autouse=True)
-def _mock_arq_pool_for_send_email_tests(request: pytest.FixtureRequest) -> Iterator[None]:
+def _mock_arq_pool_for_send_email_tests(
+    request: pytest.FixtureRequest,
+) -> Iterator[None]:
     node_name = request.node.name
     if (
         "send_quote_email" not in node_name
@@ -635,6 +641,52 @@ async def test_create_quote_allows_empty_line_items_and_returns_empty_list(
     list_response = await client.get("/api/quotes")
     assert list_response.status_code == 200
     assert list_response.json()[0]["item_count"] == 0
+
+
+async def test_create_quote_emits_quote_created_business_event(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    emitted_events: list[dict[str, str]] = []
+
+    def _capture(message: str) -> None:
+        emitted_events.append(json.loads(message))
+
+    monkeypatch.setattr(event_logger._EVENT_LOGGER, "info", _capture)  # noqa: SLF001
+
+    credentials = _credentials()
+    csrf_token = await _register_and_login(client, credentials)
+    customer_id = await _create_customer(client, csrf_token)
+
+    response = await client.post(
+        "/api/quotes",
+        json={
+            "customer_id": customer_id,
+            "transcript": "quote transcript",
+            "line_items": [{"description": "line item", "details": None, "price": 55}],
+            "total_amount": 55,
+            "notes": None,
+            "source_type": "text",
+        },
+        headers={"X-CSRF-Token": csrf_token},
+    )
+
+    assert response.status_code == 201
+    payload = response.json()
+    user = await _get_user_by_email(db_session, credentials["email"])
+
+    quote_created_events = [
+        event
+        for event in emitted_events
+        if event.get("event") == "quote.created" and event.get("quote_id") == payload["id"]
+    ]
+    assert len(quote_created_events) == 1
+
+    quote_created_event = quote_created_events[0]
+    assert quote_created_event["quote_id"] == payload["id"]
+    assert quote_created_event["customer_id"] == customer_id
+    assert quote_created_event["user_id"] == str(user.id)
 
 
 async def test_update_quote_preserves_line_items_when_omitted(
@@ -5102,7 +5154,9 @@ async def test_patch_quote_doc_type_to_invoice_accepts_explicit_due_date(
     assert invoice_detail_response.json()["due_date"] == "2026-05-20"
 
 
-async def test_patch_quote_doc_type_after_share_returns_409(client: AsyncClient) -> None:
+async def test_patch_quote_doc_type_after_share_returns_409(
+    client: AsyncClient,
+) -> None:
     csrf_token = await _register_and_login(client, _credentials())
     customer_id = await _create_customer(client, csrf_token)
     quote = await _create_quote(client, csrf_token, customer_id)
@@ -5583,7 +5637,9 @@ async def test_patch_invoice_doc_type_to_quote_regenerates_number_and_clears_due
     assert stored_document.due_date is None
 
 
-async def test_patch_invoice_doc_type_after_share_returns_409(client: AsyncClient) -> None:
+async def test_patch_invoice_doc_type_after_share_returns_409(
+    client: AsyncClient,
+) -> None:
     csrf_token = await _register_and_login(client, _credentials())
     customer_id = await _create_customer(client, csrf_token)
     direct_invoice = await _create_direct_invoice(

--- a/backend/app/features/quotes/tests/test_service.py
+++ b/backend/app/features/quotes/tests/test_service.py
@@ -11,6 +11,7 @@ import pytest
 from app.features.auth.models import User
 from app.features.quotes import service as quote_service_module
 from app.features.quotes.models import QuoteStatus
+from app.features.quotes.mutation import service as quote_mutation_service_module
 from app.features.quotes.schemas import QuoteUpdateRequest
 from app.features.quotes.service import QuoteRepositoryProtocol, QuoteService
 
@@ -108,7 +109,11 @@ class _UnusedStorageService:
 async def test_update_quote_with_unchanged_rendered_values_preserves_pdf_artifact(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(quote_service_module, "log_event", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        quote_mutation_service_module,
+        "log_event",
+        lambda *args, **kwargs: None,
+    )
 
     user = User(
         email="owner@example.com",
@@ -154,7 +159,11 @@ async def test_update_quote_with_unchanged_rendered_values_preserves_pdf_artifac
 async def test_update_quote_rejects_clearing_assigned_customer(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(quote_service_module, "log_event", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        quote_mutation_service_module,
+        "log_event",
+        lambda *args, **kwargs: None,
+    )
 
     user = User(
         email="owner@example.com",
@@ -199,7 +208,11 @@ async def test_update_quote_rejects_clearing_assigned_customer(
 async def test_update_quote_rejects_reassigning_shared_quote_customer(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(quote_service_module, "log_event", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        quote_mutation_service_module,
+        "log_event",
+        lambda *args, **kwargs: None,
+    )
 
     user = User(
         email="owner@example.com",
@@ -244,7 +257,11 @@ async def test_update_quote_rejects_reassigning_shared_quote_customer(
 async def test_update_quote_rejects_reassigning_when_linked_invoice_exists(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(quote_service_module, "log_event", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        quote_mutation_service_module,
+        "log_event",
+        lambda *args, **kwargs: None,
+    )
 
     user = User(
         email="owner@example.com",
@@ -289,7 +306,11 @@ async def test_update_quote_rejects_reassigning_when_linked_invoice_exists(
 async def test_update_quote_skips_linked_invoice_lookup_when_customer_not_patched(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(quote_service_module, "log_event", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        quote_mutation_service_module,
+        "log_event",
+        lambda *args, **kwargs: None,
+    )
 
     user = User(
         email="owner@example.com",


### PR DESCRIPTION
## Summary
- Phase 5 implementation for quote creation and draft orchestration slice under Task #352.
- Added `QuoteCreationService` in `backend/app/features/quotes/creation/` and delegated create/manual-draft/extracted-draft orchestration from `QuoteService`.
- Preserved route-level draft logging ownership in `api.py` and preserved worker `commit=False` behavior.
- Added parity tests for sequence-collision retry seam and create-quote `quote.created` business-event emission.

## Gated Context
- This is the Phase 5 task execution after the gated kickoff request for Task #352.
- Scope follows the planned Phase 5 behavior-parity contract and keeps `QuoteService` as the stable public facade.

## Verification
- Targeted selectors from Task #352:
  - `cd backend && .venv/bin/pytest app/features/quotes/tests/test_quotes.py::test_create_quote_allows_empty_line_items_and_returns_empty_list app/features/quotes/tests/test_quotes.py::test_create_quote_emits_quote_created_business_event app/features/quotes/tests/test_quotes.py::test_create_manual_draft_without_customer_persists_empty_draft_and_logs_manual_event app/features/quotes/tests/test_quotes.py::test_create_quote_returns_404_for_nonexistent_customer 'app/features/quotes/tests/test_quotes.py::test_create_quote_rejects_invalid_optional_pricing_without_persisting_document[pricing_payload3-Tax rate must be between 0 and 1]' app/features/quotes/tests/test_quotes.py::test_extract_combined_notes_only_success app/worker/tests/test_job_registry.py::test_extraction_job_stores_result_json_on_success app/features/quotes/tests/test_creation_service.py::test_create_quote_document_retries_on_sequence_collision`
- Full backend contract:
  - `make backend-verify`

Closes #352
