### PR TITLE
Task #383: Stabilize quote/invoice API test helpers and fixtures

### DIFF
--- a/backend/app/features/invoices/tests/test_invoice_api.py
+++ b/backend/app/features/invoices/tests/test_invoice_api.py
@@ -5,6 +5,16 @@ from __future__ import annotations
 import pytest
 from app.features.quotes.models import Document, QuoteStatus
 from app.features.quotes.tests import test_quotes as quotes_test_module
+from app.features.quotes.tests.support.helpers import (
+    _create_approved_invoice,
+    _create_customer,
+    _create_direct_invoice,
+    _create_quote,
+    _credentials,
+    _register_and_login,
+    _set_invoice_status,
+    _set_quote_status,
+)
 from app.shared.input_limits import (
     DOCUMENT_TRANSCRIPT_MAX_CHARS,
 )
@@ -20,14 +30,6 @@ _override_storage_service_dependency = quotes_test_module._override_storage_serv
 _override_quote_service_dependency = quotes_test_module._override_quote_service_dependency
 _override_extraction_service_dependency = quotes_test_module._override_extraction_service_dependency
 _reset_rate_limiter = quotes_test_module._reset_rate_limiter
-_create_approved_invoice = quotes_test_module._create_approved_invoice
-_create_customer = quotes_test_module._create_customer
-_create_direct_invoice = quotes_test_module._create_direct_invoice
-_create_quote = quotes_test_module._create_quote
-_credentials = quotes_test_module._credentials
-_register_and_login = quotes_test_module._register_and_login
-_set_invoice_status = quotes_test_module._set_invoice_status
-_set_quote_status = quotes_test_module._set_quote_status
 
 
 async def test_create_direct_invoice_rejects_transcript_over_limit(

--- a/backend/app/features/invoices/tests/test_invoice_doc_type.py
+++ b/backend/app/features/invoices/tests/test_invoice_doc_type.py
@@ -7,6 +7,14 @@ from uuid import UUID
 import pytest
 from app.features.quotes.models import Document, QuoteStatus
 from app.features.quotes.tests import test_quotes as quotes_test_module
+from app.features.quotes.tests.support.helpers import (
+    _create_customer,
+    _create_direct_invoice,
+    _create_quote,
+    _credentials,
+    _register_and_login,
+    _set_invoice_status,
+)
 from httpx import AsyncClient
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -19,12 +27,6 @@ _override_storage_service_dependency = quotes_test_module._override_storage_serv
 _override_quote_service_dependency = quotes_test_module._override_quote_service_dependency
 _override_extraction_service_dependency = quotes_test_module._override_extraction_service_dependency
 _reset_rate_limiter = quotes_test_module._reset_rate_limiter
-_create_customer = quotes_test_module._create_customer
-_create_direct_invoice = quotes_test_module._create_direct_invoice
-_create_quote = quotes_test_module._create_quote
-_credentials = quotes_test_module._credentials
-_register_and_login = quotes_test_module._register_and_login
-_set_invoice_status = quotes_test_module._set_invoice_status
 
 
 @pytest.mark.parametrize("starting_status", [QuoteStatus.DRAFT, QuoteStatus.READY])

--- a/backend/app/features/invoices/tests/test_invoice_email.py
+++ b/backend/app/features/invoices/tests/test_invoice_email.py
@@ -11,6 +11,23 @@ from app.features.event_logs.models import EventLog
 from app.features.invoices.repository import InvoiceRepository
 from app.features.quotes.models import QuoteStatus
 from app.features.quotes.tests import test_quotes as quotes_test_module
+from app.features.quotes.tests.support.helpers import (
+    _assert_async_email_job_response,
+    _create_customer,
+    _create_direct_invoice,
+    _credentials,
+    _get_user_by_email,
+    _register_and_login,
+    _send_email_headers,
+    _set_invoice_status,
+    _set_profile_for_email_delivery,
+    _set_user_phone_number,
+)
+from app.features.quotes.tests.support.mocks import (
+    _FailingAbortIdempotencyStore,
+    _InProgressIdempotencyStore,
+    _MockEmailService,
+)
 from app.main import app
 from app.shared import observability
 from app.shared.dependencies import get_idempotency_store
@@ -27,20 +44,6 @@ _override_extraction_service_dependency = quotes_test_module._override_extractio
 _reset_rate_limiter = quotes_test_module._reset_rate_limiter
 _mock_arq_pool_for_send_email_tests = quotes_test_module._mock_arq_pool_for_send_email_tests
 mock_email_service = quotes_test_module.mock_email_service
-
-_MockEmailService = quotes_test_module._MockEmailService
-_FailingAbortIdempotencyStore = quotes_test_module._FailingAbortIdempotencyStore
-_InProgressIdempotencyStore = quotes_test_module._InProgressIdempotencyStore
-_assert_async_email_job_response = quotes_test_module._assert_async_email_job_response
-_send_email_headers = quotes_test_module._send_email_headers
-_register_and_login = quotes_test_module._register_and_login
-_credentials = quotes_test_module._credentials
-_set_profile_for_email_delivery = quotes_test_module._set_profile_for_email_delivery
-_set_user_phone_number = quotes_test_module._set_user_phone_number
-_create_customer = quotes_test_module._create_customer
-_create_direct_invoice = quotes_test_module._create_direct_invoice
-_set_invoice_status = quotes_test_module._set_invoice_status
-_get_user_by_email = quotes_test_module._get_user_by_email
 
 
 async def test_send_invoice_email_shares_invoice_delivers_email_and_logs_success(

--- a/backend/app/features/invoices/tests/test_invoice_outcomes.py
+++ b/backend/app/features/invoices/tests/test_invoice_outcomes.py
@@ -7,6 +7,13 @@ import json
 import pytest
 from app.features.quotes.models import QuoteStatus
 from app.features.quotes.tests import test_quotes as quotes_test_module
+from app.features.quotes.tests.support.helpers import (
+    _create_customer,
+    _create_direct_invoice,
+    _credentials,
+    _register_and_login,
+    _set_invoice_status,
+)
 from app.shared import event_logger
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -19,11 +26,6 @@ _override_storage_service_dependency = quotes_test_module._override_storage_serv
 _override_quote_service_dependency = quotes_test_module._override_quote_service_dependency
 _override_extraction_service_dependency = quotes_test_module._override_extraction_service_dependency
 _reset_rate_limiter = quotes_test_module._reset_rate_limiter
-_create_customer = quotes_test_module._create_customer
-_create_direct_invoice = quotes_test_module._create_direct_invoice
-_credentials = quotes_test_module._credentials
-_register_and_login = quotes_test_module._register_and_login
-_set_invoice_status = quotes_test_module._set_invoice_status
 
 
 @pytest.mark.parametrize(

--- a/backend/app/features/quotes/tests/support/__init__.py
+++ b/backend/app/features/quotes/tests/support/__init__.py
@@ -1,0 +1,1 @@
+"""Shared test support for quote/invoice API integration tests."""

--- a/backend/app/features/quotes/tests/support/helpers.py
+++ b/backend/app/features/quotes/tests/support/helpers.py
@@ -1,0 +1,282 @@
+from __future__ import annotations
+
+from datetime import date
+from uuid import UUID, uuid4
+
+from httpx import AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from app.features.auth.models import User
+from app.features.auth.service import CSRF_COOKIE_NAME
+from app.features.quotes.models import Document, QuoteStatus
+from app.worker.job_registry import extraction_job, pdf_job
+from app.worker.runtime import (
+    DEFAULT_MAX_TRIES,
+    DEFAULT_RETRY_BASE_SECONDS,
+    DEFAULT_RETRY_JITTER_SECONDS,
+    WorkerRuntimeSettings,
+)
+
+from .mocks import (
+    _MockExtractionIntegration,
+    _MockPdfIntegration,
+    _MockStorageService,
+)
+
+
+def _send_email_headers(csrf_token: str, *, idempotency_key: str | None = None) -> dict[str, str]:
+    return {
+        "X-CSRF-Token": csrf_token,
+        "Idempotency-Key": idempotency_key or uuid4().hex,
+    }
+
+
+def _assert_async_email_job_response(response, *, document_id: str) -> dict[str, object]:
+    assert response.status_code == 202
+    payload = response.json()
+    assert payload["job_type"] == "email"
+    assert payload["status"] == "pending"
+    assert payload["document_id"] == document_id
+    return payload
+
+
+async def _register_and_login(client: AsyncClient, credentials: dict[str, str]) -> str:
+    register_response = await client.post("/api/auth/register", json=credentials)
+    assert register_response.status_code == 201
+
+    login_response = await client.post("/api/auth/login", json=credentials)
+    assert login_response.status_code == 200
+    csrf_token = client.cookies.get(CSRF_COOKIE_NAME)
+    assert csrf_token is not None
+    return csrf_token
+
+
+async def _create_customer(
+    client: AsyncClient,
+    csrf_token: str,
+    *,
+    name: str = "Quote Test Customer",
+    email: str | None = None,
+    phone: str | None = None,
+    address: str | None = None,
+) -> str:
+    response = await client.post(
+        "/api/customers",
+        json={
+            "name": name,
+            "email": email,
+            "phone": phone,
+            "address": address,
+        },
+        headers={"X-CSRF-Token": csrf_token},
+    )
+    assert response.status_code == 201
+    return response.json()["id"]
+
+
+async def _create_quote(client: AsyncClient, csrf_token: str, customer_id: str) -> dict[str, str]:
+    response = await client.post(
+        "/api/quotes",
+        json={
+            "customer_id": customer_id,
+            "transcript": "quote transcript",
+            "line_items": [{"description": "line item", "details": None, "price": 55}],
+            "total_amount": 55,
+            "notes": "Original note",
+            "source_type": "text",
+        },
+        headers={"X-CSRF-Token": csrf_token},
+    )
+    assert response.status_code == 201
+    return response.json()
+
+
+async def _create_direct_invoice(
+    client: AsyncClient,
+    csrf_token: str,
+    customer_id: str,
+    *,
+    title: str | None,
+    transcript: str,
+    total_amount: int,
+) -> dict[str, object]:
+    response = await client.post(
+        "/api/invoices",
+        json={
+            "customer_id": customer_id,
+            "title": title,
+            "transcript": transcript,
+            "line_items": [{"description": "line item", "details": None, "price": total_amount}],
+            "total_amount": total_amount,
+            "notes": "Original note",
+            "source_type": "text",
+        },
+        headers={"X-CSRF-Token": csrf_token},
+    )
+    assert response.status_code == 201
+    return response.json()
+
+
+async def _create_approved_invoice(
+    client: AsyncClient,
+    csrf_token: str,
+    db_session: AsyncSession,
+) -> dict[str, object]:
+    customer_id = await _create_customer(client, csrf_token)
+    quote = await _create_quote(client, csrf_token, customer_id)
+    await _set_quote_status(db_session, quote["id"], QuoteStatus.APPROVED)
+
+    response = await client.post(
+        f"/api/quotes/{quote['id']}/convert-to-invoice",
+        headers={"X-CSRF-Token": csrf_token},
+    )
+    assert response.status_code == 201
+    return response.json()
+
+
+async def _set_profile_for_email_delivery(client: AsyncClient, csrf_token: str) -> None:
+    response = await client.patch(
+        "/api/profile",
+        json={
+            "business_name": "Summit Exterior Care",
+            "first_name": "Jane",
+            "last_name": "Doe",
+            "trade_type": "Landscaper",
+            "timezone": "America/New_York",
+        },
+        headers={"X-CSRF-Token": csrf_token},
+    )
+    assert response.status_code == 200
+
+
+async def _set_user_phone_number(
+    db_session: AsyncSession,
+    *,
+    email: str,
+    phone_number: str,
+) -> None:
+    user = await _get_user_by_email(db_session, email)
+    user.phone_number = phone_number
+    await db_session.commit()
+
+
+async def _set_user_email_and_phone_number(
+    db_session: AsyncSession,
+    *,
+    email: str,
+    updated_email: str,
+    phone_number: str | None,
+) -> None:
+    user = await _get_user_by_email(db_session, email)
+    user.email = updated_email
+    user.phone_number = phone_number
+    await db_session.commit()
+
+
+async def _get_user_by_email(db_session: AsyncSession, email: str) -> User:
+    user = await db_session.scalar(select(User).where(User.email == email))
+    assert user is not None
+    return user
+
+
+async def _set_quote_status(
+    db_session: AsyncSession,
+    quote_id: str,
+    status: QuoteStatus,
+) -> None:
+    quote = await db_session.scalar(select(Document).where(Document.id == UUID(quote_id)))
+    assert quote is not None
+    quote.status = status
+    await db_session.commit()
+
+
+async def _set_invoice_status(
+    db_session: AsyncSession,
+    invoice_id: object,
+    status: QuoteStatus,
+) -> None:
+    assert isinstance(invoice_id, str)
+    invoice = await db_session.scalar(select(Document).where(Document.id == UUID(invoice_id)))
+    assert invoice is not None
+    invoice.status = status
+    await db_session.commit()
+
+
+async def _run_pdf_job(db_session: AsyncSession, *, job_id: object) -> None:
+    assert isinstance(job_id, str)
+    session_maker = async_sessionmaker(
+        bind=db_session.bind,
+        class_=AsyncSession,
+        expire_on_commit=False,
+    )
+    runtime = WorkerRuntimeSettings(
+        session_maker=session_maker,
+        max_tries=DEFAULT_MAX_TRIES,
+        retry_base_seconds=DEFAULT_RETRY_BASE_SECONDS,
+        retry_jitter_seconds=DEFAULT_RETRY_JITTER_SECONDS,
+    )
+    await pdf_job(
+        {
+            "job_try": 1,
+            "worker_runtime": runtime,
+            "pdf_integration": _MockPdfIntegration(),
+            "storage_service": _MockStorageService(),
+        },
+        job_id,
+    )
+
+
+async def _run_extraction_job(
+    db_session: AsyncSession,
+    *,
+    job_id: object,
+    source_type: str,
+    capture_detail: str,
+    customer_id: str | None = None,
+    append_to_quote: bool = False,
+    transcript: str = "mulch the front beds",
+    job_try: int = 1,
+    extraction_integration: object | None = None,
+    correlation_id: str | None = None,
+) -> None:
+    assert isinstance(job_id, str)
+    session_maker = async_sessionmaker(
+        bind=db_session.bind,
+        class_=AsyncSession,
+        expire_on_commit=False,
+    )
+    runtime = WorkerRuntimeSettings(
+        session_maker=session_maker,
+        max_tries=DEFAULT_MAX_TRIES,
+        retry_base_seconds=DEFAULT_RETRY_BASE_SECONDS,
+        retry_jitter_seconds=DEFAULT_RETRY_JITTER_SECONDS,
+    )
+    resolved_extraction_integration = extraction_integration or _MockExtractionIntegration()
+    await extraction_job(
+        {
+            "job_try": job_try,
+            "worker_runtime": runtime,
+            "extraction_integration": resolved_extraction_integration,
+        },
+        job_id,
+        correlation_id=correlation_id,
+        transcript=transcript,
+        source_type=source_type,
+        capture_detail=capture_detail,
+        customer_id=customer_id,
+        append_to_quote=append_to_quote,
+    )
+
+
+def _format_human_date(value: object) -> str:
+    assert isinstance(value, str)
+    return date.fromisoformat(value).strftime("%b %d, %Y").replace(" 0", " ")
+
+
+def _credentials() -> dict[str, str]:
+    suffix = uuid4().hex[:12]
+    return {
+        "email": f"user-{suffix}@example.com",
+        "password": "StrongPass123!",
+    }

--- a/backend/app/features/quotes/tests/support/mocks.py
+++ b/backend/app/features/quotes/tests/support/mocks.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from types import SimpleNamespace
+from typing import TypedDict
+
+from app.features.quotes.repository import QuoteRenderContext
+from app.features.quotes.schemas import ExtractionResult, LineItemExtracted
+from app.integrations.audio import AudioClip, AudioError
+from app.integrations.email import EmailConfigurationError, EmailMessage, EmailSendError
+from app.integrations.extraction import ExtractionError
+from app.integrations.storage import StorageNotFoundError
+from app.integrations.transcription import TranscriptionError
+from app.shared.idempotency import IdempotencyBeginResult
+
+
+class _MockExtractionIntegration:
+    async def extract(self, notes: str) -> ExtractionResult:
+        if "malformed" in notes.lower():
+            raise ExtractionError("mock malformed extraction payload")
+
+        normalized_notes = notes.strip()
+        if "needs-review" in normalized_notes.lower() or normalized_notes.startswith(
+            "transcript from stitched"
+        ):
+            return ExtractionResult(
+                transcript=normalized_notes,
+                line_items=[
+                    LineItemExtracted(
+                        description="Brown mulch",
+                        details="5 yards",
+                        price=120,
+                        flagged=True,
+                        flag_reason="Unit or price sounds inconsistent with the transcript",
+                    )
+                ],
+                total=120,
+                confidence_notes=[],
+            )
+
+        return ExtractionResult(
+            transcript=normalized_notes,
+            line_items=[
+                LineItemExtracted(
+                    description="Brown mulch",
+                    details="5 yards",
+                    price=120,
+                )
+            ],
+            total=120,
+            confidence_notes=[],
+        )
+
+
+class _MockPdfIntegration:
+    def render(self, context: QuoteRenderContext) -> bytes:
+        return f"PDF for {context.doc_number}".encode()
+
+
+class _MockAudioIntegration:
+    def normalize_and_stitch(self, clips: Sequence[AudioClip]) -> bytes:
+        if not clips:
+            raise AudioError("At least one audio clip is required")
+
+        if any(len(clip.content) == 0 for clip in clips):
+            raise AudioError("Audio clip is empty")
+
+        if any(clip.content == b"unsupported" for clip in clips):
+            raise AudioError("Audio clip format is not supported or file is corrupted")
+
+        if any(clip.content == b"trigger-transcription-error" for clip in clips):
+            return b"trigger-transcription-error"
+
+        return f"stitched-{len(clips)}".encode()
+
+
+class _MockTranscriptionIntegration:
+    async def transcribe(self, audio_wav: bytes) -> str:
+        if audio_wav == b"trigger-transcription-error":
+            raise TranscriptionError("mock transcription outage")
+        return f"transcript from {audio_wav.decode()}"
+
+
+class _MockStorageService:
+    def fetch_bytes(self, object_path: str) -> bytes:
+        raise StorageNotFoundError(object_path)
+
+    def upload(
+        self,
+        *,
+        prefix: str,
+        filename: str,
+        data: bytes,
+        content_type: str,
+    ) -> str:
+        del data
+        del content_type
+        return f"{prefix.strip('/')}/{filename.lstrip('/')}"
+
+    def delete(self, object_path: str) -> None:
+        del object_path
+
+
+class _MockEmailService:
+    def __init__(self) -> None:
+        self.messages: list[EmailMessage] = []
+        self.raise_configuration_error = False
+        self.raise_send_error = False
+
+    async def send(self, message: EmailMessage) -> None:
+        if self.raise_configuration_error:
+            raise EmailConfigurationError("Email delivery is not configured")
+        if self.raise_send_error:
+            raise EmailSendError("Provider failure")
+        self.messages.append(message)
+
+
+class _FailingAbortIdempotencyStore:
+    async def begin(self, **_: object) -> IdempotencyBeginResult:
+        return IdempotencyBeginResult(kind="started")
+
+    async def abort(self, **_: object) -> None:
+        raise RuntimeError("redis unavailable")
+
+    async def complete(self, **_: object) -> None:
+        return None
+
+
+class _InProgressIdempotencyStore:
+    async def begin(self, **_: object) -> IdempotencyBeginResult:
+        return IdempotencyBeginResult(kind="in_progress")
+
+    async def abort(self, **_: object) -> None:
+        return None
+
+    async def complete(self, **_: object) -> None:
+        return None
+
+
+class _MockArqPool:
+    class _EnqueueCall(TypedDict):
+        function: str
+        args: tuple[object, ...]
+        kwargs: dict[str, object]
+
+    def __init__(self) -> None:
+        self.calls: list[_MockArqPool._EnqueueCall] = []
+
+    async def enqueue_job(self, function: str, *args: object, **kwargs: object) -> object:
+        self.calls.append(
+            {
+                "function": function,
+                "args": args,
+                "kwargs": kwargs,
+            }
+        )
+        return SimpleNamespace(job_id=kwargs.get("_job_id"))
+
+
+class _FailingArqPool:
+    async def enqueue_job(self, function: str, *args: object, **kwargs: object) -> object:
+        del function
+        del args
+        del kwargs
+        raise RuntimeError("redis unavailable")
+
+
+class _RetryableProviderError(Exception):
+    def __init__(self, status_code: int) -> None:
+        super().__init__(f"provider error {status_code}")
+        self.status_code = status_code
+
+
+class _RetryableFailureExtractionIntegration:
+    async def extract(self, notes: str) -> ExtractionResult:
+        del notes
+        raise ExtractionError("Claude request failed: retryable") from _RetryableProviderError(429)

--- a/backend/app/features/quotes/tests/test_quote_append_extraction.py
+++ b/backend/app/features/quotes/tests/test_quote_append_extraction.py
@@ -16,6 +16,20 @@ from app.features.quotes.models import Document
 from app.features.quotes.schemas import ExtractionResult
 from app.features.quotes.service import QuoteService, QuoteServiceError
 from app.features.quotes.tests import test_quotes as quotes_test_module
+from app.features.quotes.tests.support.helpers import (
+    _create_customer,
+    _create_quote,
+    _credentials,
+    _get_user_by_email,
+    _register_and_login,
+    _run_extraction_job,
+)
+from app.features.quotes.tests.support.mocks import (
+    _MockArqPool,
+    _MockExtractionIntegration,
+    _MockStorageService,
+    _RetryableProviderError,
+)
 from app.integrations.extraction import ExtractionError
 from app.main import app
 
@@ -27,16 +41,6 @@ _override_storage_service_dependency = quotes_test_module._override_storage_serv
 _override_quote_service_dependency = quotes_test_module._override_quote_service_dependency
 _override_extraction_service_dependency = quotes_test_module._override_extraction_service_dependency
 _reset_rate_limiter = quotes_test_module._reset_rate_limiter
-_register_and_login = quotes_test_module._register_and_login
-_credentials = quotes_test_module._credentials
-_create_customer = quotes_test_module._create_customer
-_create_quote = quotes_test_module._create_quote
-_get_user_by_email = quotes_test_module._get_user_by_email
-_MockArqPool = quotes_test_module._MockArqPool
-_MockStorageService = quotes_test_module._MockStorageService
-_MockExtractionIntegration = quotes_test_module._MockExtractionIntegration
-_RetryableProviderError = quotes_test_module._RetryableProviderError
-_run_extraction_job = quotes_test_module._run_extraction_job
 
 
 async def test_append_extraction_sync_retryable_failure_uses_degraded_append_semantics(

--- a/backend/app/features/quotes/tests/test_quote_auth_csrf.py
+++ b/backend/app/features/quotes/tests/test_quote_auth_csrf.py
@@ -8,6 +8,13 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.features.auth.service import CSRF_COOKIE_NAME
 from app.features.quotes.tests import test_quotes as quotes_test_module
+from app.features.quotes.tests.support.helpers import (
+    _create_approved_invoice,
+    _create_customer,
+    _create_quote,
+    _credentials,
+    _register_and_login,
+)
 
 pytestmark = pytest.mark.asyncio
 
@@ -17,11 +24,6 @@ _override_storage_service_dependency = quotes_test_module._override_storage_serv
 _override_quote_service_dependency = quotes_test_module._override_quote_service_dependency
 _override_extraction_service_dependency = quotes_test_module._override_extraction_service_dependency
 _reset_rate_limiter = quotes_test_module._reset_rate_limiter
-_register_and_login = quotes_test_module._register_and_login
-_credentials = quotes_test_module._credentials
-_create_customer = quotes_test_module._create_customer
-_create_quote = quotes_test_module._create_quote
-_create_approved_invoice = quotes_test_module._create_approved_invoice
 
 
 @pytest.mark.parametrize(

--- a/backend/app/features/quotes/tests/test_quote_crud.py
+++ b/backend/app/features/quotes/tests/test_quote_crud.py
@@ -14,6 +14,17 @@ from app.features.quotes.models import Document, LineItem, QuoteStatus
 from app.features.quotes.repository import QuoteRepository
 from app.features.quotes.schemas import LineItemDraft
 from app.features.quotes.tests import test_quotes as quotes_test_module
+from app.features.quotes.tests.support.helpers import (
+    _create_customer,
+    _create_quote,
+    _credentials,
+    _get_user_by_email,
+    _register_and_login,
+    _run_pdf_job,
+    _send_email_headers,
+    _set_quote_status,
+)
+from app.features.quotes.tests.support.mocks import _MockArqPool
 from app.main import app
 from app.shared import event_logger
 from app.shared.input_limits import (
@@ -33,15 +44,6 @@ _override_storage_service_dependency = quotes_test_module._override_storage_serv
 _override_quote_service_dependency = quotes_test_module._override_quote_service_dependency
 _override_extraction_service_dependency = quotes_test_module._override_extraction_service_dependency
 _reset_rate_limiter = quotes_test_module._reset_rate_limiter
-_MockArqPool = quotes_test_module._MockArqPool
-_create_customer = quotes_test_module._create_customer
-_create_quote = quotes_test_module._create_quote
-_credentials = quotes_test_module._credentials
-_get_user_by_email = quotes_test_module._get_user_by_email
-_register_and_login = quotes_test_module._register_and_login
-_run_pdf_job = quotes_test_module._run_pdf_job
-_send_email_headers = quotes_test_module._send_email_headers
-_set_quote_status = quotes_test_module._set_quote_status
 
 
 async def test_quote_crud_happy_path_with_ordering_and_line_item_replacement(

--- a/backend/app/features/quotes/tests/test_quote_email.py
+++ b/backend/app/features/quotes/tests/test_quote_email.py
@@ -14,6 +14,24 @@ from app.features.event_logs.models import EventLog
 from app.features.quotes.models import QuoteStatus
 from app.features.quotes.repository import QuoteRepository
 from app.features.quotes.tests import test_quotes as quotes_test_module
+from app.features.quotes.tests.support.helpers import (
+    _assert_async_email_job_response,
+    _create_customer,
+    _create_quote,
+    _credentials,
+    _get_user_by_email,
+    _register_and_login,
+    _send_email_headers,
+    _set_profile_for_email_delivery,
+    _set_quote_status,
+    _set_user_email_and_phone_number,
+    _set_user_phone_number,
+)
+from app.features.quotes.tests.support.mocks import (
+    _FailingAbortIdempotencyStore,
+    _InProgressIdempotencyStore,
+    _MockEmailService,
+)
 from app.main import app
 from app.shared import event_logger, observability
 from app.shared.dependencies import get_idempotency_store
@@ -28,21 +46,6 @@ _override_extraction_service_dependency = quotes_test_module._override_extractio
 _reset_rate_limiter = quotes_test_module._reset_rate_limiter
 _mock_arq_pool_for_send_email_tests = quotes_test_module._mock_arq_pool_for_send_email_tests
 mock_email_service = quotes_test_module.mock_email_service
-
-_MockEmailService = quotes_test_module._MockEmailService
-_FailingAbortIdempotencyStore = quotes_test_module._FailingAbortIdempotencyStore
-_InProgressIdempotencyStore = quotes_test_module._InProgressIdempotencyStore
-_assert_async_email_job_response = quotes_test_module._assert_async_email_job_response
-_send_email_headers = quotes_test_module._send_email_headers
-_register_and_login = quotes_test_module._register_and_login
-_credentials = quotes_test_module._credentials
-_set_profile_for_email_delivery = quotes_test_module._set_profile_for_email_delivery
-_set_user_phone_number = quotes_test_module._set_user_phone_number
-_set_user_email_and_phone_number = quotes_test_module._set_user_email_and_phone_number
-_create_customer = quotes_test_module._create_customer
-_create_quote = quotes_test_module._create_quote
-_set_quote_status = quotes_test_module._set_quote_status
-_get_user_by_email = quotes_test_module._get_user_by_email
 
 
 async def test_send_quote_email_shares_quote_delivers_email_and_logs_success(

--- a/backend/app/features/quotes/tests/test_quote_extraction.py
+++ b/backend/app/features/quotes/tests/test_quote_extraction.py
@@ -19,6 +19,22 @@ from app.features.quotes.models import Document, QuoteStatus
 from app.features.quotes.schemas import ExtractionResult
 from app.features.quotes.service import QuoteService, QuoteServiceError
 from app.features.quotes.tests import test_quotes as quotes_test_module
+from app.features.quotes.tests.support.helpers import (
+    _create_customer,
+    _credentials,
+    _get_user_by_email,
+    _register_and_login,
+    _run_extraction_job,
+)
+from app.features.quotes.tests.support.mocks import (
+    _FailingArqPool,
+    _MockArqPool,
+    _MockAudioIntegration,
+    _MockExtractionIntegration,
+    _MockTranscriptionIntegration,
+    _RetryableFailureExtractionIntegration,
+    _RetryableProviderError,
+)
 from app.integrations.extraction import ExtractionError
 from app.main import app
 from app.shared import event_logger
@@ -33,18 +49,6 @@ _override_storage_service_dependency = quotes_test_module._override_storage_serv
 _override_quote_service_dependency = quotes_test_module._override_quote_service_dependency
 _override_extraction_service_dependency = quotes_test_module._override_extraction_service_dependency
 _reset_rate_limiter = quotes_test_module._reset_rate_limiter
-_register_and_login = quotes_test_module._register_and_login
-_credentials = quotes_test_module._credentials
-_create_customer = quotes_test_module._create_customer
-_get_user_by_email = quotes_test_module._get_user_by_email
-_MockArqPool = quotes_test_module._MockArqPool
-_FailingArqPool = quotes_test_module._FailingArqPool
-_RetryableFailureExtractionIntegration = quotes_test_module._RetryableFailureExtractionIntegration
-_MockExtractionIntegration = quotes_test_module._MockExtractionIntegration
-_RetryableProviderError = quotes_test_module._RetryableProviderError
-_MockAudioIntegration = quotes_test_module._MockAudioIntegration
-_MockTranscriptionIntegration = quotes_test_module._MockTranscriptionIntegration
-_run_extraction_job = quotes_test_module._run_extraction_job
 
 
 async def test_convert_notes_returns_422_for_extraction_errors(

--- a/backend/app/features/quotes/tests/test_quote_outcomes.py
+++ b/backend/app/features/quotes/tests/test_quote_outcomes.py
@@ -12,6 +12,13 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.features.quotes.models import Document, QuoteStatus
 from app.features.quotes.repository import QuoteRepository
 from app.features.quotes.tests import test_quotes as quotes_test_module
+from app.features.quotes.tests.support.helpers import (
+    _create_customer,
+    _create_quote,
+    _credentials,
+    _register_and_login,
+    _set_quote_status,
+)
 from app.shared import event_logger
 
 pytestmark = pytest.mark.asyncio
@@ -22,11 +29,6 @@ _override_storage_service_dependency = quotes_test_module._override_storage_serv
 _override_quote_service_dependency = quotes_test_module._override_quote_service_dependency
 _override_extraction_service_dependency = quotes_test_module._override_extraction_service_dependency
 _reset_rate_limiter = quotes_test_module._reset_rate_limiter
-_create_customer = quotes_test_module._create_customer
-_create_quote = quotes_test_module._create_quote
-_credentials = quotes_test_module._credentials
-_register_and_login = quotes_test_module._register_and_login
-_set_quote_status = quotes_test_module._set_quote_status
 
 
 async def test_mark_won_quote_returns_404_for_different_users_quote(

--- a/backend/app/features/quotes/tests/test_quote_to_invoice.py
+++ b/backend/app/features/quotes/tests/test_quote_to_invoice.py
@@ -12,6 +12,14 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.features.quotes.models import Document, QuoteStatus
 from app.features.quotes.repository import QuoteRepository
 from app.features.quotes.tests import test_quotes as quotes_test_module
+from app.features.quotes.tests.support.helpers import (
+    _create_customer,
+    _create_quote,
+    _credentials,
+    _get_user_by_email,
+    _register_and_login,
+    _set_quote_status,
+)
 
 pytestmark = pytest.mark.asyncio
 
@@ -21,12 +29,6 @@ _override_storage_service_dependency = quotes_test_module._override_storage_serv
 _override_quote_service_dependency = quotes_test_module._override_quote_service_dependency
 _override_extraction_service_dependency = quotes_test_module._override_extraction_service_dependency
 _reset_rate_limiter = quotes_test_module._reset_rate_limiter
-_create_customer = quotes_test_module._create_customer
-_create_quote = quotes_test_module._create_quote
-_credentials = quotes_test_module._credentials
-_get_user_by_email = quotes_test_module._get_user_by_email
-_register_and_login = quotes_test_module._register_and_login
-_set_quote_status = quotes_test_module._set_quote_status
 
 
 @pytest.mark.parametrize(

--- a/backend/app/features/quotes/tests/test_quotes.py
+++ b/backend/app/features/quotes/tests/test_quotes.py
@@ -1,39 +1,22 @@
-"""Quote API behavior tests for extraction, CRUD flow, and ownership scoping."""
+"""Quote API shared fixture wiring and compatibility exports for split tests."""
 
 from __future__ import annotations
 
-from collections.abc import Iterator, Sequence
-from datetime import date
-from types import SimpleNamespace
-from typing import Annotated, TypedDict
-from uuid import UUID, uuid4
+from collections.abc import Iterator
+from typing import Annotated
 
 import pytest
 from fastapi import Depends
-from httpx import AsyncClient
-from sqlalchemy import select
-from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.database import get_db
-from app.features.auth.models import User
-from app.features.auth.service import CSRF_COOKIE_NAME
 from app.features.invoices import (
     email_delivery_service as invoice_email_delivery_service,
 )
 from app.features.quotes import email_delivery_service
 from app.features.quotes.extraction_service import ExtractionService
-from app.features.quotes.models import Document, QuoteStatus
-from app.features.quotes.repository import QuoteRenderContext, QuoteRepository
-from app.features.quotes.schemas import (
-    ExtractionResult,
-    LineItemExtracted,
-)
+from app.features.quotes.repository import QuoteRepository
 from app.features.quotes.service import QuoteService
-from app.integrations.audio import AudioClip, AudioError
-from app.integrations.email import EmailConfigurationError, EmailMessage, EmailSendError
-from app.integrations.extraction import ExtractionError
-from app.integrations.storage import StorageNotFoundError
-from app.integrations.transcription import TranscriptionError
 from app.main import app
 from app.shared.dependencies import (
     get_email_service,
@@ -41,15 +24,73 @@ from app.shared.dependencies import (
     get_quote_service,
     get_storage_service,
 )
-from app.shared.idempotency import IdempotencyBeginResult
 from app.shared.rate_limit import reset_local_rate_limit_state
-from app.worker.job_registry import extraction_job, pdf_job
-from app.worker.runtime import (
-    DEFAULT_MAX_TRIES,
-    DEFAULT_RETRY_BASE_SECONDS,
-    DEFAULT_RETRY_JITTER_SECONDS,
-    WorkerRuntimeSettings,
+
+from .support.helpers import (
+    _assert_async_email_job_response,
+    _create_approved_invoice,
+    _create_customer,
+    _create_direct_invoice,
+    _create_quote,
+    _credentials,
+    _format_human_date,
+    _get_user_by_email,
+    _register_and_login,
+    _run_extraction_job,
+    _run_pdf_job,
+    _send_email_headers,
+    _set_invoice_status,
+    _set_profile_for_email_delivery,
+    _set_quote_status,
+    _set_user_email_and_phone_number,
+    _set_user_phone_number,
 )
+from .support.mocks import (
+    _FailingAbortIdempotencyStore,
+    _FailingArqPool,
+    _InProgressIdempotencyStore,
+    _MockArqPool,
+    _MockAudioIntegration,
+    _MockEmailService,
+    _MockExtractionIntegration,
+    _MockPdfIntegration,
+    _MockStorageService,
+    _MockTranscriptionIntegration,
+    _RetryableFailureExtractionIntegration,
+    _RetryableProviderError,
+)
+
+__all__ = [
+    "_assert_async_email_job_response",
+    "_create_approved_invoice",
+    "_create_customer",
+    "_create_direct_invoice",
+    "_create_quote",
+    "_credentials",
+    "_FailingAbortIdempotencyStore",
+    "_FailingArqPool",
+    "_format_human_date",
+    "_get_user_by_email",
+    "_InProgressIdempotencyStore",
+    "_MockArqPool",
+    "_MockAudioIntegration",
+    "_MockEmailService",
+    "_MockExtractionIntegration",
+    "_MockPdfIntegration",
+    "_MockStorageService",
+    "_MockTranscriptionIntegration",
+    "_register_and_login",
+    "_RetryableFailureExtractionIntegration",
+    "_RetryableProviderError",
+    "_run_extraction_job",
+    "_run_pdf_job",
+    "_send_email_headers",
+    "_set_invoice_status",
+    "_set_profile_for_email_delivery",
+    "_set_quote_status",
+    "_set_user_email_and_phone_number",
+    "_set_user_phone_number",
+]
 
 pytestmark = pytest.mark.asyncio
 
@@ -61,185 +102,6 @@ def _reset_email_delivery_fallback_cache() -> Iterator[None]:
     yield
     email_delivery_service._EMAIL_SENT_FALLBACK_TIMESTAMPS.clear()  # noqa: SLF001
     invoice_email_delivery_service._EMAIL_SENT_FALLBACK_TIMESTAMPS.clear()  # noqa: SLF001
-
-
-class _MockExtractionIntegration:
-    async def extract(self, notes: str) -> ExtractionResult:
-        if "malformed" in notes.lower():
-            raise ExtractionError("mock malformed extraction payload")
-
-        normalized_notes = notes.strip()
-        if "needs-review" in normalized_notes.lower() or normalized_notes.startswith(
-            "transcript from stitched"
-        ):
-            return ExtractionResult(
-                transcript=normalized_notes,
-                line_items=[
-                    LineItemExtracted(
-                        description="Brown mulch",
-                        details="5 yards",
-                        price=120,
-                        flagged=True,
-                        flag_reason="Unit or price sounds inconsistent with the transcript",
-                    )
-                ],
-                total=120,
-                confidence_notes=[],
-            )
-
-        return ExtractionResult(
-            transcript=normalized_notes,
-            line_items=[
-                LineItemExtracted(
-                    description="Brown mulch",
-                    details="5 yards",
-                    price=120,
-                )
-            ],
-            total=120,
-            confidence_notes=[],
-        )
-
-
-class _MockPdfIntegration:
-    def render(self, context: QuoteRenderContext) -> bytes:
-        return f"PDF for {context.doc_number}".encode()
-
-
-class _MockAudioIntegration:
-    def normalize_and_stitch(self, clips: Sequence[AudioClip]) -> bytes:
-        if not clips:
-            raise AudioError("At least one audio clip is required")
-
-        if any(len(clip.content) == 0 for clip in clips):
-            raise AudioError("Audio clip is empty")
-
-        if any(clip.content == b"unsupported" for clip in clips):
-            raise AudioError("Audio clip format is not supported or file is corrupted")
-
-        if any(clip.content == b"trigger-transcription-error" for clip in clips):
-            return b"trigger-transcription-error"
-
-        return f"stitched-{len(clips)}".encode()
-
-
-class _MockTranscriptionIntegration:
-    async def transcribe(self, audio_wav: bytes) -> str:
-        if audio_wav == b"trigger-transcription-error":
-            raise TranscriptionError("mock transcription outage")
-        return f"transcript from {audio_wav.decode()}"
-
-
-class _MockStorageService:
-    def fetch_bytes(self, object_path: str) -> bytes:
-        raise StorageNotFoundError(object_path)
-
-    def upload(
-        self,
-        *,
-        prefix: str,
-        filename: str,
-        data: bytes,
-        content_type: str,
-    ) -> str:
-        del data
-        del content_type
-        return f"{prefix.strip('/')}/{filename.lstrip('/')}"
-
-    def delete(self, object_path: str) -> None:
-        del object_path
-
-
-class _MockEmailService:
-    def __init__(self) -> None:
-        self.messages: list[EmailMessage] = []
-        self.raise_configuration_error = False
-        self.raise_send_error = False
-
-    async def send(self, message: EmailMessage) -> None:
-        if self.raise_configuration_error:
-            raise EmailConfigurationError("Email delivery is not configured")
-        if self.raise_send_error:
-            raise EmailSendError("Provider failure")
-        self.messages.append(message)
-
-
-class _FailingAbortIdempotencyStore:
-    async def begin(self, **_: object) -> IdempotencyBeginResult:
-        return IdempotencyBeginResult(kind="started")
-
-    async def abort(self, **_: object) -> None:
-        raise RuntimeError("redis unavailable")
-
-    async def complete(self, **_: object) -> None:
-        return None
-
-
-class _InProgressIdempotencyStore:
-    async def begin(self, **_: object) -> IdempotencyBeginResult:
-        return IdempotencyBeginResult(kind="in_progress")
-
-    async def abort(self, **_: object) -> None:
-        return None
-
-    async def complete(self, **_: object) -> None:
-        return None
-
-
-class _MockArqPool:
-    class _EnqueueCall(TypedDict):
-        function: str
-        args: tuple[object, ...]
-        kwargs: dict[str, object]
-
-    def __init__(self) -> None:
-        self.calls: list[_MockArqPool._EnqueueCall] = []
-
-    async def enqueue_job(self, function: str, *args: object, **kwargs: object) -> object:
-        self.calls.append(
-            {
-                "function": function,
-                "args": args,
-                "kwargs": kwargs,
-            }
-        )
-        return SimpleNamespace(job_id=kwargs.get("_job_id"))
-
-
-class _FailingArqPool:
-    async def enqueue_job(self, function: str, *args: object, **kwargs: object) -> object:
-        del function
-        del args
-        del kwargs
-        raise RuntimeError("redis unavailable")
-
-
-class _RetryableProviderError(Exception):
-    def __init__(self, status_code: int) -> None:
-        super().__init__(f"provider error {status_code}")
-        self.status_code = status_code
-
-
-class _RetryableFailureExtractionIntegration:
-    async def extract(self, notes: str) -> ExtractionResult:
-        del notes
-        raise ExtractionError("Claude request failed: retryable") from _RetryableProviderError(429)
-
-
-def _send_email_headers(csrf_token: str, *, idempotency_key: str | None = None) -> dict[str, str]:
-    return {
-        "X-CSRF-Token": csrf_token,
-        "Idempotency-Key": idempotency_key or uuid4().hex,
-    }
-
-
-def _assert_async_email_job_response(response, *, document_id: str) -> dict[str, object]:
-    assert response.status_code == 202
-    payload = response.json()
-    assert payload["job_type"] == "email"
-    assert payload["status"] == "pending"
-    assert payload["document_id"] == document_id
-    return payload
 
 
 @pytest.fixture(autouse=True)
@@ -313,243 +175,3 @@ def _mock_arq_pool_for_send_email_tests(
         yield
     finally:
         app.state.arq_pool = original_pool
-
-
-async def _register_and_login(client: AsyncClient, credentials: dict[str, str]) -> str:
-    register_response = await client.post("/api/auth/register", json=credentials)
-    assert register_response.status_code == 201
-    login_response = await client.post("/api/auth/login", json=credentials)
-    assert login_response.status_code == 200
-    csrf_token = client.cookies.get(CSRF_COOKIE_NAME)
-    assert csrf_token is not None
-    return csrf_token
-
-
-async def _create_customer(
-    client: AsyncClient,
-    csrf_token: str,
-    *,
-    name: str = "Quote Test Customer",
-    email: str | None = None,
-    phone: str | None = None,
-    address: str | None = None,
-) -> str:
-    response = await client.post(
-        "/api/customers",
-        json={
-            "name": name,
-            "email": email,
-            "phone": phone,
-            "address": address,
-        },
-        headers={"X-CSRF-Token": csrf_token},
-    )
-    assert response.status_code == 201
-    return response.json()["id"]
-
-
-async def _create_quote(client: AsyncClient, csrf_token: str, customer_id: str) -> dict[str, str]:
-    response = await client.post(
-        "/api/quotes",
-        json={
-            "customer_id": customer_id,
-            "transcript": "quote transcript",
-            "line_items": [{"description": "line item", "details": None, "price": 55}],
-            "total_amount": 55,
-            "notes": "Original note",
-            "source_type": "text",
-        },
-        headers={"X-CSRF-Token": csrf_token},
-    )
-    assert response.status_code == 201
-    return response.json()
-
-
-async def _create_direct_invoice(
-    client: AsyncClient,
-    csrf_token: str,
-    customer_id: str,
-    *,
-    title: str | None,
-    transcript: str,
-    total_amount: int,
-) -> dict[str, object]:
-    response = await client.post(
-        "/api/invoices",
-        json={
-            "customer_id": customer_id,
-            "title": title,
-            "transcript": transcript,
-            "line_items": [{"description": "line item", "details": None, "price": total_amount}],
-            "total_amount": total_amount,
-            "notes": "Original note",
-            "source_type": "text",
-        },
-        headers={"X-CSRF-Token": csrf_token},
-    )
-    assert response.status_code == 201
-    return response.json()
-
-
-async def _create_approved_invoice(
-    client: AsyncClient,
-    csrf_token: str,
-    db_session: AsyncSession,
-) -> dict[str, object]:
-    customer_id = await _create_customer(client, csrf_token)
-    quote = await _create_quote(client, csrf_token, customer_id)
-    await _set_quote_status(db_session, quote["id"], QuoteStatus.APPROVED)
-
-    response = await client.post(
-        f"/api/quotes/{quote['id']}/convert-to-invoice",
-        headers={"X-CSRF-Token": csrf_token},
-    )
-    assert response.status_code == 201
-    return response.json()
-
-
-async def _set_profile_for_email_delivery(client: AsyncClient, csrf_token: str) -> None:
-    response = await client.patch(
-        "/api/profile",
-        json={
-            "business_name": "Summit Exterior Care",
-            "first_name": "Jane",
-            "last_name": "Doe",
-            "trade_type": "Landscaper",
-            "timezone": "America/New_York",
-        },
-        headers={"X-CSRF-Token": csrf_token},
-    )
-    assert response.status_code == 200
-
-
-async def _set_user_phone_number(
-    db_session: AsyncSession,
-    *,
-    email: str,
-    phone_number: str,
-) -> None:
-    user = await _get_user_by_email(db_session, email)
-    user.phone_number = phone_number
-    await db_session.commit()
-
-
-async def _set_user_email_and_phone_number(
-    db_session: AsyncSession,
-    *,
-    email: str,
-    updated_email: str,
-    phone_number: str | None,
-) -> None:
-    user = await _get_user_by_email(db_session, email)
-    user.email = updated_email
-    user.phone_number = phone_number
-    await db_session.commit()
-
-
-async def _get_user_by_email(db_session: AsyncSession, email: str) -> User:
-    user = await db_session.scalar(select(User).where(User.email == email))
-    assert user is not None
-    return user
-
-
-async def _set_quote_status(
-    db_session: AsyncSession,
-    quote_id: str,
-    status: QuoteStatus,
-) -> None:
-    quote = await db_session.scalar(select(Document).where(Document.id == UUID(quote_id)))
-    assert quote is not None
-    quote.status = status
-    await db_session.commit()
-
-
-async def _set_invoice_status(
-    db_session: AsyncSession,
-    invoice_id: object,
-    status: QuoteStatus,
-) -> None:
-    assert isinstance(invoice_id, str)
-    invoice = await db_session.scalar(select(Document).where(Document.id == UUID(invoice_id)))
-    assert invoice is not None
-    invoice.status = status
-    await db_session.commit()
-
-
-async def _run_pdf_job(db_session: AsyncSession, *, job_id: object) -> None:
-    assert isinstance(job_id, str)
-    session_maker = async_sessionmaker(
-        bind=db_session.bind,
-        class_=AsyncSession,
-        expire_on_commit=False,
-    )
-    runtime = WorkerRuntimeSettings(
-        session_maker=session_maker,
-        max_tries=DEFAULT_MAX_TRIES,
-        retry_base_seconds=DEFAULT_RETRY_BASE_SECONDS,
-        retry_jitter_seconds=DEFAULT_RETRY_JITTER_SECONDS,
-    )
-    await pdf_job(
-        {
-            "job_try": 1,
-            "worker_runtime": runtime,
-            "pdf_integration": _MockPdfIntegration(),
-            "storage_service": _MockStorageService(),
-        },
-        job_id,
-    )
-
-
-async def _run_extraction_job(
-    db_session: AsyncSession,
-    *,
-    job_id: object,
-    source_type: str,
-    capture_detail: str,
-    customer_id: str | None = None,
-    append_to_quote: bool = False,
-    transcript: str = "mulch the front beds",
-    job_try: int = 1,
-    extraction_integration: object | None = None,
-    correlation_id: str | None = None,
-) -> None:
-    assert isinstance(job_id, str)
-    session_maker = async_sessionmaker(
-        bind=db_session.bind,
-        class_=AsyncSession,
-        expire_on_commit=False,
-    )
-    runtime = WorkerRuntimeSettings(
-        session_maker=session_maker,
-        max_tries=DEFAULT_MAX_TRIES,
-        retry_base_seconds=DEFAULT_RETRY_BASE_SECONDS,
-        retry_jitter_seconds=DEFAULT_RETRY_JITTER_SECONDS,
-    )
-    resolved_extraction_integration = extraction_integration or _MockExtractionIntegration()
-    await extraction_job(
-        {
-            "job_try": job_try,
-            "worker_runtime": runtime,
-            "extraction_integration": resolved_extraction_integration,
-        },
-        job_id,
-        correlation_id=correlation_id,
-        transcript=transcript,
-        source_type=source_type,
-        capture_detail=capture_detail,
-        customer_id=customer_id,
-        append_to_quote=append_to_quote,
-    )
-
-
-def _format_human_date(value: object) -> str:
-    assert isinstance(value, str)
-    return date.fromisoformat(value).strftime("%b %d, %Y").replace(" 0", " ")
-
-
-def _credentials() -> dict[str, str]:
-    suffix = uuid4().hex[:12]
-    return {
-        "email": f"user-{suffix}@example.com",
-        "password": "StrongPass123!",
-    }


### PR DESCRIPTION
## Summary
- extract shared quote/invoice API test mocks into `backend/app/features/quotes/tests/support/mocks.py`
- extract shared async/sync helper functions into `backend/app/features/quotes/tests/support/helpers.py`
- slim `test_quotes.py` into fixture wiring plus compatibility exports while keeping pytest fixture anchoring intact
- update quote/invoice consumer test modules to import non-fixture helpers directly from `support` and reduce repetitive alias blocks

## Verification
- cd backend && rtk .venv/bin/pytest app/features/quotes/tests/test_quote_auth_csrf.py -x --tb=short
- cd backend && rtk .venv/bin/pytest app/features/quotes/tests/test_pdf.py app/features/quotes/tests/test_extraction.py -q
- cd backend && rtk .venv/bin/pytest app/features/quotes/tests/test_quote_crud.py app/features/invoices/tests/test_invoice_api.py -q
- rtk make backend-verify

Closes #383