### PR TITLE
Task 366: invoice modularity program closeout docs hardening

### DIFF
--- a/backend/app/features/invoices/service.py
+++ b/backend/app/features/invoices/service.py
@@ -1,8 +1,9 @@
-"""Invoice service orchestration.
+"""Invoice service facade for invoice domain orchestration.
 
-This module applies invoice domain rules on top of repository reads/writes.
-It owns creation, quote conversion, list/detail access, and invoice PDF/share
-side effects while preserving quote-service error semantics for the API layer.
+`InvoiceService` is the stable public entrypoint for routes and sibling
+orchestrators. Write/side-effect behavior is delegated to behavior-slice
+collaborators (creation/share/pdf_artifacts/mutation/outcomes), while read-side
+list/detail access intentionally remains on the facade.
 """
 
 from __future__ import annotations
@@ -162,7 +163,7 @@ class PdfIntegrationProtocol(Protocol):
 
 
 class InvoiceService:
-    """Coordinate invoice domain rules with persistence and PDF rendering."""
+    """Stable invoice facade coordinating slice collaborators and read-side calls."""
 
     def __init__(
         self,

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -11,12 +11,17 @@
 backend/app/
   admin/         — internal-only API-key routes excluded from public schema
   core/          — config, database, security primitives
-  features/      — feature modules (auth, quotes, customers, profile)
+  features/      — feature modules (auth, quotes, invoices, customers, profile)
     registry.py  — central model import for Alembic discovery
   shared/        — cross-cutting: dependencies, rate limiting, exceptions, observability
   integrations/  — external service adapters (audio, transcription, pdf)
   worker/        — ARQ worker settings and background job entrypoints
 ```
+
+Invoices follow the thin-facade modularity pattern: `backend/app/features/invoices/service.py`
+is the stable `InvoiceService` entrypoint and delegates write/side-effect behavior to
+`share/`, `pdf_artifacts/`, `creation/`, `mutation/`, and `outcomes/`, while
+`list_invoices` and `get_invoice_detail` remain intentional facade read-surface methods.
 
 ### Frontend layout
 ```

--- a/docs/BACKEND_MODULARITY.md
+++ b/docs/BACKEND_MODULARITY.md
@@ -264,4 +264,23 @@ The key decisions were:
 - repository dependency went through a slice-specific protocol implemented by the existing repository
 - public contracts stayed unchanged
 
+The completed invoice modularity program follows the same durable shape:
+
+```text
+backend/app/features/invoices/
+  service.py
+  share/
+  pdf_artifacts/
+  creation/
+  mutation/
+  outcomes/
+```
+
+The key decisions were:
+- `InvoiceService` remains the stable public facade
+- each slice package exposes one coordinator/service for facade delegation
+- slice packages use narrow, slice-specific repository protocols over the existing repository implementation
+- routes and worker email orchestration continue depending on `InvoiceService`, not invoice slice package imports
+- read-side `list_invoices` and `get_invoice_detail` intentionally remain on the facade
+
 Future backend modularity work should use the same pattern unless a later architecture decision explicitly replaces it.

--- a/docs/PATTERNS.md
+++ b/docs/PATTERNS.md
@@ -16,6 +16,7 @@ Record conventions that already exist in code.
 - Each slice package exposes one coordinator/service to the public facade; package roots stay minimal.
 - Slices depend on narrow slice-specific repository protocols backed by the existing repository unless a task explicitly scopes a new repository.
 - Treat first-pass modularity work as no-contract refactors and prove parity with targeted behavior checks plus `make backend-verify`.
+- Invoices now follow the same thin-facade pattern as quotes (`service.py` facade + `share/`, `pdf_artifacts/`, `creation/`, `mutation/`, `outcomes/`); use [BACKEND_MODULARITY.md](./BACKEND_MODULARITY.md) for full rules.
 
 ## SQLAlchemy 2.0 Style (Mandatory)
 - Use SQLAlchemy 2.0 typed ORM style: `Mapped[...]` with `mapped_column(...)`.


### PR DESCRIPTION
## Summary
- refresh invoice facade module/class docstrings to reflect the shipped thin-facade + slice-collaborator design
- extend backend modularity docs with the invoice end-state tree and concise closeout bullets
- add a single invoice modularity pointer in patterns and a minimal invoice layout note in architecture docs

## Scope
- no-contract hardening only (docs/comments)
- no behavior, API contract, worker flow, or dependency wiring changes

## Verification
- make backend-verify
- import guardrail spot check: no new imports of invoice internal slices from outside backend/app/features/invoices

Closes #366
