### PR TITLE
Task #363: Extract invoice outcomes lifecycle slice

### DIFF
--- a/backend/app/features/invoices/outcomes/__init__.py
+++ b/backend/app/features/invoices/outcomes/__init__.py
@@ -1,0 +1,5 @@
+"""Invoice outcome lifecycle slice."""
+
+from app.features.invoices.outcomes.service import InvoiceOutcomeService
+
+__all__ = ["InvoiceOutcomeService"]

--- a/backend/app/features/invoices/outcomes/service.py
+++ b/backend/app/features/invoices/outcomes/service.py
@@ -1,0 +1,86 @@
+"""Invoice outcome lifecycle orchestration."""
+
+from __future__ import annotations
+
+from typing import Literal, Protocol
+from uuid import UUID
+
+from app.features.quotes.errors import QuoteServiceError
+from app.features.quotes.models import Document, QuoteStatus
+from app.shared.event_logger import log_event
+
+_INVOICE_OUTCOME_MUTABLE_STATUSES = frozenset(
+    {
+        QuoteStatus.SENT,
+        QuoteStatus.PAID,
+        QuoteStatus.VOID,
+    }
+)
+
+
+class InvoiceOutcomeRepositoryProtocol(Protocol):
+    """Repository behavior required by invoice outcome orchestration."""
+
+    async def get_by_id(self, invoice_id: UUID, user_id: UUID) -> Document | None: ...
+
+    async def commit(self) -> None: ...
+
+    async def refresh(self, invoice: Document) -> Document: ...
+
+
+class InvoiceOutcomeService:
+    """Own paid/void invoice outcome transitions and event side effects."""
+
+    def __init__(self, *, repository: InvoiceOutcomeRepositoryProtocol) -> None:
+        self._repository = repository
+
+    async def mark_invoice_paid(self, *, user_id: UUID, invoice_id: UUID) -> Document:
+        """Mark one invoice as paid when the current status is mutable."""
+        return await self._mark_invoice_outcome(
+            user_id=user_id,
+            invoice_id=invoice_id,
+            next_status=QuoteStatus.PAID,
+            event_name="invoice_paid",
+            action_label="paid",
+        )
+
+    async def mark_invoice_voided(self, *, user_id: UUID, invoice_id: UUID) -> Document:
+        """Mark one invoice as void when the current status is mutable."""
+        return await self._mark_invoice_outcome(
+            user_id=user_id,
+            invoice_id=invoice_id,
+            next_status=QuoteStatus.VOID,
+            event_name="invoice_voided",
+            action_label="void",
+        )
+
+    async def _mark_invoice_outcome(
+        self,
+        *,
+        user_id: UUID,
+        invoice_id: UUID,
+        next_status: QuoteStatus,
+        event_name: Literal["invoice_paid", "invoice_voided"],
+        action_label: Literal["paid", "void"],
+    ) -> Document:
+        invoice = await self._repository.get_by_id(invoice_id, user_id)
+        if invoice is None:
+            raise QuoteServiceError(detail="Not found", status_code=404)
+        if invoice.status == next_status:
+            return invoice
+        if invoice.status not in _INVOICE_OUTCOME_MUTABLE_STATUSES:
+            raise QuoteServiceError(
+                detail=f"Only sent, paid, or void invoices can be marked {action_label}.",
+                status_code=409,
+            )
+
+        invoice.status = next_status
+        await self._repository.commit()
+        refreshed_invoice = await self._repository.refresh(invoice)
+        log_event(
+            event_name,
+            user_id=user_id,
+            invoice_id=refreshed_invoice.id,
+            customer_id=refreshed_invoice.customer_id,
+        )
+        return refreshed_invoice

--- a/backend/app/features/invoices/service.py
+++ b/backend/app/features/invoices/service.py
@@ -17,6 +17,7 @@ from sqlalchemy import inspect as sa_inspect
 from app.features.auth.models import User
 from app.features.invoices.creation import InvoiceCreationService
 from app.features.invoices.mutation import InvoiceMutationService
+from app.features.invoices.outcomes import InvoiceOutcomeService
 from app.features.invoices.pdf_artifacts import InvoicePdfArtifactService
 from app.features.invoices.repository import (
     InvoiceDetailRow,
@@ -29,20 +30,11 @@ from app.features.invoices.schemas import InvoiceCreateRequest, InvoiceUpdateReq
 from app.features.invoices.share import InvoiceShareService
 from app.features.jobs.models import JobRecord
 from app.features.jobs.service import JobService
-from app.features.quotes.models import Document, QuoteStatus
+from app.features.quotes.models import Document
 from app.features.quotes.repository import QuoteRenderContext
 from app.features.quotes.schemas import LineItemDraft
 from app.features.quotes.service import QuoteRepositoryProtocol, QuoteServiceError
 from app.integrations.storage import StorageServiceProtocol
-from app.shared.event_logger import log_event
-
-_INVOICE_OUTCOME_MUTABLE_STATUSES = frozenset(
-    {
-        QuoteStatus.SENT,
-        QuoteStatus.PAID,
-        QuoteStatus.VOID,
-    }
-)
 
 
 class InvoiceRepositoryProtocol(Protocol):
@@ -201,6 +193,7 @@ class InvoiceService:
             repository=invoice_repository,
             delete_obsolete_artifact=self._pdf_artifact_service.delete_obsolete_artifact,
         )
