### PR TITLE
Task #377: Mode-routed AGENTS bootstrap follow-up

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,9 +1,10 @@
 # Stima Copilot Instructions
 
 Follow repo workflow and review constraints from:
-- `AGENTS.md`
-- `docs/ISSUES_WORKFLOW.md`
-- `docs/REVIEW_CHECKLIST.md`
+- `AGENTS.md` (mode-routed bootstrap)
+- `docs/template/KICKOFF.md` (execution/review prompt contract)
+- `docs/ISSUES_WORKFLOW.md` when planning/issue control-plane rules are in scope or unclear
+- `docs/REVIEW_CHECKLIST.md` when running deeper review checklist coverage
 
 Prioritize meaningful defects and risks:
 - correctness

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,20 +1,48 @@
 # AGENTS.md — Stima
 
-## Start Here (Canonical Entrypoint)
+## Bootstrap (Mode-Routed Entrypoint)
 
-Read in this order:
-1. `AGENTS.md` (this file)
-2. `docs/ISSUES_WORKFLOW.md`
-3. `docs/WORKFLOW.md`
-4. Task issue / Execution Brief / PR context
+Start here, then choose the path that matches the session's primary intent. Paths are not a lock: if the session changes (for example implementation -> planning), switch to that path's read list from that point.
 
-Read conditionally (only when relevant):
-- `docs/template/KICKOFF.md` for kickoff, review handoff, or post-review patch flows
-- `backend/AGENTS.md` for backend work (`area:backend`, `area:database`, or files under `backend/`)
-- `frontend/AGENTS.md` for frontend work (`area:frontend` or files under `frontend/`)
-- `docs/README.md`, `docs/ARCHITECTURE.md`, `docs/DESIGN.md`, `docs/PATTERNS.md`, `docs/REVIEW_CHECKLIST.md` only when touched scope requires them
+Universal quality floor:
+- Keep changes surgical and consistent with existing style.
+- Do not change unrelated files.
+- Do not modify applied migrations; add a new migration when needed.
+- Preserve existing contracts unless task scope says otherwise.
+- Use verification tiers from `docs/WORKFLOW.md` section **Verification Tiers**.
+- Keep broad verify targets (`make backend-verify`, `make frontend-verify`, `make verify`) as PR/final gates unless scope requires earlier coverage.
+- Load `backend/AGENTS.md` for backend scope (`area:backend`, `area:database`, or files under `backend/`).
+- Load `frontend/AGENTS.md` for frontend scope (`area:frontend` or files under `frontend/`).
+
+### A) Implement Existing Task
+Read in order:
+1. Task issue / Execution Brief / PR context
+2. Relevant subtree `AGENTS.md`
+3. `docs/template/KICKOFF.md` section 1
+4. `docs/WORKFLOW.md` sections only as needed (for example: `Verification Tiers`, `Boundary And Dependency Rules`, `Stateful Cross-Layer Hardening Gate`)
+
+### B) Review PR
+Read in order:
+1. PR / Task context
+2. `docs/template/KICKOFF.md` section 3a and section 3b constraints
+3. `.github/prompts/review-task.prompt.md` when full reviewer prompt body is needed without repo context (use either section 3b inline context or this prompt body; do not double-load)
+4. Relevant subtree `AGENTS.md` only when touched scope requires it
+
+### C) Plan / Create Issues / Choose Mode
+Read:
+1. `docs/ISSUES_WORKFLOW.md` (authoritative for control plane)
+2. `docs/template/KICKOFF.md` section 2 for planning-only kickoff format
+3. Additional planning docs only when needed by touched scope
+
+### D) Docs / Architecture / Pattern Work
+Read only touched docs:
+- `docs/README.md`, `docs/ARCHITECTURE.md`, `docs/DESIGN.md`, `docs/PATTERNS.md`, `docs/REVIEW_CHECKLIST.md`
 - `docs/GREENFIELD_BLUEPRINT.md` only for greenfield/restructure tasks
 - `skills/*` playbooks only when explicitly requested or clearly required by the task
+
+### Escape Hatch (Any Path)
+
+If control-plane rules, issue labels, execution mode, Spec/Task lifecycle, or branching requirements are unclear, read `docs/ISSUES_WORKFLOW.md` before changing process, creating/closing issues, or branching strategy.
 
 ## Nested AGENTS Discovery
 

--- a/docs/MIGRATION_GUIDE.md
+++ b/docs/MIGRATION_GUIDE.md
@@ -31,11 +31,11 @@ This guide explains how to use this template as the foundation for a new project
 7. Keep execution mode defaults strict: default to `single`; use `gated`/`fast` only when explicitly requested.
 8. Keep ceremony conditional: second review pass only when explicitly requested; decision briefs and doc updates only when behavior/contracts/architecture changed.
 
-Recommended onboarding order for agents:
-1. `AGENTS.md`
-2. `docs/ISSUES_WORKFLOW.md`
-3. `docs/template/KICKOFF.md`
-4. `docs/WORKFLOW.md`
+Recommended onboarding paths for agents:
+1. Implement existing Task: `AGENTS.md` -> Task/Execution Brief/PR context -> `docs/template/KICKOFF.md` section 1 -> relevant `docs/WORKFLOW.md` sections only as needed.
+2. Review PR: `AGENTS.md` -> PR/Task context -> `docs/template/KICKOFF.md` section 3a (and 3b constraints) -> `.github/prompts/review-task.prompt.md` only when full prompt body is needed.
+3. Plan/create issues/choose mode: `AGENTS.md` -> `docs/ISSUES_WORKFLOW.md` -> `docs/template/KICKOFF.md` section 2.
+4. Escape hatch: if mode/labels/lifecycle/branching are unclear in any path, read `docs/ISSUES_WORKFLOW.md` before proceeding.
 
 Kickoff split:
 - Planning kickoff (`feature -> issue artifacts`) is planning-only: no code changes, no PR.

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -11,6 +11,7 @@
 - Execution control plane (modes, DoR/DoD, branching, issue lifecycle): `docs/ISSUES_WORKFLOW.md` (authoritative)
 - Kickoff prompts and reviewer output contract: `docs/template/KICKOFF.md` (authoritative)
 - This file (`WORKFLOW.md`) summarizes the implementation loop and engineering defaults.
+- For narrow execute/review work, load this file by section as routed from `AGENTS.md`; a full sequential read is not required.
 
 ## Greenfield Baseline (Default)
 
@@ -86,7 +87,7 @@ git fetch --prune origin
 
 ## Issues Workflow (Control Plane)
 
-Read `docs/ISSUES_WORKFLOW.md` before implementation.
+Use `AGENTS.md` bootstrap paths to decide when `docs/ISSUES_WORKFLOW.md` must be loaded. It is required for planning, issue creation, mode/lifecycle decisions, and any control-plane uncertainty.
 
 Core rule:
 


### PR DESCRIPTION
## Summary
- convert root `AGENTS.md` startup into a mode-routed bootstrap with explicit paths for implementation, review, planning, and docs work
- move execute/review startup to Task/PR-first context loading, keep subtree AGENTS discovery explicit, and add an ISSUES_WORKFLOW escape hatch for control-plane uncertainty
- align coherence docs so they no longer imply the old universal read order (`docs/WORKFLOW.md`, `docs/MIGRATION_GUIDE.md`, `.github/copilot-instructions.md`)

## Scope
- Phase A only (mode routing + coherence pass)
- Phase B (`docs/WORKFLOW.md` split) intentionally deferred to a separate follow-up task

## Verification
- make template-verify

Closes #377