### PR TITLE
Task #387: V1 polish auth friction pass

### DIFF
--- a/frontend/src/features/auth/components/LoginForm.tsx
+++ b/frontend/src/features/auth/components/LoginForm.tsx
@@ -74,7 +74,7 @@ export function LoginForm(): React.ReactElement {
               />
               <button
                 type="button"
-                className="absolute inset-y-0 right-3 text-xs font-semibold text-primary"
+                className="absolute inset-y-0 right-3 cursor-pointer text-xs font-semibold text-primary"
                 aria-label={isPasswordVisible ? "Hide password" : "Show password"}
                 aria-pressed={isPasswordVisible}
                 onClick={() => setIsPasswordVisible((visible) => !visible)}

--- a/frontend/src/features/auth/components/LoginForm.tsx
+++ b/frontend/src/features/auth/components/LoginForm.tsx
@@ -65,6 +65,8 @@ export function LoginForm(): React.ReactElement {
                 id="password"
                 type={isPasswordVisible ? "text" : "password"}
                 autoComplete="current-password"
+                required
+                aria-required="true"
                 value={password}
                 onChange={(event) => setPassword(event.target.value)}
                 className={[

--- a/frontend/src/features/auth/components/LoginForm.tsx
+++ b/frontend/src/features/auth/components/LoginForm.tsx
@@ -18,6 +18,7 @@ export function LoginForm(): React.ReactElement {
   const location = useLocation();
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
+  const [isPasswordVisible, setIsPasswordVisible] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [flashMessage, setFlashMessage] = useState(
@@ -51,16 +52,37 @@ export function LoginForm(): React.ReactElement {
             id="email"
             label="Email"
             type="email"
+            autoComplete="email"
             value={email}
             onChange={(event) => setEmail(event.target.value)}
           />
-          <Input
-            id="password"
-            label="Password"
-            type="password"
-            value={password}
-            onChange={(event) => setPassword(event.target.value)}
-          />
+          <div className="flex flex-col gap-1">
+            <label htmlFor="password" className="text-sm font-medium text-on-surface">
+              Password
+            </label>
+            <div className="relative">
+              <input
+                id="password"
+                type={isPasswordVisible ? "text" : "password"}
+                autoComplete="current-password"
+                value={password}
+                onChange={(event) => setPassword(event.target.value)}
+                className={[
+                  "w-full bg-surface-container-high rounded-lg px-4 py-3 pr-20 font-body text-sm text-on-surface",
+                  "placeholder:text-outline focus:outline-none focus:ring-2 focus:ring-primary/30 focus:bg-surface-container-lowest transition-all",
+                ].join(" ")}
+              />
+              <button
+                type="button"
+                className="absolute inset-y-0 right-3 text-xs font-semibold text-primary"
+                aria-label={isPasswordVisible ? "Hide password" : "Show password"}
+                aria-pressed={isPasswordVisible}
+                onClick={() => setIsPasswordVisible((visible) => !visible)}
+              >
+                {isPasswordVisible ? "Hide" : "Show"}
+              </button>
+            </div>
+          </div>
 
           <p className="-mt-1 text-right text-sm text-on-surface-variant">
             <Link to="/forgot-password" className="font-semibold text-primary">

--- a/frontend/src/features/auth/components/RegisterForm.tsx
+++ b/frontend/src/features/auth/components/RegisterForm.tsx
@@ -60,6 +60,8 @@ export function RegisterForm(): React.ReactElement {
                 id="password"
                 type={isPasswordVisible ? "text" : "password"}
                 autoComplete="new-password"
+                required
+                aria-required="true"
                 value={password}
                 onChange={(event) => setPassword(event.target.value)}
                 className={[
@@ -87,6 +89,8 @@ export function RegisterForm(): React.ReactElement {
                 id="confirm-password"
                 type={isConfirmPasswordVisible ? "text" : "password"}
                 autoComplete="new-password"
+                required
+                aria-required="true"
                 value={confirmPassword}
                 onChange={(event) => setConfirmPassword(event.target.value)}
                 aria-invalid={showPasswordMismatch}

--- a/frontend/src/features/auth/components/RegisterForm.tsx
+++ b/frontend/src/features/auth/components/RegisterForm.tsx
@@ -69,7 +69,7 @@ export function RegisterForm(): React.ReactElement {
               />
               <button
                 type="button"
-                className="absolute inset-y-0 right-3 text-xs font-semibold text-primary"
+                className="absolute inset-y-0 right-3 cursor-pointer text-xs font-semibold text-primary"
                 aria-label={isPasswordVisible ? "Hide password" : "Show password"}
                 aria-pressed={isPasswordVisible}
                 onClick={() => setIsPasswordVisible((visible) => !visible)}
@@ -98,7 +98,7 @@ export function RegisterForm(): React.ReactElement {
               />
               <button
                 type="button"
-                className="absolute inset-y-0 right-3 text-xs font-semibold text-primary"
+                className="absolute inset-y-0 right-3 cursor-pointer text-xs font-semibold text-primary"
                 aria-label={isConfirmPasswordVisible ? "Hide confirm password" : "Show confirm password"}
                 aria-pressed={isConfirmPasswordVisible}
                 onClick={() => setIsConfirmPasswordVisible((visible) => !visible)}

--- a/frontend/src/features/auth/components/RegisterForm.tsx
+++ b/frontend/src/features/auth/components/RegisterForm.tsx
@@ -10,12 +10,20 @@ export function RegisterForm(): React.ReactElement {
   const navigate = useNavigate();
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [isPasswordVisible, setIsPasswordVisible] = useState(false);
+  const [isConfirmPasswordVisible, setIsConfirmPasswordVisible] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const passwordsMatch = password === confirmPassword;
+  const showPasswordMismatch = confirmPassword.length > 0 && !passwordsMatch;
 
   const onSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     setError(null);
+    if (!passwordsMatch) {
+      return;
+    }
     setIsSubmitting(true);
 
     try {
@@ -39,16 +47,71 @@ export function RegisterForm(): React.ReactElement {
             id="email"
             label="Email"
             type="email"
+            autoComplete="email"
             value={email}
             onChange={(event) => setEmail(event.target.value)}
           />
-          <Input
-            id="password"
-            label="Password"
-            type="password"
-            value={password}
-            onChange={(event) => setPassword(event.target.value)}
-          />
+          <div className="flex flex-col gap-1">
+            <label htmlFor="password" className="text-sm font-medium text-on-surface">
+              Password
+            </label>
+            <div className="relative">
+              <input
+                id="password"
+                type={isPasswordVisible ? "text" : "password"}
+                autoComplete="new-password"
+                value={password}
+                onChange={(event) => setPassword(event.target.value)}
+                className={[
+                  "w-full bg-surface-container-high rounded-lg px-4 py-3 pr-20 font-body text-sm text-on-surface",
+                  "placeholder:text-outline focus:outline-none focus:ring-2 focus:ring-primary/30 focus:bg-surface-container-lowest transition-all",
+                ].join(" ")}
+              />
+              <button
+                type="button"
+                className="absolute inset-y-0 right-3 text-xs font-semibold text-primary"
+                aria-label={isPasswordVisible ? "Hide password" : "Show password"}
+                aria-pressed={isPasswordVisible}
+                onClick={() => setIsPasswordVisible((visible) => !visible)}
+              >
+                {isPasswordVisible ? "Hide" : "Show"}
+              </button>
+            </div>
+          </div>
+          <div className="flex flex-col gap-1">
+            <label htmlFor="confirm-password" className="text-sm font-medium text-on-surface">
+              Confirm Password
+            </label>
+            <div className="relative">
+              <input
+                id="confirm-password"
+                type={isConfirmPasswordVisible ? "text" : "password"}
+                autoComplete="new-password"
+                value={confirmPassword}
+                onChange={(event) => setConfirmPassword(event.target.value)}
+                aria-invalid={showPasswordMismatch}
+                aria-describedby={showPasswordMismatch ? "confirm-password-error" : undefined}
+                className={[
+                  "w-full bg-surface-container-high rounded-lg px-4 py-3 pr-28 font-body text-sm text-on-surface",
+                  "placeholder:text-outline focus:outline-none focus:ring-2 focus:ring-primary/30 focus:bg-surface-container-lowest transition-all",
+                ].join(" ")}
+              />
+              <button
+                type="button"
+                className="absolute inset-y-0 right-3 text-xs font-semibold text-primary"
+                aria-label={isConfirmPasswordVisible ? "Hide confirm password" : "Show confirm password"}
+                aria-pressed={isConfirmPasswordVisible}
+                onClick={() => setIsConfirmPasswordVisible((visible) => !visible)}
+              >
+                {isConfirmPasswordVisible ? "Hide" : "Show"}
+              </button>
+            </div>
+            {showPasswordMismatch ? (
+              <p id="confirm-password-error" className="text-xs text-error">
+                Passwords do not match.
+              </p>
+            ) : null}
+          </div>
 
           {error ? (
             <div role="alert" className="rounded-lg border-l-4 border-error bg-error-container p-4">
@@ -56,7 +119,12 @@ export function RegisterForm(): React.ReactElement {
             </div>
           ) : null}
 
-          <Button type="submit" isLoading={isSubmitting} className="w-full">
+          <Button
+            type="submit"
+            isLoading={isSubmitting}
+            disabled={!passwordsMatch}
+            className="w-full"
+          >
             Create Account →
           </Button>
         </form>

--- a/frontend/src/features/auth/tests/LoginForm.test.tsx
+++ b/frontend/src/features/auth/tests/LoginForm.test.tsx
@@ -55,7 +55,7 @@ describe("LoginForm", () => {
     fireEvent.change(await screen.findByLabelText(/email/i), {
       target: { value: "user@example.com" },
     });
-    fireEvent.change(await screen.findByLabelText(/password/i), {
+    fireEvent.change(await screen.findByLabelText(/^password$/i), {
       target: { value: "super-secret" },
     });
     fireEvent.click(screen.getByRole("button", { name: /sign in/i }));
@@ -90,7 +90,7 @@ describe("LoginForm", () => {
     fireEvent.change(await screen.findByLabelText(/email/i), {
       target: { value: "user@example.com" },
     });
-    fireEvent.change(await screen.findByLabelText(/password/i), {
+    fireEvent.change(await screen.findByLabelText(/^password$/i), {
       target: { value: "super-secret" },
     });
     fireEvent.click(screen.getByRole("button", { name: /sign in/i }));
@@ -108,7 +108,7 @@ describe("LoginForm", () => {
     fireEvent.change(await screen.findByLabelText(/email/i), {
       target: { value: "user@example.com" },
     });
-    fireEvent.change(await screen.findByLabelText(/password/i), {
+    fireEvent.change(await screen.findByLabelText(/^password$/i), {
       target: { value: "bad" },
     });
     fireEvent.click(screen.getByRole("button", { name: /sign in/i }));
@@ -136,5 +136,26 @@ describe("LoginForm", () => {
     expect(
       await screen.findByText("Password reset successful. Please sign in."),
     ).toBeInTheDocument();
+  });
+
+  it("toggles password visibility with accessible button state", async () => {
+    mockedAuthService.me.mockRejectedValueOnce(new Error("Not authenticated"));
+
+    renderLogin();
+
+    const passwordInput = await screen.findByLabelText(/^password$/i);
+    const showToggle = screen.getByRole("button", { name: /show password/i });
+
+    expect(passwordInput).toHaveAttribute("type", "password");
+    expect(showToggle).toHaveAttribute("type", "button");
+    expect(showToggle).toHaveAttribute("aria-pressed", "false");
+
+    fireEvent.click(showToggle);
+
+    expect(passwordInput).toHaveAttribute("type", "text");
+    expect(screen.getByRole("button", { name: /hide password/i })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
   });
 });

--- a/frontend/src/features/auth/tests/RegisterForm.test.tsx
+++ b/frontend/src/features/auth/tests/RegisterForm.test.tsx
@@ -55,7 +55,10 @@ describe("RegisterForm", () => {
     fireEvent.change(await screen.findByLabelText(/email/i), {
       target: { value: "new@example.com" },
     });
-    fireEvent.change(await screen.findByLabelText(/password/i), {
+    fireEvent.change(await screen.findByLabelText(/^password$/i), {
+      target: { value: "strong-password" },
+    });
+    fireEvent.change(await screen.findByLabelText(/^confirm password$/i), {
       target: { value: "strong-password" },
     });
     fireEvent.click(screen.getByRole("button", { name: /create account/i }));
@@ -84,11 +87,71 @@ describe("RegisterForm", () => {
     fireEvent.change(await screen.findByLabelText(/email/i), {
       target: { value: "new@example.com" },
     });
-    fireEvent.change(await screen.findByLabelText(/password/i), {
+    fireEvent.change(await screen.findByLabelText(/^password$/i), {
+      target: { value: "weak" },
+    });
+    fireEvent.change(await screen.findByLabelText(/^confirm password$/i), {
       target: { value: "weak" },
     });
     fireEvent.click(screen.getByRole("button", { name: /create account/i }));
 
     expect(await screen.findByRole("alert")).toHaveTextContent("Email already exists");
+  });
+
+  it("blocks submit and shows inline mismatch feedback until passwords match", async () => {
+    mockedAuthService.me.mockRejectedValueOnce(new Error("Not authenticated"));
+
+    renderRegister();
+    expect(await screen.findByRole("main")).toHaveClass("screen-radial-backdrop");
+
+    fireEvent.change(await screen.findByLabelText(/email/i), {
+      target: { value: "new@example.com" },
+    });
+    fireEvent.change(await screen.findByLabelText(/^password$/i), {
+      target: { value: "strong-password" },
+    });
+    fireEvent.change(await screen.findByLabelText(/^confirm password$/i), {
+      target: { value: "different-password" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /create account/i }));
+
+    expect(mockedAuthService.register).not.toHaveBeenCalled();
+    expect(screen.getByText("Passwords do not match.")).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText(/^confirm password$/i), {
+      target: { value: "strong-password" },
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByText("Passwords do not match.")).not.toBeInTheDocument();
+    });
+  });
+
+  it("toggles visibility for password and confirm-password fields", async () => {
+    mockedAuthService.me.mockRejectedValueOnce(new Error("Not authenticated"));
+
+    renderRegister();
+
+    const passwordInput = await screen.findByLabelText(/^password$/i);
+    const confirmPasswordInput = await screen.findByLabelText(/^confirm password$/i);
+    const passwordToggle = screen.getByRole("button", { name: /show password/i });
+    const confirmPasswordToggle = screen.getByRole("button", { name: /show confirm password/i });
+
+    expect(passwordInput).toHaveAttribute("type", "password");
+    expect(confirmPasswordInput).toHaveAttribute("type", "password");
+
+    fireEvent.click(passwordToggle);
+    fireEvent.click(confirmPasswordToggle);
+
+    expect(passwordInput).toHaveAttribute("type", "text");
+    expect(confirmPasswordInput).toHaveAttribute("type", "text");
+    expect(screen.getByRole("button", { name: /hide password/i })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    expect(screen.getByRole("button", { name: /hide confirm password/i })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
   });
 });

--- a/frontend/src/shared/components/Input.tsx
+++ b/frontend/src/shared/components/Input.tsx
@@ -6,6 +6,7 @@ interface InputProps {
   placeholder?: string;
   className?: string;
   type?: string;
+  autoComplete?: string;
   required?: boolean;
   hideLabel?: boolean;
   maxLength?: number;
@@ -20,6 +21,7 @@ export function Input({
   placeholder,
   className,
   type = "text",
+  autoComplete,
   required = false,
   hideLabel = false,
   maxLength,
@@ -48,6 +50,7 @@ export function Input({
       <input
         id={id}
         type={type}
+        autoComplete={autoComplete}
         value={value}
         onChange={onChange}
         required={required}


### PR DESCRIPTION
## Summary
- add register confirm-password with inline mismatch feedback that clears when fields match
- add accessible show/hide password toggles on login and register password fields
- add autocomplete hints for login/register email and password fields
- extend auth form tests for mismatch and visibility toggles

## Verification
- cd frontend && npx vitest run src/features/auth/tests/RegisterForm.test.tsx src/features/auth/tests/LoginForm.test.tsx
- make frontend-verify

Refs #385
Closes #387