### PR TITLE
Task #378: split WORKFLOW.md into IMPLEMENT/REVIEW/VERIFY

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ Universal quality floor:
 - Do not change unrelated files.
 - Do not modify applied migrations; add a new migration when needed.
 - Preserve existing contracts unless task scope says otherwise.
-- Use verification tiers from `docs/WORKFLOW.md` section **Verification Tiers**.
+- Use verification tiers from `docs/workflow/VERIFY.md` section **Verification Tiers**.
 - Keep broad verify targets (`make backend-verify`, `make frontend-verify`, `make verify`) as PR/final gates unless scope requires earlier coverage.
 - Load `backend/AGENTS.md` for backend scope (`area:backend`, `area:database`, or files under `backend/`).
 - Load `frontend/AGENTS.md` for frontend scope (`area:frontend` or files under `frontend/`).
@@ -19,7 +19,7 @@ Read in order:
 1. Task issue / Execution Brief / PR context
 2. Relevant subtree `AGENTS.md`
 3. `docs/template/KICKOFF.md` section 1
-4. `docs/WORKFLOW.md` sections only as needed (for example: `Verification Tiers`, `Boundary And Dependency Rules`, `Stateful Cross-Layer Hardening Gate`)
+4. `docs/workflow/IMPLEMENT.md` and `docs/workflow/VERIFY.md` sections only as needed (for example: `Boundary And Dependency Rules`, `Stateful Cross-Layer Hardening Gate`, `Verification Tiers`)
 
 ### B) Review PR
 Read in order:
@@ -70,7 +70,7 @@ Canonical kickoff prompts:
 1. Restate goal/non-goals/acceptance criteria from the Task issue.
 2. Create/switch to dedicated branch `task-<id>-<slug>` before edits.
 3. Implement minimally and preserve existing contracts unless scope says otherwise.
-4. Run verification by tier (`docs/WORKFLOW.md` Verification Tiers):
+4. Run verification by tier (`docs/workflow/VERIFY.md` Verification Tiers):
    - Tier 1 during implementation (smallest checks proving changed behavior)
    - Tier 2 after `ACTIONABLE` review patches (targeted reruns)
    - Tier 3 broad PR/final gate checks (`make backend-verify`, `make frontend-verify`, `make verify` as applicable)
@@ -95,7 +95,7 @@ Use only when the operator explicitly requests `execution=parallel`:
 
 ## Agent Output Budget
 
-Canonical norms live in `docs/WORKFLOW.md` under **Agent Output Budget**.
+Canonical norms live in `docs/workflow/REVIEW.md` under **Agent Output Budget**.
 
 ## Guardrails
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,4 +5,6 @@ Open additional docs only when the task touches those surfaces:
 - docs/DESIGN.md
 - docs/PATTERNS.md
 - docs/REVIEW_CHECKLIST.md
-- docs/WORKFLOW.md
+- docs/workflow/IMPLEMENT.md
+- docs/workflow/REVIEW.md
+- docs/workflow/VERIFY.md

--- a/docs/DEFERRED.md
+++ b/docs/DEFERRED.md
@@ -70,7 +70,7 @@ Extraction, PDF, and email jobs carry important retry, terminal-failure, stale-r
 ## Backend LOC Hard-Fail Enforcement
 
 **Source:** 2026-04-12 quote modularity planning review
-**Where:** `scripts/check_file_sizes.sh`, `Makefile`, `docs/WORKFLOW.md`, and `docs/PATTERNS.md`
+**Where:** `scripts/check_file_sizes.sh`, `Makefile`, `docs/workflow/IMPLEMENT.md`, `docs/workflow/VERIFY.md`, and `docs/PATTERNS.md`
 
 Backend file-size checks currently warn for route/service/repository modules over the target budget. The eventual hard-fail threshold should remain `>350` LOC because it matches the documented split/follow-up threshold in the workflow docs.
 

--- a/docs/GREENFIELD_BLUEPRINT.md
+++ b/docs/GREENFIELD_BLUEPRINT.md
@@ -17,6 +17,10 @@ Stima/
   CLAUDE.md
   docs/
     WORKFLOW.md
+    workflow/
+      IMPLEMENT.md
+      REVIEW.md
+      VERIFY.md
     ISSUES_WORKFLOW.md
     GREENFIELD_BLUEPRINT.md
     MIGRATION_GUIDE.md
@@ -104,5 +108,5 @@ For refactors declared as "no API/contract change", verify:
 Root stays lean — only agent/Claude entrypoints:
 
 - Keep at root: `AGENTS.md`, `CLAUDE.md`.
-- Keep in `docs/`: `WORKFLOW.md`, `ISSUES_WORKFLOW.md`, `GREENFIELD_BLUEPRINT.md`, `MIGRATION_GUIDE.md`, `ARCHITECTURE.md`, `PATTERNS.md`, `REVIEW_CHECKLIST.md`, ADRs, runbooks.
+- Keep in `docs/`: `WORKFLOW.md`, `workflow/*.md`, `ISSUES_WORKFLOW.md`, `GREENFIELD_BLUEPRINT.md`, `MIGRATION_GUIDE.md`, `ARCHITECTURE.md`, `PATTERNS.md`, `REVIEW_CHECKLIST.md`, ADRs, runbooks.
 - Keep automation playbooks under `skills/`.

--- a/docs/ISSUES_WORKFLOW.md
+++ b/docs/ISSUES_WORKFLOW.md
@@ -171,7 +171,7 @@ cd backend && ruff check . && mypy . && bandit -r app/ && pytest && cd ../fronte
 
 Prefer repo-level verify entrypoints when available (for example: `make backend-verify`, `make frontend-verify`).
 
