### PR TITLE
Task #375: optimize instruction surface and verification tiers

### DIFF
--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -29,9 +29,23 @@ Default: this Task should represent the entire feature end-to-end unless split c
 - [ ] ...
 
 ## Verification
-```bash
-cd backend && ruff check . && mypy . && bandit -r app/ && pytest && cd ../frontend && npx tsc --noEmit && npx eslint src/ && npx vitest run && npm run build
-```
+Use tiered verification. Fill exact commands for each tier that apply.
+
+### Tier 1 - Implementation loop (smallest checks proving changed behavior)
+- Backend example: `cd backend && .venv/bin/pytest app/features/<feature>/tests/test_<scope>.py`
+- Frontend example: `cd frontend && npx vitest run src/features/<feature>/tests/<file>.test.tsx`
+- Docs/template/tooling example: `make template-verify`
+
+### Tier 2 - Post-review patch verification (targeted reruns)
+- `<exact targeted command for patched findings>`
+
+### Tier 3 - PR/final gate verification (broad checks)
+- Backend scope: `make backend-verify`
+- Frontend scope: `make frontend-verify`
+- Cross-surface scope: `make verify`
+
+### Tier 4 - Operator-only heavy verification (optional)
+- `<manual/live/provider-backed check, if required by task>`
 
 ## PR checklist
 - [ ] PR references this issue (`Closes #...`)

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,39 +1,20 @@
-# RTK — Token-Optimized CLI
+# Stima Copilot Instructions
 
-**rtk** is a CLI proxy that filters and compresses command outputs, saving 60-90% tokens.
+Follow repo workflow and review constraints from:
+- `AGENTS.md`
+- `docs/ISSUES_WORKFLOW.md`
+- `docs/REVIEW_CHECKLIST.md`
 
-## Rule
+Prioritize meaningful defects and risks:
+- correctness
+- regressions
+- contract drift
+- security
+- performance
+- missing tests/docs for changed behavior
 
-Always prefix shell commands with `rtk`:
+Be strict on boundaries, acceptance criteria, and externally visible behavior.
+Be flexible inside those boundaries when code remains readable and consistent with repo patterns.
 
-```bash
-# Instead of:              Use:
-git status                 rtk git status
-git log -10                rtk git log -10
-cargo test                 rtk cargo test
-docker ps                  rtk docker ps
-kubectl get pods           rtk kubectl pods
-```
-
-## Meta commands (use directly)
-
-```bash
-rtk gain              # Token savings dashboard
-rtk gain --history    # Per-command savings history
-rtk discover          # Find missed rtk opportunities
-rtk proxy <cmd>       # Run raw (no filtering) but track usage
-```
-
-# Stima Copilot Code Review Instructions
-
-You are reviewing changes for the Stima project. Follow these rules exactly:
-
-1. Enforce the exact review checklist in docs/REVIEW_CHECKLIST.md (Lean Review Mode + all boundary, layering, and contract rules).
-2. Never suggest changes that violate AGENTS.md (single-task PRs, file-size budgets, no migration edits, match existing style, no AI co-author spam).
-3. Respect “tight boundaries, loose middle”: be strict on contracts, acceptance criteria, layer boundaries, verification, and no-contract parity claims. Be flexible inside those boundaries only if the code stays readable and consistent with docs/PATTERNS.md.
-4. Keep review comments focused on real defects or meaningful risks: correctness, regressions, missing tests/docs for changed behavior, contract drift, security, performance, and architectural inconsistency.
-5. Do not flag normal workflow steps such as learning handoffs or planning checkpoints as review defects.
-6. Prioritize: security, contract-sensitive behavior, stateful changes, and missing test coverage for business logic. Ignore pure UI polish unless it breaks mobile voice/PDF flow.
-7. Reference exact file paths and line numbers. Keep comments concise.
-
-If something looks like it violates the above, say “Potential contract violation — requires agent handoff per WORKFLOW.md”.
+Do not flag normal workflow artifacts (planning checkpoints, reviewer tutoring handoffs) as defects.
+Reference exact file paths and line numbers.

--- a/.github/prompts/review-task.prompt.md
+++ b/.github/prompts/review-task.prompt.md
@@ -1,0 +1,42 @@
+Review Task #<task-id> / PR #<pr-id> on branch <task-branch> vs <base-branch>.
+
+Goal:
+- Identify correctness bugs, regressions, contract drift, boundary/pattern violations, and missing tests/docs.
+
+Review Scope (in priority order):
+1. Correctness and regressions (runtime behavior, edge cases, state transitions)
+2. Contract parity (status codes, response shapes, error semantics, side effects) when no contract change is claimed
+3. Architecture consistency (layer boundaries, dependency direction, service/repository responsibilities)
+4. Security and performance risks introduced by this diff
+5. Missing or weak tests/docs/comment-contract coverage for changed behavior
+
+Constraints:
+- Use local diff and repository context first.
+- Expand to surrounding code/tests/docs only when change touches state transitions, contracts, shared utilities, templates, or cross-layer behavior.
+- No environment triage loops or worktree setup.
+- Run targeted checks only when needed to validate a specific finding.
+- Do not rerun broad verification already reported green unless prior results are suspect.
+- Keep output concise and findings-first.
+- No command transcript unless a command failed and that failure matters to a finding.
+- For stateful/cross-layer tasks, verify status/action/error/side-effect parity across affected states.
+- If verdict is `APPROVED`, include lightweight tutoring handoff per `docs/template/KICKOFF.md` section 4 in the same response.
+- Classify findings as:
+  - merge-blocking bug/contract issue
+  - quick hardening fix
+  - follow-up product/UX decision
+- Avoid escalating unresolved wording/copy/product decisions as correctness bugs unless they violate a documented contract.
+- Be strict about contract drift, verification gaps, acceptance-criteria misses, and layer-boundary violations.
+- Do not return `APPROVED` while required PR checks are failing, stale, or missing unless explicitly inspected and determined non-blocking.
+
+Required Output:
+1. Verdict: `APPROVED` or `ACTIONABLE`
+2. Findings (if `ACTIONABLE`), one per line:
+   - `[severity] file/path:line | category | issue | impact | required fix`
+   - severity: `critical|high|medium|low`
+   - category: `correctness|regression|contract|architecture|security|performance|tests|docs`
+3. Verification notes:
+   - targeted checks run (if any) and why
+   - whether PR CI/check status was inspected, and any blocking failures
+4. Residual risk/testing gaps:
+   - up to 5 concise bullets
+5. If verdict is `APPROVED`, end with the section 4 lightweight tutoring handoff in the same response

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,240 +2,84 @@
 
 ## Start Here (Canonical Entrypoint)
 
-`AGENTS.md` is the canonical entrypoint for agents and contributors in this repository.
-
-Must-read in this order:
+Read in this order:
 1. `AGENTS.md` (this file)
 2. `docs/ISSUES_WORKFLOW.md`
-3. `docs/template/KICKOFF.md` (if present)
-4. `docs/WORKFLOW.md`
+3. `docs/WORKFLOW.md`
+4. Task issue / Execution Brief / PR context
 
 Read conditionally (only when relevant):
