### PR TITLE
Task #395: add V2 extraction internals and worker payload bridge

### DIFF
--- a/backend/app/features/quotes/api.py
+++ b/backend/app/features/quotes/api.py
@@ -301,7 +301,7 @@ async def extract_combined(
         )
 
     try:
-        transcript = await extraction_service.prepare_combined_transcript(
+        prepared_capture_input = await extraction_service.prepare_capture_input(
             clip_inputs,
             notes,
             user_id=user.id,
@@ -325,7 +325,7 @@ async def extract_combined(
             str(job.id),
             _job_id=str(job.id),
             correlation_id=current_correlation_id(),
-            transcript=transcript,
+            prepared_capture_input=prepared_capture_input.model_dump(mode="json"),
             source_type=source_type,
             capture_detail=capture_detail,
             customer_id=str(customer_id) if customer_id is not None else None,
@@ -411,7 +411,7 @@ async def append_extraction(
         )
 
     try:
-        transcript = await extraction_service.prepare_combined_transcript(
+        prepared_capture_input = await extraction_service.prepare_capture_input(
             clip_inputs,
             notes,
             user_id=user.id,
@@ -436,7 +436,7 @@ async def append_extraction(
             str(job.id),
             _job_id=str(job.id),
             correlation_id=current_correlation_id(),
-            transcript=transcript,
+            prepared_capture_input=prepared_capture_input.model_dump(mode="json"),
             source_type=source_type,
             capture_detail=capture_detail,
             append_to_quote=True,

--- a/backend/app/features/quotes/extraction_service.py
+++ b/backend/app/features/quotes/extraction_service.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import Protocol
+from typing import Literal, Protocol
 from uuid import UUID
 
 import sentry_sdk
@@ -15,7 +15,7 @@ from app.features.quotes.extraction_outcomes import (
     log_draft_generation_failed_event,
     should_persist_degraded_retryable_error,
 )
-from app.features.quotes.schemas import ExtractionResult
+from app.features.quotes.schemas import ExtractionResult, PreparedCaptureInput
 from app.features.quotes.service import QuoteServiceError
 from app.integrations.audio import AudioClip, AudioError
 from app.integrations.extraction import ExtractionError
@@ -30,7 +30,7 @@ from app.shared.input_limits import (
 class ExtractionIntegrationProtocol(Protocol):
     """Structural protocol for extraction integration dependency."""
 
-    async def extract(self, notes: str) -> ExtractionResult: ...
+    async def extract(self, capture_input: PreparedCaptureInput) -> ExtractionResult: ...
 
 
 class AudioIntegrationProtocol(Protocol):
@@ -70,23 +70,20 @@ class ExtractionService:
 
     async def convert_notes(self, notes: str) -> ExtractionResult:
         """Extract structured line items from freeform notes."""
-        try:
-            return await self._extraction.extract(notes)
-        except ExtractionError as exc:
-            sentry_sdk.capture_exception(exc)
-            raise QuoteServiceError(
-                detail=f"Extraction failed: {exc}",
-                status_code=422,
-            ) from exc
+        prepared_input = PreparedCaptureInput.from_legacy_transcript(
+            transcript=notes,
+            source_type="text",
+        )
+        return await self._extract_prepared_input(prepared_input)
 
-    async def prepare_combined_transcript(
+    async def prepare_capture_input(
         self,
         clips: Sequence[CaptureAudioClip] | None,
         notes: str | None,
         *,
         user_id: UUID | None = None,
-    ) -> str:
-        """Normalize user inputs into one validated transcript for extraction."""
+    ) -> PreparedCaptureInput:
+        """Normalize capture input into structured transcript + provenance."""
         normalized_notes = (notes or "").strip()
         has_clips = bool(clips)
         if not has_clips and not normalized_notes:
@@ -95,25 +92,53 @@ class ExtractionService:
                 status_code=400,
             )
 
-        source_type = (
+        capture_detail = (
             "audio+notes" if has_clips and normalized_notes else "audio" if has_clips else "notes"
         )
-        log_event("quote_started", user_id=user_id, detail=source_type)
+        log_event("quote_started", user_id=user_id, detail=capture_detail)
         if has_clips:
-            log_event("audio_uploaded", user_id=user_id, detail=source_type)
+            log_event("audio_uploaded", user_id=user_id, detail=capture_detail)
 
+        raw_transcript: str | None = None
         combined_text = normalized_notes
         if clips:
-            transcript = await self._transcribe_clips(clips)
-            combined_text = transcript
+            raw_transcript = await self._transcribe_clips(clips)
+            combined_text = raw_transcript
             if normalized_notes:
-                combined_text = f"{transcript}\n\n{normalized_notes}"
+                combined_text = f"{raw_transcript}\n\n{normalized_notes}"
 
         _validate_transcript_length(
             combined_text,
             max_chars=EXTRACTION_TRANSCRIPT_MAX_CHARS,
         )
-        return combined_text
+        source_type: Literal["text", "voice", "voice+text"]
+        if raw_transcript is not None and normalized_notes:
+            source_type = "voice+text"
+        elif raw_transcript is not None:
+            source_type = "voice"
+        else:
+            source_type = "text"
+        return PreparedCaptureInput(
+            transcript=combined_text,
+            source_type=source_type,
+            raw_typed_notes=normalized_notes or None,
+            raw_transcript=raw_transcript,
+        )
+
+    async def prepare_combined_transcript(
+        self,
+        clips: Sequence[CaptureAudioClip] | None,
+        notes: str | None,
+        *,
+        user_id: UUID | None = None,
+    ) -> str:
+        """Return the flattened transcript string for compatibility call sites."""
+        prepared_input = await self.prepare_capture_input(
+            clips,
+            notes,
+            user_id=user_id,
+        )
+        return prepared_input.transcript
 
     async def extract_combined(
         self,
@@ -125,13 +150,13 @@ class ExtractionService:
     ) -> ExtractionResult:
         """Extract quote line items from optional clips plus optional typed notes."""
         try:
-            combined_text = await self.prepare_combined_transcript(
+            prepared_input = await self.prepare_capture_input(
                 clips,
                 notes,
                 user_id=user_id,
             )
             try:
-                extraction = await self.convert_notes(combined_text)
+                extraction = await self._extract_prepared_input(prepared_input)
             except QuoteServiceError as exc:
                 should_persist_degraded = (
                     allow_degraded_persist_on_retryable_failure
@@ -141,7 +166,7 @@ class ExtractionService:
                     )
                 )
                 if should_persist_degraded:
-                    return build_degraded_extraction_result(transcript=combined_text)
+                    return build_degraded_extraction_result(transcript=prepared_input.transcript)
                 raise
         except QuoteServiceError:
             source_type = (
@@ -151,6 +176,19 @@ class ExtractionService:
                 log_draft_generation_failed_event(user_id=user_id, capture_detail=source_type)
             raise
         return extraction
+
+    async def _extract_prepared_input(
+        self,
+        prepared_input: PreparedCaptureInput,
+    ) -> ExtractionResult:
+        try:
+            return await self._extraction.extract(prepared_input)
+        except ExtractionError as exc:
+            sentry_sdk.capture_exception(exc)
+            raise QuoteServiceError(
+                detail=f"Extraction failed: {exc}",
+                status_code=422,
+            ) from exc
 
     async def _transcribe_clips(self, clips: Sequence[CaptureAudioClip]) -> str:
         """Normalize clip uploads and return the resulting transcript."""

--- a/backend/app/features/quotes/schemas.py
+++ b/backend/app/features/quotes/schemas.py
@@ -138,7 +138,7 @@ class PricingHints(BaseModel):
 class ExtractionSuggestion(BaseModel):
     """Suggestion payload for notes-like content placement."""
 
-    text: str = Field(min_length=1, max_length=DOCUMENT_NOTES_MAX_CHARS)
+    text: str = Field(min_length=1, max_length=LINE_ITEM_DETAILS_MAX_CHARS)
     confidence: PlacementConfidence
     source: UnresolvedSegmentSource
 

--- a/backend/app/features/quotes/schemas.py
+++ b/backend/app/features/quotes/schemas.py
@@ -9,6 +9,7 @@ from uuid import UUID
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from app.shared.input_limits import (
+    AUDIO_TRANSCRIPT_MAX_CHARS,
     CONFIDENCE_NOTE_MAX_CHARS,
     CONFIDENCE_NOTES_MAX_ITEMS,
     DOCUMENT_LINE_ITEMS_MAX_ITEMS,
@@ -43,6 +44,158 @@ class LineItemExtracted(LineItemDraft):
 
     flagged: bool = False
     flag_reason: str | None = None
+
+
+class PreparedCaptureInput(BaseModel):
+    """Structured capture input preserving typed vs voice provenance."""
+
+    transcript: str = Field(min_length=1, max_length=EXTRACTION_TRANSCRIPT_MAX_CHARS)
+    source_type: Literal["text", "voice", "voice+text"]
+    raw_typed_notes: str | None = Field(default=None, max_length=NOTE_INPUT_MAX_CHARS)
+    raw_transcript: str | None = Field(default=None, max_length=AUDIO_TRANSCRIPT_MAX_CHARS)
+
+    @classmethod
+    def from_legacy_transcript(
+        cls,
+        *,
+        transcript: str,
+        source_type: Literal["text", "voice"] = "text",
+    ) -> PreparedCaptureInput:
+        """Build structured input from legacy single-string payloads."""
+        normalized_transcript = transcript.strip()
+        if source_type == "voice":
+            return cls(
+                transcript=normalized_transcript,
+                source_type="voice",
+                raw_typed_notes=None,
+                raw_transcript=normalized_transcript,
+            )
+        return cls(
+            transcript=normalized_transcript,
+            source_type="text",
+            raw_typed_notes=normalized_transcript,
+            raw_transcript=None,
+        )
+
+    @model_validator(mode="after")
+    def validate_source_provenance(self) -> PreparedCaptureInput:
+        """Ensure source-specific provenance fields stay coherent."""
+        if self.source_type == "text":
+            if self.raw_typed_notes is None:
+                raise ValueError("raw_typed_notes is required for text source_type")
+            if self.raw_transcript is not None:
+                raise ValueError("raw_transcript must be null for text source_type")
+        elif self.source_type == "voice":
+            if self.raw_transcript is None:
+                raise ValueError("raw_transcript is required for voice source_type")
+            if self.raw_typed_notes is not None:
+                raise ValueError("raw_typed_notes must be null for voice source_type")
+        else:
+            if self.raw_typed_notes is None or self.raw_transcript is None:
+                raise ValueError(
+                    "raw_typed_notes and raw_transcript are required for voice+text source_type"
+                )
+        return self
+
+
+class CaptureSegmentHints(BaseModel):
+    """Deterministic segmentation hints for model-side placement."""
+
+    has_explicit_price: bool
+    price_value: float | None
+    looks_like_heading: bool
+    looks_like_notes_heading: bool
+    looks_like_line_item: bool
+
+
+class CaptureSegment(BaseModel):
+    """One normalized segment generated from capture transcript text."""
+
+    index: int = Field(ge=0)
+    raw_text: str = Field(min_length=1, max_length=EXTRACTION_TRANSCRIPT_MAX_CHARS)
+    normalized_text: str = Field(min_length=1, max_length=EXTRACTION_TRANSCRIPT_MAX_CHARS)
+    hints: CaptureSegmentHints
+
+
+PlacementConfidence = Literal["high", "medium", "low"]
+UnresolvedSegmentSource = Literal[
+    "leftover_classification",
+    "typed_conflict",
+    "transcript_conflict",
+]
+
+
+class PricingHints(BaseModel):
+    """Structured pricing suggestions returned by V2 extraction."""
+
+    explicit_total: float | None = None
+    deposit_amount: float | None = None
+    tax_rate: float | None = None
+    discount_type: DiscountType | None = None
+    discount_value: float | None = None
+
+
+class ExtractionSuggestion(BaseModel):
+    """Suggestion payload for notes-like content placement."""
+
+    text: str = Field(min_length=1, max_length=DOCUMENT_NOTES_MAX_CHARS)
+    confidence: PlacementConfidence
+    source: UnresolvedSegmentSource
+
+
+class UnresolvedSegment(BaseModel):
+    """Minimal unresolved capture segment surfaced for downstream handling."""
+
+    raw_text: str = Field(min_length=1, max_length=EXTRACTION_TRANSCRIPT_MAX_CHARS)
+    confidence: Literal["medium", "low"]
+    source: UnresolvedSegmentSource
+
+
+class LineItemExtractedV2(LineItemExtracted):
+    """V2 extraction line-item contract with placement metadata."""
+
+    raw_text: str = Field(min_length=1, max_length=EXTRACTION_TRANSCRIPT_MAX_CHARS)
+    confidence: PlacementConfidence = "medium"
+
+
+class ExtractionResultV2(BaseModel):
+    """Internal V2 extraction contract used by integration/guards."""
+
+    transcript: str = Field(min_length=1, max_length=EXTRACTION_TRANSCRIPT_MAX_CHARS)
+    pipeline_version: Literal["v2"] = "v2"
+    line_items: list[LineItemExtractedV2] = Field(
+        default_factory=list,
+        max_length=DOCUMENT_LINE_ITEMS_MAX_ITEMS,
+    )
+    pricing_hints: PricingHints = Field(default_factory=PricingHints)
+    customer_notes_suggestion: ExtractionSuggestion | None = None
+    unresolved_segments: list[UnresolvedSegment] = Field(default_factory=list)
+    confidence_notes: list[Annotated[str, Field(max_length=CONFIDENCE_NOTE_MAX_CHARS)]] = Field(
+        default_factory=list,
+        max_length=CONFIDENCE_NOTES_MAX_ITEMS,
+    )
+    extraction_tier: Literal["primary", "degraded"] = "primary"
+    extraction_degraded_reason_code: str | None = None
+
+    def to_v1_result(self) -> ExtractionResult:
+        """Project the internal V2 payload onto the existing V1 contract."""
+        return ExtractionResult(
+            transcript=self.transcript,
+            line_items=[
+                LineItemExtracted(
+                    description=item.description,
+                    details=item.details,
+                    price=item.price,
+                    flagged=item.flagged,
+                    flag_reason=item.flag_reason,
+                )
+                for item in self.line_items
+            ],
+            total=self.pricing_hints.explicit_total,
+            confidence_notes=self.confidence_notes,
+            extraction_tier=self.extraction_tier,
+            extraction_degraded_reason_code=self.extraction_degraded_reason_code,
+        )
 
 
 class ExtractionResult(BaseModel):

--- a/backend/app/features/quotes/tests/support/helpers.py
+++ b/backend/app/features/quotes/tests/support/helpers.py
@@ -10,6 +10,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 from app.features.auth.models import User
 from app.features.auth.service import CSRF_COOKIE_NAME
 from app.features.quotes.models import Document, QuoteStatus
+from app.features.quotes.schemas import PreparedCaptureInput
 from app.worker.job_registry import extraction_job, pdf_job
 from app.worker.runtime import (
     DEFAULT_MAX_TRIES,
@@ -236,6 +237,7 @@ async def _run_extraction_job(
     customer_id: str | None = None,
     append_to_quote: bool = False,
     transcript: str = "mulch the front beds",
+    prepared_capture_input: PreparedCaptureInput | dict[str, object] | None = None,
     job_try: int = 1,
     extraction_integration: object | None = None,
     correlation_id: str | None = None,
@@ -262,6 +264,7 @@ async def _run_extraction_job(
         job_id,
         correlation_id=correlation_id,
         transcript=transcript,
+        prepared_capture_input=prepared_capture_input,
         source_type=source_type,
         capture_detail=capture_detail,
         customer_id=customer_id,

--- a/backend/app/features/quotes/tests/support/mocks.py
+++ b/backend/app/features/quotes/tests/support/mocks.py
@@ -5,7 +5,7 @@ from types import SimpleNamespace
 from typing import TypedDict
 
 from app.features.quotes.repository import QuoteRenderContext
-from app.features.quotes.schemas import ExtractionResult, LineItemExtracted
+from app.features.quotes.schemas import ExtractionResult, LineItemExtracted, PreparedCaptureInput
 from app.integrations.audio import AudioClip, AudioError
 from app.integrations.email import EmailConfigurationError, EmailMessage, EmailSendError
 from app.integrations.extraction import ExtractionError
@@ -15,11 +15,11 @@ from app.shared.idempotency import IdempotencyBeginResult
 
 
 class _MockExtractionIntegration:
-    async def extract(self, notes: str) -> ExtractionResult:
-        if "malformed" in notes.lower():
+    async def extract(self, notes: PreparedCaptureInput | str) -> ExtractionResult:
+        normalized_notes = _capture_transcript(notes)
+        if "malformed" in normalized_notes.lower():
             raise ExtractionError("mock malformed extraction payload")
 
-        normalized_notes = notes.strip()
         if "needs-review" in normalized_notes.lower() or normalized_notes.startswith(
             "transcript from stitched"
         ):
@@ -50,6 +50,12 @@ class _MockExtractionIntegration:
             total=120,
             confidence_notes=[],
         )
+
+
+def _capture_transcript(notes: PreparedCaptureInput | str) -> str:
+    if isinstance(notes, PreparedCaptureInput):
+        return notes.transcript.strip()
+    return notes.strip()
 
 
 class _MockPdfIntegration:
@@ -172,6 +178,6 @@ class _RetryableProviderError(Exception):
 
 
 class _RetryableFailureExtractionIntegration:
-    async def extract(self, notes: str) -> ExtractionResult:
+    async def extract(self, notes: PreparedCaptureInput | str) -> ExtractionResult:
         del notes
         raise ExtractionError("Claude request failed: retryable") from _RetryableProviderError(429)

--- a/backend/app/features/quotes/tests/test_extraction.py
+++ b/backend/app/features/quotes/tests/test_extraction.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
@@ -11,6 +12,7 @@ import httpx
 import pytest
 
 import app.integrations.extraction as extraction_module
+from app.features.quotes.schemas import PreparedCaptureInput
 from app.features.quotes.tests.fixtures.transcripts import TRANSCRIPTS
 from app.integrations.extraction import (
     EXTRACTION_TOOL_SCHEMA,
@@ -113,7 +115,7 @@ async def test_extract_preserves_total_only_payload() -> None:
                                 "price": None,
                             }
                         ],
-                        "total": 2100,
+                        "pricing_hints": {"explicit_total": 2100},
                         "confidence_notes": [],
                     },
                 }
@@ -237,7 +239,7 @@ async def test_extract_attempts_one_repair_then_accepts_valid_repaired_payload()
                                     "price": 125,
                                 }
                             ],
-                            "total": 125,
+                            "pricing_hints": {"explicit_total": 125},
                             "confidence_notes": [],
                         },
                     }
@@ -611,7 +613,7 @@ async def test_extract_adds_warning_when_total_has_no_priced_line_items() -> Non
                                 "price": None,
                             }
                         ],
-                        "total": 2100,
+                        "pricing_hints": {"explicit_total": 2100},
                         "confidence_notes": [],
                     },
                 }