-When a Makefile verify contract exists (see `docs/WORKFLOW.md`), use those canonical targets in Task verification sections.
+When a Makefile verify contract exists (see `docs/workflow/VERIFY.md`), use those canonical targets in Task verification sections.
 
 ## Codex + GitHub CLI Playbook
 

--- a/docs/MIGRATION_GUIDE.md
+++ b/docs/MIGRATION_GUIDE.md
@@ -5,7 +5,8 @@ This guide explains how to use this template as the foundation for a new project
 ## What this template provides
 
 - Agent operating rules (`AGENTS.md`)
-- Core workflow (`docs/WORKFLOW.md`)
+- Core workflow index (`docs/WORKFLOW.md`)
+- Split workflow guides (`docs/workflow/IMPLEMENT.md`, `docs/workflow/REVIEW.md`, `docs/workflow/VERIFY.md`)
 - Issue-driven execution control plane (`docs/ISSUES_WORKFLOW.md`)
 - Canonical kickoff/review prompts (`docs/template/KICKOFF.md`)
 - Documentation skeletons (`docs/ARCHITECTURE.md`, `docs/PATTERNS.md`, `docs/REVIEW_CHECKLIST.md`)
@@ -32,7 +33,7 @@ This guide explains how to use this template as the foundation for a new project
 8. Keep ceremony conditional: second review pass only when explicitly requested; decision briefs and doc updates only when behavior/contracts/architecture changed.
 
 Recommended onboarding paths for agents:
-1. Implement existing Task: `AGENTS.md` -> Task/Execution Brief/PR context -> `docs/template/KICKOFF.md` section 1 -> relevant `docs/WORKFLOW.md` sections only as needed.
+1. Implement existing Task: `AGENTS.md` -> Task/Execution Brief/PR context -> `docs/template/KICKOFF.md` section 1 -> relevant `docs/workflow/IMPLEMENT.md` + `docs/workflow/VERIFY.md` sections only as needed.
 2. Review PR: `AGENTS.md` -> PR/Task context -> `docs/template/KICKOFF.md` section 3a (and 3b constraints) -> `.github/prompts/review-task.prompt.md` only when full prompt body is needed.
 3. Plan/create issues/choose mode: `AGENTS.md` -> `docs/ISSUES_WORKFLOW.md` -> `docs/template/KICKOFF.md` section 2.
 4. Escape hatch: if mode/labels/lifecycle/branching are unclear in any path, read `docs/ISSUES_WORKFLOW.md` before proceeding.

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,7 +11,10 @@ Use this index to keep template docs easy to traverse.
 
 ## Workflow Docs
 
-- `WORKFLOW.md` — implementation loop and engineering defaults
+- `WORKFLOW.md` — workflow index and source-of-truth routing
+- `workflow/IMPLEMENT.md` — implementation loop and engineering defaults
+- `workflow/REVIEW.md` — review follow-up and handoff defaults
+- `workflow/VERIFY.md` — verification tiers and canonical commands
 - `ISSUES_WORKFLOW.md` — issue modes, DoR/DoD, branching rules
 - `GREENFIELD_BLUEPRINT.md` — default repo structure baseline
 - `MIGRATION_GUIDE.md` — template adoption guide for new and existing repos

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -1,5 +1,7 @@
 # WORKFLOW.md — Stima
 
+Stima workflow index: use this file to route into implementation, review, and verification guidance without loading one monolithic workflow doc.
+
 ## Project Context
 
 - **Project:** `Stima`
@@ -8,325 +10,144 @@
 
 ## Source Of Truth (By Rule Type)
 
-- Execution control plane (modes, DoR/DoD, branching, issue lifecycle): `docs/ISSUES_WORKFLOW.md` (authoritative)
-- Kickoff prompts and reviewer output contract: `docs/template/KICKOFF.md` (authoritative)
-- This file (`WORKFLOW.md`) summarizes the implementation loop and engineering defaults.
-- For narrow execute/review work, load this file by section as routed from `AGENTS.md`; a full sequential read is not required.
+| Rule type | Authoritative source |
+| --- | --- |
+| Execution control plane (modes, DoR/DoD, branching, issue lifecycle) | `docs/ISSUES_WORKFLOW.md` |
+| Kickoff prompts and reviewer output contract | `docs/template/KICKOFF.md` |
+| Implementation-loop guidance | `docs/workflow/IMPLEMENT.md` |
+| Review-loop guidance | `docs/workflow/REVIEW.md` |
+| Verification tiers and commands | `docs/workflow/VERIFY.md` |
+
+## Workflow Docs
+
+- `docs/workflow/IMPLEMENT.md` - development loop, implementation defaults, hardening, boundaries, parity, scope, and toolchain expectations.
+- `docs/workflow/REVIEW.md` - lean review mode, output budget, delta-only patch norms, and learning handoff rules.
+- `docs/workflow/VERIFY.md` - verification tiers, canonical `make` targets, command baselines, and agent runtime notes.
+
+## Legacy Section Redirects
+
+This index retains former section names from the monolithic `WORKFLOW.md` and points each to its new canonical location.
 
 ## Greenfield Baseline (Default)
 
-For new repositories, use `docs/GREENFIELD_BLUEPRINT.md` as the baseline.
-
-Core defaults:
-
-- Backend structure: feature-first modules with explicit layering `api -> services -> repositories -> integrations/libs`.
-- Frontend structure: feature-first under `src/features/<feature>` with shared modules in `src/shared`.
-- Route/page modules stay thin; orchestration belongs in services/hooks.
-- No-contract refactors must pass the parity lock checklist.
-- Runtime/toolchain contracts are explicit and pinned.
+Moved to `docs/workflow/IMPLEMENT.md#greenfield-baseline-default`.
 
 ## Development Loop
 