-- `docs/GREENFIELD_BLUEPRINT.md` for greenfield repos or explicit restructuring tasks
-- `docs/README.md`, `docs/ARCHITECTURE.md`, `docs/DESIGN.md`, `docs/PATTERNS.md`, `docs/REVIEW_CHECKLIST.md` for domain/contract/pattern/UI changes
+- `docs/template/KICKOFF.md` for kickoff, review handoff, or post-review patch flows
+- `backend/AGENTS.md` for backend work (`area:backend`, `area:database`, or files under `backend/`)
+- `frontend/AGENTS.md` for frontend work (`area:frontend` or files under `frontend/`)
+- `docs/README.md`, `docs/ARCHITECTURE.md`, `docs/DESIGN.md`, `docs/PATTERNS.md`, `docs/REVIEW_CHECKLIST.md` only when touched scope requires them
+- `docs/GREENFIELD_BLUEPRINT.md` only for greenfield/restructure tasks
 - `skills/*` playbooks only when explicitly requested or clearly required by the task
 
-## Unit of Work Rule
+## Nested AGENTS Discovery
 
-- **Default unit of work is a GitHub Issue.**
-- Use `single` mode by default: one feature -> one Task issue -> one PR.
-- Use `gated` or `fast` only when the user explicitly requests it.
-- In `fast` mode, no issue creation is required (per `docs/ISSUES_WORKFLOW.md` criteria).
-- Convert freeform requests into the selected issue mode before implementation.
-- For issue-backed work, work one Task issue at a time.
+Many tools auto-inject root `AGENTS.md` only. Route to subtree rules explicitly:
+- If primary scope is backend or `area:backend`/`area:database`, read `backend/AGENTS.md` before implementation.
+- If primary scope is frontend or `area:frontend`, read `frontend/AGENTS.md` before implementation.
+- For cross-cutting/doc tasks, apply both subtree files only when their scopes are touched.
+
+## Unit Of Work And Modes
+
+- Default unit of work: GitHub Task issue.
+- Default mode: `single` (`1 feature -> 1 Task -> 1 PR`).
+- Use `gated` or `fast` only when explicitly requested.
+- For issue-backed work, execute one ready Task issue at a time.
 - PRs close Task issues (`Closes #123`), not Specs.
-- Specs close only when all child Tasks are done or explicitly deferred.
-- Detailed control-plane rules are canonical in `docs/ISSUES_WORKFLOW.md`.
-- For one-shot issue body + `gh` command generation, use `skills/spec-workflow-gh.md`.
-- Canonical kickoff types:
-  - Planning kickoff (issue planning only): `Run kickoff for feature <feature-id> from <filename> mode=<single|gated|fast>, planning-only (no code changes, no PR).`
-  - Execution kickoff (implementation): `Run kickoff for existing Task #<task-id> mode=single.`
-  - Execution kickoff (isolated parallel local execution): `Run kickoff for existing Task #<task-id> mode=single execution=parallel.`
-  - If an Execution Brief exists, reference it after the Task prompt and use it as the working handoff; the GitHub Task issue remains authoritative.
-  - If `mode` is omitted, default to `single`.
-  - Do not switch to `gated` or `fast` unless explicitly requested.
-  - Planning kickoff output: issue body file(s), `gh issue create` command(s) when applicable, created issue link(s), and a 3-5 step implementation plan.
-  - Execution kickoff output: implementation + verification + PR + short reviewer kickoff (`docs/template/KICKOFF.md` section 3a) + final completion after explicit `APPROVED`, with the lightweight tutoring handoff generated once by the approving reviewer in that same response.
-  - Use `docs/template/KICKOFF.md` for the exact brief-first execution, delta-only patch, and reviewer prompt wording instead of restating stable repo rules in task-local prompts.
+- Specs close when all child Tasks are done or explicitly deferred.
 
-## Agent Operating Loop
+Canonical kickoff prompts:
+- Planning kickoff: `Run kickoff for feature <feature-id> from <filename> mode=<single|gated|fast>, planning-only (no code changes, no PR).`
+- Execution kickoff: `Run kickoff for existing Task #<task-id> mode=single.`
+- Parallel local execution (only when explicitly requested): `Run kickoff for existing Task #<task-id> mode=single execution=parallel.`
 
-1. Whiteboard scope under `plans/YYYY-MM-DD/` or in spec docs (scratch only). Many operators keep `plans/` uncommitted or sparse-commit to avoid bloating the remote; treat paths as local working artifacts unless you explicitly commit them.
-   - **Multi-artifact workstreams** (Spec + child Task bodies + optional Execution Briefs / kickoff scratch): use one folder per workstream, e.g. `plans/YYYY-MM-DD/<workstream-slug>/`, and keep `spec-*.md`, `task-*.md`, and brief files (e.g. `brief-<task-slug>.md` or `execution-brief-<task-slug>.md`) together. Use a stable hyphenated `workstream-slug` so `--body-file` paths stay copy-pasteable.
-   - **One-off scratch** (single note or one draft task body): a flat file `plans/YYYY-MM-DD/<type>-<slug>.md` is fine.
-2. Choose execution mode and create required issue(s) (`single` unless explicitly asked for `gated`/`fast`; `fast` can skip issue creation).
-3. Restate goal and acceptance criteria.
-4. Plan minimal files and scope.
-5. Implement with tight, surgical changes.
-6. Run verification commands once (or once per code change set).
-7. For issue-backed work, open PR that closes the Task issue; close Spec after child Tasks are done/deferred.
-8. Provide the short reviewer kickoff (`docs/template/KICKOFF.md` section 3a) for a separate review pass; paste the full section 3b brief only if the operator explicitly requests it.
-9. Patch only actionable findings, rerun relevant verification, and repeat review only if explicitly requested.
-10. After explicit reviewer verdict `APPROVED`, finalize the Task or Spec; do not generate a second lightweight tutoring handoff after approval is relayed back.
-11. Finalize: return the completion output and then close/complete the Task or Spec as applicable.
+## Execution Defaults
 