@@ -625,7 +627,7 @@ async def test_extract_adds_warning_when_total_has_no_priced_line_items() -> Non
     assert result.extraction_tier == "primary"
     assert result.extraction_degraded_reason_code is None
     assert any(
-        "Total was extracted without any priced line items" in note
+        "Explicit total was extracted without any priced line items" in note
         for note in result.confidence_notes
     )
 
@@ -674,6 +676,8 @@ async def test_tool_schema_line_items_include_optional_flag_fields() -> None:
     assert line_item_schema["properties"]["flag_reason"] == {"type": ["string", "null"]}
     assert "flagged" not in line_item_schema["required"]
     assert "flag_reason" not in line_item_schema["required"]
+    assert "raw_text" in line_item_schema["required"]
+    assert "confidence" in line_item_schema["required"]
 
 
 @pytest.mark.parametrize("fixture_name", sorted(TRANSCRIPTS))
@@ -686,7 +690,17 @@ async def test_extract_exercises_all_transcript_fixtures(fixture_name: str) -> N
         assert messages
         last_message = messages[-1]
         assert isinstance(last_message, dict)
-        assert last_message["content"] == transcript
+        content = last_message["content"]
+        assert isinstance(content, str)
+        request_payload = json.loads(content)
+        prepared_capture_input = request_payload["prepared_capture_input"]
+        assert prepared_capture_input["transcript"] == transcript
+        assert prepared_capture_input["source_type"] == "text"
+        assert prepared_capture_input["raw_typed_notes"] == transcript
+        assert prepared_capture_input["raw_transcript"] is None
+        capture_segments = request_payload["capture_segments"]
+        assert capture_segments
+        assert capture_segments[0]["raw_text"]
         return _FakeResponse(
             content=[
                 {
@@ -767,7 +781,7 @@ async def test_extract_emits_trace_events_for_primary_repair_and_result_stages(
                                     "price": 125,
                                 }
                             ],
-                            "total": 125,
+                            "pricing_hints": {"explicit_total": 125},
                             "confidence_notes": [],
                         },
                     }