-Every feature follows:
-
-1. Whiteboard
-2. Document
-3. Implement
-4. Verify
-5. Review handoff
-6. Patch (if needed)
-7. In-chat learning handoff in the approving review response
-8. Finalize
+Moved to `docs/workflow/IMPLEMENT.md#development-loop`.
 
 ## Agent Output Budget
 
-Default chat output should stay concise and non-duplicative:
-
-1. Findings-first: lead with what changed, key risks, and verification outcome.
-2. Bounded recap: when Task issue scope is already explicit, avoid long restatements.
-3. No duplicate verification blocks: report commands run and result; include only minimal failure context when needed.
-4. Completion summaries: changed files + one-line intent per file; avoid re-deriving stable repo rules.
-5. Review replies: `ACTIONABLE` should be finding-focused with minimal preamble; `APPROVED` follows the tutoring handoff contract.
+Moved to `docs/workflow/REVIEW.md#agent-output-budget`.
 
 ## Operator Flow Optimization
 
-Use this as the default human-in-the-loop sequence to reduce handoff overhead:
-
-1. Plan scope and choose mode (`single` by default; `gated`/`fast` only when explicitly requested).
-2. For issue-backed work (`single`/`gated`), use the brief-first execution flow in `docs/template/KICKOFF.md`: keep the Task issue authoritative, add an Execution Brief only for task-local deltas, and reference analog docs when relevant.
-3. Open PR with `Closes #<task-id>`.
-4. Run one reviewer pass: implementation agent posts the short kickoff from `docs/template/KICKOFF.md` section 3a; reviewer follows section 3b for scope/output shape and loads `.github/prompts/review-task.prompt.md` when the full brief is needed.
-5. If verdict is `ACTIONABLE`, use the delta-only patch handoff from `docs/template/KICKOFF.md` and rerun targeted verification only unless scope expands.
-6. When verdict is `APPROVED`, the approving reviewer includes the lightweight tutoring handoff in that same response; the implementation agent then finalizes without generating a second handoff.
-7. Merge PR and sync local branch.
-8. If this Task belongs to a Spec, check whether all sibling Tasks are now done or deferred; if so, close the Spec issue.
+Moved to `docs/workflow/IMPLEMENT.md#operator-flow-optimization`.
 
 ## Optional Parallel Local Execution
 
-For independent Task issues, the operator may request isolated local execution:
-
-```text
-Run kickoff for existing Task #<id> mode=single execution=parallel.
-```
-
-This is a local checkout strategy, not a new issue workflow mode.
-
-Rules:
-- GitHub issues remain the execution source of truth
-- the main checkout is the control-plane workspace
-- each parallel Task gets its own dedicated branch and linked worktree via `scripts/worktree-init.sh`
-- reviewers use the PR diff / branch diff as the entrypoint; they do not create worktrees
-- do not use parallel execution by default for migrations, shared contracts, or tightly coupled stateful work
-
-Post-merge cleanup (operator, in the main checkout):
-```bash
-git worktree remove --force ../stima-wt/task-<id>-<slug>
-git branch -d task-<id>-<slug>
-git fetch --prune origin
-```
+Moved to `docs/workflow/IMPLEMENT.md#optional-parallel-local-execution`.
 
 ## Issues Workflow (Control Plane)
 
-Use `AGENTS.md` bootstrap paths to decide when `docs/ISSUES_WORKFLOW.md` must be loaded. It is required for planning, issue creation, mode/lifecycle decisions, and any control-plane uncertainty.
-
-Core rule:
-
-- GitHub issues are the execution source of truth.
-- Choose execution mode: `single` by default; use `gated` or `fast` only when explicitly requested.
-- Default sizing is 1 feature -> 1 Task -> 1 PR unless split criteria apply.
-- PRs close Tasks.
-- Specs close only when all child Tasks are done or deferred.
-- For `single` and `gated` modes, create a dedicated Task branch before implementation.
-- Backend-coupled work must have Decision Locks checked before implementation.
-- After major refactors, open one docs-only Task for readability hardening (comments + `docs/PATTERNS.md` updates), with no behavior changes.
-
-Definition of Ready and Definition of Done are defined in `docs/ISSUES_WORKFLOW.md` and are mandatory gates.
+Moved to `docs/workflow/IMPLEMENT.md#issues-workflow-control-plane`.
 
 ## Canonical Kickoff Prompts
 
-Use `docs/template/KICKOFF.md` for copy-paste kickoff prompts.
-
-- Planning kickoff (feature -> issue planning only): no code changes, no PR.
-- Execution kickoff (existing Task -> implement/verify/PR): run only when Task issue already exists.
+Moved to `docs/workflow/IMPLEMENT.md#canonical-kickoff-prompts`.
 
 ## Stateful Cross-Layer Hardening Gate
 
-For Tasks that touch any of the following:
-- state transitions or lifecycle/status machines
-- frontend action visibility/enabled-state logic
-- external provider side effects
-- transport/error semantics or contract-sensitive behavior
-
-run one explicit hardening pass before reviewer handoff.
-
-Hardening pass checklist:
-- Behavior matrix matches implementation across all affected states
-- UI action matrix matches intended enabled/disabled/hidden behavior
-- Success, error, and retry semantics are aligned across backend, frontend, and docs
-- Failure paths are checked explicitly (for example provider failure, persistence failure, rollback/fallback behavior)
-- Canonical verification target(s) for the touched scope pass before push
-
-If canonical verification is blocked locally, stop and report that clearly before pushing follow-up fixes.
-Do not rely on confidence or partial checks when the Task changes contract-sensitive or stateful behavior.
+Moved to `docs/workflow/IMPLEMENT.md#stateful-cross-layer-hardening-gate`.
 
 ## Boundary And Dependency Rules
 