-## Project Context
-
-- **Project:** `Stima`
-- **Stack:** `FastAPI + SQLAlchemy + Alembic + PostgreSQL + Vite + React + TypeScript + Tailwind CSS v4`
-- **Repo layout:** `Feature-first monorepo with backend/ and frontend/ modules`
-
-## Operating Rules
-
-- Do not add co-author attribution to commits or PRs. Do not append `Co-Authored-By:` trailers, AI attribution lines, or any agent/tool credit to commit messages or PR descriptions.
-- Keep solutions simple and explicit.
-- Make surgical changes only.
-- Match existing style and conventions.
-- Use SQLAlchemy 2.0 style only in backend code (`Mapped`/`mapped_column`, `select()` + async session methods). Do not use SQLAlchemy 1.x `Column()` model style or `db.query(...)`.
-- Follow `docs/CODE_COMMENTING_CONTRACT.md` for in-code comment/docstring standards.
-- Do not install dependencies without approval.
-- Do not change unrelated files.
-- Do not modify applied migrations; create a new migration.
-- Keep code review lean: focus on major bugs/regressions and missing tests.
-- In review mode, avoid environment triage loops, worktree setup, and repeated full-suite verification unless a blocker requires it.
-- For no-contract refactors, use the parity lock checklist (status/shape/error/side-effects) before merge.
-- Keep runtime/toolchain contracts explicit and consistent across README, local verify commands, and CI.
-- For bug fixes, backend business logic, contract-sensitive behavior, and stateful/cross-layer changes, identify the test/assertion to add first when practical. This is guidance for higher-risk work, not strict TDD.
-
-## Codebase Modularity Defaults
-
-- Default for greenfield repos: follow `docs/GREENFIELD_BLUEPRINT.md`.
-- Backend layering default: `api -> services -> repositories -> integrations/libs`.
-- Frontend layering default: `src/app` route shells + `src/features/<feature>` + `src/shared`.
-- Keep feature boundaries explicit: feature internals stay private; cross-feature usage should go through public exports.
-- If a repo already uses a different structure, preserve it unless a dedicated migration task explicitly scopes restructuring.
-- Practical file-size budgets:
-  - frontend components target `<=250` LOC
-  - frontend hooks/services target `<=180` LOC
-  - backend route/service/repository modules target `<=220` LOC
-  - split or create linked follow-up when any frontend module exceeds `450/300` LOC (component vs hook/service) or backend route/service/repository exceeds `350` LOC
+1. Restate goal/non-goals/acceptance criteria from the Task issue.
+2. Create/switch to dedicated branch `task-<id>-<slug>` before edits.
+3. Implement minimally and preserve existing contracts unless scope says otherwise.
+4. Run verification by tier (`docs/WORKFLOW.md` Verification Tiers):
+   - Tier 1 during implementation (smallest checks proving changed behavior)
+   - Tier 2 after `ACTIONABLE` review patches (targeted reruns)
+   - Tier 3 broad PR/final gate checks (`make backend-verify`, `make frontend-verify`, `make verify` as applicable)
+5. Open PR with `Closes #<task-id>`.
+6. Return the short reviewer kickoff from `docs/template/KICKOFF.md` section 3a.
 
 ## Parallel Local Execution (Optional)
 
-Use only when the operator explicitly requests `execution=parallel`.
-
-- `mode` still controls the issue workflow (`single`, `gated`, `fast`).
-- `execution=parallel` controls local implementation isolation only.
-
-Rules:
+Use only when the operator explicitly requests `execution=parallel`:
 - one Task issue -> one branch -> one worktree -> one PR
-- run `scripts/worktree-init.sh <task-id> [slug]` before any code changes; use the printed `WORKTREE_READY` path as the working directory
-- before running verification, confirm symlinks exist for any gitignored dep directories the task needs: `backend/.venv` and/or `frontend/node_modules`; if missing, the operator must create them from the main checkout before verification will succeed
-- never use `git worktree add --force`
-- if the branch or worktree path already exists, stop and report instead of improvising
-- keep the main checkout as the control-plane workspace (planning, review coordination, merge, post-merge sync)
-- do not default to parallel execution for migrations, shared API-contract changes, auth/state-machine changes, or other tightly coupled backend/stateful work unless explicitly planned
+- run `scripts/worktree-init.sh <task-id> [slug]` before code edits
+- work only in returned `WORKTREE_READY` path
+- confirm needed symlinks (`backend/.venv`, `frontend/node_modules`) before verification
+- do not use `git worktree add --force`
 
-## Decision Brief (Conditional)
+## Reviewer And Completion Contract
 
-For non-trivial fixes/features, include a short decision brief only when behavior/contracts/architecture decisions changed:
+- Default review follow-up is lean: verdict `APPROVED` or `ACTIONABLE`.
+- If `ACTIONABLE`, patch listed findings only and rerun targeted verification unless scope expands.
+- If `APPROVED`, finalize Task/Spec; do not generate a second tutoring handoff after approval is relayed.
+- Lightweight tutoring handoff is generated once by the approving reviewer in the same `APPROVED` response.
 
-- **Chosen approach:** what was implemented.
-- **Alternative considered:** one realistic alternative.
-- **Tradeoff:** why this choice won (complexity/risk/perf/security).
-- **Revisit trigger:** when the alternative should be reconsidered.
+## Agent Output Budget
 
-For tiny quick fixes with no contract change, decision brief is optional.
+Canonical norms live in `docs/WORKFLOW.md` under **Agent Output Budget**.
 
-## Workflow Order
+## Guardrails
 
-1. Read `docs/ISSUES_WORKFLOW.md`
-2. Read `docs/template/KICKOFF.md`
-3. Read `docs/WORKFLOW.md`
-4. Read `docs/GREENFIELD_BLUEPRINT.md` only for greenfield/restructure tasks
-5. Read project docs in `docs/README.md, docs/ARCHITECTURE.md, docs/PATTERNS.md, docs/REVIEW_CHECKLIST.md` only when needed for touched scope
-6. Execute one ready Task issue
+- Keep changes surgical and consistent with existing style.
+- Do not install dependencies without approval.
+- Do not modify applied migrations; add a new migration when needed.
+- Do not change unrelated files.
+- Do not add AI/tool attribution trailers to commits or PR descriptions.
+- Prefer normal shell commands; use manual `rtk` forms only when needed and supported.
 
-## Reviewer Handoff Contract
+## Verification Runtime Notes
 
