### PR TITLE
Task 386: Polish quote PDF trust pass and finalize preview overflow/layout fixes

### DIFF
--- a/backend/app/features/quotes/tests/test_pdf_template.py
+++ b/backend/app/features/quotes/tests/test_pdf_template.py
@@ -823,7 +823,7 @@ def test_render_uses_a4_page_size_and_polished_quote_layout_styles(
         re.DOTALL,
     )
     assert re.search(
-        r"\.signature-line\s*\{[^}]*border-bottom:\s*1px solid #d1d5db;",
+        r"\.signature-line\s*\{[^}]*border-bottom:\s*1px solid #111827;",
         rendered_html,
         re.DOTALL,
     )

--- a/backend/app/features/quotes/tests/test_pdf_template.py
+++ b/backend/app/features/quotes/tests/test_pdf_template.py
@@ -41,6 +41,7 @@ def _make_context(
     customer_address: str | None = None,
     notes: str | None = None,
     line_item_details: str | None = None,
+    line_items: list[QuoteRenderLineItem] | None = None,
     subtotal_amount: Decimal | None = None,
     discount_type: str | None = None,
     discount_value: Decimal | None = None,
@@ -81,7 +82,9 @@ def _make_context(
         balance_due=balance_due,
         notes=notes,
         due_date=due_date,
-        line_items=[
+        line_items=line_items
+        if line_items is not None
+        else [
             QuoteRenderLineItem(
                 description="Leaf cleanup",
                 details=line_item_details,
@@ -209,6 +212,16 @@ def test_render_shows_conditional_pricing_breakdown_rows(
     assert "$11.00" in rendered_html
     assert "$30.00" in rendered_html
     assert "$91.00" in rendered_html
+    assert "-$30.00" not in rendered_html
+    assert re.search(
+        (
+            r"<div class=\"total-row total-row--deposit\">\s*"
+            r"<p class=\"total-label\">Deposit</p>\s*"
+            r"<p class=\"total-amount\">\$30.00</p>"
+        ),
+        rendered_html,
+        re.DOTALL,
+    )
 
 
 def test_render_omits_internal_quote_title_from_pdf(
@@ -281,7 +294,7 @@ def test_render_orders_customer_details_as_name_address_phone_and_omits_email(
         (
             r"<p class=\"label\">Prepared For</p>\s*"
             r"<p class=\"value\">Jamie Customer</p>\s*"
-            r"<p class=\"value\">123 Main St</p>\s*"
+            r"<p class=\"value value--multiline\">123 Main St</p>\s*"
             r"<p class=\"value\">\+1-555-000-1111</p>"
         ),
         rendered_html,
@@ -327,6 +340,38 @@ def test_render_stacks_line_item_details_in_description_column(
         re.DOTALL,
     )
     assert "<th>Details</th>" not in rendered_html
+
+
+def test_render_preserves_multiline_customer_address_in_pdf(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured_html: list[str] = []
+
+    class _FakeHTML:
+        def __init__(self, *, string: str, base_url: str) -> None:
+            del base_url
+            captured_html.append(string)
+
+        def write_pdf(self) -> bytes:
+            return b"fake-pdf"
+
+    monkeypatch.setattr("app.integrations.pdf.HTML", _FakeHTML)
+    template_dir = Path(__file__).resolve().parents[3] / "templates"
+    integration = PdfIntegration(template_dir=template_dir)
+
+    result = integration.render(
+        _make_context(
+            updated_at=datetime(2026, 3, 1, 12, 6, tzinfo=UTC),
+            line_item_price=Decimal("120.00"),
+            total=Decimal("120.00"),
+            customer_address="123 Main St\nSuite 200",
+        )
+    )
+
+    assert result == b"fake-pdf"
+    rendered_html = captured_html[0]
+    assert "value--multiline" in rendered_html
+    assert "123 Main St\nSuite 200" in rendered_html
 
 
 def test_render_includes_due_date_and_doc_label_for_invoices(
@@ -375,9 +420,77 @@ def test_render_includes_due_date_and_doc_label_for_invoices(
         rendered_html,
         re.DOTALL,
     )
+    assert "CUSTOMER SIGNATURE" not in rendered_html
+    assert 'class="signature-area"' not in rendered_html
 
 
-def test_render_includes_contractor_contact_details_when_present(
+def test_render_shows_quote_signature_area_only_for_quote_doc_label(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured_html: list[str] = []
+
+    class _FakeHTML:
+        def __init__(self, *, string: str, base_url: str) -> None:
+            del base_url
+            captured_html.append(string)
+
+        def write_pdf(self) -> bytes:
+            return b"fake-pdf"
+
+    monkeypatch.setattr("app.integrations.pdf.HTML", _FakeHTML)
+    template_dir = Path(__file__).resolve().parents[3] / "templates"
+    integration = PdfIntegration(template_dir=template_dir)
+
+    quote_result = integration.render(
+        _make_context(
+            doc_label="Quote",
+            line_item_price=Decimal("120.00"),
+            total=Decimal("120.00"),
+        )
+    )
+    invoice_result = integration.render(
+        _make_context(
+            doc_label="Invoice",
+            doc_number="I-201",
+            line_item_price=Decimal("120.00"),
+            total=Decimal("120.00"),
+        )
+    )
+
+    assert quote_result == b"fake-pdf"
+    assert invoice_result == b"fake-pdf"
+    assert len(captured_html) == 2
+    quote_html, invoice_html = captured_html
+    assert "CUSTOMER SIGNATURE" in quote_html
+    assert "ACCEPTANCE" not in quote_html.upper()
+    assert "ACCEPTED BY" not in quote_html.upper()
+    assert "ACCEPTANCE" not in invoice_html.upper()
+    assert "ACCEPTED BY" not in invoice_html.upper()
+    assert re.search(
+        r"<p class=\"signature-field-label\">CUSTOMER SIGNATURE</p>",
+        quote_html,
+        re.DOTALL,
+    )
+    assert '<p class="signature-field-label">DATE</p>' not in quote_html
+    assert 'class="signature-line"' in quote_html
+    assert 'class="signature-label-row"' in quote_html
+    assert re.search(r'class="notes-column(?:\s|")', quote_html)
+    assert 'class="totals-stack totals-stack--with-signature"' in quote_html
+    total_block_pos = quote_html.find('class="total-block"')
+    signature_pos = quote_html.find('class="signature-area"')
+    signature_line_pos = quote_html.find('class="signature-line"')
+    signature_labels_pos = quote_html.find('class="signature-label-row"')
+    assert total_block_pos != -1
+    assert signature_pos != -1
+    assert signature_line_pos != -1
+    assert signature_labels_pos != -1
+    assert total_block_pos < signature_pos
+    assert signature_line_pos < signature_labels_pos
+    assert "CUSTOMER SIGNATURE" not in invoice_html
+    assert 'class="signature-area"' not in invoice_html
+
+
+def test_render_includes_contractor_contact_details_in_header_only(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     captured_html: list[str] = []
@@ -406,6 +519,8 @@ def test_render_includes_contractor_contact_details_when_present(
 
     assert result == b"fake-pdf"
     rendered_html = captured_html[0]
+    assert "Prepared By" not in rendered_html
+    assert 'class="header-contact"' in rendered_html
     assert "+1-555-111-2222" in rendered_html
     assert "owner@example.com" in rendered_html
 
@@ -538,7 +653,7 @@ def test_render_includes_logo_image_only_when_logo_data_uri_is_present(
     assert result == b"fake-pdf"
     assert len(captured_html) == 1
     assert 'class="company-logo"' in captured_html[0]
-    assert "max-height: 56px" in captured_html[0]
+    assert "max-height: 84px" in captured_html[0]
 
 
 def test_render_uses_a4_page_size_and_polished_quote_layout_styles(
@@ -575,6 +690,28 @@ def test_render_uses_a4_page_size_and_polished_quote_layout_styles(
     assert "@bottom-center" in rendered_html
     assert 'content: "Page " counter(page) " of " counter(pages);' in rendered_html
     assert "page-break-inside: avoid;" in rendered_html
+    assert re.search(
+        r"table\.line-items tbody td\s*\{[^}]*padding:\s*8px 8px;",
+        rendered_html,
+        re.DOTALL,
+    )
+    assert re.search(
+        (
+            r"\.line-item-description\s*\{[^}]*display:\s*block;"
+            r"[^}]*overflow-wrap:\s*anywhere;"
+        ),
+        rendered_html,
+        re.DOTALL,
+    )
+    assert re.search(
+        (
+            r"\.line-item-details\s*\{[^}]*margin-top:\s*1px;"
+            r"[^}]*padding-left:\s*2ch;"
+            r"[^}]*overflow-wrap:\s*anywhere;"
+        ),
+        rendered_html,
+        re.DOTALL,
+    )
     assert "overflow-wrap: break-word;" in rendered_html
     assert re.search(r"\.meta-right\s*\{[^}]*text-align:\s*right;", rendered_html, re.DOTALL)
     assert re.search(r"\.meta-details\s*\{[^}]*width:\s*auto;", rendered_html, re.DOTALL)
@@ -629,6 +766,72 @@ def test_render_uses_a4_page_size_and_polished_quote_layout_styles(
     assert "font-weight: 700;" in rendered_html
     assert "font-size: 16px;" in rendered_html
     assert re.search(r"\.total-block\s*\{[^}]*border-top:", rendered_html, re.DOTALL)
+    assert ".post-content" in rendered_html
+    assert 'class="post-content post-content--with-notes"' in rendered_html
+    assert ".total-row--supporting" in rendered_html
+    assert ".total-row--final" in rendered_html
+    assert ".total-row--deposit" in rendered_html
+    assert ".total-row--balance" in rendered_html
+    assert re.search(
+        (
+            r"\.total-row--supporting \.total-amount\s*\{[^}]*font-size:\s*13px;"
+            r"[^}]*font-weight:\s*500;"
+        ),
+        rendered_html,
+        re.DOTALL,
+    )
+    assert re.search(
+        r"\.total-row--final \.total-amount\s*\{[^}]*font-size:\s*17px;",
+        rendered_html,
+        re.DOTALL,
+    )
+    assert re.search(
+        (
+            r"\.total-row--deposit \.total-amount\s*\{[^}]*font-size:\s*14px;"
+            r"[^}]*font-weight:\s*600;"
+        ),
+        rendered_html,
+        re.DOTALL,
+    )
+    assert re.search(
+        r"\.total-row--balance \.total-amount\s*\{[^}]*font-size:\s*18px;[^}]*font-weight:\s*700;",
+        rendered_html,
+        re.DOTALL,
+    )
+    assert re.search(r"\.totals-stack\s*\{[^}]*width:\s*220px;", rendered_html, re.DOTALL)
+    assert re.search(
+        (
+            r"\.totals-stack--with-signature\s*\{[^}]*page-break-inside:\s*avoid;"
+            r"[^}]*break-inside:\s*avoid-page;"
+        ),
+        rendered_html,
+        re.DOTALL,
+    )
+    assert re.search(
+        r"\.signature-area\s*\{[^}]*margin-top:\s*60px;",
+        rendered_html,
+        re.DOTALL,
+    )
+    assert re.search(
+        r"\.signature-label-row\s*\{[^}]*justify-content:\s*flex-start;",
+        rendered_html,
+        re.DOTALL,
+    )
+    assert re.search(
+        r"\.signature-label-row\s*\{[^}]*margin-top:\s*7px;",
+        rendered_html,
+        re.DOTALL,
+    )
+    assert re.search(
+        r"\.signature-line\s*\{[^}]*border-bottom:\s*1px solid #d1d5db;",
+        rendered_html,
+        re.DOTALL,
+    )
+    assert re.search(
+        r"\.signature-field-label\s*\{[^}]*font-size:\s*10px;[^}]*text-transform:\s*uppercase;",
+        rendered_html,
+        re.DOTALL,
+    )
     assert re.search(r"\.notes\s*\{[^}]*border-left:", rendered_html, re.DOTALL)
     assert "#9ca3af" in rendered_html
     assert not re.search(r"\.notes\s*\{[^}]*\bborder:", rendered_html, re.DOTALL)
@@ -636,6 +839,43 @@ def test_render_uses_a4_page_size_and_polished_quote_layout_styles(
     line_items_table, total_block = rendered_html.split('<section class="total-block">', maxsplit=1)
     assert "</table>" in line_items_table
     assert "<table" not in total_block
+
+
+def test_render_places_notes_in_left_column_with_totals_on_right_before_signature(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured_html: list[str] = []
+
+    class _FakeHTML:
+        def __init__(self, *, string: str, base_url: str) -> None:
+            del base_url
+            captured_html.append(string)
+
+        def write_pdf(self) -> bytes:
+            return b"fake-pdf"
+
+    monkeypatch.setattr("app.integrations.pdf.HTML", _FakeHTML)
+    template_dir = Path(__file__).resolve().parents[3] / "templates"
+    integration = PdfIntegration(template_dir=template_dir)
+
+    result = integration.render(
+        _make_context(
+            line_item_price=Decimal("120.00"),
+            total=Decimal("120.00"),
+            notes="Call before arrival",
+        )
+    )
+
+    assert result == b"fake-pdf"
+    rendered_html = captured_html[0]
+    assert 'class="post-content post-content--with-notes"' in rendered_html
+    notes_pos = rendered_html.find('class="notes"')
+    totals_pos = rendered_html.find('class="total-block"')
+    signature_pos = rendered_html.find('class="signature-area"')
+    assert notes_pos != -1
+    assert totals_pos != -1
+    assert signature_pos != -1
+    assert notes_pos < totals_pos < signature_pos
 
 
 def test_render_handles_sparse_quote_without_blank_placeholders(
@@ -677,7 +917,50 @@ def test_render_handles_sparse_quote_without_blank_placeholders(
     assert 'class="company-logo"' not in rendered_html
     assert 'class="notes"' not in rendered_html
     assert 'class="line-item-details"' not in rendered_html
+    assert "CUSTOMER SIGNATURE" in rendered_html
+    assert "ACCEPTED BY" not in rendered_html.upper()
     assert rendered_html.count("&mdash;") == 2
+
+
+def test_render_handles_denser_quote_layout_without_placeholder_regressions(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured_html: list[str] = []
+
+    class _FakeHTML:
+        def __init__(self, *, string: str, base_url: str) -> None:
+            del base_url
+            captured_html.append(string)
+
+        def write_pdf(self) -> bytes:
+            return b"fake-pdf"
+
+    monkeypatch.setattr("app.integrations.pdf.HTML", _FakeHTML)
+    template_dir = Path(__file__).resolve().parents[3] / "templates"
+    integration = PdfIntegration(template_dir=template_dir)
+
+    result = integration.render(
+        _make_context(
+            line_item_price=Decimal("120.00"),
+            total=Decimal("780.00"),
+            line_items=[
+                QuoteRenderLineItem(
+                    description=f"Line item {index}",
+                    details="Detailed scope line",
+                    price=Decimal("130.00"),
+                )
+                for index in range(1, 7)
+            ],
+            notes="Keep gate closed after service.",
+        )
+    )
+
+    assert result == b"fake-pdf"
+    rendered_html = captured_html[0]
+    assert rendered_html.count('class="line-item-description"') == 6
+    assert "page-break-inside: avoid;" in rendered_html
+    assert "$None" not in rendered_html
+    assert 'class="signature-area"' in rendered_html
 
 
 def test_build_render_context_formats_dates_in_business_timezone() -> None:

--- a/backend/app/templates/quote.html
+++ b/backend/app/templates/quote.html
@@ -40,10 +40,16 @@
         background: #ffffff;
       }
 
+      main {
+        min-height: 240mm;
+        display: flex;
+        flex-direction: column;
+      }
+
       .header {
         border-bottom: 1px solid #d1d5db;
-        padding-bottom: 20px;
-        margin-bottom: 24px;
+        padding-bottom: 14px;
+        margin-bottom: 14px;
       }
 
       .header-grid {
@@ -53,6 +59,10 @@
 
       .header-grid td {
         vertical-align: top;
+      }
+
+      .header-company-cell {
+        padding-right: 20px;
       }
 
       .header-logo-cell {
@@ -78,36 +88,37 @@
       }
 
       .owner-name {
-        margin: 8px 0 0;
+        margin: 6px 0 0;
         font-size: 14px;
         font-weight: 700;
         color: #1f2937;
       }
 
       .header-contact {
-        margin: 4px 0 0;
-        font-size: 13px;
+        margin: 3px 0 0;
+        font-size: 12px;
         color: #4b5563;
       }
 
       .company-logo {
         display: block;
-        max-height: 56px;
+        max-height: 84px;
         width: auto;
-        max-width: 200px;
+        max-width: 240px;
+        object-fit: contain;
         margin-left: auto;
       }
 
       .meta-grid {
         width: 100%;
         border-collapse: collapse;
-        margin-bottom: 24px;
+        margin-bottom: 12px;
       }
 
       .meta-grid td {
         width: 50%;
         vertical-align: top;
-        padding: 0 24px 12px 0;
+        padding: 0 20px 6px 0;
       }
 
       .meta-right {
@@ -122,7 +133,7 @@
       }
 
       .meta-details td {
-        padding: 0 0 8px;
+        padding: 0 0 6px;
         vertical-align: top;
       }
 
@@ -158,14 +169,18 @@
       }
 
       .value {
-        margin: 0;
+        margin: 0 0 2px;
         font-size: 14px;
+      }
+
+      .value--multiline {
+        white-space: pre-line;
       }
 
       table.line-items {
         width: 100%;
         border-collapse: collapse;
-        margin-top: 8px;
+        margin-top: 4px;
       }
 
       table.line-items thead th {
@@ -175,7 +190,7 @@
         letter-spacing: 0.04em;
         color: #6b7280;
         border-bottom: 1px solid #d1d5db;
-        padding: 10px 8px;
+        padding: 8px 8px;
       }
 
       table.line-items thead th.price-col {
@@ -188,7 +203,7 @@
 
       table.line-items tbody td {
         border-bottom: 1px solid #e5e7eb;
-        padding: 14px 8px;
+        padding: 8px 8px;
         font-size: 13px;
         vertical-align: top;
         overflow-wrap: break-word;
@@ -201,23 +216,64 @@
       }
 
       .line-item-description {
+        display: block;
         font-size: 14px;
         font-weight: 700;
         color: #111827;
+        overflow-wrap: anywhere;
+        word-break: break-word;
       }
 
       .line-item-details {
         display: block;
-        margin-top: 4px;
+        margin-top: 1px;
+        padding-left: 2ch;
         color: #4b5563;
         font-size: 12px;
         font-weight: 400;
+        overflow-wrap: anywhere;
+        word-break: break-word;
+      }
+
+      .post-content {
+        display: flex;
+        align-items: flex-start;
+        gap: 18px;
+        margin-top: 8px;
+      }
+
+      .post-content--totals-only {
+        justify-content: flex-end;
+      }
+
+      .notes-column {
+        flex: 1 1 auto;
+        min-width: 0;
+        max-width: calc(100% - 240px);
+      }
+
+      .totals-stack {
+        width: 220px;
+        margin: 0 0 0 auto;
+        flex: 0 0 280px;
+      }
+
+      .totals-stack--with-signature {
+        width: 360px;
+        max-width: 100%;
+        page-break-inside: avoid;
+        break-inside: avoid-page;
+      }
+
+      .totals-stack--with-signature .total-block {
+        width: 220px;
+        margin-left: auto;
       }
 
       .total-block {
-        width: 220px;
-        margin: 16px 0 0 auto;
-        padding-top: 12px;
+        width: 100%;
+        margin: 0;
+        padding-top: 6px;
         border-top: 2px solid #111827;
       }
 
@@ -225,22 +281,63 @@
         display: flex;
         align-items: baseline;
         justify-content: space-between;
-        gap: 12px;
-        margin-top: 8px;
+        gap: 10px;
+        margin-top: 3px;
       }
 
       .total-row:first-child {
         margin-top: 0;
       }
 
+      .total-row--supporting .total-label {
+        color: #6b7280;
+        font-size: 11px;
+      }
+
+      .total-row--supporting .total-amount {
+        color: #4b5563;
+        font-size: 13px;
+        font-weight: 500;
+      }
+
       .total-row--final {
-        margin-top: 12px;
-        padding-top: 10px;
+        margin-top: 6px;
+        padding-top: 4px;
         border-top: 1px solid #d1d5db;
       }
 
+      .total-row--final .total-label {
+        color: #374151;
+      }
+
+      .total-row--final .total-amount {
+        font-size: 17px;
+      }
+
+      .total-row--deposit .total-label {
+        color: #4b5563;
+      }
+
+      .total-row--deposit .total-amount {
+        font-size: 14px;
+        font-weight: 600;
+        color: #374151;
+      }
+
       .total-row--balance {
+        margin-top: 6px;
+        padding-top: 5px;
+        border-top: 1px solid #d1d5db;
+      }
+
+      .total-row--balance .total-label {
+        color: #111827;
+      }
+
+      .total-row--balance .total-amount {
+        font-size: 18px;
         font-weight: 700;
+        color: #111827;
       }
 
       .total-label {
@@ -259,8 +356,9 @@
       }
 
       .notes {
-        margin-top: 24px;
-        padding-left: 16px;
+        margin: 0;
+        margin-top: 5px;
+        padding-left: 12px;
         border-left: 3px solid #9ca3af;
       }
 
@@ -268,6 +366,32 @@
         margin: 0;
         font-size: 13px;
         white-space: pre-wrap;
+      }
+
+      .signature-area {
+        margin-top: 60px;
+      }
+
+      .signature-line {
+        /* border-bottom: 1px solid #d1d5db; */
+        border-bottom: 1px solid #111827;
+      }
+
+      .signature-label-row {
+        display: flex;
+        justify-content: flex-start;
+        align-items: baseline;
+        gap: 12px;
+        margin-top: 7px;
+      }
+
+      .signature-field-label {
+        margin: 0;
+        font-size: 10px;
+        font-weight: 700;
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+        color: #6b7280;
       }
     </style>
   </head>
@@ -280,7 +404,7 @@
         <table class="header-grid">
           <tbody>
             <tr>
-              <td>
+              <td class="header-company-cell">
                 {% if display_name %}
                 <h1 class="company-name">{{ display_name }}</h1>
                 {% endif %}
@@ -312,7 +436,7 @@
               <p class="label">Prepared For</p>
               <p class="value">{{ customer_name }}</p>
               {% if customer_address %}
-              <p class="value">{{ customer_address }}</p>
+              <p class="value value--multiline">{{ customer_address }}</p>
               {% endif %}
               {% if customer_phone %}
               <p class="value">{{ customer_phone }}</p>
@@ -370,9 +494,25 @@
         </tbody>
       </table>
 
-      <section class="total-block">
+      {% if notes or doc_label == "Quote" %}
+      <section class="post-content post-content--with-notes">
+        <div class="notes-column">
+          {% if notes %}
+          <section class="notes">
+            <p class="label">Notes</p>
+            <p>{{ notes }}</p>
+          </section>
+          {% endif %}
+        </div>
+        <section class="totals-stack{% if doc_label == "Quote" %} totals-stack--with-signature{% endif %}">
+          <section class="total-block">
+      {% else %}
+      <section class="post-content post-content--totals-only">
+        <section class="totals-stack">
+          <section class="total-block">
+      {% endif %}
         {% if discount_amount is not none or tax_amount is not none or deposit_amount is not none %}
-        <div class="total-row">
+        <div class="total-row total-row--supporting">
           <p class="total-label">Subtotal</p>
           <p class="total-amount">
             {% if subtotal_amount is not none %}
@@ -383,13 +523,13 @@
           </p>
         </div>
         {% if discount_amount is not none %}
-        <div class="total-row">
+        <div class="total-row total-row--supporting">
           <p class="total-label">Discount</p>
           <p class="total-amount">-${{ "{:,.2f}".format(discount_amount) }}</p>
         </div>
         {% endif %}
         {% if tax_amount is not none %}
-        <div class="total-row">
+        <div class="total-row total-row--supporting">
           <p class="total-label">Tax</p>
           <p class="total-amount">${{ "{:,.2f}".format(tax_amount) }}</p>
         </div>
@@ -405,7 +545,7 @@
           </p>
         </div>
         {% if deposit_amount is not none %}
-        <div class="total-row">
+        <div class="total-row total-row--deposit">
           <p class="total-label">Deposit</p>
           <p class="total-amount">${{ "{:,.2f}".format(deposit_amount) }}</p>
         </div>
@@ -431,13 +571,16 @@
         </p>
         {% endif %}
       </section>
-
-      {% if notes %}
-      <section class="notes">
-        <p class="label">Notes</p>
-        <p>{{ notes }}</p>
+      {% if doc_label == "Quote" %}
+      <section class="signature-area">
+        <div class="signature-line"></div>
+        <div class="signature-label-row">
+          <p class="signature-field-label">CUSTOMER SIGNATURE</p>
+        </div>
       </section>
       {% endif %}
+      </section>
+      </section>
     </main>
   </body>
 </html>

--- a/backend/app/templates/quote.html
+++ b/backend/app/templates/quote.html
@@ -373,7 +373,6 @@
       }
 
       .signature-line {
-        /* border-bottom: 1px solid #d1d5db; */
         border-bottom: 1px solid #111827;
       }
 

--- a/frontend/src/features/public/components/PublicQuotePage.tsx
+++ b/frontend/src/features/public/components/PublicQuotePage.tsx
@@ -194,19 +194,21 @@ export function PublicQuotePage(): React.ReactElement {
     },
     resolveLineItemSum(documentData.line_items.map((item) => item.price)),
   );
+  const isInvoice = documentData.doc_type === "invoice";
+  const summaryGridColsClass = isInvoice ? "lg:grid-cols-3" : "lg:grid-cols-2";
 
   return (
     <main className="screen-radial-backdrop min-h-screen px-4 py-6 text-on-surface sm:px-6 lg:py-10">
       <div className="mx-auto max-w-4xl">
         <section className="overflow-hidden rounded-[1.75rem] border border-surface-container-high bg-surface-container-lowest ghost-shadow">
           <div className="forest-gradient px-5 py-6 text-on-primary sm:px-8 sm:py-8">
-            <div className="flex items-start gap-4">
-              <div className="flex h-16 w-16 shrink-0 items-center justify-center overflow-hidden rounded-2xl bg-on-primary/15 text-xl font-semibold uppercase text-on-primary">
+            <div className="flex items-start gap-3 sm:gap-4">
+              <div className="flex h-16 w-20 shrink-0 items-center justify-center overflow-hidden rounded-2xl bg-on-primary/15 text-xl font-semibold uppercase text-on-primary ring-1 ring-on-primary/20 sm:h-20 sm:w-24 sm:text-2xl">
                 {showLogo ? (
                   <img
                     src={documentData.logo_url}
                     alt={displayBusinessName ? `${displayBusinessName} logo` : `${getDocumentLabel(documentData)} logo`}
-                    className="h-full w-full object-cover"
+                    className="h-full w-full object-contain p-2"
                     onError={() => setHiddenLogoUrl(documentData.logo_url)}
                   />
                 ) : (
@@ -219,7 +221,7 @@ export function PublicQuotePage(): React.ReactElement {
                     {displayBusinessName}
                   </p>
                 ) : null}
-                <h1 className="mt-3 text-3xl font-semibold leading-tight">
+                <h1 className="mt-2 text-2xl font-semibold leading-tight sm:mt-3 sm:text-3xl">
                   {getDisplayTitle(documentData)}
                 </h1>
                 <p className="mt-2 text-sm text-on-primary/80">
@@ -236,7 +238,9 @@ export function PublicQuotePage(): React.ReactElement {
               </div>
             ) : null}
 
-            <section className="grid gap-4 rounded-2xl bg-surface-container-low p-4 sm:grid-cols-2 lg:grid-cols-3">
+            <section
+              className={`grid gap-4 rounded-2xl bg-surface-container-low p-4 sm:grid-cols-2 ${summaryGridColsClass}`}
+            >
               <div>
                 <p className="text-xs font-semibold uppercase tracking-[0.25em] text-outline">
                   Customer
@@ -251,7 +255,7 @@ export function PublicQuotePage(): React.ReactElement {
                   {documentData.total_amount !== null ? formatCurrency(documentData.total_amount) : "TBD"}
                 </p>
               </div>
-              {documentData.doc_type === "invoice" ? (
+              {isInvoice ? (
                 <div className="lg:text-right">
                   <p className="text-xs font-semibold uppercase tracking-[0.25em] text-outline">
                     Due Date
@@ -261,6 +265,41 @@ export function PublicQuotePage(): React.ReactElement {
                   </p>
                 </div>
               ) : null}
+            </section>
+
+            <section>
+              <div className="flex items-center justify-between gap-3">
+                <h2 className="text-sm font-semibold uppercase tracking-[0.25em] text-outline">
+                  Line Items
+                </h2>
+                <span className="text-xs text-on-surface-variant">
+                  {documentData.line_items.length} item{documentData.line_items.length === 1 ? "" : "s"}
+                </span>
+              </div>
+              <ul className="mt-4 space-y-3">
+                {documentData.line_items.map((item, index) => (
+                  <li
+                    key={`${index}-${item.description}-${item.details ?? "none"}`}
+                    className="rounded-2xl border border-surface-container-high bg-surface-container-lowest p-4"
+                  >
+                    <div className="flex items-start justify-between gap-4">
+                      <div className="min-w-0">
+                        <p className="font-semibold break-words [overflow-wrap:anywhere]">
+                          {item.description}
+                        </p>
+                        {item.details ? (
+                          <p className="mt-1 text-sm text-on-surface-variant break-words [overflow-wrap:anywhere]">
+                            {item.details}
+                          </p>
+                        ) : null}
+                      </div>
+                      <p className="shrink-0 text-sm font-semibold">
+                        {item.price !== null ? formatCurrency(item.price) : "TBD"}
+                      </p>
+                    </div>
+                  </li>
+                ))}
+              </ul>
             </section>
 
             {pricingBreakdown.hasPricingBreakdown ? (
@@ -283,37 +322,6 @@ export function PublicQuotePage(): React.ReactElement {
                 </div>
               </section>
             ) : null}
-
-            <section>
-              <div className="flex items-center justify-between gap-3">
-                <h2 className="text-sm font-semibold uppercase tracking-[0.25em] text-outline">
-                  Line Items
-                </h2>
-                <span className="text-xs text-on-surface-variant">
-                  {documentData.line_items.length} item{documentData.line_items.length === 1 ? "" : "s"}
-                </span>
-              </div>
-              <ul className="mt-4 space-y-3">
-                {documentData.line_items.map((item, index) => (
-                  <li
-                    key={`${index}-${item.description}-${item.details ?? "none"}`}
-                    className="rounded-2xl border border-surface-container-high bg-surface-container-lowest p-4"
-                  >
-                    <div className="flex items-start justify-between gap-4">
-                      <div className="min-w-0">
-                        <p className="font-semibold">{item.description}</p>
-                        {item.details ? (
-                          <p className="mt-1 text-sm text-on-surface-variant">{item.details}</p>
-                        ) : null}
-                      </div>
-                      <p className="shrink-0 text-sm font-semibold">
-                        {item.price !== null ? formatCurrency(item.price) : "TBD"}
-                      </p>
-                    </div>
-                  </li>
-                ))}
-              </ul>
-            </section>
 
             {documentData.notes ? (
               <section className="rounded-2xl border border-surface-container-high bg-surface-container-lowest p-4">

--- a/frontend/src/features/public/tests/PublicQuotePage.test.tsx
+++ b/frontend/src/features/public/tests/PublicQuotePage.test.tsx
@@ -88,8 +88,8 @@ function makePublicInvoice(overrides: Partial<PublicInvoice> = {}): PublicInvoic
   };
 }
 
-function renderScreen(path = "/doc/token-1"): void {
-  render(
+function renderScreen(path = "/doc/token-1") {
+  return render(
     <MemoryRouter initialEntries={[path]}>
       <Routes>
         <Route path="/doc/:token" element={<PublicQuotePage />} />
@@ -199,6 +199,76 @@ describe("PublicQuotePage", () => {
     expect(screen.getByText("$59.00")).toBeInTheDocument();
   });
 
+  it("renders line items before pricing breakdown rows for quote and invoice documents", async () => {
+    mockedPublicService.getDocument
+      .mockResolvedValueOnce(
+        makePublicQuote({
+          total_amount: 110,
+          tax_rate: 0.1,
+          line_items: [
+            {
+              description: "Mulch refresh",
+              details: "Front beds",
+              price: 100,
+            },
+          ],
+        }),
+      )
+      .mockResolvedValueOnce(
+        makePublicInvoice({
+          total_amount: 110,
+          tax_rate: 0.1,
+          line_items: [
+            {
+              description: "Invoice service",
+              details: null,
+              price: 100,
+            },
+          ],
+        }),
+      );
+
+    const quoteView = renderScreen("/doc/token-quote");
+    const quoteLineItemsHeading = await screen.findByRole("heading", { name: "Line Items" });
+    const quoteSubtotal = screen.getByText("Subtotal");
+    expect(
+      quoteLineItemsHeading.compareDocumentPosition(quoteSubtotal) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    quoteView.unmount();
+
+    renderScreen("/doc/token-invoice");
+    const invoiceLineItemsHeading = await screen.findByRole("heading", { name: "Line Items" });
+    const invoiceSubtotal = screen.getByText("Subtotal");
+    expect(
+      invoiceLineItemsHeading.compareDocumentPosition(invoiceSubtotal) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+
+  it("wraps long unbroken line-item description and details in the public preview", async () => {
+    const longDescription = "A".repeat(220);
+    const longDetails = "B".repeat(180);
+    mockedPublicService.getDocument.mockResolvedValueOnce(
+      makePublicQuote({
+        line_items: [
+          {
+            description: longDescription,
+            details: longDetails,
+            price: 200,
+          },
+        ],
+      }),
+    );
+
+    renderScreen();
+
+    const description = await screen.findByText(longDescription);
+    const details = screen.getByText(longDetails);
+    expect(description.className).toContain("[overflow-wrap:anywhere]");
+    expect(description.className).toContain("break-words");
+    expect(details.className).toContain("[overflow-wrap:anywhere]");
+    expect(details.className).toContain("break-words");
+  });
+
   it("renders invoice variants without quote-only status messaging", async () => {
     mockedPublicService.getDocument.mockResolvedValueOnce(makePublicInvoice());
 
@@ -209,6 +279,30 @@ describe("PublicQuotePage", () => {
     expect(screen.getByText("Due Date")).toBeInTheDocument();
     expect(screen.getByText("May 04, 2026")).toBeInTheDocument();
     expect(screen.queryByText("This quote has been accepted")).not.toBeInTheDocument();
+  });
+
+  it("uses two summary columns for quotes and three for invoices on large screens", async () => {
+    mockedPublicService.getDocument
+      .mockResolvedValueOnce(makePublicQuote())
+      .mockResolvedValueOnce(makePublicInvoice());
+
+    const quoteView = renderScreen("/doc/token-quote-grid");
+    await screen.findByRole("heading", { name: "Spring Cleanup" });
+    const quoteSummarySection = screen
+      .getByText("Customer")
+      .closest("section");
+    expect(quoteSummarySection).toBeTruthy();
+    expect(quoteSummarySection?.className).toContain("lg:grid-cols-2");
+    expect(quoteSummarySection?.className).not.toContain("lg:grid-cols-3");
+    quoteView.unmount();
+
+    renderScreen("/doc/token-invoice-grid");
+    await screen.findByRole("heading", { name: "Spring Cleanup Invoice" });
+    const invoiceSummarySection = screen
+      .getByText("Customer")
+      .closest("section");
+    expect(invoiceSummarySection).toBeTruthy();
+    expect(invoiceSummarySection?.className).toContain("lg:grid-cols-3");
   });
 
   it("falls back to owner name when business name is missing", async () => {

--- a/frontend/src/features/quotes/components/QuoteLineItemsSection.tsx
+++ b/frontend/src/features/quotes/components/QuoteLineItemsSection.tsx
@@ -26,9 +26,13 @@ export function QuoteLineItemsSection({
             className="ghost-shadow flex items-start justify-between rounded-lg bg-surface-container-lowest p-3"
           >
             <div className="min-w-0 flex-1">
-              <p className="font-medium text-on-surface">{item.description}</p>
+              <p className="font-medium text-on-surface break-words [overflow-wrap:anywhere]">
+                {item.description}
+              </p>
               {item.details ? (
-                <p className="mt-1 text-sm text-on-surface-variant">{item.details}</p>
+                <p className="mt-1 text-sm text-on-surface-variant break-words [overflow-wrap:anywhere]">
+                  {item.details}
+                </p>
               ) : null}
             </div>
             <p className="ml-4 shrink-0 font-bold text-on-surface">

--- a/frontend/src/features/quotes/tests/QuotePreview.test.tsx
+++ b/frontend/src/features/quotes/tests/QuotePreview.test.tsx
@@ -817,6 +817,33 @@ describe("QuotePreview", () => {
     expect(screen.getByText("TBD")).toBeInTheDocument();
   });
 
+  it("wraps long unbroken line-item description and details in quote preview", async () => {
+    const longDescription = "A".repeat(220);
+    const longDetails = "B".repeat(180);
+    mockedQuoteService.getQuote.mockResolvedValueOnce(
+      makeQuoteDetail({
+        line_items: [
+          {
+            id: "line-1",
+            description: longDescription,
+            details: longDetails,
+            price: 120,
+            sort_order: 0,
+          },
+        ],
+      }),
+    );
+
+    renderScreen();
+
+    const description = await screen.findByText(longDescription);
+    const details = screen.getByText(longDetails);
+    expect(description.className).toContain("[overflow-wrap:anywhere]");
+    expect(description.className).toContain("break-words");
+    expect(details.className).toContain("[overflow-wrap:anywhere]");
+    expect(details.className).toContain("break-words");
+  });
+
   it("keeps details and line items above the primary action area", async () => {
     renderScreen();
 


### PR DESCRIPTION
## Summary
- Polish quote PDF presentation in `quote.html` for denser, more intentional customer delivery
- Remove duplicate body identity (`Prepared By`) and keep contractor identity in header only
- Keep signature quote-only, place it below totals, and keep totals + signature together for pagination
- Tighten line-item/totals spacing and preserve pricing hierarchy (`Balance Due` strongest, deposit positive)
- Improve long unbroken line-item wrapping across:
  - PDF template
  - public shared quote page
  - authenticated quote preview page
- Fix large-screen summary grid alignment on public quote page (2 cols for quote, 3 for invoice)
- Align signature border style test assertion with active template style

## Scope guardrails honored
- Business address intentionally deferred (no business-address schema/API/settings/profile changes)
- No share-token, route, lifecycle/status contract, or signature persistence/workflow changes

## Files changed
- `backend/app/templates/quote.html`
- `backend/app/features/quotes/tests/test_pdf_template.py`
- `frontend/src/features/public/components/PublicQuotePage.tsx`
- `frontend/src/features/public/tests/PublicQuotePage.test.tsx`
- `frontend/src/features/quotes/components/QuoteLineItemsSection.tsx`
- `frontend/src/features/quotes/tests/QuotePreview.test.tsx`

## Verification
- `cd backend && .venv/bin/pytest app/features/quotes/tests/test_pdf_template.py -q`
- `cd frontend && npx vitest run src/features/public/tests/PublicQuotePage.test.tsx`
- `cd frontend && npx vitest run src/features/quotes/tests/QuotePreview.test.tsx`

Closes #386