-- Be strict about scope, contracts, acceptance criteria, verification, and layer boundaries. Be flexible about internal decomposition and helper structure as long as the implementation stays readable, testable, and consistent with repo patterns.
-- Allowed: `api -> services -> repositories -> integrations/libs`.
-- Disallowed: reverse imports or cross-layer shortcuts.
-- Public service functions must add value (orchestration, policy, validation, transactions), not argument pass-through.
-- Repositories own persistence/query logic only and should not raise transport-layer errors.
-- Enforce boundary direction with lightweight guardrail checks/tests where possible.
+Moved to `docs/workflow/IMPLEMENT.md#boundary-and-dependency-rules`.
 
 ## Refactor Parity Lock (No Contract Change)
 
-If a Task claims "no API/contract change", verify and report:
-
-1. Status code parity (success + error paths).
-2. Response schema parity (fields/types/envelope shape).
-3. Error semantics parity (externally visible behavior).
-4. Side-effect parity (DB writes, queue, storage, notifications).
+Moved to `docs/workflow/IMPLEMENT.md#refactor-parity-lock-no-contract-change`.
 
 ## Lean Review Mode (Default)
 
-After implementation and PR creation, run one focused reviewer follow-up pass:
-
-- Reviewer scope: major correctness bugs, regressions, and missing tests/docs.
-- Reviewer output: `APPROVED` or `ACTIONABLE`.
-- If `ACTIONABLE`, patch findings and rerun only relevant verification.
-- If `APPROVED`, the approving reviewer posts the required in-chat learning handoff in that same response before the implementation agent claims completion.
-- Default to one review pass; run a second pass only when explicitly requested.
-
-Default reviewer constraints:
-
-- use local branch diff/repo context first
-- skip broad environment triage unless blocked
-- do not create worktrees by default
-- do not rerun full verification already reported green
-- report findings first; no command-by-command transcript unless a command failed
-- be strict about contracts, boundary violations, verification gaps, and parity claims; do not nitpick internal helper decomposition when readability, testability, and repo-pattern consistency are intact
-
-Reviewer note for stateful/cross-layer Tasks:
-- default to matrix/parity review first:
-  - status/action parity
-  - error/detail parity
-  - side-effect parity
-  - failure/retry parity
-- separate correctness defects from product decisions that should become follow-up tasks
+Moved to `docs/workflow/REVIEW.md#lean-review-mode-default`.
 
 ## Canonical Reviewer Follow-Up Prompt
 
-After opening a Task PR, default to the short reviewer kickoff in `docs/template/KICKOFF.md` section 3a. Section 3b there defines the authoritative output contract and points to `.github/prompts/review-task.prompt.md` for the full brief.
-Do not redefine the format in this file; keep `docs/template/KICKOFF.md` as the single source of truth.
+Moved to `docs/workflow/REVIEW.md#canonical-reviewer-follow-up-prompt`.
 
 ## Learning Handoff (Required Completion Gate)
 
-The lightweight tutoring handoff is generated once, by the approving reviewer, in the same `APPROVED` response for the completed unit (`Task` completion and `Spec` closure).
-
-- Do not generate a second learning handoff after approval is relayed back; the implementation agent finalizes after approval.
-- Do not create a separate markdown handoff unless explicitly requested.
-- Keep it ephemeral and practical, not archival documentation.
-- Keep it to 4 short bullets:
-  - what changed
-  - why it was done this way
-  - one tradeoff or pattern worth learning
-  - what to review first
-- Add 3-6 code pointers using `path:line-line — why it matters` format.
+Moved to `docs/workflow/REVIEW.md#learning-handoff-required-completion-gate`.
 
 ## Planning And Scope
 
-- One issue at a time.
-- Default to one end-to-end Task per feature.
-- Keep changes surgical.
-- Split Tasks only when `docs/ISSUES_WORKFLOW.md` split criteria apply.
+Moved to `docs/workflow/IMPLEMENT.md#planning-and-scope`.
 
 ### Selective Test-First Guidance
 
-- When practical, bug fixes, backend business logic, contract-sensitive behavior, and stateful/cross-layer changes should identify the first test or assertion to add before implementation.
-- This is not full TDD and does not require red-green-refactor for every task.
-- UI polish, exploratory work, copy tweaks, and other low-risk changes can stay lighter when the risk profile does not justify front-loading tests.
+Moved to `docs/workflow/IMPLEMENT.md#selective-test-first-guidance`.
 
 ### Default Modularity
 
-- Frontend greenfield default: `src/features/<feature>/*` plus `src/shared/*`.
-- Backend greenfield default: `backend/app/features/<feature>/*` with explicit api/service/repository boundaries.
-- For existing repos, preserve current structure unless a dedicated migration task scopes restructuring.
+Moved to `docs/workflow/IMPLEMENT.md#default-modularity`.
 
 ### Practical File-Size Budgets
 
-- Frontend leaf components: target `<=250` LOC.
-- Frontend single-purpose hooks/services: target `<=180` LOC.
-- Backend route/service/repository modules: target `<=220` LOC.
-- `300-400` LOC can be acceptable when cohesive; split or create linked follow-up when:
-  - frontend component exceeds `450` LOC
-  - frontend hook/service exceeds `300` LOC
-  - backend route/service/repository exceeds `350` LOC
+Moved to `docs/workflow/IMPLEMENT.md#practical-file-size-budgets`.
 
 ## Decision Brief Requirement
 
-For non-trivial changes that modify behavior/contracts/architecture, include a short decision brief:
-
-- chosen approach
-- one alternative considered
-- tradeoff behind the choice (complexity/risk/perf/security)
-- revisit trigger for when the alternative becomes preferable
-
-For small tasks with no contract/behavior change, decision brief is optional.
+Moved to `docs/workflow/IMPLEMENT.md#decision-brief-requirement`.
 
 ## Toolchain Contract (Mandatory)
 