-After implementation PR is open, the implementation agent provides a reviewer prompt containing:
-
-- Task/PR identifier and branch/base
-- verification already run
-- explicit request for `APPROVED` or `ACTIONABLE`
-
-Reviewer pass default constraints:
-
-- use local diff context first
-- no broad environment triage by default
-- no worktree creation by default
-- no rerun of broad verification already reported green
-- no command transcript in output unless a command failed
-- default to one review pass; run a second pass only if the user explicitly requests it
-- if verdict is `APPROVED`, the approving reviewer ends that same response with the lightweight tutoring handoff, generated once
-
-Default: paste only the short reviewer kickoff from `docs/template/KICKOFF.md` section 3a (plus verification summary). Reviewer output shape and constraints are defined in section 3b; use the full section 3b inline copy only when the operator requests it or the reviewer lacks repo access.
-
-## Learning Handoff Contract
-
-Required completion gate:
-
-- Post a learning handoff whenever a Task is finished and whenever a Spec is closed.
-- The lightweight tutoring handoff is generated once, by the approving reviewer, in the same `APPROVED` response.
-- Do not generate a second learning handoff after approval is relayed back; the implementation agent finalizes after approval.
-- Post it directly in the same chat/thread; do not create a separate markdown handoff unless explicitly requested.
-- Keep it brief, tutor-style, and practical rather than archival.
-- Required shape:
-  - 4 short bullets covering:
-    - what changed
-    - why it was done this way
-    - one tradeoff or pattern worth learning
-    - what to review first
-  - 3-6 code pointers using `path:line-line — why it matters` format
-
-## Verification
-
-### Agent Runtime Note
-
-- Do **not** run `make db-verify` from agent sessions. It can hang/long-run in this environment and block execution.
-- Do **not** run `make extraction-live` from agent sessions. If live validation is needed, request the human operator to run it manually and share the output.
-- For Task verification in agent runs, use `make backend-verify` and/or `make frontend-verify` per issue scope.
-- Do **not** run bare `pytest` from agent sessions. For targeted backend tests, use `cd backend && .venv/bin/pytest ...` so the repo venv is always used.
-- Backend pytest in this repo depends on host-local services configured by `backend/conftest.py` (for example the local Postgres test DB). If backend tests are required for the task, request escalated permissions and run them outside the sandbox instead of retrying inside the network-isolated sandbox.
-- If a sandboxed backend pytest run hangs before reaching assertions or during startup/collection, suspect sandbox-to-local-service access before assuming an application bug.
-- Only run DB migration verification when explicitly requested by a human operator outside agent flow.
-
-### Full
-
-```bash
-cd backend && ruff check . && mypy . && bandit -r app/ && pytest && cd ../frontend && npx tsc --noEmit && npx eslint src/ && npx vitest run && npm run build
-```
-
-### Frontend
-
-```bash
-cd frontend && npx tsc --noEmit && npx eslint src/ && npx vitest run && npm run build
-```
-
-### Backend
-
-```bash
-cd backend && ruff check . && mypy . && bandit -r app/ && pytest
-```
-
-### DB
-
-```bash
-cd backend && alembic upgrade head
-```
-
-If the repo defines a Makefile verification contract, prefer canonical `make` targets (for example: `make verify`, `make backend-verify`, `make frontend-verify`) over ad-hoc command variants.
-
-## Documentation Discipline
-
-Treat doc updates like failing tests. Keep architecture, patterns, checklists, and ADRs current.
-
-## Skills Note
-
-`skills/*.md` are portable procedural playbooks unless your runtime explicitly loads them.
-
-## Skill Governance
-
-Keep external skills high-signal and conflict-free:
-
-- Rule ownership:
-  - execution control plane (modes/DoR/DoD/branching): `docs/ISSUES_WORKFLOW.md` (authoritative)
-  - kickoff and reviewer output contract: `docs/template/KICKOFF.md` (authoritative)
-  - implementation loop and quality defaults: `docs/WORKFLOW.md`
-  - onboarding and operating constraints: `AGENTS.md`
-- For skills, precedence order is: repo docs above -> local `skills/*` -> external installed skills.
-- Install external skills globally in Codex home, not inside project repos.
-- Keep a small baseline (about 4-6 active external skills).
-- Use skills intentionally (named skill or clear task match), not by default for every request.
-- Avoid overlap: keep one primary skill per domain (API design, DB design, security, TypeScript).
-- If an external skill conflicts with repo docs, follow repo docs and treat the skill as advisory.
-- Review and prune unused or low-value skills regularly.
-
-## RTK command preference
-
-When running shell commands, prefer `rtk`-prefixed commands for token-heavy output.
-
-Examples:
-- `rtk git status`
-- `rtk git diff`
-- `rtk rg "pattern" .`
-- `rtk pytest`
-
-## Optional Later
-
-MCP is out of scope for v1. It can be added later to automate issue creation/labeling/CI summaries.
+- Do not run `make db-verify` from agent sessions.
+- Do not run live/provider-backed checks from agent sessions (for example `make extraction-live`); ask the human operator to run and share output.
+- Prefer canonical `make` targets for Tier 3 gates when the repo defines them.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,8 @@
 @AGENTS.md
-@docs/ARCHITECTURE.md
-@docs/DESIGN.md
-@docs/PATTERNS.md
-@docs/REVIEW_CHECKLIST.md
-@docs/WORKFLOW.md
+
+Open additional docs only when the task touches those surfaces:
+- docs/ARCHITECTURE.md
+- docs/DESIGN.md
+- docs/PATTERNS.md
+- docs/REVIEW_CHECKLIST.md
+- docs/WORKFLOW.md

--- a/KICKOFF_PROMPT.md
+++ b/KICKOFF_PROMPT.md
@@ -1,137 +1,29 @@
-## Parallel Worktree Setup
+# KICKOFF_PROMPT.md — Operator Quick Reference
 
-```bash
-# 1. Create worktree
-scripts/worktree-init.sh <task-id>
+Single purpose: quick copy-paste shortcuts that point to canonical prompts.
 
-# 2. Symlink deps (skip whichever the task doesn't need)
-ln -s /home/odys/stima/frontend/node_modules /home/odys/stima-wt/task-<id>-<slug>/frontend/node_modules
-ln -s /home/odys/stima/backend/.venv         /home/odys/stima-wt/task-<id>-<slug>/backend/.venv
+Canonical source of truth:
+- `docs/template/KICKOFF.md`
 
-# 3. Open worktree window
-code /home/odys/stima-wt/task-<id>-<slug>
-```
-
-Run kickoff from the worktree window:
-```
-Run kickoff for existing Task #<task-id> mode=single.
-```
-
-Preview frontend changes on a separate port:
-```bash
-cd /home/odys/stima-wt/task-<id>-<slug>/frontend && npm run dev -- --port <port>
-```
-
-Post-merge cleanup:
-```bash
-git worktree remove --force ../stima-wt/task-<id>-<slug>
-git branch -d task-<id>-<slug>
-git fetch --prune origin
-```
-
----
-
-## Tasks + Review
+## Execution
 
 Run kickoff for existing Task #<task-id> mode=single.
 
 Reference <execution-brief-filepath>  # when present
 Reference <analog-filepath>  # when relevant
 
----
+## Review request
 
-Review Task #<task-id> / PR #<pr-id> on branch <task-branch> vs <base-branch>.
+Use `docs/template/KICKOFF.md` section 3a.
 
----
+## Full reviewer brief
 
-Patch Task #<task-id> / PR #<pr-id> on branch <task-branch> after review.
+Use `.github/prompts/review-task.prompt.md`.
 
-Reference <execution-brief-filepath>  # when present
-Reference <analog-filepath>  # when relevant
+## Post-review patch
 
-Inputs:
-- Review verdict: ACTIONABLE
-- Findings to address: <paste only the findings being patched>
+Use `docs/template/KICKOFF.md` Delta-Only Patch Handoff.
 
----
-**Rereview**
-
-Re-review Task #<task-id> / PR #<pr-id> after patching.
-
-Reference:
-- prior review findings
-- patched summary
-- targeted verification run
-
-Focus:
-- confirm whether the listed findings were resolved
-- identify any regressions introduced by the patch
-- return APPROVED or ACTIONABLE
-
----
-**Copilot**
-
-Review all GitHub Copilot comments on Task #<task-id> / PR #<pr-id>.
-
-For each comment decide:
-- ACCEPT
-- REJECT
-- DEFER
-
-Stay inside approved task scope and single mode.
-Use the Stima review contract and repo docs as the standard.
-Return:
-1. decisions with one-line reasons
-2. any code changes made
-3. final verdict: APPROVED / ACTIONABLE / NO_CHANGES_NEEDED
-
----
-
-## Planning
-
-Lets whiteboard feature <feature-id> from <plan-filepath>.
-
-Goal:
-- Make the task concrete enough for issue creation and later implementation.
-
-Work toward:
-1. Problem framing
-2. Smallest viable implementation plan
-3. Risks and edge cases
-4. Testable acceptance criteria
-5. Exact verification commands
-6. Issue-ready markdown
-
----
-
-Review the plan in <plan-filepath> before execution.
-
-Check for:
-1. Scope creep
-2. Missing edge cases or error paths
-3. Acceptance criteria that are not testable
-4. Verification gaps
-5. Unresolved decisions that will block implementation
-
-Output: READY or NEEDS WORK, with one-line findings if NEEDS WORK.
-
----
+## Planning-only kickoff
 
 Run kickoff for feature <feature-id> from <plan-filepath> mode=<single|gated|fast>, planning-only (no code changes, no PR).