@@ -787,3 +801,50 @@ async def test_extract_emits_trace_events_for_primary_repair_and_result_stages(
     assert ("repair", "started") in {(call["stage"], call["outcome"]) for call in trace_calls}
     assert ("repair", "succeeded") in {(call["stage"], call["outcome"]) for call in trace_calls}
     assert ("result", "succeeded") in {(call["stage"], call["outcome"]) for call in trace_calls}
+
+
+async def test_extract_preserves_mixed_provenance_in_model_request_payload() -> None:
+    prepared_capture_input = PreparedCaptureInput(
+        transcript="voice transcript text\n\ntyped note text",
+        source_type="voice+text",
+        raw_typed_notes="typed note text",
+        raw_transcript="voice transcript text",
+    )
+    captured_messages: list[str] = []
+
+    def _factory(kwargs: dict[str, object]) -> _FakeResponse:
+        messages = kwargs["messages"]
+        assert isinstance(messages, list)
+        assert messages
+        first_message = messages[0]
+        assert isinstance(first_message, dict)
+        content = first_message["content"]
+        assert isinstance(content, str)
+        captured_messages.append(content)
+        return _FakeResponse(
+            content=[
+                {
+                    "type": "tool_use",
+                    "input": {
+                        "transcript": prepared_capture_input.transcript,
+                        "line_items": [],
+                        "confidence_notes": [],
+                    },
+                }
+            ]
+        )
+
+    integration = ExtractionIntegration(
+        api_key="test",
+        model="test-model",
+        client=_FakeClient(_factory),
+    )
+
+    result = await integration.extract(prepared_capture_input)
+
+    assert result.transcript == prepared_capture_input.transcript
+    assert captured_messages
+    request_payload = json.loads(captured_messages[0])
+    assert request_payload["prepared_capture_input"]["source_type"] == "voice+text"
+    assert request_payload["prepared_capture_input"]["raw_typed_notes"] == "typed note text"
+    assert request_payload["prepared_capture_input"]["raw_transcript"] == "voice transcript text"

--- a/backend/app/features/quotes/tests/test_extraction.py
+++ b/backend/app/features/quotes/tests/test_extraction.py
@@ -803,6 +803,82 @@ async def test_extract_emits_trace_events_for_primary_repair_and_result_stages(
     assert ("result", "succeeded") in {(call["stage"], call["outcome"]) for call in trace_calls}
 
 
+async def test_guard_flags_line_items_with_price_in_description() -> None:
+    transcript = TRANSCRIPTS["clean_with_total"]
+    client = _FakeClient(
+        lambda _: _FakeResponse(
+            content=[
+                {
+                    "type": "tool_use",
+                    "input": {
+                        "transcript": transcript,
+                        "line_items": [
+                            {
+                                "description": "Premium service $500",
+                                "details": None,
+                                "price": None,
+                            },
+                            {
+                                "description": "Standard service",
+                                "details": None,
+                                "price": 200,
+                            },
+                        ],
+                        "total": None,
+                        "confidence_notes": [],
+                    },
+                }
+            ]
+        )
+    )
+    integration = ExtractionIntegration(api_key="test", model="test-model", client=client)
+
+    result = await integration.extract(transcript)
+
+    assert result.line_items[0].flagged is True
+    assert "price token" in (result.line_items[0].flag_reason or "").lower()
+    assert result.line_items[1].flagged is False
+    assert any("price token" in note.lower() for note in result.confidence_notes)
+
+
+async def test_guard_flags_line_items_with_duplicate_details() -> None:
+    transcript = TRANSCRIPTS["clean_with_total"]
+    client = _FakeClient(
+        lambda _: _FakeResponse(
+            content=[
+                {
+                    "type": "tool_use",
+                    "input": {
+                        "transcript": transcript,
+                        "line_items": [
+                            {
+                                "description": "Mulch installation",
+                                "details": "Mulch installation",
+                                "price": 150,
+                            },
+                            {
+                                "description": "Weed removal",
+                                "details": "Spot treatment only",
+                                "price": 75,
+                            },
+                        ],
+                        "total": None,
+                        "confidence_notes": [],
+                    },
+                }
+            ]
+        )
+    )
+    integration = ExtractionIntegration(api_key="test", model="test-model", client=client)
+
+    result = await integration.extract(transcript)
+
+    assert result.line_items[0].flagged is True
+    assert "duplicate" in (result.line_items[0].flag_reason or "").lower()
+    assert result.line_items[1].flagged is False
+    assert any("duplicate" in note.lower() for note in result.confidence_notes)
+
+
 async def test_extract_preserves_mixed_provenance_in_model_request_payload() -> None:
     prepared_capture_input = PreparedCaptureInput(
         transcript="voice transcript text\n\ntyped note text",

--- a/backend/app/features/quotes/tests/test_extraction_service.py
+++ b/backend/app/features/quotes/tests/test_extraction_service.py
@@ -8,7 +8,7 @@ import pytest
 import sentry_sdk
 
 from app.features.quotes.extraction_service import CaptureAudioClip, ExtractionService
-from app.features.quotes.schemas import ExtractionResult
+from app.features.quotes.schemas import ExtractionResult, PreparedCaptureInput
 from app.features.quotes.service import QuoteServiceError
 from app.integrations.audio import AudioClip, AudioError
 from app.integrations.extraction import ExtractionError
@@ -23,8 +23,8 @@ pytestmark = pytest.mark.asyncio
 
 
 class _FailingExtractionIntegration:
-    async def extract(self, notes: str) -> ExtractionResult:
-        del notes
+    async def extract(self, capture_input: PreparedCaptureInput) -> ExtractionResult:
+        del capture_input
         raise ExtractionError("mock extraction failure")
 
 
@@ -48,12 +48,12 @@ class _SuccessfulAudioIntegration:
 
 class _SuccessfulExtractionIntegration:
     def __init__(self) -> None:
-        self.calls: list[str] = []
+        self.calls: list[PreparedCaptureInput] = []
 
-    async def extract(self, notes: str) -> ExtractionResult:
-        self.calls.append(notes)
+    async def extract(self, capture_input: PreparedCaptureInput) -> ExtractionResult:
+        self.calls.append(capture_input)
         return ExtractionResult(
-            transcript=notes,
+            transcript=capture_input.transcript,
             line_items=[],
             confidence_notes=[],
         )
@@ -131,7 +131,12 @@ async def test_extract_combined_allows_audio_and_notes_up_to_extraction_limit() 
     result = await service.extract_combined([_clip()], notes)
 
     expected_transcript = f"{transcript}\n\n{notes}"
-    assert extraction.calls == [expected_transcript]
+    assert len(extraction.calls) == 1
+    prepared_capture_input = extraction.calls[0]
+    assert prepared_capture_input.source_type == "voice+text"
+    assert prepared_capture_input.raw_typed_notes == notes
+    assert prepared_capture_input.raw_transcript == transcript
+    assert prepared_capture_input.transcript == expected_transcript
     assert result.transcript == expected_transcript
     assert len(result.transcript) == EXTRACTION_TRANSCRIPT_MAX_CHARS
 

--- a/backend/app/features/quotes/tests/test_quote_append_extraction.py
+++ b/backend/app/features/quotes/tests/test_quote_append_extraction.py
@@ -208,7 +208,12 @@ async def test_append_extraction_enqueues_async_job_for_owned_quote(
             "kwargs": {
                 "_job_id": str(jobs[0].id),
                 "correlation_id": response_correlation_id,
-                "transcript": "append this",
+                "prepared_capture_input": {
+                    "transcript": "append this",
+                    "source_type": "text",
+                    "raw_typed_notes": "append this",
+                    "raw_transcript": None,
+                },
                 "source_type": "text",
                 "capture_detail": "notes",
                 "append_to_quote": True,

--- a/backend/app/features/quotes/tests/test_quote_extraction.py
+++ b/backend/app/features/quotes/tests/test_quote_extraction.py
@@ -16,7 +16,7 @@ from app.features.jobs.models import JobRecord, JobStatus, JobType
 from app.features.jobs.repository import JobRepository
 from app.features.quotes.extraction_service import ExtractionService
 from app.features.quotes.models import Document, QuoteStatus
-from app.features.quotes.schemas import ExtractionResult
+from app.features.quotes.schemas import ExtractionResult, PreparedCaptureInput
 from app.features.quotes.service import QuoteService, QuoteServiceError
 from app.features.quotes.tests import test_quotes as quotes_test_module
 from app.features.quotes.tests.support.helpers import (
@@ -279,7 +279,12 @@ async def test_extract_combined_enqueues_async_job_when_arq_pool_is_available(
             "kwargs": {
                 "_job_id": str(jobs[0].id),
                 "correlation_id": response_correlation_id,
-                "transcript": "mulch the front beds",
+                "prepared_capture_input": {
+                    "transcript": "mulch the front beds",
+                    "source_type": "text",
+                    "raw_typed_notes": "mulch the front beds",
+                    "raw_transcript": None,
+                },
                 "source_type": "text",
                 "capture_detail": "notes",
                 "customer_id": None,
@@ -743,11 +748,11 @@ async def test_convert_notes_rejects_when_concurrency_limit_is_exhausted(
             self.started = asyncio.Event()
             self.release = asyncio.Event()
 
-        async def extract(self, notes: str) -> ExtractionResult:
+        async def extract(self, notes: PreparedCaptureInput) -> ExtractionResult:
             self.started.set()
             await self.release.wait()
             return ExtractionResult(
-                transcript=notes,
+                transcript=notes.transcript,
                 line_items=[],
                 total=None,
                 confidence_notes=[],

--- a/backend/app/integrations/extraction.py
+++ b/backend/app/integrations/extraction.py
@@ -15,7 +15,15 @@ import anthropic
 from anthropic import AsyncAnthropic
 from pydantic import ValidationError
 
-from app.features.quotes.schemas import ExtractionResult, LineItemExtracted
+from app.features.quotes.schemas import (
+    CaptureSegment,
+    CaptureSegmentHints,
+    ExtractionResult,
+    ExtractionResultV2,
+    LineItemExtractedV2,
+    PreparedCaptureInput,
+    PricingHints,
+)
 from app.shared.extraction_logger import log_extraction_trace
 from app.shared.input_limits import (
     CONFIDENCE_NOTE_MAX_CHARS,
@@ -33,12 +41,17 @@ EXTRACTION_TOOL_SCHEMA: dict[str, Any] = {
     "type": "object",
     "properties": {
         "transcript": {"type": "string", "maxLength": EXTRACTION_TRANSCRIPT_MAX_CHARS},
+        "pipeline_version": {"type": "string", "enum": ["v2"]},
         "line_items": {
             "type": "array",
             "maxItems": DOCUMENT_LINE_ITEMS_MAX_ITEMS,
             "items": {
                 "type": "object",
                 "properties": {
+                    "raw_text": {
+                        "type": "string",
+                        "maxLength": EXTRACTION_TRANSCRIPT_MAX_CHARS,
+                    },
                     "description": {
                         "type": "string",
                         "maxLength": LINE_ITEM_DESCRIPTION_MAX_CHARS,
@@ -50,12 +63,66 @@ EXTRACTION_TOOL_SCHEMA: dict[str, Any] = {
                     "price": {"type": ["number", "null"]},
                     "flagged": {"type": "boolean"},
                     "flag_reason": {"type": ["string", "null"]},
+                    "confidence": {"type": "string", "enum": ["high", "medium", "low"]},
                 },
-                "required": ["description"],
+                "required": ["raw_text", "description", "confidence"],
                 "additionalProperties": False,
             },
         },
-        "total": {"type": ["number", "null"]},
+        "pricing_hints": {
+            "type": "object",
+            "properties": {
+                "explicit_total": {"type": ["number", "null"]},
+                "deposit_amount": {"type": ["number", "null"]},
+                "tax_rate": {"type": ["number", "null"]},
+                "discount_type": {"type": ["string", "null"], "enum": ["fixed", "percent", None]},
+                "discount_value": {"type": ["number", "null"]},
+            },
+            "additionalProperties": False,
+        },
+        "customer_notes_suggestion": {
+            "type": ["object", "null"],
+            "properties": {
+                "text": {
+                    "type": "string",
+                    "maxLength": LINE_ITEM_DETAILS_MAX_CHARS,
+                },
+                "confidence": {"type": "string", "enum": ["high", "medium", "low"]},
+                "source": {
+                    "type": "string",
+                    "enum": [
+                        "leftover_classification",
+                        "typed_conflict",
+                        "transcript_conflict",
+                    ],
+                },
+            },
+            "required": ["text", "confidence", "source"],
+            "additionalProperties": False,
+        },
+        "unresolved_segments": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "raw_text": {
+                        "type": "string",
+                        "maxLength": EXTRACTION_TRANSCRIPT_MAX_CHARS,
+                    },
+                    "confidence": {"type": "string", "enum": ["medium", "low"]},
+                    "source": {
+                        "type": "string",
+                        "enum": [
+                            "leftover_classification",
+                            "typed_conflict",
+                            "transcript_conflict",
+                        ],
+                    },
+                },
+                "required": ["raw_text", "confidence", "source"],
+                "additionalProperties": False,
+            },
+        },
         "confidence_notes": {
             "type": "array",
             "maxItems": CONFIDENCE_NOTES_MAX_ITEMS,
@@ -65,13 +132,23 @@ EXTRACTION_TOOL_SCHEMA: dict[str, Any] = {
             },
         },
     },
-    "required": ["transcript", "line_items", "confidence_notes"],
+    "required": [
+        "transcript",
+        "pipeline_version",
+        "line_items",
+        "pricing_hints",
+        "customer_notes_suggestion",
+        "unresolved_segments",
+        "confidence_notes",
+    ],
     "additionalProperties": False,
 }
 
 EXTRACTION_SYSTEM_PROMPT = (
-    "Extract quote line items and totals from contractor notes. "
-    "Do not invent pricing. Use null for missing prices and totals. "
+    "Extract quote line items, pricing hints, and unresolved capture details from structured "
+    "capture input. "
+    "Do not invent pricing. Use null for missing values and keep confidence_notes sparse "
+    "and operator-relevant. "
     "Set line-item flagged=true only for strong review signals: likely audio mishears, "
     "clearly implausible single-item prices, or critically ambiguous quantity/unit phrasing. "
     "When flagged=true, include a short flag_reason. Keep flagged false otherwise. "
@@ -99,13 +176,18 @@ _SEMANTIC_NOTE_EMPTY_LINE_ITEMS_SUBSTANTIAL_TRANSCRIPT = (
     "No line items were extracted from a substantial transcript; manual review is required."
 )
 _SEMANTIC_NOTE_TOTAL_WITHOUT_PRICED_ITEMS = (
-    "Total was extracted without any priced line items; review pricing details."
+    "Explicit total was extracted without any priced line items; review pricing details."
 )
 _SEMANTIC_NOTE_DUPLICATE_LINE_ITEMS = (
     "Duplicate extracted line items were detected and flagged for review."
 )
 _SEMANTIC_FLAG_REASON_DUPLICATE_LINE_ITEM = "Possible duplicate line item from extraction output"
 _WHITESPACE_PATTERN = re.compile(r"\s+")
+_BLANK_LINE_SPLIT_PATTERN = re.compile(r"\n\s*\n+")
+_BULLET_PREFIX_PATTERN = re.compile(r"^\s*(?:[-*•]|\d+[.)])\s+")
+_HEADING_PATTERN = re.compile(r"^[A-Za-z][A-Za-z0-9 /\-]{0,40}:\s*$")
+_NOTES_HEADING_PATTERN = re.compile(r"^\s*notes?\s*:\s*$", re.IGNORECASE)
+_PRICE_PATTERN = re.compile(r"\$?\s*(\d+(?:\.\d{1,2})?)")
 
 _RETRY_BASE_DELAY_SECONDS = 0.25
 _RETRY_MAX_DELAY_SECONDS = 2.0
@@ -171,11 +253,9 @@ class ExtractionIntegration:
         )
         self._client = client
 
-    async def extract(self, notes: str) -> ExtractionResult:
-        """Call Claude structured output and validate the response contract."""
-        normalized_notes = notes.strip()
-        if not normalized_notes:
-            raise ExtractionError("notes cannot be empty")
+    async def extract(self, capture_input: PreparedCaptureInput | str) -> ExtractionResult:
+        """Call Claude structured output and validate the V2 contract."""
+        prepared_input = _coerce_prepared_capture_input(capture_input)
         _set_last_call_metadata(
             model_id=self._primary_model,
             token_usage=None,
@@ -203,7 +283,7 @@ class ExtractionIntegration:
             try:
                 return await self._extract_for_tier(
                     typed_client,
-                    normalized_notes,
+                    prepared_input,
                     tier=tier,
                 )
             except ExtractionError as exc:
@@ -264,18 +344,19 @@ class ExtractionIntegration:
     async def _extract_for_tier(
         self,
         typed_client: Any,
-        normalized_notes: str,
+        prepared_input: PreparedCaptureInput,
         *,
         tier: _ExtractionTierConfig,
     ) -> ExtractionResult:
+        request_content = _build_extraction_request(prepared_input)
         log_extraction_trace(
             _TRACE_EVENT_NAME,
             stage=tier.tier,
             outcome="started",
             extraction_model_id=tier.model_id,
             extraction_prompt_variant=tier.prompt_variant,
-            transcript_chars=len(normalized_notes),
-            raw_transcript=normalized_notes,
+            transcript_chars=len(prepared_input.transcript),
+            raw_transcript=prepared_input.transcript,
         )
         _set_last_call_metadata(
             model_id=tier.model_id,
@@ -286,7 +367,7 @@ class ExtractionIntegration:
 
         response = await self._request_with_retry(
             typed_client,
-            normalized_notes,
+            request_content,
             model_id=tier.model_id,
             invocation_tier=tier.tier,
             prompt_variant=tier.prompt_variant,
@@ -304,9 +385,14 @@ class ExtractionIntegration:
         )
 
         payload = _extract_tool_payload(response)
-        payload.setdefault("transcript", normalized_notes)
+        payload.setdefault("transcript", prepared_input.transcript)
+        payload.setdefault("pipeline_version", "v2")
         payload.setdefault("line_items", [])
+        payload.setdefault("pricing_hints", {})
+        payload.setdefault("customer_notes_suggestion", None)
+        payload.setdefault("unresolved_segments", [])
         payload.setdefault("confidence_notes", [])
+        payload["line_items"] = _normalize_line_item_payloads(payload.get("line_items"))
         log_extraction_trace(
             _TRACE_EVENT_NAME,
             stage=tier.tier,
@@ -317,14 +403,18 @@ class ExtractionIntegration:
             token_output_tokens=_token_usage_value(response_token_usage, "output_tokens"),
             line_item_count=_list_count(payload.get("line_items")),
             confidence_note_count=_list_count(payload.get("confidence_notes")),
-            total_present=payload.get("total") is not None if "total" in payload else None,
-            raw_transcript=normalized_notes,
+            total_present=(
+                _pricing_hints_payload(payload.get("pricing_hints")).get("explicit_total")
+                is not None
+            ),
+            raw_transcript=prepared_input.transcript,
             raw_tool_payload=payload,
         )
 
         try:
-            validated_result = ExtractionResult.model_validate(payload)
-            result = _apply_semantic_guard_rules(validated_result)
+            validated_result_v2 = ExtractionResultV2.model_validate(payload)
+            guarded_result_v2 = _apply_semantic_guard_rules(validated_result_v2)
+            result = guarded_result_v2.to_v1_result()
             _log_result_trace(
                 result=result,
                 invocation_tier=tier.tier,
@@ -346,14 +436,14 @@ class ExtractionIntegration:
                 extraction_model_id=response_model_id,
                 extraction_prompt_variant=repair_prompt_variant,
                 validation_error_count=len(validation_errors),
-                raw_transcript=normalized_notes,
+                raw_transcript=prepared_input.transcript,
                 raw_tool_payload=payload,
             )
             try:
                 repair_response = await self._request_with_retry(
                     typed_client,
                     _build_repair_request(
-                        notes=normalized_notes,
+                        notes=request_content,
                         invalid_payload=payload,
                         validation_errors=validation_errors,
                     ),
@@ -387,11 +477,18 @@ class ExtractionIntegration:
             repair_usage = _extract_token_usage(repair_response)
             repair_model_id = getattr(repair_response, "model", None) or tier.model_id
             repair_payload = _extract_tool_payload(repair_response)
-            repair_payload.setdefault("transcript", normalized_notes)
+            repair_payload.setdefault("transcript", prepared_input.transcript)
+            repair_payload.setdefault("pipeline_version", "v2")
             repair_payload.setdefault("line_items", [])
+            repair_payload.setdefault("pricing_hints", {})
+            repair_payload.setdefault("customer_notes_suggestion", None)
+            repair_payload.setdefault("unresolved_segments", [])
             repair_payload.setdefault("confidence_notes", [])
+            repair_payload["line_items"] = _normalize_line_item_payloads(
+                repair_payload.get("line_items")
+            )
             try:
-                repaired_result = ExtractionResult.model_validate(repair_payload)
+                repaired_result_v2 = ExtractionResultV2.model_validate(repair_payload)
             except ValidationError:
                 _set_last_call_metadata(
                     model_id=repair_model_id,
@@ -414,11 +511,11 @@ class ExtractionIntegration:
                     reason="repair_invalid",
                     token_input_tokens=_token_usage_value(repair_usage, "input_tokens"),
                     token_output_tokens=_token_usage_value(repair_usage, "output_tokens"),
-                    raw_transcript=normalized_notes,
+                    raw_transcript=prepared_input.transcript,
                     raw_tool_payload=repair_payload,
                 )
                 degraded_result = _build_validation_repair_failed_result(
-                    transcript=normalized_notes
+                    transcript=prepared_input.transcript
                 )
                 _log_result_trace(
                     result=degraded_result,
@@ -449,12 +546,16 @@ class ExtractionIntegration:
                 line_item_count=_list_count(repair_payload.get("line_items")),
                 confidence_note_count=_list_count(repair_payload.get("confidence_notes")),
                 total_present=(
-                    repair_payload.get("total") is not None if "total" in repair_payload else None
+                    _pricing_hints_payload(repair_payload.get("pricing_hints")).get(
+                        "explicit_total"
+                    )
+                    is not None
                 ),
-                raw_transcript=normalized_notes,
+                raw_transcript=prepared_input.transcript,
                 raw_tool_payload=repair_payload,
             )
-            result = _apply_semantic_guard_rules(repaired_result)
+            guarded_result_v2 = _apply_semantic_guard_rules(repaired_result_v2)
+            result = guarded_result_v2.to_v1_result()
             _log_result_trace(
                 result=result,
                 invocation_tier=tier.tier,
@@ -491,8 +592,8 @@ class ExtractionIntegration:
                         {
                             "name": EXTRACTION_TOOL_NAME,
                             "description": (
-                                "Extract quote line items, optional per-item pricing, "
-                                "optional total, and confidence notes."
+                                "Extract quote line items, pricing hints, unresolved segments, "
+                                "optional customer-notes suggestion, and sparse confidence notes."
                             ),
                             "input_schema": EXTRACTION_TOOL_SCHEMA,
                         }
@@ -565,6 +666,139 @@ def _extract_tool_payload(response: object) -> dict[str, Any]:
             return dict(tool_input)
 
     raise ExtractionError("Claude response missing structured tool output")
+
+
+def _coerce_prepared_capture_input(
+    capture_input: PreparedCaptureInput | str,
+) -> PreparedCaptureInput:
+    if isinstance(capture_input, PreparedCaptureInput):
+        return capture_input
+    normalized_text = capture_input.strip()
+    if not normalized_text:
+        raise ExtractionError("notes cannot be empty")
+    return PreparedCaptureInput.from_legacy_transcript(
+        transcript=normalized_text,
+        source_type="text",
+    )
+
+
+def _build_extraction_request(prepared_input: PreparedCaptureInput) -> str:
+    segments = _segment_capture_input(prepared_input.transcript)
+    request_payload = {
+        "prepared_capture_input": prepared_input.model_dump(mode="json"),
+        "capture_segments": [segment.model_dump(mode="json") for segment in segments],
+        "instructions": {
+            "line_item_description_rule": (
+                "Use short customer-facing labels; move remainder to details."
+            ),
+            "pricing_rule": (
+                "Do not invent pricing. Use pricing_hints for explicit pricing directives only."
+            ),
+            "confidence_notes_rule": "Only include sparse, operator-relevant review notes.",
+        },
+    }
+    return json.dumps(request_payload, ensure_ascii=True, separators=(",", ":"))
+
+
+def _segment_capture_input(transcript: str) -> list[CaptureSegment]:
+    stripped = transcript.strip()
+    if not stripped:
+        return []
+
+    chunks: list[str] = []
+    for block in _BLANK_LINE_SPLIT_PATTERN.split(stripped):
+        block_text = block.strip()
+        if not block_text:
+            continue
+        lines = [line.strip() for line in block_text.splitlines() if line.strip()]
+        if not lines:
+            continue
+        if len(lines) == 1:
+            chunks.append(lines[0])
+            continue
+        for line in lines:
+            if _BULLET_PREFIX_PATTERN.match(line):
+                chunks.append(line)
+            elif _HEADING_PATTERN.match(line):
+                chunks.append(line)
+            else:
+                chunks.append(line)
+
+    segments: list[CaptureSegment] = []
+    for index, raw_text in enumerate(chunks):
+        normalized_text = _normalize_segment_text(raw_text)
+        hints = _build_segment_hints(raw_text=raw_text, normalized_text=normalized_text)
+        segments.append(
+            CaptureSegment(
+                index=index,
+                raw_text=raw_text,
+                normalized_text=normalized_text,
+                hints=hints,
+            )
+        )
+    return segments
+
+
+def _normalize_segment_text(text: str) -> str:
+    normalized = _WHITESPACE_PATTERN.sub(" ", text.strip())
+    normalized = re.sub(r"\bw/\b", "with", normalized, flags=re.IGNORECASE)
+    normalized = normalized.replace("+", " and ")
+    return _WHITESPACE_PATTERN.sub(" ", normalized).strip()
+
+
+def _build_segment_hints(*, raw_text: str, normalized_text: str) -> CaptureSegmentHints:
+    explicit_price_match = _PRICE_PATTERN.search(raw_text)
+    price_value = (
+        _parse_price_value(explicit_price_match.group(1)) if explicit_price_match else None
+    )
+    looks_like_heading = _HEADING_PATTERN.match(raw_text) is not None
+    looks_like_notes_heading = _NOTES_HEADING_PATTERN.match(raw_text) is not None
+    looks_like_line_item = _BULLET_PREFIX_PATTERN.match(raw_text) is not None or (
+        price_value is not None and not looks_like_heading
+    )
+    return CaptureSegmentHints(
+        has_explicit_price=price_value is not None,
+        price_value=price_value,
+        looks_like_heading=looks_like_heading,
+        looks_like_notes_heading=looks_like_notes_heading,
+        looks_like_line_item=looks_like_line_item,
+    )
+
+
+def _parse_price_value(candidate: str) -> float | None:
+    try:
+        return float(candidate)
+    except ValueError:
+        return None
+
+
+def _normalize_line_item_payloads(value: object) -> object:
+    if not isinstance(value, list):
+        return value
+
+    normalized_items: list[dict[str, Any]] = []
+    for item in value:
+        if not isinstance(item, dict):
+            continue
+        normalized_item = dict(item)
+        description = normalized_item.get("description")
+        normalized_item.setdefault(
+            "raw_text",
+            (
+                description
+                if isinstance(description, str) and description.strip()
+                else "Unspecified item"
+            ),
+        )
+        normalized_item.setdefault("confidence", "medium")
+        normalized_items.append(normalized_item)
+    return normalized_items
+
+
+def _pricing_hints_payload(value: object) -> dict[str, Any]:
+    if isinstance(value, dict):
+        return value
+    return PricingHints().model_dump(mode="json")
 
 
 def _is_retryable_provider_error(exc: Exception) -> bool:
@@ -736,12 +970,12 @@ def _build_validation_repair_failed_result(*, transcript: str) -> ExtractionResu
     )
 
 
-def _apply_semantic_guard_rules(result: ExtractionResult) -> ExtractionResult:
+def _apply_semantic_guard_rules(result: ExtractionResultV2) -> ExtractionResultV2:
     """Apply incident-informed semantic checks after schema validation succeeds.
 
     Rule outcomes are intentionally constrained:
     - Empty line items + substantial transcript -> degraded (allowlisted structural failure).
-    - Total without priced line items -> warning note only (tier remains primary).
+    - Explicit total without priced line items -> warning note only (tier remains primary).
     - Duplicate extracted line items -> line-level flags + warning note only.
     """
 
@@ -761,6 +995,8 @@ def _apply_semantic_guard_rules(result: ExtractionResult) -> ExtractionResult:
     if _should_warn_for_total_without_priced_items(result):
         _append_semantic_note(confidence_notes, _SEMANTIC_NOTE_TOTAL_WITHOUT_PRICED_ITEMS)
 
+    line_items = _flag_line_items_with_price_in_description(line_items, confidence_notes)
+    line_items = _flag_line_items_with_duplicate_details(line_items, confidence_notes)
     line_items = _apply_duplicate_line_item_flags(line_items, confidence_notes)
 
     return result.model_copy(
@@ -774,7 +1010,7 @@ def _apply_semantic_guard_rules(result: ExtractionResult) -> ExtractionResult:
 
 
 def _should_degrade_for_empty_line_items_with_substantial_transcript(
-    result: ExtractionResult,
+    result: ExtractionResultV2,
 ) -> bool:
     if result.extraction_tier == "degraded" or result.line_items:
         return False
@@ -784,18 +1020,18 @@ def _should_degrade_for_empty_line_items_with_substantial_transcript(
     return len(normalized_transcript.split()) >= _SEMANTIC_EMPTY_LINE_ITEMS_MIN_WORDS
 
 
-def _should_warn_for_total_without_priced_items(result: ExtractionResult) -> bool:
+def _should_warn_for_total_without_priced_items(result: ExtractionResultV2) -> bool:
     return (
-        result.total is not None
+        result.pricing_hints.explicit_total is not None
         and bool(result.line_items)
         and not any(item.price is not None for item in result.line_items)
     )
 
 
 def _apply_duplicate_line_item_flags(
-    line_items: list[LineItemExtracted],
+    line_items: list[LineItemExtractedV2],
     confidence_notes: list[str],
-) -> list[LineItemExtracted]:
+) -> list[LineItemExtractedV2]:
     duplicate_groups: dict[tuple[str, float | None], list[int]] = {}
     for index, item in enumerate(line_items):
         normalized_description = _normalize_line_item_description(item.description)
@@ -823,6 +1059,62 @@ def _apply_duplicate_line_item_flags(
     return updated_items
 
 
+def _flag_line_items_with_price_in_description(
+    line_items: list[LineItemExtractedV2],
+    confidence_notes: list[str],
+) -> list[LineItemExtractedV2]:
+    flagged_indexes = [
+        index for index, item in enumerate(line_items) if _contains_price_token(item.description)
+    ]
+    if not flagged_indexes:
+        return line_items
+
+    _append_semantic_note(
+        confidence_notes,
+        "Line-item descriptions should not include price tokens; review flagged items.",
+    )
+    updated_items = list(line_items)
+    for index in flagged_indexes:
+        current = updated_items[index]
+        updated_items[index] = current.model_copy(
+            update={
+                "flagged": True,
+                "flag_reason": current.flag_reason or "Description includes price tokens",
+            }
+        )
+    return updated_items
+
+
+def _flag_line_items_with_duplicate_details(
+    line_items: list[LineItemExtractedV2],
+    confidence_notes: list[str],
+) -> list[LineItemExtractedV2]:
+    flagged_indexes = [
+        index
+        for index, item in enumerate(line_items)
+        if item.details is not None
+        and _normalize_line_item_description(item.details)
+        == _normalize_line_item_description(item.description)
+    ]
+    if not flagged_indexes:
+        return line_items
+
+    _append_semantic_note(
+        confidence_notes,
+        "Some line-item details duplicate the description; review flagged items.",
+    )
+    updated_items = list(line_items)
+    for index in flagged_indexes:
+        current = updated_items[index]
+        updated_items[index] = current.model_copy(
+            update={
+                "flagged": True,
+                "flag_reason": current.flag_reason or "Details duplicate description",
+            }
+        )
+    return updated_items
+
+
 def _normalize_line_item_description(value: str) -> str:
     collapsed_whitespace = _WHITESPACE_PATTERN.sub(" ", value.strip())
     return collapsed_whitespace.casefold()
@@ -834,3 +1126,7 @@ def _append_semantic_note(confidence_notes: list[str], note: str) -> None:
     if len(confidence_notes) >= CONFIDENCE_NOTES_MAX_ITEMS:
         return
     confidence_notes.append(note)
+
+
+def _contains_price_token(text: str) -> bool:
+    return _PRICE_PATTERN.search(text) is not None

--- a/backend/app/integrations/extraction.py
+++ b/backend/app/integrations/extraction.py
@@ -716,13 +716,7 @@ def _segment_capture_input(transcript: str) -> list[CaptureSegment]:
         if len(lines) == 1:
             chunks.append(lines[0])
             continue
-        for line in lines:
-            if _BULLET_PREFIX_PATTERN.match(line):
-                chunks.append(line)
-            elif _HEADING_PATTERN.match(line):
-                chunks.append(line)
-            else:
-                chunks.append(line)
+        chunks.extend(lines)
 
     segments: list[CaptureSegment] = []
     for index, raw_text in enumerate(chunks):

--- a/backend/app/worker/job_registry.py
+++ b/backend/app/worker/job_registry.py
@@ -12,6 +12,7 @@ from typing import Any, Literal, cast
 from uuid import UUID
 
 from arq.worker import Retry, func
+from pydantic import ValidationError
 
 from app.core.config import get_settings
 from app.features.invoices.email_delivery_service import InvoiceEmailDeliveryService
@@ -26,7 +27,7 @@ from app.features.quotes.extraction_outcomes import (
     should_persist_degraded_retryable_error,
 )
 from app.features.quotes.repository import QuoteEmailContext, QuoteRepository
-from app.features.quotes.schemas import ExtractionResult
+from app.features.quotes.schemas import ExtractionResult, PreparedCaptureInput
 from app.features.quotes.service import QuoteService, QuoteServiceError
 from app.integrations.email import EmailService
 from app.integrations.extraction import (
@@ -81,14 +82,20 @@ async def extraction_job(
     job_id: str,
     *,
     correlation_id: str | None = None,
-    transcript: str,
+    transcript: str | None = None,
+    prepared_capture_input: dict[str, Any] | PreparedCaptureInput | None = None,
     source_type: str = "text",
     capture_detail: str | None = None,
     customer_id: str | None = None,
     append_to_quote: bool = False,
 ) -> None:
-    """Run durable quote extraction against the transcript prepared by the API."""
+    """Run durable quote extraction against prepared capture input."""
     parsed_job_id = UUID(job_id)
+    resolved_capture_input = _resolve_prepared_capture_input(
+        transcript=transcript,
+        prepared_capture_input=prepared_capture_input,
+        source_type=source_type,
+    )
     resolved_capture_detail = _resolve_worker_capture_detail(
         source_type=source_type,
         capture_detail=capture_detail,
@@ -100,7 +107,11 @@ async def extraction_job(
             job_type=JobType.EXTRACTION,
             job_name=EXTRACTION_JOB_NAME,
             correlation_id=correlation_id,
-            handler=lambda: _extract_quote_data(ctx, transcript, job_id=parsed_job_id),
+            handler=lambda: _extract_quote_data(
+                ctx,
+                resolved_capture_input,
+                job_id=parsed_job_id,
+            ),
             on_success=lambda runtime, result: _store_extraction_result(
                 runtime,
                 job_id=parsed_job_id,
@@ -226,7 +237,7 @@ async def _deliver_email(ctx: dict[str, Any], *, job_id: UUID) -> None:
 
 async def _extract_quote_data(
     ctx: dict[str, Any],
-    transcript: str,
+    prepared_capture_input: PreparedCaptureInput,
     *,
     job_id: UUID,
 ) -> ExtractionResult:
@@ -245,7 +256,7 @@ async def _extract_quote_data(
     )
 
     try:
-        result = await extraction_integration.extract(transcript)
+        result = await extraction_integration.extract(prepared_capture_input)
     except ExtractionError as exc:
         metadata = _pop_extraction_call_metadata(extraction_integration)
         resolved_last_model_id = _resolve_last_model_id(
@@ -277,13 +288,13 @@ async def _extract_quote_data(
                 metadata.repair_validation_error_count if metadata is not None else None
             ),
             error_class=_compact_error_class(exc),
-            transcript_sha256=_transcript_sha256(transcript),
+            transcript_sha256=_transcript_sha256(prepared_capture_input.transcript),
         )
         if should_persist_degraded_retryable_error(
             exc,
             is_final_attempt=is_final_attempt,
         ):
-            return build_degraded_extraction_result(transcript=transcript)
+            return build_degraded_extraction_result(transcript=prepared_capture_input.transcript)
         if is_retryable:
             raise RetryableJobError(str(exc)) from exc
         raise
@@ -314,7 +325,7 @@ async def _extract_quote_data(
             extraction_degraded_reason_code=result.extraction_degraded_reason_code,
             repair_validation_error_count=metadata.repair_validation_error_count,
             token_usage=metadata.token_usage,
-            transcript_sha256=_transcript_sha256(transcript),
+            transcript_sha256=_transcript_sha256(prepared_capture_input.transcript),
         )
     return result
 
@@ -496,6 +507,32 @@ def _resolve_worker_capture_detail(*, source_type: str, capture_detail: str | No
     if source_type == "voice":
         return "audio"
     return "notes"
+
+
+def _resolve_prepared_capture_input(
+    *,
+    transcript: str | None,
+    prepared_capture_input: dict[str, Any] | PreparedCaptureInput | None,
+    source_type: str,
+) -> PreparedCaptureInput:
+    if isinstance(prepared_capture_input, PreparedCaptureInput):
+        return prepared_capture_input
+    if isinstance(prepared_capture_input, dict):
+        try:
+            return PreparedCaptureInput.model_validate(prepared_capture_input)
+        except ValidationError as exc:
+            raise NonRetryableJobError("Extraction job prepared_capture_input is invalid") from exc
+
+    normalized_transcript = (transcript or "").strip()
+    if not normalized_transcript:
+        raise NonRetryableJobError(
+            "Extraction job requires transcript or prepared_capture_input payload"
+        )
+    prepared_source_type: Literal["text", "voice"] = "voice" if source_type == "voice" else "text"
+    return PreparedCaptureInput.from_legacy_transcript(
+        transcript=normalized_transcript,
+        source_type=prepared_source_type,
+    )
 
 
 async def _store_extraction_result(

--- a/backend/app/worker/tests/test_job_registry.py
+++ b/backend/app/worker/tests/test_job_registry.py
@@ -11,7 +11,7 @@ from app.features.auth.models import User
 from app.features.jobs.models import JobRecord, JobStatus, JobType
 from app.features.jobs.repository import JobRepository
 from app.features.quotes.models import Document
-from app.features.quotes.schemas import ExtractionResult
+from app.features.quotes.schemas import ExtractionResult, PreparedCaptureInput
 from app.features.quotes.service import QuoteServiceError
 from app.integrations.extraction import ExtractionCallMetadata, ExtractionError
 from app.shared import event_logger, observability
@@ -65,10 +65,11 @@ async def test_extraction_job_accepts_legacy_enqueued_payload_without_source_met
     record = await repository.create(user_id=user.id, job_type=JobType.EXTRACTION)
     await db_session.commit()
 
+    capture_integration = _CaptureInputExtractionIntegration()
     await extraction_job(
         _worker_context(
             db_session,
-            extraction_integration=_SuccessfulExtractionIntegration(),
+            extraction_integration=capture_integration,
         ),
         str(record.id),
         transcript="legacy queued transcript",
@@ -83,6 +84,11 @@ async def test_extraction_job_accepts_legacy_enqueued_payload_without_source_met
     assert persisted_quote is not None  # nosec B101 - pytest assertion
     assert persisted_quote.source_type == "text"  # nosec B101 - pytest assertion
     assert persisted_quote.transcript == "legacy queued transcript"  # nosec B101 - pytest assertion
+    assert len(capture_integration.received_inputs) == 1  # nosec B101 - pytest assertion
+    legacy_input = capture_integration.received_inputs[0]
+    assert legacy_input.source_type == "text"  # nosec B101 - pytest assertion
+    assert legacy_input.raw_typed_notes == "legacy queued transcript"  # nosec B101 - pytest assertion
+    assert legacy_input.raw_transcript is None  # nosec B101 - pytest assertion
 
 
 async def test_extraction_job_marks_terminal_when_draft_persistence_fails(
@@ -322,9 +328,26 @@ async def test_extraction_job_uses_enqueued_correlation_id_and_logs_failure_meta
 
 
 class _SuccessfulExtractionIntegration:
-    async def extract(self, notes: str) -> ExtractionResult:
+    async def extract(self, notes: PreparedCaptureInput | str) -> ExtractionResult:
+        transcript = _capture_transcript(notes)
         return ExtractionResult(
-            transcript=notes,
+            transcript=transcript,
+            line_items=[],
+            total=None,
+            confidence_notes=[],
+        )
+
+
+class _CaptureInputExtractionIntegration:
+    def __init__(self) -> None:
+        self.received_inputs: list[PreparedCaptureInput] = []
+
+    async def extract(self, notes: PreparedCaptureInput | str) -> ExtractionResult:
+        transcript = _capture_transcript(notes)
+        if isinstance(notes, PreparedCaptureInput):
+            self.received_inputs.append(notes)
+        return ExtractionResult(
+            transcript=transcript,
             line_items=[],
             total=None,
             confidence_notes=[],
@@ -338,7 +361,7 @@ class _RetryableProviderError(Exception):
 
 
 class _RetryableFailureExtractionIntegration:
-    async def extract(self, notes: str) -> ExtractionResult:
+    async def extract(self, notes: PreparedCaptureInput | str) -> ExtractionResult:
         del notes
         raise ExtractionError("Claude request failed: retryable") from _RetryableProviderError(429)
 
@@ -346,9 +369,10 @@ class _RetryableFailureExtractionIntegration:
 class _ValidationRepairFailedExtractionIntegration:
     model_id = "claude-haiku-4-5-20251001"
 
-    async def extract(self, notes: str) -> ExtractionResult:
+    async def extract(self, notes: PreparedCaptureInput | str) -> ExtractionResult:
+        transcript = _capture_transcript(notes)
         return ExtractionResult(
-            transcript=notes,
+            transcript=transcript,
             line_items=[],
             total=None,
             confidence_notes=[],
@@ -367,7 +391,7 @@ class _ValidationRepairFailedExtractionIntegration:
 
 
 class _NonRetryableFailureExtractionIntegration:
-    async def extract(self, notes: str) -> ExtractionResult:
+    async def extract(self, notes: PreparedCaptureInput | str) -> ExtractionResult:
         del notes
         raise ExtractionError("Claude request failed: malformed payload")
 
@@ -381,7 +405,7 @@ class _NonRetryableProviderError(Exception):
 class _MetadataFailureExtractionIntegration:
     model_id = "claude-haiku-4-5-20251001"
 
-    async def extract(self, notes: str) -> ExtractionResult:
+    async def extract(self, notes: PreparedCaptureInput | str) -> ExtractionResult:
         del notes
         raise ExtractionError(
             "Claude request failed: malformed payload"
@@ -405,6 +429,12 @@ async def _seed_user(db_session: AsyncSession) -> User:
     db_session.add(user)
     await db_session.flush()
     return user
+
+
+def _capture_transcript(notes: PreparedCaptureInput | str) -> str:
+    if isinstance(notes, PreparedCaptureInput):
+        return notes.transcript
+    return notes
 
 
 def _worker_context(


### PR DESCRIPTION
## Summary
- add internal V2 extraction contracts (`ExtractionResultV2`, `PreparedCaptureInput`, segmentation hints/types) while preserving V1 API and persistence output shapes
- refactor extraction orchestration/integration to run on `PreparedCaptureInput` provenance and deterministic capture segmentation before model invocation
- update extraction schema/prompt/validation/repair/guard flow to validate V2 tool payloads and project safely back to V1 results
- add worker payload bridge so `jobs.extraction` accepts both legacy `transcript` kwargs and structured `prepared_capture_input` payloads
- update quote async enqueue paths to send structured capture input and extend tests for provenance + legacy worker compatibility

## Verification
- `cd backend && .venv/bin/ruff check . --cache-dir .ruff_cache && .venv/bin/ruff format --check .`
- `cd backend && .venv/bin/pytest app/features/quotes/tests/test_extraction.py app/features/quotes/tests/test_extraction_service.py app/features/quotes/tests/test_quote_extraction.py -v -m "not live and not extraction_eval and not extraction_quality" -o cache_dir=.pytest_cache`
- `cd backend && .venv/bin/pytest app/worker/tests/test_job_registry.py app/features/quotes/tests/test_quote_append_extraction.py -v -m "not live and not extraction_eval and not extraction_quality" -o cache_dir=.pytest_cache`
- `make backend-verify`

Closes #395