-- Pin runtime versions in-repo (for example `.nvmrc`, `.python-version`, or equivalent).
-- Declare Node requirements in `package.json` `engines` when frontend tooling depends on specific Node versions.
-- Keep README prerequisites, local verify commands, and CI runtime versions aligned.
-- Verification should fail fast on version mismatch.
+Moved to `docs/workflow/IMPLEMENT.md#toolchain-contract-mandatory`.
 
 ## Verification
 
-Run the relevant checks before claiming completion.
+Moved to `docs/workflow/VERIFY.md#verification`.
 
 ### Verification Tiers
 
-- Tier 1 (implementation loop): run the smallest checks that prove changed behavior.
-- Tier 2 (post-review patch): rerun only checks needed for patched findings unless scope expands.
-- Tier 3 (PR/final gate): run canonical broad verify targets for affected surfaces (`make backend-verify`, `make frontend-verify`, `make verify` as applicable).
-- Tier 4 (operator-only heavy): live/provider/manual or unusually expensive checks only when explicitly required.
-
-Agent execution note:
-- Do not run live/provider-backed verification targets from agent sessions (for example `make extraction-live`); ask the human operator to run them manually and share output.
-- Do not run bare `pytest` from agent sessions. Use `make backend-verify` for broad backend verification, or `cd backend && .venv/bin/pytest ...` for targeted backend tests so the repo venv is used consistently.
-- Backend pytest depends on host-local services in this repo's test harness (see `backend/conftest.py`). When backend tests are needed from an agent session, prefer an escalated run outside the sandbox over repeated retries inside the network-isolated sandbox.
-- If sandboxed backend pytest hangs during startup, collection, or before first assertion, treat sandbox/service access as the default suspect and verify that path before debugging application code.
+Moved to `docs/workflow/VERIFY.md#verification-tiers`.
 
 ### Makefile Verification Contract (Recommended)
 
-If the repo uses `make` for verification, standardize on these targets:
-
-- `make verify` (full verification aggregator)
-- `make backend-verify` (backend lint/type-check/tests/security checks as applicable)
-- `make frontend-verify` (frontend type-check/tests/lint/build as applicable)
-- `make db-verify` (migrations/schema checks when applicable)
-- `make template-verify` (template-level checks such as unresolved-token guard)
-
-Contract rules:
-
-- Targets must be deterministic, non-interactive, and fail-fast (non-zero exit on failure).
-- CI should run the same `make` targets used locally.
-- Keep target names and scope stable; if changed, update README + workflow docs in the same Task.
+Moved to `docs/workflow/VERIFY.md#makefile-verification-contract-recommended`.
 
 ### Full Verification
 
-```bash
-cd backend && ruff check . && mypy . && bandit -r app/ && pytest && cd ../frontend && npx tsc --noEmit && npx eslint src/ && npx vitest run && npm run build
-```
+Moved to `docs/workflow/VERIFY.md#full-verification`.
 
 ### Frontend Verification
 
-```bash
-cd frontend && npx tsc --noEmit && npx eslint src/ && npx vitest run && npm run build
-```
+Moved to `docs/workflow/VERIFY.md#frontend-verification`.
 
 ### Backend Verification
 
-```bash
-cd backend && ruff check . && mypy . && bandit -r app/ && pytest
-```
+Moved to `docs/workflow/VERIFY.md#backend-verification`.
 
 ### Database Verification
 
-```bash
-cd backend && alembic upgrade head
-```
+Moved to `docs/workflow/VERIFY.md#database-verification`.
 
 ### Verification Baseline Expectations
 
-- Backend: boundary guardrail check + lint + type-check + tests + security scan.
-- Frontend: type-check + tests + lint + production build.
-- No-contract refactors: include parity lock results in final verification summary.
-- Template maintenance: unresolved-token guard passes (`./scripts/check-unresolved-template-tokens.sh`).
+Moved to `docs/workflow/VERIFY.md#verification-baseline-expectations`.
 
 ## Documentation
 
-Update docs only when behavior/contracts/patterns changed.
-
-For in-code documentation and comment quality requirements, follow `docs/CODE_COMMENTING_CONTRACT.md`.
-
-Docs paths:
-
-- `docs/README.md, docs/ARCHITECTURE.md, docs/PATTERNS.md, docs/REVIEW_CHECKLIST.md`
+Moved to `docs/workflow/IMPLEMENT.md#documentation`.
 
 ## CI
 
-- `GitHub Actions: .github/workflows/backend-test.yml and .github/workflows/frontend-test.yml`
+Moved to `docs/workflow/IMPLEMENT.md#ci`.
 
 ## Documentation Layout
 
-Root stays lean — only top-level entrypoints:
-
-- Root: `AGENTS.md`, `CLAUDE.md`.
-- Subtree entrypoints: `backend/AGENTS.md`, `frontend/AGENTS.md` (loaded conditionally by scope).
-- `docs/`: `WORKFLOW.md`, `ISSUES_WORKFLOW.md`, `GREENFIELD_BLUEPRINT.md`, `MIGRATION_GUIDE.md`, `ARCHITECTURE.md`, `PATTERNS.md`, `REVIEW_CHECKLIST.md`, ADRs, runbooks.
-- `skills/`: procedural playbooks only.
+Moved to `docs/workflow/IMPLEMENT.md#documentation-layout`.
 
 ## Optional Later
 
-MCP is optional and not part of v1. Introduce it only when you need automation for issue operations or CI summaries.
+Moved to `docs/workflow/IMPLEMENT.md#optional-later`.

--- a/docs/template/EXECUTION_BRIEF.md
+++ b/docs/template/EXECUTION_BRIEF.md
@@ -58,7 +58,7 @@ Capture commands by tier so reruns stay proportional:
 
 ## Do Not Include
 