-
----
-
-Create an Execution Brief for Task #<task-id> using docs/template/EXECUTION_BRIEF.md.
-
-Reference:
-- <task-issue-link>
-- <plan-filepath>  # optional
-- <analog-docpath>  # when relevant
-
-Constraints:
-- The GitHub Task issue remains the source of truth.
-- Keep the brief task-local and compressed.
-- Capture deltas, file scope, analogs, locked decisions, verification, and blockers only.
-- Do not restate stable repo rules or paste the full issue body.
-
----

--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -1,0 +1,47 @@
+# Backend AGENTS — Stima
+
+Apply this file when primary scope is `backend/` or issue labels include `area:backend` / `area:database`.
+
+## Backend Defaults
+
+- Preserve explicit layering: `api -> services -> repositories -> integrations/libs`.
+- Keep route modules thin; orchestration/policy belong in services.
+- Repositories own persistence/query logic only.
+- Match existing feature-first structure under `backend/app/features/*`.
+
+## Contracts And Data Rules
+
+- Use SQLAlchemy 2.0 style only (`Mapped`/`mapped_column`, `select()` + async session APIs).
+- Do not use SQLAlchemy 1.x `Column()` model style or `db.query(...)`.
+- Do not modify applied migrations; create a new migration instead.
+- For no-contract refactors, verify parity lock:
+  - status code parity
+  - response schema parity
+  - error semantics parity
+  - side-effect parity
+
+## Selective Test-First Guidance
+
+For bug fixes, backend business logic, contract-sensitive behavior, and stateful/cross-layer changes, identify the first test/assertion to add before implementation when practical.
+
+## Verification Tiers (Backend)
+
+- Tier 1 (implementation loop): smallest backend checks proving changed behavior.
+  - Example: `cd backend && .venv/bin/pytest app/features/<feature>/tests/test_<scope>.py`
+  - Example: `cd backend && ruff check app/features/<feature>`
+- Tier 2 (post-review patch): rerun only checks covering patched findings unless scope expands.
+- Tier 3 (PR/final gate): `make backend-verify` (or `make verify` when cross-surface).
+- Tier 4 (operator-only heavy): live/provider-backed checks run by human operator when explicitly required.
+
+## Agent Runtime Constraints
+
+- Do not run bare `pytest` from agent sessions; use `cd backend && .venv/bin/pytest ...` for targeted tests.
+- Backend pytest uses host-local services in this repo; if backend tests are required, prefer escalated runs over repeated sandbox retries.
+- If sandboxed pytest hangs during startup/collection, suspect sandbox-to-local-service access first.
+- Do not run `make db-verify` or live extraction checks from agent sessions.
+
+## Practical File-Size Budgets
+
+- backend route/service/repository modules target `<=220` LOC
+- `300-350` LOC can be acceptable when cohesive
+- split or create follow-up when route/service/repository exceeds `350` LOC

--- a/docs/ISSUES_WORKFLOW.md
+++ b/docs/ISSUES_WORKFLOW.md
@@ -215,7 +215,7 @@ Expected behavior:
 - create/switch to dedicated branch `task-<id>-<slug>` before implementation
 - open PR with `Closes #<task-id>`
 - follow the brief-first / analog-aware execution flow and delta-only patch handoff in `docs/template/KICKOFF.md` instead of reprinting stable repo rules in task-local prompts
-- return the short reviewer kickoff from `docs/template/KICKOFF.md` section 3a (not the full section 3b unless explicitly requested)
+- return the short reviewer kickoff from `docs/template/KICKOFF.md` section 3a; when full reviewer detail is needed, load section 3b plus `.github/prompts/review-task.prompt.md`
 
 ### Resiliency Checkpoints (Lightweight)
 

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -37,6 +37,16 @@ Every feature follows:
 7. In-chat learning handoff in the approving review response
 8. Finalize
 
+## Agent Output Budget
+
+Default chat output should stay concise and non-duplicative:
+
+1. Findings-first: lead with what changed, key risks, and verification outcome.
+2. Bounded recap: when Task issue scope is already explicit, avoid long restatements.
+3. No duplicate verification blocks: report commands run and result; include only minimal failure context when needed.
+4. Completion summaries: changed files + one-line intent per file; avoid re-deriving stable repo rules.
+5. Review replies: `ACTIONABLE` should be finding-focused with minimal preamble; `APPROVED` follows the tutoring handoff contract.
+
 ## Operator Flow Optimization
 
 Use this as the default human-in-the-loop sequence to reduce handoff overhead:
@@ -44,7 +54,7 @@ Use this as the default human-in-the-loop sequence to reduce handoff overhead:
 1. Plan scope and choose mode (`single` by default; `gated`/`fast` only when explicitly requested).
 2. For issue-backed work (`single`/`gated`), use the brief-first execution flow in `docs/template/KICKOFF.md`: keep the Task issue authoritative, add an Execution Brief only for task-local deltas, and reference analog docs when relevant.
 3. Open PR with `Closes #<task-id>`.
-4. Run one reviewer pass: implementation agent posts the short kickoff from `docs/template/KICKOFF.md` section 3a; reviewer follows section 3b for scope and output shape (or uses the section 3b inline copy when requested).
+4. Run one reviewer pass: implementation agent posts the short kickoff from `docs/template/KICKOFF.md` section 3a; reviewer follows section 3b for scope/output shape and loads `.github/prompts/review-task.prompt.md` when the full brief is needed.
 5. If verdict is `ACTIONABLE`, use the delta-only patch handoff from `docs/template/KICKOFF.md` and rerun targeted verification only unless scope expands.
 6. When verdict is `APPROVED`, the approving reviewer includes the lightweight tutoring handoff in that same response; the implementation agent then finalizes without generating a second handoff.
 7. Merge PR and sync local branch.
@@ -165,7 +175,7 @@ Reviewer note for stateful/cross-layer Tasks:
 
 ## Canonical Reviewer Follow-Up Prompt
 
-After opening a Task PR, default to the short reviewer kickoff in `docs/template/KICKOFF.md` section 3a. Section 3b there is the full inline brief and the authoritative output contract; paste it only when the operator asks or the reviewer lacks repo context.
+After opening a Task PR, default to the short reviewer kickoff in `docs/template/KICKOFF.md` section 3a. Section 3b there defines the authoritative output contract and points to `.github/prompts/review-task.prompt.md` for the full brief.
 Do not redefine the format in this file; keep `docs/template/KICKOFF.md` as the single source of truth.
 
 ## Learning Handoff (Required Completion Gate)
@@ -232,6 +242,13 @@ For small tasks with no contract/behavior change, decision brief is optional.
 ## Verification
 
 Run the relevant checks before claiming completion.
+
+### Verification Tiers
+
+- Tier 1 (implementation loop): run the smallest checks that prove changed behavior.
+- Tier 2 (post-review patch): rerun only checks needed for patched findings unless scope expands.
+- Tier 3 (PR/final gate): run canonical broad verify targets for affected surfaces (`make backend-verify`, `make frontend-verify`, `make verify` as applicable).
+- Tier 4 (operator-only heavy): live/provider/manual or unusually expensive checks only when explicitly required.
 
 Agent execution note:
 - Do not run live/provider-backed verification targets from agent sessions (for example `make extraction-live`); ask the human operator to run them manually and share output.