+        self._outcome_service = InvoiceOutcomeService(repository=invoice_repository)
 
     async def create_invoice(self, user: User, data: InvoiceCreateRequest) -> Document:
         """Create a direct invoice and retry once on sequence collisions."""
@@ -239,22 +232,16 @@ class InvoiceService:
 
     async def mark_invoice_paid(self, user: User, invoice_id: UUID) -> Document:
         """Mark one invoice as paid without changing share/access capabilities."""
-        return await self._mark_invoice_outcome(
-            user,
-            invoice_id,
-            next_status=QuoteStatus.PAID,
-            event_name="invoice_paid",
-            action_label="paid",
+        return await self._outcome_service.mark_invoice_paid(
+            user_id=_resolve_user_id(user),
+            invoice_id=invoice_id,
         )
 
     async def mark_invoice_voided(self, user: User, invoice_id: UUID) -> Document:
         """Mark one invoice as void without changing share/access capabilities."""
-        return await self._mark_invoice_outcome(
-            user,
-            invoice_id,
-            next_status=QuoteStatus.VOID,
-            event_name="invoice_voided",
-            action_label="void",
+        return await self._outcome_service.mark_invoice_voided(
+            user_id=_resolve_user_id(user),
+            invoice_id=invoice_id,
         )
 
     async def update_invoice(
@@ -325,38 +312,6 @@ class InvoiceService:
     async def get_public_logo(self, share_token: str) -> tuple[bytes, str]:
         """Return public logo bytes/content type for one shared invoice token."""
         return await self._share_service.get_public_logo(share_token)
-
-    async def _mark_invoice_outcome(
-        self,
-        user: User,
-        invoice_id: UUID,
-        *,
-        next_status: QuoteStatus,
-        event_name: str,
-        action_label: str,
-    ) -> Document:
-        user_id = _resolve_user_id(user)
-        invoice = await self._invoice_repository.get_by_id(invoice_id, user_id)
-        if invoice is None:
-            raise QuoteServiceError(detail="Not found", status_code=404)
-        if invoice.status == next_status:
-            return invoice
-        if invoice.status not in _INVOICE_OUTCOME_MUTABLE_STATUSES:
-            raise QuoteServiceError(
-                detail=f"Only sent, paid, or void invoices can be marked {action_label}.",
-                status_code=409,
-            )
-
-        invoice.status = next_status
-        await self._invoice_repository.commit()
-        refreshed_invoice = await self._invoice_repository.refresh(invoice)
-        log_event(
-            event_name,
-            user_id=user_id,
-            invoice_id=refreshed_invoice.id,
-            customer_id=refreshed_invoice.customer_id,
-        )
-        return refreshed_invoice
 
 
 def get_invoice_repository(db_repository: InvoiceRepository) -> InvoiceRepository:

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -41,7 +41,7 @@ audioop-lts==0.2.2; python_version >= "3.13"
 
 # Testing
 httpx==0.28.1
-pytest==9.0.2
+pytest==9.0.3
 pytest-asyncio==1.3.0
 pytest-cov==7.1.0
 


### PR DESCRIPTION
## Summary
- add `InvoiceOutcomeService` under `backend/app/features/invoices/outcomes/` with a slice-local repository protocol (`get_by_id`, `commit`, `refresh`)
- move invoice paid/void transition orchestration (`_mark_invoice_outcome`) and mutable-status guard into the new outcomes slice
- keep `InvoiceService` as the only external entrypoint and delegate `mark_invoice_paid` / `mark_invoice_voided` to the outcomes coordinator
- preserve event names/payload fields and commit/refresh ordering for outcome transitions

## Decision Gate
- Phase 5 gate on parent spec #354 is satisfied: the recorded decision is "invoice outcomes remain a separate final slice"

## No-Contract Parity Lock
- status codes: unchanged (`404` not found, `409` for non-mutable statuses)
- response shape: unchanged (`InvoiceResponse` via existing routes/service facade)
- error semantics: unchanged detail/message template for outcome guard (`Only sent, paid, or void invoices can be marked {action}.`)
- side effects: unchanged (`invoice_paid`/`invoice_voided` events with `user_id`, `invoice_id`, `customer_id`; idempotent early return without duplicate outcome event)

## Verification
- `cd backend && .venv/bin/pytest app/features/quotes/tests/test_quotes.py -k "mark_invoice_outcome" -v -m "not live and not extraction_eval and not extraction_quality" -o cache_dir=.pytest_cache`
- `cd backend && .venv/bin/pytest app/features/quotes/tests/test_quotes.py -k "invoice_outcome_labels_remain_editable_shareable_and_public" -v -m "not live and not extraction_eval and not extraction_quality" -o cache_dir=.pytest_cache`
- `make backend-verify`

Closes #363