-- Large pasted excerpts from `AGENTS.md`, `docs/WORKFLOW.md`, `docs/ISSUES_WORKFLOW.md`, or `docs/template/KICKOFF.md`
+- Large pasted excerpts from `AGENTS.md`, `docs/WORKFLOW.md`, `docs/workflow/*.md`, `docs/ISSUES_WORKFLOW.md`, or `docs/template/KICKOFF.md`
 - Full control-plane essays unless this task introduces a task-specific exception
 - Long pasted acceptance-criteria lists or full issue bodies; link the issue and capture delta only
 - Reviewer prompt, PR boilerplate, or learning handoff text unless this task is explicitly changing that workflow

--- a/docs/template/KICKOFF.md
+++ b/docs/template/KICKOFF.md
@@ -15,7 +15,7 @@ Use these prompts to start work on already-scoped tasks without reloading unnece
 - Execution Brief is task-local compression only.
 - Use the short reviewer kickoff by default.
 - After `ACTIONABLE`, patch listed findings only unless scope expands.
-- Verification follows tiers from `docs/WORKFLOW.md`.
+- Verification follows tiers from `docs/workflow/VERIFY.md`.
 
 ## When To Load Which Asset
 

--- a/docs/workflow/IMPLEMENT.md
+++ b/docs/workflow/IMPLEMENT.md
@@ -1,0 +1,196 @@
+# Workflow: Implement
+
+Implementation-loop guidance and engineering defaults for task execution.
+
+## Greenfield Baseline (Default)
+
+For new repositories, use `docs/GREENFIELD_BLUEPRINT.md` as the baseline.
+
+Core defaults:
+
+- Backend structure: feature-first modules with explicit layering `api -> services -> repositories -> integrations/libs`.
+- Frontend structure: feature-first under `src/features/<feature>` with shared modules in `src/shared`.
+- Route/page modules stay thin; orchestration belongs in services/hooks.
+- No-contract refactors must pass the parity lock checklist.
+- Runtime/toolchain contracts are explicit and pinned.
+
+## Development Loop
+
+Every feature follows:
+
+1. Whiteboard
+2. Document
+3. Implement
+4. Verify
+5. Review handoff
+6. Patch (if needed)
+7. In-chat learning handoff in the approving review response
+8. Finalize
+
+## Operator Flow Optimization
+
+Use this as the default human-in-the-loop sequence to reduce handoff overhead:
+
+1. Plan scope and choose mode (`single` by default; `gated`/`fast` only when explicitly requested).
+2. For issue-backed work (`single`/`gated`), use the brief-first execution flow in `docs/template/KICKOFF.md`: keep the Task issue authoritative, add an Execution Brief only for task-local deltas, and reference analog docs when relevant.
+3. Open PR with `Closes #<task-id>`.
+4. Run one reviewer pass: implementation agent posts the short kickoff from `docs/template/KICKOFF.md` section 3a; reviewer follows section 3b for scope/output shape and loads `.github/prompts/review-task.prompt.md` when the full brief is needed.
+5. If verdict is `ACTIONABLE`, use the delta-only patch handoff from `docs/template/KICKOFF.md` and rerun targeted verification only unless scope expands.
+6. When verdict is `APPROVED`, the approving reviewer includes the lightweight tutoring handoff in that same response; the implementation agent then finalizes without generating a second handoff.
+7. Merge PR and sync local branch.
+8. If this Task belongs to a Spec, check whether all sibling Tasks are now done or deferred; if so, close the Spec issue.
+
+## Optional Parallel Local Execution
+
+For independent Task issues, the operator may request isolated local execution:
+
+```text
+Run kickoff for existing Task #<id> mode=single execution=parallel.
+```
+
+This is a local checkout strategy, not a new issue workflow mode.
+
+Rules:
+- GitHub issues remain the execution source of truth
+- the main checkout is the control-plane workspace
+- each parallel Task gets its own dedicated branch and linked worktree via `scripts/worktree-init.sh`
+- reviewers use the PR diff / branch diff as the entrypoint; they do not create worktrees
+- do not use parallel execution by default for migrations, shared contracts, or tightly coupled stateful work
+
+Post-merge cleanup (operator, in the main checkout):
+```bash
+git worktree remove --force ../stima-wt/task-<id>-<slug>
+git branch -d task-<id>-<slug>
+git fetch --prune origin
+```
+
+## Issues Workflow (Control Plane)
+
+Use `AGENTS.md` bootstrap paths to decide when `docs/ISSUES_WORKFLOW.md` must be loaded. It is required for planning, issue creation, mode/lifecycle decisions, and any control-plane uncertainty.
+
+Core rule:
+
+- GitHub issues are the execution source of truth.
+- Choose execution mode: `single` by default; use `gated` or `fast` only when explicitly requested.
+- Default sizing is 1 feature -> 1 Task -> 1 PR unless split criteria apply.
+- PRs close Tasks.
+- Specs close only when all child Tasks are done or deferred.
+- For `single` and `gated` modes, create a dedicated Task branch before implementation.
+- Backend-coupled work must have Decision Locks checked before implementation.
+- After major refactors, open one docs-only Task for readability hardening (comments + `docs/PATTERNS.md` updates), with no behavior changes.
+
+Definition of Ready and Definition of Done are defined in `docs/ISSUES_WORKFLOW.md` and are mandatory gates.
+
+## Canonical Kickoff Prompts
+
+Use `docs/template/KICKOFF.md` for copy-paste kickoff prompts.
+
+- Planning kickoff (feature -> issue planning only): no code changes, no PR.
+- Execution kickoff (existing Task -> implement/verify/PR): run only when Task issue already exists.
+
+## Stateful Cross-Layer Hardening Gate
+
+For Tasks that touch any of the following:
+- state transitions or lifecycle/status machines
+- frontend action visibility/enabled-state logic
+- external provider side effects
+- transport/error semantics or contract-sensitive behavior
+
+run one explicit hardening pass before reviewer handoff.
+
+Hardening pass checklist:
+- Behavior matrix matches implementation across all affected states
+- UI action matrix matches intended enabled/disabled/hidden behavior
+- Success, error, and retry semantics are aligned across backend, frontend, and docs
+- Failure paths are checked explicitly (for example provider failure, persistence failure, rollback/fallback behavior)
+- Canonical verification target(s) for the touched scope pass before push
+
+If canonical verification is blocked locally, stop and report that clearly before pushing follow-up fixes.
+Do not rely on confidence or partial checks when the Task changes contract-sensitive or stateful behavior.
+
+## Boundary And Dependency Rules
+
+- Be strict about scope, contracts, acceptance criteria, verification, and layer boundaries. Be flexible about internal decomposition and helper structure as long as the implementation stays readable, testable, and consistent with repo patterns.
+- Allowed: `api -> services -> repositories -> integrations/libs`.
+- Disallowed: reverse imports or cross-layer shortcuts.
+- Public service functions must add value (orchestration, policy, validation, transactions), not argument pass-through.
+- Repositories own persistence/query logic only and should not raise transport-layer errors.
+- Enforce boundary direction with lightweight guardrail checks/tests where possible.
+
+## Refactor Parity Lock (No Contract Change)
+
+If a Task claims "no API/contract change", verify and report:
+
+1. Status code parity (success + error paths).
+2. Response schema parity (fields/types/envelope shape).
+3. Error semantics parity (externally visible behavior).
+4. Side-effect parity (DB writes, queue, storage, notifications).
+
+## Planning And Scope
+
+- One issue at a time.
+- Default to one end-to-end Task per feature.
+- Keep changes surgical.
+- Split Tasks only when `docs/ISSUES_WORKFLOW.md` split criteria apply.
+
+### Selective Test-First Guidance
+
+- When practical, bug fixes, backend business logic, contract-sensitive behavior, and stateful/cross-layer changes should identify the first test or assertion to add before implementation.
+- This is not full TDD and does not require red-green-refactor for every task.
+- UI polish, exploratory work, copy tweaks, and other low-risk changes can stay lighter when the risk profile does not justify front-loading tests.
+
+### Default Modularity
+
+- Frontend greenfield default: `src/features/<feature>/*` plus `src/shared/*`.
+- Backend greenfield default: `backend/app/features/<feature>/*` with explicit api/service/repository boundaries.
+- For existing repos, preserve current structure unless a dedicated migration task scopes restructuring.
+
+### Practical File-Size Budgets
+
+- Frontend leaf components: target `<=250` LOC.
+- Frontend single-purpose hooks/services: target `<=180` LOC.
+- Backend route/service/repository modules: target `<=220` LOC.
+- `300-400` LOC can be acceptable when cohesive; split or create linked follow-up when:
+  - frontend component exceeds `450` LOC
+  - frontend hook/service exceeds `300` LOC
+  - backend route/service/repository exceeds `350` LOC
+
+## Decision Brief Requirement
+
+For non-trivial changes that modify behavior/contracts/architecture, include a short decision brief:
+
+- chosen approach
+- one alternative considered
+- tradeoff behind the choice (complexity/risk/perf/security)
+- revisit trigger for when the alternative becomes preferable
+
+For small tasks with no contract/behavior change, decision brief is optional.
+
+## Toolchain Contract (Mandatory)
+
+- Pin runtime versions in-repo (for example `.nvmrc`, `.python-version`, or equivalent).
+- Declare Node requirements in `package.json` `engines` when frontend tooling depends on specific Node versions.
+- Keep README prerequisites, local verify commands, and CI runtime versions aligned.
+- Verification should fail fast on version mismatch.
+
+## Documentation
+
+Update docs only when behavior/contracts/patterns changed.
+
+For in-code documentation and comment quality requirements, follow `docs/CODE_COMMENTING_CONTRACT.md`.
+
+Docs paths:
+
+- `docs/README.md, docs/ARCHITECTURE.md, docs/PATTERNS.md, docs/REVIEW_CHECKLIST.md`
+
+## CI
+
+- `GitHub Actions: .github/workflows/backend-test.yml and .github/workflows/frontend-test.yml`
+
+## Documentation Layout
+
+- `docs/`: `WORKFLOW.md`, `workflow/IMPLEMENT.md`, `workflow/REVIEW.md`, `workflow/VERIFY.md`, `ISSUES_WORKFLOW.md`, `GREENFIELD_BLUEPRINT.md`, `MIGRATION_GUIDE.md`, `ARCHITECTURE.md`, `PATTERNS.md`, `REVIEW_CHECKLIST.md`, ADRs, runbooks.
+
+## Optional Later
+
+- `MCP support` may be added after v1 if automation needs justify the added surface area.

