### PR TITLE
Task 394: add extraction trace logging instrumentation

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -206,6 +206,10 @@ class Settings(BaseSettings):
         default="fallback_default",
         validation_alias="EXTRACTION_FALLBACK_PROMPT_VARIANT",
     )
+    extraction_trace_include_raw_content: bool = Field(
+        default=False,
+        validation_alias="EXTRACTION_TRACE_INCLUDE_RAW_CONTENT",
+    )
     transcription_model: str = Field(
         default="whisper-1",
         validation_alias="TRANSCRIPTION_MODEL",

--- a/backend/app/core/tests/test_config.py
+++ b/backend/app/core/tests/test_config.py
@@ -69,6 +69,20 @@ def test_extraction_job_reaper_settings_use_expected_defaults() -> None:
     assert settings.extraction_job_stale_ttl_seconds == 300
 
 
+def test_extraction_trace_raw_content_logging_defaults_to_disabled() -> None:
+    settings = get_settings()
+
+    assert settings.extraction_trace_include_raw_content is False
+
+
+def test_extraction_trace_raw_content_logging_can_be_enabled(monkeypatch) -> None:
+    monkeypatch.setenv("EXTRACTION_TRACE_INCLUDE_RAW_CONTENT", "true")
+
+    settings = get_settings()
+
+    assert settings.extraction_trace_include_raw_content is True
+
+
 def test_extraction_job_reaper_settings_must_be_positive(monkeypatch) -> None:
     monkeypatch.setenv("EXTRACTION_JOB_REAPER_INTERVAL_SECONDS", "0")
 

--- a/backend/app/features/quotes/tests/test_extraction.py
+++ b/backend/app/features/quotes/tests/test_extraction.py
@@ -10,6 +10,7 @@ import anthropic
 import httpx
 import pytest
 
+import app.integrations.extraction as extraction_module
 from app.features.quotes.tests.fixtures.transcripts import TRANSCRIPTS
 from app.integrations.extraction import (
     EXTRACTION_TOOL_SCHEMA,
@@ -713,3 +714,76 @@ async def test_extract_exercises_all_transcript_fixtures(fixture_name: str) -> N
 
     assert result.transcript == transcript
     assert result.line_items[0].description.startswith("Extracted from")
+
+
+async def test_extract_emits_trace_events_for_primary_repair_and_result_stages(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    transcript = TRANSCRIPTS["clean_with_total"]
+    trace_calls: list[dict[str, object]] = []
+
+    def _capture_trace(
+        event: str,
+        *,
+        stage: str,
+        outcome: str,
+        **fields: object,
+    ) -> None:
+        trace_calls.append(
+            {
+                "event": event,
+                "stage": stage,
+                "outcome": outcome,
+                **fields,
+            }
+        )
+
+    monkeypatch.setattr(extraction_module, "log_extraction_trace", _capture_trace)
+    client = _SequencedClient(
+        [
+            _FakeResponse(
+                content=[
+                    {
+                        "type": "tool_use",
+                        "input": {
+                            "transcript": transcript,
+                            "line_items": "invalid-shape",
+                            "total": 435,
+                            "confidence_notes": [],
+                        },
+                    }
+                ]
+            ),
+            _FakeResponse(
+                content=[
+                    {
+                        "type": "tool_use",
+                        "input": {
+                            "transcript": transcript,
+                            "line_items": [
+                                {
+                                    "description": "Trim shrubs",
+                                    "details": "Front beds",
+                                    "price": 125,
+                                }
+                            ],
+                            "total": 125,
+                            "confidence_notes": [],
+                        },
+                    }
+                ]
+            ),
+        ]
+    )
+    integration = ExtractionIntegration(api_key="test", model="test-model", client=client)
+
+    result = await integration.extract(transcript)
+
+    assert result.total == 125
+    assert ("primary", "started") in {(call["stage"], call["outcome"]) for call in trace_calls}
+    assert ("primary", "provider_response") in {
+        (call["stage"], call["outcome"]) for call in trace_calls
+    }
+    assert ("repair", "started") in {(call["stage"], call["outcome"]) for call in trace_calls}
+    assert ("repair", "succeeded") in {(call["stage"], call["outcome"]) for call in trace_calls}
+    assert ("result", "succeeded") in {(call["stage"], call["outcome"]) for call in trace_calls}

--- a/backend/app/integrations/extraction.py
+++ b/backend/app/integrations/extraction.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import contextvars
 import json
+import logging
 import re
 import secrets
 from dataclasses import dataclass
@@ -15,6 +16,7 @@ from anthropic import AsyncAnthropic
 from pydantic import ValidationError
 
 from app.features.quotes.schemas import ExtractionResult, LineItemExtracted
+from app.shared.extraction_logger import log_extraction_trace
 from app.shared.input_limits import (
     CONFIDENCE_NOTE_MAX_CHARS,
     CONFIDENCE_NOTES_MAX_ITEMS,
@@ -107,6 +109,7 @@ _WHITESPACE_PATTERN = re.compile(r"\s+")
 
 _RETRY_BASE_DELAY_SECONDS = 0.25
 _RETRY_MAX_DELAY_SECONDS = 2.0
+_TRACE_EVENT_NAME = "extraction.trace"
 
 
 class ExtractionError(Exception):
@@ -205,10 +208,29 @@ class ExtractionIntegration:
                 )
             except ExtractionError as exc:
                 last_error = exc
+                log_extraction_trace(
+                    _TRACE_EVENT_NAME,
+                    stage=tier.tier,
+                    outcome="failed",
+                    level=logging.WARNING,
+                    extraction_model_id=tier.model_id,
+                    extraction_prompt_variant=tier.prompt_variant,
+                    error_class=type(exc).__name__,
+                    error_message=str(exc),
+                )
                 continue
 
         if last_error is None:  # pragma: no cover - defensive invariant
             raise ExtractionError("Claude request failed")
+        log_extraction_trace(
+            _TRACE_EVENT_NAME,
+            stage="result",
+            outcome="failed",
+            level=logging.ERROR,
+            reason="all_tiers_failed",
+            error_class=type(last_error).__name__,
+            error_message=str(last_error),
+        )
         raise last_error
 
     @property
@@ -246,6 +268,15 @@ class ExtractionIntegration:
         *,
         tier: _ExtractionTierConfig,
     ) -> ExtractionResult:
+        log_extraction_trace(
+            _TRACE_EVENT_NAME,
+            stage=tier.tier,
+            outcome="started",
+            extraction_model_id=tier.model_id,
+            extraction_prompt_variant=tier.prompt_variant,
+            transcript_chars=len(normalized_notes),
+            raw_transcript=normalized_notes,
+        )
         _set_last_call_metadata(
             model_id=tier.model_id,
             token_usage=None,
@@ -276,14 +307,47 @@ class ExtractionIntegration:
         payload.setdefault("transcript", normalized_notes)
         payload.setdefault("line_items", [])
         payload.setdefault("confidence_notes", [])
+        log_extraction_trace(
+            _TRACE_EVENT_NAME,
+            stage=tier.tier,
+            outcome="provider_response",
+            extraction_model_id=response_model_id,
+            extraction_prompt_variant=tier.prompt_variant,
+            token_input_tokens=_token_usage_value(response_token_usage, "input_tokens"),
+            token_output_tokens=_token_usage_value(response_token_usage, "output_tokens"),
+            line_item_count=_list_count(payload.get("line_items")),
+            confidence_note_count=_list_count(payload.get("confidence_notes")),
+            total_present=payload.get("total") is not None if "total" in payload else None,
+            raw_transcript=normalized_notes,
+            raw_tool_payload=payload,
+        )
 
         try:
             validated_result = ExtractionResult.model_validate(payload)
-            return _apply_semantic_guard_rules(validated_result)
+            result = _apply_semantic_guard_rules(validated_result)
+            _log_result_trace(
+                result=result,
+                invocation_tier=tier.tier,
+                model_id=response_model_id,
+                prompt_variant=tier.prompt_variant,
+            )
+            return result
         except ValidationError as exc:
             validation_errors = _compact_validation_errors(exc)
             repair_prompt_variant = (
                 f"{tier.prompt_variant}:{EXTRACTION_PROMPT_VARIANT_REPAIR_SUFFIX}"
+            )
+            log_extraction_trace(
+                _TRACE_EVENT_NAME,
+                stage="repair",
+                outcome="started",
+                level=logging.WARNING,
+                extraction_invocation_tier=tier.tier,
+                extraction_model_id=response_model_id,
+                extraction_prompt_variant=repair_prompt_variant,
+                validation_error_count=len(validation_errors),
+                raw_transcript=normalized_notes,
+                raw_tool_payload=payload,
             )
             try:
                 repair_response = await self._request_with_retry(
@@ -308,6 +372,17 @@ class ExtractionIntegration:
                     repair_outcome="repair_request_failed",
                     repair_validation_error_count=len(validation_errors),
                 )
+                log_extraction_trace(
+                    _TRACE_EVENT_NAME,
+                    stage="repair",
+                    outcome="failed",
+                    level=logging.WARNING,
+                    extraction_invocation_tier=tier.tier,
+                    extraction_model_id=response_model_id,
+                    extraction_prompt_variant=repair_prompt_variant,
+                    validation_error_count=len(validation_errors),
+                    reason="repair_request_failed",
+                )
                 raise
             repair_usage = _extract_token_usage(repair_response)
             repair_model_id = getattr(repair_response, "model", None) or tier.model_id
@@ -327,7 +402,31 @@ class ExtractionIntegration:
                     repair_outcome="repair_invalid",
                     repair_validation_error_count=len(validation_errors),
                 )
-                return _build_validation_repair_failed_result(transcript=normalized_notes)
+                log_extraction_trace(
+                    _TRACE_EVENT_NAME,
+                    stage="repair",
+                    outcome="failed",
+                    level=logging.WARNING,
+                    extraction_invocation_tier=tier.tier,
+                    extraction_model_id=repair_model_id,
+                    extraction_prompt_variant=repair_prompt_variant,
+                    validation_error_count=len(validation_errors),
+                    reason="repair_invalid",
+                    token_input_tokens=_token_usage_value(repair_usage, "input_tokens"),
+                    token_output_tokens=_token_usage_value(repair_usage, "output_tokens"),
+                    raw_transcript=normalized_notes,
+                    raw_tool_payload=repair_payload,
+                )
+                degraded_result = _build_validation_repair_failed_result(
+                    transcript=normalized_notes
+                )
+                _log_result_trace(
+                    result=degraded_result,
+                    invocation_tier=tier.tier,
+                    model_id=repair_model_id,
+                    prompt_variant=repair_prompt_variant,
+                )
+                return degraded_result
             _set_last_call_metadata(
                 model_id=repair_model_id,
                 token_usage=repair_usage,
@@ -337,7 +436,32 @@ class ExtractionIntegration:
                 repair_outcome="repair_succeeded",
                 repair_validation_error_count=len(validation_errors),
             )
-            return _apply_semantic_guard_rules(repaired_result)
+            log_extraction_trace(
+                _TRACE_EVENT_NAME,
+                stage="repair",
+                outcome="succeeded",
+                extraction_invocation_tier=tier.tier,
+                extraction_model_id=repair_model_id,
+                extraction_prompt_variant=repair_prompt_variant,
+                validation_error_count=len(validation_errors),
+                token_input_tokens=_token_usage_value(repair_usage, "input_tokens"),
+                token_output_tokens=_token_usage_value(repair_usage, "output_tokens"),
+                line_item_count=_list_count(repair_payload.get("line_items")),
+                confidence_note_count=_list_count(repair_payload.get("confidence_notes")),
+                total_present=(
+                    repair_payload.get("total") is not None if "total" in repair_payload else None
+                ),
+                raw_transcript=normalized_notes,
+                raw_tool_payload=repair_payload,
+            )
+            result = _apply_semantic_guard_rules(repaired_result)
+            _log_result_trace(
+                result=result,
+                invocation_tier=tier.tier,
+                model_id=repair_model_id,
+                prompt_variant=repair_prompt_variant,
+            )
+            return result
 
     async def _request_with_retry(
         self,
@@ -530,6 +654,43 @@ def _token_usage_int(usage: object, key: str) -> int | None:
     else:
         candidate = getattr(usage, key, None)
     return candidate if isinstance(candidate, int) else None
+
+
+def _token_usage_value(usage: dict[str, int] | None, key: str) -> int | None:
+    if usage is None:
+        return None
+    value = usage.get(key)
+    return value if isinstance(value, int) else None
+
+
+def _list_count(value: object) -> int | None:
+    if isinstance(value, list):
+        return len(value)
+    return None
+
+
+def _log_result_trace(
+    *,
+    result: ExtractionResult,
+    invocation_tier: Literal["primary", "fallback"],
+    model_id: str,
+    prompt_variant: str,
+) -> None:
+    log_extraction_trace(
+        _TRACE_EVENT_NAME,
+        stage="result",
+        outcome="succeeded",
+        extraction_invocation_tier=invocation_tier,
+        extraction_model_id=model_id,
+        extraction_prompt_variant=prompt_variant,
+        extraction_tier=result.extraction_tier,
+        extraction_degraded_reason_code=result.extraction_degraded_reason_code,
+        line_item_count=len(result.line_items),
+        confidence_note_count=len(result.confidence_notes),
+        total_present=result.total is not None,
+        raw_transcript=result.transcript,
+        raw_tool_payload=result.model_dump(mode="json"),
+    )
 
 
 def _build_repair_request(

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -31,6 +31,7 @@ from app.features.quotes.api import public_router as quote_public_router
 from app.features.quotes.api import router as quote_router
 from app.shared.dependencies import get_idempotency_store
 from app.shared.event_logger import configure_event_logging
+from app.shared.extraction_logger import configure_extraction_logging
 from app.shared.observability import (
     RequestObservabilityMiddleware,
     bind_request_context,
@@ -118,6 +119,9 @@ def create_app() -> FastAPI:
     settings = get_settings()
     init_sentry(dsn=settings.sentry_dsn, environment=settings.environment)
     configure_event_logging(session_factory=get_session_maker())
+    configure_extraction_logging(
+        include_raw_content=settings.extraction_trace_include_raw_content,
+    )
     configure_security_logging()
 
     app = FastAPI(title="Stima API", lifespan=_lifespan)

--- a/backend/app/shared/extraction_logger.py
+++ b/backend/app/shared/extraction_logger.py
@@ -1,0 +1,66 @@
+"""Structured extraction trace logging helpers."""
+
+from __future__ import annotations
+
+import json
+import logging
+import sys
+from datetime import UTC, datetime
+from typing import Any
+
+from app.shared.observability import current_correlation_id
+
+EXTRACTION_LOGGER_NAME = "stima.extraction"
+_HANDLER_SENTINEL = "_stima_extraction_handler"
+_EXTRACTION_LOGGER = logging.getLogger(EXTRACTION_LOGGER_NAME)
+_INCLUDE_RAW_CONTENT = False
+
+
+def configure_extraction_logging(*, include_raw_content: bool = False) -> None:
+    """Attach stdout extraction trace logging once and refresh raw-content settings."""
+    global _INCLUDE_RAW_CONTENT
+
+    _INCLUDE_RAW_CONTENT = include_raw_content
+    _EXTRACTION_LOGGER.setLevel(logging.INFO)
+    _EXTRACTION_LOGGER.propagate = False
+    if any(getattr(handler, _HANDLER_SENTINEL, False) for handler in _EXTRACTION_LOGGER.handlers):
+        return
+
+    handler = logging.StreamHandler(stream=sys.stdout)
+    handler.setFormatter(logging.Formatter("%(message)s"))
+    setattr(handler, _HANDLER_SENTINEL, True)
+    _EXTRACTION_LOGGER.addHandler(handler)
+
+
+def log_extraction_trace(
+    event: str,
+    *,
+    stage: str,
+    outcome: str,
+    level: int = logging.INFO,
+    raw_transcript: str | None = None,
+    raw_tool_payload: Any = None,
+    **fields: Any,
+) -> None:
+    """Emit one structured extraction trace event."""
+    payload: dict[str, Any] = {
+        "event": event,
+        "timestamp": datetime.now(UTC).isoformat(),
+        "level": logging.getLevelName(level),
+        "logger": EXTRACTION_LOGGER_NAME,
+        "correlation_id": current_correlation_id(),
+        "stage": stage,
+        "outcome": outcome,
+    }
+    for key, value in fields.items():
+        if value is None:
+            continue
+        payload[key] = value
+
+    if _INCLUDE_RAW_CONTENT:
+        if raw_transcript is not None:
+            payload["raw_transcript"] = raw_transcript
+        if raw_tool_payload is not None:
+            payload["raw_tool_payload"] = raw_tool_payload
+
+    _EXTRACTION_LOGGER.log(level, json.dumps(payload, default=str, sort_keys=True))

--- a/backend/app/shared/tests/test_extraction_logger.py
+++ b/backend/app/shared/tests/test_extraction_logger.py
@@ -1,0 +1,98 @@
+"""Structured extraction trace logger tests."""
+
+from __future__ import annotations
+
+import json
+import logging
+import sys
+
+from app.shared import extraction_logger
+
+
+def test_configure_extraction_logging_uses_stdout_and_does_not_duplicate_handlers() -> None:
+    logger = logging.getLogger(extraction_logger.EXTRACTION_LOGGER_NAME)
+    original_handlers = list(logger.handlers)
+    original_level = logger.level
+    original_propagate = logger.propagate
+
+    try:
+        for handler in list(logger.handlers):
+            logger.removeHandler(handler)
+
+        extraction_logger.configure_extraction_logging()
+        extraction_logger.configure_extraction_logging()
+
+        assert logger.level == logging.INFO
+        assert logger.propagate is False
+        assert len(logger.handlers) == 1
+        handler = logger.handlers[0]
+        assert isinstance(handler, logging.StreamHandler)
+        assert handler.stream is sys.stdout
+        assert handler.formatter is not None
+        assert handler.formatter._fmt == "%(message)s"  # noqa: SLF001
+    finally:
+        for handler in list(logger.handlers):
+            logger.removeHandler(handler)
+        for handler in original_handlers:
+            logger.addHandler(handler)
+        logger.setLevel(original_level)
+        logger.propagate = original_propagate
+
+
+def test_log_extraction_trace_excludes_raw_fields_by_default(monkeypatch) -> None:
+    captured: list[tuple[int, str]] = []
+    monkeypatch.setattr(extraction_logger, "current_correlation_id", lambda: "corr-123")
+
+    def _capture(level: int, message: str) -> None:
+        captured.append((level, message))
+
+    monkeypatch.setattr(extraction_logger._EXTRACTION_LOGGER, "log", _capture)  # noqa: SLF001
+    extraction_logger.configure_extraction_logging(include_raw_content=False)
+
+    extraction_logger.log_extraction_trace(
+        "extraction.trace",
+        stage="primary",
+        outcome="started",
+        raw_transcript="operator notes",
+        raw_tool_payload={"line_items": [{"description": "trim"}]},
+        extraction_model_id="test-model",
+    )
+
+    assert len(captured) == 1
+    payload = json.loads(captured[0][1])
+    assert payload["event"] == "extraction.trace"
+    assert payload["stage"] == "primary"
+    assert payload["outcome"] == "started"
+    assert payload["correlation_id"] == "corr-123"
+    assert payload["logger"] == extraction_logger.EXTRACTION_LOGGER_NAME
+    assert payload["extraction_model_id"] == "test-model"
+    assert "raw_transcript" not in payload
+    assert "raw_tool_payload" not in payload
+
+
+def test_log_extraction_trace_includes_raw_fields_when_opted_in(monkeypatch) -> None:
+    captured: list[tuple[int, str]] = []
+    monkeypatch.setattr(extraction_logger, "current_correlation_id", lambda: "corr-456")
+
+    def _capture(level: int, message: str) -> None:
+        captured.append((level, message))
+
+    monkeypatch.setattr(extraction_logger._EXTRACTION_LOGGER, "log", _capture)  # noqa: SLF001
+    extraction_logger.configure_extraction_logging(include_raw_content=True)
+
+    extraction_logger.log_extraction_trace(
+        "extraction.trace",
+        stage="repair",
+        outcome="succeeded",
+        raw_transcript="full transcript",
+        raw_tool_payload={"line_items": [{"description": "edging"}]},
+        extraction_model_id="test-model",
+    )
+
+    assert len(captured) == 1
+    payload = json.loads(captured[0][1])
+    assert payload["stage"] == "repair"
+    assert payload["outcome"] == "succeeded"
+    assert payload["correlation_id"] == "corr-456"
+    assert payload["raw_transcript"] == "full transcript"
+    assert payload["raw_tool_payload"] == {"line_items": [{"description": "edging"}]}

--- a/backend/app/worker/runtime.py
+++ b/backend/app/worker/runtime.py
@@ -20,6 +20,7 @@ from app.core.database import get_session_maker
 from app.features.jobs.models import JobType
 from app.features.jobs.repository import JobRepository
 from app.shared.dependencies import get_extraction_integration
+from app.shared.extraction_logger import configure_extraction_logging
 from app.shared.observability import (
     bind_worker_correlation,
     configure_security_logging,
@@ -89,6 +90,9 @@ async def on_worker_startup(ctx: dict[str, Any]) -> None:
         raise ValueError("REDIS_URL must be set for worker execution")
 
     configure_security_logging()
+    configure_extraction_logging(
+        include_raw_content=settings.extraction_trace_include_raw_content,
+    )
     await ping_worker_redis(redis_url)
     ctx["worker_runtime"] = WorkerRuntimeSettings(
         session_maker=get_session_maker(),


### PR DESCRIPTION
## Summary
- add dedicated `stima.extraction` structured trace logger with correlation IDs
- instrument extraction pipeline stage traces across primary/fallback, repair, and final result stages
- default traces to metadata-only and gate raw transcript/tool payload logging behind explicit opt-in config
- add targeted tests for trace stage emission, raw logging opt-in behavior, and config defaults

## Verification
- `cd backend && .venv/bin/ruff format --check .`
- `cd backend && .venv/bin/ruff check . --cache-dir .ruff_cache`
- `cd backend && .venv/bin/pytest app/features/quotes/tests/test_extraction.py app/features/quotes/tests/test_extraction_service.py -v -m "not live and not extraction_eval and not extraction_quality" -o cache_dir=.pytest_cache`
- `cd backend && .venv/bin/pytest app/shared/tests/test_extraction_logger.py app/core/tests/test_config.py -v -o cache_dir=.pytest_cache`
- `make backend-verify`

Closes #394