@@ -302,9 +319,10 @@ Docs paths:
 
 ## Documentation Layout
 
-Root stays lean — only agent/Claude entrypoints:
+Root stays lean — only top-level entrypoints:
 
 - Root: `AGENTS.md`, `CLAUDE.md`.
+- Subtree entrypoints: `backend/AGENTS.md`, `frontend/AGENTS.md` (loaded conditionally by scope).
 - `docs/`: `WORKFLOW.md`, `ISSUES_WORKFLOW.md`, `GREENFIELD_BLUEPRINT.md`, `MIGRATION_GUIDE.md`, `ARCHITECTURE.md`, `PATTERNS.md`, `REVIEW_CHECKLIST.md`, ADRs, runbooks.
 - `skills/`: procedural playbooks only.
 

--- a/docs/template/EXECUTION_BRIEF.md
+++ b/docs/template/EXECUTION_BRIEF.md
@@ -44,9 +44,12 @@ Use this brief only when a GitHub Task issue already exists.
 
 ## Verification
 
-- `<exact command>`
-- `<exact command>`
-- `<manual check if needed>`
+Capture commands by tier so reruns stay proportional:
+
+- Tier 1 (implementation loop): `<smallest command proving changed behavior>`
+- Tier 2 (post-review patch): `<targeted rerun for patched finding>`
+- Tier 3 (PR/final gate): `<canonical broad verify command for touched surface>`
+- Tier 4 (operator-only heavy, when needed): `<manual/live check>`
 
 ## Open Product Decisions / Blockers
 

--- a/docs/template/KICKOFF.md
+++ b/docs/template/KICKOFF.md
@@ -1,6 +1,32 @@
 # Kickoff Prompts
 
-Use these prompts to start an agent on already-scoped work with predictable output.
+Use these prompts to start work on already-scoped tasks without reloading unnecessary instruction text.
+
+## Types
+
+- Execute existing Task issue
+- Planning-only kickoff
+- Reviewer follow-up after Task PR
+- Delta-only patch handoff after `ACTIONABLE`
+
+## Defaults
+
+- Task issue remains authoritative.
+- Execution Brief is task-local compression only.
+- Use the short reviewer kickoff by default.
+- After `ACTIONABLE`, patch listed findings only unless scope expands.
+- Verification follows tiers from `docs/WORKFLOW.md`.
+
+## When To Load Which Asset
+
+| Situation | Load |
+| --- | --- |
+| Implement existing Task | `docs/template/KICKOFF.md` section 1 |
+| Planning-only kickoff | `docs/template/KICKOFF.md` section 2 |
+| Request review after opening PR | `docs/template/KICKOFF.md` section 3a |
+| Full reviewer brief needed | `.github/prompts/review-task.prompt.md` |
+| Patch after `ACTIONABLE` | `docs/template/KICKOFF.md` Delta-Only Patch Handoff |
+| Approving handoff format | `docs/template/KICKOFF.md` section 4 |
 
 ## 1) Execute Existing Task Issue
 
@@ -11,47 +37,30 @@ Reference <execution-brief-filepath>  # when present
 Reference <analog-filepath>  # when relevant
 
 Then execute the full Task flow end-to-end:
-1. Restate goal, non-goals, acceptance criteria, and exact verification commands from the Task issue. If an Execution Brief exists, use it as the working handoff for task-local deltas only; the Task issue remains the source of truth.
-2. Branch / checkout setup:
-   - default execution: create/switch to branch `task-<id>-<slug>`
-   - if `execution=parallel`: run `scripts/worktree-init.sh <task-id> [slug]`, work only inside the returned `WORKTREE_READY` path, and use the created branch there; before running verification confirm that `backend/.venv` and/or `frontend/node_modules` symlinks exist inside the worktree — if missing, stop and ask the operator to create them from the main checkout
-3. Implement minimally and surgically, preserving existing contracts unless issue scope says otherwise.
-4. Run relevant verification once after implementation.
+1. Restate goal, non-goals, acceptance criteria, and verification commands from the Task issue.
+2. Branch/checkout setup:
+   - default: create/switch to `task-<id>-<slug>`
+   - `execution=parallel`: run `scripts/worktree-init.sh <task-id> [slug]`, use returned `WORKTREE_READY` path only, and verify `backend/.venv` / `frontend/node_modules` symlinks before verification.
+3. Implement minimally and preserve contracts unless issue scope says otherwise.
+4. Run relevant verification by tier.
 5. Open PR with `Closes #<task-id>`.
-6. Return the **short reviewer kickoff** from section 3a below only. Do **not** paste the full section 3b brief unless the operator explicitly asks for the inline copy.
+6. Return the short reviewer kickoff from section 3a.
 7. After review verdict:
-   - if verdict is `ACTIONABLE`: use the delta-only patch handoff below; patch listed findings only and rerun targeted verification unless scope expands.
-   - if verdict is `APPROVED`: finalize the Task and return the final completion summary; do not generate a second lightweight tutoring handoff after approval is relayed back.
-8. If the Task touches state transitions, frontend action availability, external provider side effects, or contract/error semantics, include a short Behavior Matrix before implementation.
-
-Behavior Matrix (required for stateful/cross-layer tasks):
-- States/statuses involved and allowed actions per state
-- Endpoint success/error codes and exact externally visible error semantics
-- Side effects per path (DB writes, event logs, provider calls, token/state changes)
-- Failure-path outcomes (what still changes if downstream provider or persistence fails)
-
-Open Product Decisions (required when applicable):
-- List any unresolved UX/content decisions that should not be silently locked in by implementation or tests
-- If unresolved, explicitly mark them as follow-up candidates rather than encoding them as "correct" behavior
-
-Constraints:
-- Apply stable repo defaults from `AGENTS.md`, `docs/ISSUES_WORKFLOW.md`, and `docs/WORKFLOW.md` by reference unless this Task introduces a task-specific exception.
-- Keep mode `single` unless explicitly requested otherwise.
-- For bug fixes, backend business logic, contract-sensitive behavior, and stateful/cross-layer changes, identify the first test/assertion to add before implementation when practical.
-- No environment triage loops, no worktree setup, no broad verification reruns.
-- For live/provider-backed checks (for example `make extraction-live`), ask the human operator to run them manually and share output instead of running them in agent sessions.
-- Keep output concise and findings-first.
+   - `ACTIONABLE`: use Delta-Only Patch Handoff below.
+   - `APPROVED`: finalize Task and return completion summary.
 ```
 
-### Recommended Operator Flow
+Behavior Matrix (required for stateful/cross-layer tasks):
+- states/statuses and allowed actions
+- externally visible success/error semantics
+- side effects per path
+- failure-path outcomes
 
-- `Task issue`: authoritative scope, acceptance criteria, and verification.
-- `Execution Brief`: optional compressed working handoff for task-local deltas, file scope, blockers, and locked decisions; it never replaces the Task issue.
-- `Analog docs`: optional references such as `docs/analogs/*`; point to them when a repeated pattern applies instead of reprinting repo guidance.
-- `Kickoff`: reference the Task plus the brief and analogs that matter for this execution pass.
-- `Post-review patching`: if review returns `ACTIONABLE` and scope is unchanged, use the delta-only handoff below instead of rehydrating the full Task.
+Open Product Decisions (when applicable):
+- list unresolved UX/content decisions that should not be silently locked by implementation/tests
+- if unresolved, mark as follow-up candidate
 
-### Delta-Only Patch Handoff (Post-Review)
+## Delta-Only Patch Handoff (Post-Review)
 
 ```text
 Patch Task #<task-id> / PR #<pr-id> on branch <task-branch> after review.
@@ -61,61 +70,14 @@ Reference <analog-filepath>  # when relevant
 
 Inputs:
 - Review verdict: ACTIONABLE
-- Findings to address: <paste only the findings being patched>
+- Findings to address: <paste only findings being patched>
 
 Deliver:
-1. Patch the listed findings only. If a finding requires scope expansion or exposes a product/contract ambiguity, stop and flag that before editing.
-2. Keep the Task issue authoritative; use the Execution Brief only for task-local deltas that still apply.
-3. Rerun targeted verification for the patched behavior only unless scope expansion invalidates the previous green results.
-4. Return a concise patch summary, the targeted verification run, and any follow-up needed.
-
-Constraints:
-- Do not restate the full Task scope, stable repo rules, or reviewer contract unless the findings change them.
-- No broad verification reruns or environment triage loops by default.
-- Preserve existing contracts unless a listed finding explicitly requires a contract correction.
+1. Patch listed findings only.
+2. Keep Task issue authoritative.
+3. Rerun targeted verification unless scope expanded.
+4. Return concise patch summary + targeted verification + follow-up (if any).
 ```
-
-
-
-## Feature Discovery
-
-What are the highest-value features or improvements I could add next?
-
-Explore the codebase to understand the current state, then suggest 3-5 candidates ranked by impact. The project is currently <pre-launch | post-launch>.
-
-For each candidate:
-- What it is (one sentence)
-- Why it's high value at this stage
-- Rough effort signal (small / medium / large)
-
-Output a ranked list. We'll pick one and move into a whiteboard session.
-
-## Whiteboard
-
-Lets whiteboard out feature Task <TaskNumber> from <FileLocation>
-
-I'd like to talk through the specifics and get the plan concrete enough to draw out the task and gh issue.
-
-We're working toward — by the end of our discussion, not immediately:
-1. Problem framing (goal, non-goals, constraints).
-2. Implementation plan (3-5 steps, smallest viable path first).
-3. Risks and edge cases.
-4. Acceptance criteria (testable checks, not prose).
-5. Verification plan (exact commands).
-6. Issue artifact markdown ready for `gh issue create --body-file`.
-
-## Plan Review
-
-Review the plan above before we move to execution.
-
-Check for:
-1. Scope creep — anything beyond the stated goal.
-2. Missing edge cases or error paths.
-3. Acceptance criteria that aren't testable.
-4. Verification gaps (missing commands, untestable claims).
-5. Unresolved decisions that will block implementation.
-
-Output: READY or NEEDS WORK, with one-line findings if NEEDS WORK.
 
 ## 2) Planning-Only Kickoff (No Code Changes)
 
@@ -123,162 +85,49 @@ Output: READY or NEEDS WORK, with one-line findings if NEEDS WORK.
 Run kickoff for feature <feature-id> from <filename> mode=<single|gated|fast>, planning-only (no code changes, no PR).
 
 Deliver:
-1. Problem framing (goal, non-goals, constraints).
-2. Proposed implementation plan (3-5 steps, smallest viable path first).
-3. Risks and edge cases.
-4. Acceptance criteria draft.
-5. Verification plan (exact commands).
-6. `Why this approach` checkpoint:
-   - chosen approach
-   - one rejected alternative
-   - main tradeoff
-   - assumptions/contracts that must hold
-7. Recommended issue artifact markdown (Task/Spec as applicable) ready for `gh issue create --body-file` when applicable.
-8. Execution Brief decision:
-   - Decide whether the resulting Task warrants an Execution Brief.
-   - Create one when task-local deltas, analog references, locked decisions, blockers, or task complexity would make implementation handoff meaningfully smaller and clearer.
-   - If yes, generate a filled Execution Brief using `docs/template/EXECUTION_BRIEF.md`.
-   - If no, state briefly why the Task issue is already compact enough without one.
-
-After a Task issue is created, create an Execution Brief only when task-local deltas, analog references, or locked decisions would make implementation handoff meaningfully smaller and clearer.
-
-Constraints:
-- Keep it lean and concrete.
-- Default to one Task unless explicitly asked for split/gated mode.
-- No speculative architecture.
-- Reference stable repo rules from canonical docs instead of reprinting them in the issue artifact unless the task introduces an exception.
-- For bug fixes, backend business logic, contract-sensitive behavior, and stateful/cross-layer changes, identify the first test/assertion to add when practical.
-- UI polish, exploratory work, copy tweaks, and other low-risk changes can stay lighter.
+1. Problem framing
+2. 3-5 step implementation plan
+3. Risks and edge cases
+4. Testable acceptance criteria draft
+5. Verification plan (exact commands)
+6. Why this approach checkpoint
+7. Issue-ready markdown artifact(s)
+8. Execution Brief decision (create only when it materially compresses execution handoff)
 ```
 
-Notes:
-- If `mode=gated`, output Spec + default child Task issue bodies and commands.
-- If `mode=fast`, output a quick-fix checklist and verification plan; no issue creation by default.
-
-## 3) Reviewer follow-up after Task PR
+## 3) Reviewer Follow-Up After Task PR
 
 ### 3a) Short reviewer kickoff (default)
-
-Use this after opening a Task PR. It keeps the implementation agent output small; the reviewer loads **section 3b** in-repo for the full scope and output shape.
 
 ```text
 Review Task #<task-id> / PR #<pr-id> | branch `<task-branch>` vs `<base-branch>`.
 
 Implementation verification (already run, green): <e.g. make backend-verify>
 
-Follow `docs/template/KICKOFF.md` section **3b) Full reviewer brief** for review scope, constraints, and required output shape. Reply with `APPROVED` or `ACTIONABLE` per that section. If `APPROVED`, end the same response with the lightweight tutoring handoff per **section 4** there.
+Follow `docs/template/KICKOFF.md` section **3b) Full reviewer brief** for review scope, constraints, and required output shape. Reply with `APPROVED` or `ACTIONABLE` per that section. If `APPROVED`, end the same response with the lightweight tutoring handoff per section 4.
 ```
 
-### 3b) Full reviewer brief (optional inline copy)
+### 3b) Full reviewer brief (authoritative source)
 
-Use this exact prompt when the reviewer thread will not have repo access to `docs/template/KICKOFF.md`, or when the operator explicitly requests the full inline brief.
+Use `.github/prompts/review-task.prompt.md`.
 
-```text
-Review Task #<task-id> / PR #<pr-id> on branch <task-branch> vs <base-branch>.
+Required output shape remains authoritative:
+1. Verdict: `APPROVED` or `ACTIONABLE`
+2. Findings (if `ACTIONABLE`): `[severity] path:line | category | issue | impact | required fix`
+3. Verification notes
+4. Residual risk/testing gaps
+5. If `APPROVED`, include section 4 lightweight tutoring handoff in the same response
 
-Goal:
-- Identify correctness bugs, regressions, contract drift, boundary/pattern violations, and missing tests/docs.
+## 4) Required Lightweight Tutoring Handoff (Reviewer-Owned)
 
-Review Scope (in priority order):
-1. Correctness and regressions (runtime behavior, edge cases, state transitions)
-2. Contract parity (status codes, response shapes, error semantics, side effects) if scope claims no contract change
-3. Architecture consistency (layer boundaries, dependency direction, service/repository responsibilities)
-4. Security and performance risks introduced by this diff
-5. Missing or weak tests/docs/comment-contract coverage for changed behavior
-
-Constraints:
-- Use local diff and repository context first.
-- Use the local diff as the review entrypoint. Expand to surrounding code/tests/docs only when the change touches state transitions, contracts, shared utilities, templates, or cross-layer behavior.
-- No environment triage loops or worktree setup.
-- Run targeted checks only when needed to validate a specific finding.
-- Do not rerun broad verification already reported green unless prior results are suspect.
-- Keep output concise and findings-first.
-- No command transcript unless a command failed and that failure matters to a finding.
-- For stateful/cross-layer Tasks, verify status/action/error/side-effect parity across all affected states, not just the changed happy path.
-- If the verdict is `APPROVED`, end the same response with the lightweight tutoring handoff from section 4.
-- Classify findings as one of:
-  - merge-blocking bug/contract issue
-  - quick hardening fix
-  - follow-up product/UX decision
-- Avoid escalating unresolved wording/copy/product decisions as correctness bugs unless they violate a documented contract.
-- Be strict about contract drift, verification gaps, acceptance-criteria misses, and layer-boundary violations. Be flexible about internal helper decomposition when readability, testability, and repo-pattern consistency are intact.
-- Do not return `APPROVED` while required PR checks are failing, stale, or missing unless you explicitly inspected that CI state and determined it is non-blocking.
-
-
-Required Output:
-1. Verdict: APPROVED or ACTIONABLE
-2. Findings (if ACTIONABLE), one per line with:
-   [severity] file/path:line | category | issue | impact | required fix
-   - severity: critical/high/medium/low
-   - category: correctness|regression|contract|architecture|security|performance|tests|docs
-3. Verification notes:
-   - targeted checks run (if any) and why
-   - whether PR CI/check status was inspected, and any blocking failures
-4. Residual risk/testing gaps:
-   - up to 5 concise bullets
-5. If verdict is `APPROVED`, end with the lightweight tutoring handoff from section 4 in the same chat response
-```
-
-## 4) Required Lightweight Tutoring Handoff In Chat (Reviewer-Owned)
-
-The lightweight tutoring handoff is generated once, by the approving reviewer, in the same `APPROVED` response.
-Do not generate a second learning handoff after approval is relayed back.
-
-Post it directly in the same chat/thread.
-Do not create a separate markdown handoff unless explicitly requested.
-Keep it lightweight enough to generate and consume in about five minutes.
-Use plain English, tutoring tone, and cap it at 4 short bullets plus 3-6 code pointers.
+The approving reviewer generates this once in the same `APPROVED` response.
 
 ```text
 - What changed: <2-3 sentences max>
 - Why it was done this way: <brief rationale>
-- Tradeoff or pattern worth learning: <one thing to teach>
+- Tradeoff or pattern worth learning: <one point>
 - What to review first: <how a junior operator should read the diff>
 
 Code pointers:
 - `path:line-line — why it matters`
-```
-
-
-## 5) Copilot/Codex Code Review PR Review Triage Prompt (Light)
-
-Copy-paste this exact prompt when GitHub Copilot or Codex leaves comments on a Task PR:
-
-```text
-Review all GitHub Copilot comments on Task #<task-id> / PR #<pr-number>.
-
-You are the final decision maker. Evaluate every comment strictly against the Stima contract:
-
-- docs/REVIEW_CHECKLIST.md
-- AGENTS.md (single-task scope, file-size budgets, no migration edits, match style)
-- docs/WORKFLOW.md (Lean Review Mode + tight boundaries, loose middle)
-
-For each comment decide:
-- ACCEPT → valid and in-scope; make the smallest surgical fix if needed
-- REJECT → violates contract; state the exact rule
-- DEFER → useful but out-of-scope; create a one-line follow-up issue
-
-Constraints:
-- Stay inside the approved task scope and single mode.
-- Never make large refactors or pattern changes just because Copilot suggested them.
-- Respect “tight boundaries, loose middle”.
-
-Output (keep it short):
-1. Bullet list of decisions with one-line reasons.
-2. Any code changes made (file + one-line summary).
-3. Final verdict: APPROVED / ACTIONABLE / NO_CHANGES_NEEDED
-
-This review step is for findings triage only. Do not generate a learning handoff here. Reserve the lightweight tutoring handoff for the final approving reviewer response when the change is explicitly approved.
-```
-
-## 6) Grill-me planning
-```
-Interview me relentlessly about every aspect of this plan until
-we reach a shared understanding. Walk down each branch of the design
-tree resolving dependencies between decisions one by one.
-
-If a question can be answered by exploring the codebase, explore
-the codebase instead.
-
-For each question, provide your recommended answer.
 ```

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -1,0 +1,30 @@
+# Frontend AGENTS — Stima
+
+Apply this file when primary scope is `frontend/` or issue labels include `area:frontend`.
+
+## Frontend Defaults
+
+- Preserve feature-first structure: `src/features/<feature>` with shared code in `src/shared`.
+- Keep route/page shells thin; move behavior into feature hooks/services/components.
+- Keep feature boundaries explicit and avoid cross-feature internals.
+
+## UI/Behavior Safety
+
+- For stateful UI changes, verify action availability across relevant states.
+- Preserve existing API/error contracts unless task scope explicitly changes them.
+- If behavior decisions are unresolved, capture them as follow-up candidates instead of silently locking them in tests.
+
+## Verification Tiers (Frontend)
+
+- Tier 1 (implementation loop): smallest frontend checks proving changed behavior.
+  - Example: `cd frontend && npx vitest run src/features/<feature>/tests/<file>.test.tsx`
+  - Example: `cd frontend && npx eslint src/features/<feature>`
+- Tier 2 (post-review patch): rerun only checks covering patched findings unless scope expands.
+- Tier 3 (PR/final gate): `make frontend-verify` (or `make verify` when cross-surface).
+- Tier 4 (operator-only heavy): manual/live checks only when explicitly required.
+
+## Practical File-Size Budgets
+
+- frontend components target `<=250` LOC
+- frontend hooks/services target `<=180` LOC
+- split or create follow-up when component exceeds `450` LOC or hook/service exceeds `300` LOC


### PR DESCRIPTION
## Summary
- slim always-on instruction entrypoints by reducing `CLAUDE.md` preload and refactoring root `AGENTS.md` into a control-plane router
- add scoped `backend/AGENTS.md` and `frontend/AGENTS.md` plus explicit nested-discovery guidance
- convert kickoff docs to index + conditional loading, extract one full reviewer workflow into `.github/prompts/review-task.prompt.md`, and align related references
- rewrite task template and workflow/brief docs for tiered verification and add canonical agent output budget guidance
- replace `.github/copilot-instructions.md` with a compact RTK-free review contract; RTK hook automation in `.github/hooks/rtk-rewrite.json` remains unchanged

## Verification
- make template-verify

Closes #375