--- a/docs/workflow/REVIEW.md
+++ b/docs/workflow/REVIEW.md
@@ -1,0 +1,63 @@
+# Workflow: Review
+
+Review-loop guidance, patch follow-up norms, and completion handoff expectations.
+
+## Agent Output Budget
+
+Default chat output should stay concise and non-duplicative:
+
+1. Findings-first: lead with what changed, key risks, and verification outcome.
+2. Bounded recap: when Task issue scope is already explicit, avoid long restatements.
+3. No duplicate verification blocks: report commands run and result; include only minimal failure context when needed.
+4. Completion summaries: changed files + one-line intent per file; avoid re-deriving stable repo rules.
+5. Review replies: `ACTIONABLE` should be finding-focused with minimal preamble; `APPROVED` follows the tutoring handoff contract.
+
+## Lean Review Mode (Default)
+
+After implementation and PR creation, run one focused reviewer follow-up pass:
+
+- Reviewer scope: major correctness bugs, regressions, and missing tests/docs.
+- Reviewer output: `APPROVED` or `ACTIONABLE`.
+- If `ACTIONABLE`, patch findings and rerun only relevant verification.
+- If `APPROVED`, the approving reviewer posts the required in-chat learning handoff in that same response before the implementation agent claims completion.
+- Default to one review pass; run a second pass only when explicitly requested.
+
+Default reviewer constraints:
+
+- use local branch diff/repo context first
+- skip broad environment triage unless blocked
+- do not create worktrees by default
+- do not rerun full verification already reported green
+- report findings first; no command-by-command transcript unless a command failed
+- be strict about contracts, boundary violations, verification gaps, and parity claims; do not nitpick internal helper decomposition when readability, testability, and repo-pattern consistency are intact
+
+Reviewer note for stateful/cross-layer Tasks:
+- default to matrix/parity review first:
+  - status/action parity
+  - error/detail parity
+  - side-effect parity
+  - failure/retry parity
+- separate correctness defects from product decisions that should become follow-up tasks
+
+## Canonical Reviewer Follow-Up Prompt
+
+After opening a Task PR, default to the short reviewer kickoff in `docs/template/KICKOFF.md` section 3a. Section 3b there defines the authoritative output contract and points to `.github/prompts/review-task.prompt.md` for the full brief.
+Do not redefine the format in this file; keep `docs/template/KICKOFF.md` as the single source of truth.
+
+## Delta-Only Patch Norm
+
+When a review verdict is `ACTIONABLE`, use the delta-only patch handoff in `docs/template/KICKOFF.md` and patch listed findings only unless scope expands.
+
+## Learning Handoff (Required Completion Gate)
+
+The lightweight tutoring handoff is generated once, by the approving reviewer, in the same `APPROVED` response for the completed unit (`Task` completion and `Spec` closure).
+
+- Do not generate a second learning handoff after approval is relayed back; the implementation agent finalizes after approval.
+- Do not create a separate markdown handoff unless explicitly requested.
+- Keep it ephemeral and practical, not archival documentation.
+- Keep it to 4 short bullets:
+  - what changed
+  - why it was done this way
+  - one tradeoff or pattern worth learning
+  - what to review first
+- Add 3-6 code pointers using `path:line-line — why it matters` format.

