### PR TITLE
refactor(invoices): extract creation lifecycle slice

### DIFF
--- a/backend/app/features/invoices/creation/__init__.py
+++ b/backend/app/features/invoices/creation/__init__.py
@@ -1,0 +1,5 @@
+"""Invoice creation lifecycle slice."""
+
+from app.features.invoices.creation.service import InvoiceCreationService
+
+__all__ = ["InvoiceCreationService"]

--- a/backend/app/features/invoices/creation/service.py
+++ b/backend/app/features/invoices/creation/service.py
@@ -1,0 +1,221 @@
+"""Invoice creation and quote-conversion lifecycle service."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from datetime import date
+from typing import Protocol
+from uuid import UUID
+
+from sqlalchemy.exc import IntegrityError
+
+from app.features.invoices.repository import build_default_due_date
+from app.features.invoices.schemas import InvoiceCreateRequest
+from app.features.quotes.models import Document
+from app.features.quotes.schemas import LineItemDraft
+from app.features.quotes.service import QuoteServiceError, ensure_quote_customer_assigned
+from app.shared.event_logger import log_event
+from app.shared.pricing import (
+    PricingValidationError,
+    document_field_float_or_none,
+    validate_document_pricing_input,
+)
+
+
+class InvoiceCreationRepositoryProtocol(Protocol):
+    """Narrow invoice repository surface used by invoice creation flows."""
+
+    async def customer_exists_for_user(self, *, user_id: UUID, customer_id: UUID) -> bool: ...
+
+    async def create(
+        self,
+        *,
+        user_id: UUID,
+        customer_id: UUID,
+        title: str | None,
+        transcript: str,
+        line_items: list[LineItemDraft],
+        total_amount: float | None,
+        tax_rate: float | None,
+        discount_type: str | None,
+        discount_value: float | None,
+        deposit_amount: float | None,
+        notes: str | None,
+        source_type: str,
+        due_date: date,
+    ) -> Document: ...
+
+    async def create_from_quote(
+        self,
+        *,
+        source_quote: Document,
+        due_date: date,
+    ) -> Document: ...
+
+    async def get_by_source_document_id(
+        self,
+        *,
+        source_document_id: UUID,
+        user_id: UUID,
+    ) -> Document | None: ...
+
+    async def commit(self) -> None: ...
+
+    async def rollback(self) -> None: ...
+
+
+class QuoteCreationSourceRepositoryProtocol(Protocol):
+    """Narrow quote repository surface used by quote conversion flow."""
+
+    async def get_by_id(self, quote_id: UUID, user_id: UUID) -> Document | None: ...
+
+
+class InvoiceCreationService:
+    """Own direct invoice creation and quote-to-invoice conversion behavior."""
+
+    def __init__(
+        self,
+        *,
+        invoice_repository: InvoiceCreationRepositoryProtocol,
+        quote_repository: QuoteCreationSourceRepositoryProtocol,
+    ) -> None:
+        self._invoice_repository = invoice_repository
+        self._quote_repository = quote_repository
+
+    async def create_invoice(self, *, user_id: UUID, data: InvoiceCreateRequest) -> Document:
+        """Create a direct invoice and retry once on sequence collisions."""
+        customer_exists = await self._invoice_repository.customer_exists_for_user(
+            user_id=user_id,
+            customer_id=data.customer_id,
+        )
+        if not customer_exists:
+            raise QuoteServiceError(detail="Not found", status_code=404)
+
+        validated_pricing = _validate_document_pricing_for_invoice(
+            total_amount=data.total_amount,
+            line_items=data.line_items,
+            discount_type=data.discount_type,
+            discount_value=data.discount_value,
+            tax_rate=data.tax_rate,
+            deposit_amount=data.deposit_amount,
+        )
+
+        for attempt in range(2):
+            try:
+                invoice = await self._invoice_repository.create(
+                    user_id=user_id,
+                    customer_id=data.customer_id,
+                    title=data.title,
+                    transcript=data.transcript,
+                    line_items=data.line_items,
+                    total_amount=document_field_float_or_none(validated_pricing.total_amount),
+                    tax_rate=document_field_float_or_none(validated_pricing.tax_rate),
+                    discount_type=validated_pricing.discount_type,
+                    discount_value=document_field_float_or_none(validated_pricing.discount_value),
+                    deposit_amount=document_field_float_or_none(validated_pricing.deposit_amount),
+                    notes=data.notes,
+                    source_type=data.source_type,
+                    due_date=build_default_due_date(),
+                )
+                await self._invoice_repository.commit()
+                log_event(
+                    "invoice_created",
+                    user_id=user_id,
+                    customer_id=invoice.customer_id,
+                )
+                return invoice
+            except IntegrityError as exc:
+                await self._invoice_repository.rollback()
+                if attempt == 0 and _is_doc_sequence_collision(exc):
+                    continue
+                if _is_doc_sequence_collision(exc):
+                    raise QuoteServiceError(
+                        detail="Unable to create invoice",
+                        status_code=409,
+                    ) from exc
+                raise
+
+        raise QuoteServiceError(detail="Unable to create invoice", status_code=409)
+
+    async def convert_quote_to_invoice(self, *, user_id: UUID, quote_id: UUID) -> Document:
+        """Create one invoice from a quote unless a linked invoice already exists."""
+        quote = await self._quote_repository.get_by_id(quote_id, user_id)
+        if quote is None:
+            raise QuoteServiceError(detail="Not found", status_code=404)
+        ensure_quote_customer_assigned(quote)
+
+        existing_invoice = await self._invoice_repository.get_by_source_document_id(
+            source_document_id=quote.id,
+            user_id=user_id,
+        )
+        if existing_invoice is not None:
+            raise QuoteServiceError(
+                detail="An invoice already exists for this quote",
+                status_code=409,
+            )
+
+        for attempt in range(2):
+            try:
+                invoice = await self._invoice_repository.create_from_quote(
+                    source_quote=quote,
+                    due_date=build_default_due_date(),
+                )
+                await self._invoice_repository.commit()
+                break
+            except IntegrityError as exc:
+                await self._invoice_repository.rollback()
+                duplicate_invoice = await self._invoice_repository.get_by_source_document_id(
+                    source_document_id=quote.id,
+                    user_id=user_id,
+                )
+                if duplicate_invoice is not None:
+                    raise QuoteServiceError(
+                        detail="An invoice already exists for this quote",
+                        status_code=409,
+                    ) from exc
+                if attempt == 0 and _is_doc_sequence_collision(exc):
+                    continue
+                if _is_doc_sequence_collision(exc):
+                    raise QuoteServiceError(
+                        detail="Unable to create invoice",
+                        status_code=409,
+                    ) from exc
+                raise
+        else:
+            raise QuoteServiceError(detail="Unable to create invoice", status_code=409)
+
+        log_event(
+            "invoice_created",
+            user_id=user_id,
+            quote_id=quote.id,
+            customer_id=invoice.customer_id,
+        )
+        return invoice
+
+
+def _is_doc_sequence_collision(exc: IntegrityError) -> bool:
+    """Return true when IntegrityError was caused by doc-sequence uniqueness collision."""
+    message = str(exc.orig)
+    return "uq_documents_user_type_sequence" in message
+
+
+def _validate_document_pricing_for_invoice(
+    *,
+    total_amount: float | None,
+    line_items: Sequence[object] | None,
+    discount_type: str | None,
+    discount_value: float | None,
+    tax_rate: float | None,
+    deposit_amount: float | None,
+):
+    try:
+        return validate_document_pricing_input(
+            total_amount=total_amount,
+            line_items=line_items,
+            discount_type=discount_type,
+            discount_value=discount_value,
+            tax_rate=tax_rate,
+            deposit_amount=deposit_amount,
+        )
+    except PricingValidationError as exc:
+        raise QuoteServiceError(detail=str(exc), status_code=422) from exc

--- a/backend/app/features/invoices/service.py
+++ b/backend/app/features/invoices/service.py
@@ -17,6 +17,7 @@ from sqlalchemy import inspect as sa_inspect
 from sqlalchemy.exc import IntegrityError
 
 from app.features.auth.models import User
+from app.features.invoices.creation import InvoiceCreationService
 from app.features.invoices.pdf_artifacts import InvoicePdfArtifactService
 from app.features.invoices.repository import (
     InvoiceDetailRow,
@@ -24,7 +25,6 @@ from app.features.invoices.repository import (
     InvoiceListItemSummary,
     InvoicePublicShareRecord,
     InvoiceRepository,
-    build_default_due_date,
 )
 from app.features.invoices.schemas import InvoiceCreateRequest, InvoiceUpdateRequest
 from app.features.invoices.share import InvoiceShareService
@@ -37,7 +37,6 @@ from app.features.quotes.service import (
     QuoteRepositoryProtocol,
     QuoteServiceError,
     build_doc_number,
-    ensure_quote_customer_assigned,
 )
 from app.integrations.storage import StorageServiceProtocol
 from app.shared.event_logger import log_event
@@ -211,6 +210,10 @@ class InvoiceService:
         self._quote_repository = quote_repository
         self._pdf = pdf_integration
         self._storage_service = storage_service
+        self._creation_service = InvoiceCreationService(
+            invoice_repository=invoice_repository,
+            quote_repository=quote_repository,
+        )
         self._share_service = InvoiceShareService(
             repository=invoice_repository,
             pdf_integration=pdf_integration,
@@ -223,59 +226,10 @@ class InvoiceService:
 
     async def create_invoice(self, user: User, data: InvoiceCreateRequest) -> Document:
         """Create a direct invoice and retry once on sequence collisions."""
-        user_id = _resolve_user_id(user)
-        customer_exists = await self._invoice_repository.customer_exists_for_user(
-            user_id=user_id,
-            customer_id=data.customer_id,
+        return await self._creation_service.create_invoice(
+            user_id=_resolve_user_id(user),
+            data=data,
         )
-        if not customer_exists:
-            raise QuoteServiceError(detail="Not found", status_code=404)
-
-        validated_pricing = _validate_document_pricing_for_invoice(
-            total_amount=data.total_amount,
-            line_items=data.line_items,
-            discount_type=data.discount_type,
-            discount_value=data.discount_value,
-            tax_rate=data.tax_rate,
-            deposit_amount=data.deposit_amount,
-        )
-
-        for attempt in range(2):
-            try:
-                invoice = await self._invoice_repository.create(
-                    user_id=user_id,
-                    customer_id=data.customer_id,
-                    title=data.title,
-                    transcript=data.transcript,
-                    line_items=data.line_items,
-                    total_amount=document_field_float_or_none(validated_pricing.total_amount),
-                    tax_rate=document_field_float_or_none(validated_pricing.tax_rate),
-                    discount_type=validated_pricing.discount_type,
-                    discount_value=document_field_float_or_none(validated_pricing.discount_value),
-                    deposit_amount=document_field_float_or_none(validated_pricing.deposit_amount),
-                    notes=data.notes,
-                    source_type=data.source_type,
-                    due_date=build_default_due_date(),
-                )
-                await self._invoice_repository.commit()
-                log_event(
-                    "invoice_created",
-                    user_id=user_id,
-                    customer_id=invoice.customer_id,
-                )
-                return invoice
-            except IntegrityError as exc:
-                await self._invoice_repository.rollback()
-                if attempt == 0 and _is_doc_sequence_collision(exc):
-                    continue
-                if _is_doc_sequence_collision(exc):
-                    raise QuoteServiceError(
-                        detail="Unable to create invoice",
-                        status_code=409,
-                    ) from exc
-                raise
-
-        raise QuoteServiceError(detail="Unable to create invoice", status_code=409)
 
     async def list_invoices(
         self,
@@ -290,59 +244,10 @@ class InvoiceService:
 
     async def convert_quote_to_invoice(self, user: User, quote_id: UUID) -> Document:
         """Create one invoice from a quote unless a linked invoice already exists."""
-        user_id = _resolve_user_id(user)
-        quote = await self._quote_repository.get_by_id(quote_id, user_id)
-        if quote is None:
-            raise QuoteServiceError(detail="Not found", status_code=404)
-        ensure_quote_customer_assigned(quote)
-
-        existing_invoice = await self._invoice_repository.get_by_source_document_id(
-            source_document_id=quote.id,
-            user_id=user_id,
+        return await self._creation_service.convert_quote_to_invoice(
+            user_id=_resolve_user_id(user),
+            quote_id=quote_id,
         )
-        if existing_invoice is not None:
-            raise QuoteServiceError(
-                detail="An invoice already exists for this quote",
-                status_code=409,
-            )
-
-        for attempt in range(2):
-            try:
-                invoice = await self._invoice_repository.create_from_quote(
-                    source_quote=quote,
-                    due_date=build_default_due_date(),
-                )
-                await self._invoice_repository.commit()
-                break
-            except IntegrityError as exc:
-                await self._invoice_repository.rollback()
-                duplicate_invoice = await self._invoice_repository.get_by_source_document_id(
-                    source_document_id=quote.id,
-                    user_id=user_id,
-                )
-                if duplicate_invoice is not None:
-                    raise QuoteServiceError(
-                        detail="An invoice already exists for this quote",
-                        status_code=409,
-                    ) from exc
-                if attempt == 0 and _is_doc_sequence_collision(exc):
-                    continue
-                if _is_doc_sequence_collision(exc):
-                    raise QuoteServiceError(
-                        detail="Unable to create invoice",
-                        status_code=409,
-                    ) from exc
-                raise
-        else:
-            raise QuoteServiceError(detail="Unable to create invoice", status_code=409)
-
-        log_event(
-            "invoice_created",
-            user_id=user_id,
-            quote_id=quote.id,
-            customer_id=invoice.customer_id,
-        )
-        return invoice
 
     async def get_invoice_detail(self, user: User, invoice_id: UUID) -> InvoiceDetailRow:
         """Return one user-owned invoice detail row or raise not found."""

--- a/backend/app/features/invoices/tests/test_service.py
+++ b/backend/app/features/invoices/tests/test_service.py
@@ -10,6 +10,7 @@ from uuid import uuid4
 import pytest
 from app.features.auth.models import User
 from app.features.invoices import service as invoice_service_module
+from app.features.invoices.creation import service as invoice_creation_service_module
 from app.features.invoices.schemas import InvoiceCreateRequest, InvoiceUpdateRequest
 from app.features.invoices.service import InvoiceRepositoryProtocol, InvoiceService
 from app.features.quotes.models import QuoteStatus
@@ -270,7 +271,7 @@ async def test_convert_quote_to_invoice_retries_sequence_collision_once(
     def _capture_log_event(event: str, **payload: object) -> None:
         logged_events.append({"event": event, **payload})
 
-    monkeypatch.setattr(invoice_service_module, "log_event", _capture_log_event)
+    monkeypatch.setattr(invoice_creation_service_module, "log_event", _capture_log_event)
 
     user = User(
         email="owner@example.com",


### PR DESCRIPTION
## Summary
- add `invoices/creation/` with `InvoiceCreationService` and narrow repository protocols for direct invoice creation and quote conversion
- delegate `InvoiceService.create_invoice` and `InvoiceService.convert_quote_to_invoice` to the new creation slice while keeping `InvoiceService` as the only external facade entrypoint
- keep duplicated `_is_doc_sequence_collision` and `_validate_document_pricing_for_invoice` in both `creation/service.py` and `invoices/service.py` intentionally for Phase 3 parity; this duplication is time-bounded and will be removed during Phase 4 mutation extraction
- update invoice service unit test monkeypatch seam for moved `invoice_created` logging

## Parity Lock (No Contract Change)
- status code parity: preserved for direct create and quote conversion (404/409/422 paths unchanged)
- response shape parity: preserved (same `Document` flow through existing API response mappers)
- error semantics parity: preserved (`QuoteServiceError` details/status codes unchanged)
- side-effect parity: preserved (`invoice_created` payload fields and sequence-collision retry/rollback choreography unchanged)

## Verification
- `cd backend && .venv/bin/pytest app/features/invoices/tests/test_service.py -k "create_invoice or convert_quote" -v -m "not live and not extraction_eval and not extraction_quality" -o cache_dir=.pytest_cache` (passed: 2 selected)
- `cd backend && .venv/bin/pytest app/features/quotes/tests/test_quotes.py -k "convert_quote_to_invoice" -v -m "not live and not extraction_eval and not extraction_quality" -o cache_dir=.pytest_cache` (passed: 12 selected)
- `cd backend && .venv/bin/pytest app/features/quotes/tests/test_quotes.py -k "invoice and create" -v -m "not live and not extraction_eval and not extraction_quality" -o cache_dir=.pytest_cache` (passed: 10 selected)
- `make backend-verify` (passed: 600 passed, 9 skipped, 19 deselected)

Closes #359