--- a/docs/workflow/VERIFY.md
+++ b/docs/workflow/VERIFY.md
@@ -1,0 +1,67 @@
+# Workflow: Verify
+
+Verification tiers, canonical commands, and runtime constraints.
+
+## Verification
+
+Run the relevant checks before claiming completion.
+
+### Verification Tiers
+
+- Tier 1 (implementation loop): run the smallest checks that prove changed behavior.
+- Tier 2 (post-review patch): rerun only checks needed for patched findings unless scope expands.
+- Tier 3 (PR/final gate): run canonical broad verify targets for affected surfaces (`make backend-verify`, `make frontend-verify`, `make verify` as applicable).
+- Tier 4 (operator-only heavy): live/provider/manual or unusually expensive checks only when explicitly required.
+
+Agent execution note:
+- Do not run live/provider-backed verification targets from agent sessions (for example `make extraction-live`); ask the human operator to run them manually and share output.
+- Do not run bare `pytest` from agent sessions. Use `make backend-verify` for broad backend verification, or `cd backend && .venv/bin/pytest ...` for targeted backend tests so the repo venv is used consistently.
+- Backend pytest depends on host-local services in this repo's test harness (see `backend/conftest.py`). When backend tests are needed from an agent session, prefer an escalated run outside the sandbox over repeated retries inside the network-isolated sandbox.
+- If sandboxed backend pytest hangs during startup, collection, or before first assertion, treat sandbox/service access as the default suspect and verify that path before debugging application code.
+
+### Makefile Verification Contract (Recommended)
+
+If the repo uses `make` for verification, standardize on these targets:
+
+- `make verify` (full verification aggregator)
+- `make backend-verify` (backend lint/type-check/tests/security checks as applicable)
+- `make frontend-verify` (frontend type-check/tests/lint/build as applicable)
+- `make db-verify` (migrations/schema checks when applicable)
+- `make template-verify` (template-level checks such as unresolved-token guard)
+
+Contract rules:
+
+- Targets must be deterministic, non-interactive, and fail-fast (non-zero exit on failure).
+- CI should run the same `make` targets used locally.
+- Keep target names and scope stable; if changed, update README + workflow docs in the same Task.
+
+### Full Verification
+
+```bash
+cd backend && ruff check . && mypy . && bandit -r app/ && pytest && cd ../frontend && npx tsc --noEmit && npx eslint src/ && npx vitest run && npm run build
+```
+
+### Frontend Verification
+
+```bash
+cd frontend && npx tsc --noEmit && npx eslint src/ && npx vitest run && npm run build
+```
+
+### Backend Verification
+
+```bash
+cd backend && ruff check . && mypy . && bandit -r app/ && pytest
+```
+
+### Database Verification
+
+```bash
+cd backend && alembic upgrade head
+```
+
+### Verification Baseline Expectations
+
+- Backend: boundary guardrail check + lint + type-check + tests + security scan.
+- Frontend: type-check + tests + lint + production build.
+- No-contract refactors: include parity lock results in final verification summary.
+- Template maintenance: unresolved-token guard passes (`./scripts/check-unresolved-template-tokens.sh`).


### PR DESCRIPTION
## Summary
- split monolithic docs/WORKFLOW.md into docs/workflow/IMPLEMENT.md, REVIEW.md, and VERIFY.md
- convert docs/WORKFLOW.md into a thin workflow index with source-of-truth routing plus legacy section redirects
- update canonical inbound references across AGENTS/CLAUDE/docs/template/docs index files to target docs/workflow/* where appropriate

## Verification
- make template-verify

## Notes
- dependency: Task #377 merged first (as required by issue)

Closes #378