### PR TITLE
Task #396: V2 extraction API migration, seeding, sidecar, line-item flags

### DIFF
--- a/backend/alembic/versions/20260415_0023_add_extraction_review_sidecar_and_line_item_flags.py
+++ b/backend/alembic/versions/20260415_0023_add_extraction_review_sidecar_and_line_item_flags.py
@@ -1,0 +1,48 @@
+"""Add extraction review metadata sidecar and line-item flag columns.
+
+Revision ID: 20260415_0023
+Revises: 20260410_0022
+Create Date: 2026-04-15
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = "20260415_0023"
+down_revision: str | None = "20260410_0022"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "documents",
+        sa.Column(
+            "extraction_review_metadata",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=True,
+        ),
+    )
+
+    op.add_column(
+        "line_items",
+        sa.Column(
+            "flagged",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+    )
+    op.add_column("line_items", sa.Column("flag_reason", sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("line_items", "flag_reason")
+    op.drop_column("line_items", "flagged")
+    op.drop_column("documents", "extraction_review_metadata")

--- a/backend/app/features/jobs/tests/test_jobs_api.py
+++ b/backend/app/features/jobs/tests/test_jobs_api.py
@@ -61,8 +61,17 @@ async def test_get_job_status_returns_owned_extraction_result(
     assert payload["quote_id"] == str(quote.id)  # nosec B101 - pytest assertion
     assert payload["extraction_result"] == {  # nosec B101 - pytest assertion
         "transcript": "mulch the beds",
+        "pipeline_version": "v2",
         "line_items": [],
-        "total": None,
+        "pricing_hints": {
+            "explicit_total": None,
+            "deposit_amount": None,
+            "tax_rate": None,
+            "discount_type": None,
+            "discount_value": None,
+        },
+        "customer_notes_suggestion": None,
+        "unresolved_segments": [],
         "confidence_notes": [],
         "extraction_tier": "primary",
         "extraction_degraded_reason_code": None,

--- a/backend/app/features/quotes/api.py
+++ b/backend/app/features/quotes/api.py
@@ -38,6 +38,7 @@ from app.features.quotes.extraction_outcomes import (
     log_draft_generation_failed_event,
 )
 from app.features.quotes.extraction_service import CaptureAudioClip, ExtractionService
+from app.features.quotes.review_metadata import normalize_extraction_review_metadata
 from app.features.quotes.schemas import (
     ConvertNotesRequest,
     DiscountType,
@@ -548,6 +549,10 @@ async def get_quote(
             job_id=quote.pdf_artifact_job_id,
             job_status=quote.pdf_artifact_job_status,
             terminal_error=quote.pdf_artifact_terminal_error,
+        ),
+        extraction_review_metadata=normalize_extraction_review_metadata(
+            quote.extraction_review_metadata,
+            extraction_degraded_reason_code=quote.extraction_degraded_reason_code,
         ),
     )
 

--- a/backend/app/features/quotes/creation/service.py
+++ b/backend/app/features/quotes/creation/service.py
@@ -11,9 +11,11 @@ from sqlalchemy.exc import IntegrityError
 from app.features.quotes.errors import QuoteServiceError
 from app.features.quotes.extraction_outcomes import classify_extraction_result
 from app.features.quotes.models import Document
+from app.features.quotes.review_metadata import build_extraction_review_metadata
 from app.features.quotes.schemas import (
     ExtractionResult,
     LineItemDraft,
+    PricingFieldName,
     QuoteCreateRequest,
 )
 from app.shared.event_logger import log_event
@@ -46,6 +48,7 @@ class QuoteCreationRepositoryProtocol(Protocol):
         source_type: str,
         extraction_tier: str | None = None,
         extraction_degraded_reason_code: str | None = None,
+        extraction_review_metadata: dict[str, object] | None = None,
     ) -> Document: ...
 
     async def commit(self) -> None: ...
@@ -129,6 +132,24 @@ class QuoteCreationService:
             customer_id=customer_id,
         )
         extraction_metadata = classify_extraction_result(extraction_result)
+        seeded_notes = _seeded_notes_from_result(extraction_result)
+        seeded_pricing_fields = _seeded_pricing_fields(extraction_result)
+        extraction_review_metadata = build_extraction_review_metadata(
+            extraction_result,
+            seeded_notes=seeded_notes is not None,
+            seeded_notes_confidence=(
+                extraction_result.customer_notes_suggestion.confidence
+                if extraction_result.customer_notes_suggestion is not None
+                else None
+            ),
+            seeded_notes_source=(
+                extraction_result.customer_notes_suggestion.source
+                if extraction_result.customer_notes_suggestion is not None
+                else None
+            ),
+            seeded_pricing_fields=seeded_pricing_fields,
+            existing_metadata=None,
+        )
         try:
             quote = await self._create_quote_document(
                 user_id=user_id,
@@ -140,18 +161,21 @@ class QuoteCreationService:
                         description=item.description,
                         details=item.details,
                         price=item.price,
+                        flagged=item.flagged,
+                        flag_reason=item.flag_reason,
                     )
                     for item in extraction_result.line_items
                 ],
-                total_amount=extraction_result.total,
-                tax_rate=None,
-                discount_type=None,
-                discount_value=None,
-                deposit_amount=None,
-                notes=None,
+                total_amount=extraction_result.pricing_hints.explicit_total,
+                tax_rate=extraction_result.pricing_hints.tax_rate,
+                discount_type=extraction_result.pricing_hints.discount_type,
+                discount_value=extraction_result.pricing_hints.discount_value,
+                deposit_amount=extraction_result.pricing_hints.deposit_amount,
+                notes=seeded_notes,
                 source_type=source_type,
                 extraction_tier=extraction_metadata.tier,
                 extraction_degraded_reason_code=extraction_metadata.degraded_reason_code,
+                extraction_review_metadata=extraction_review_metadata.model_dump(mode="json"),
             )
         except QuoteServiceError:
             raise
@@ -237,6 +261,7 @@ class QuoteCreationService:
         source_type: Literal["text", "voice"],
         extraction_tier: str | None = None,
         extraction_degraded_reason_code: str | None = None,
+        extraction_review_metadata: dict[str, object] | None = None,
     ) -> Document:
         for attempt in range(2):
             try:
@@ -255,6 +280,7 @@ class QuoteCreationService:
                     source_type=source_type,
                     extraction_tier=extraction_tier,
                     extraction_degraded_reason_code=extraction_degraded_reason_code,
+                    extraction_review_metadata=extraction_review_metadata,
                 )
             except IntegrityError as exc:
                 await self._repository.rollback()
@@ -291,3 +317,25 @@ def _validate_document_pricing_for_quote(
         )
     except PricingValidationError as exc:
         raise QuoteServiceError(detail=str(exc), status_code=422) from exc
+
+
+def _seeded_notes_from_result(extraction_result: ExtractionResult) -> str | None:
+    suggestion = extraction_result.customer_notes_suggestion
+    if suggestion is None:
+        return None
+    normalized = suggestion.text.strip()
+    return normalized or None
+
+
+def _seeded_pricing_fields(extraction_result: ExtractionResult) -> set[PricingFieldName]:
+    pricing_hints = extraction_result.pricing_hints
+    seeded: set[PricingFieldName] = set()
+    if pricing_hints.explicit_total is not None:
+        seeded.add("explicit_total")
+    if pricing_hints.deposit_amount is not None:
+        seeded.add("deposit_amount")
+    if pricing_hints.tax_rate is not None:
+        seeded.add("tax_rate")
+    if pricing_hints.discount_type is not None and pricing_hints.discount_value is not None:
+        seeded.add("discount")
+    return seeded

--- a/backend/app/features/quotes/extraction_append/service.py
+++ b/backend/app/features/quotes/extraction_append/service.py
@@ -10,6 +10,10 @@ from uuid import UUID
 from app.features.quotes.errors import QuoteServiceError
 from app.features.quotes.extraction_outcomes import classify_extraction_result
 from app.features.quotes.models import Document, QuoteStatus
+from app.features.quotes.review_metadata import (
+    build_extraction_review_metadata,
+    normalize_extraction_review_metadata,
+)
 from app.features.quotes.schemas import ExtractionResult, LineItemDraft
 from app.shared.pricing import (
     PricingValidationError,
@@ -48,6 +52,7 @@ class QuoteExtractionAppendRepositoryProtocol(Protocol):
         line_items: list[LineItemDraft],
         extraction_tier: str | None = None,
         extraction_degraded_reason_code: str | None = None,
+        extraction_review_metadata: dict[str, object] | None = None,
     ) -> Document: ...
 
     async def invalidate_pdf_artifact(self, document: Document) -> str | None: ...
@@ -98,6 +103,8 @@ class QuoteExtractionAppendService:
                 description=item.description,
                 details=item.details,
                 price=item.price,
+                flagged=item.flagged,
+                flag_reason=item.flag_reason,
             )
             for item in extraction_result.line_items
         ]
@@ -107,6 +114,8 @@ class QuoteExtractionAppendService:
                     description=line_item.description,
                     details=line_item.details,
                     price=document_field_float_or_none(line_item.price),
+                    flagged=line_item.flagged,
+                    flag_reason=line_item.flag_reason,
                 )
                 for line_item in quote.line_items
             ],
@@ -139,6 +148,17 @@ class QuoteExtractionAppendService:
             appended_transcript=extraction_result.transcript,
         )
         extraction_metadata = classify_extraction_result(extraction_result)
+        merged_review_metadata = build_extraction_review_metadata(
+            extraction_result,
+            seeded_notes=False,
+            seeded_notes_confidence=None,
+            seeded_notes_source=None,
+            seeded_pricing_fields=set(),
+            existing_metadata=normalize_extraction_review_metadata(
+                quote.extraction_review_metadata,
+                extraction_degraded_reason_code=quote.extraction_degraded_reason_code,
+            ),
+        )
         updated_quote = await self._repository.append_extraction(
             document=quote,
             transcript=next_transcript,
@@ -146,6 +166,7 @@ class QuoteExtractionAppendService:
             line_items=appended_line_items,
             extraction_tier=extraction_metadata.tier,
             extraction_degraded_reason_code=extraction_metadata.degraded_reason_code,
+            extraction_review_metadata=merged_review_metadata.model_dump(mode="json"),
         )
         obsolete_artifact_path = await self._repository.invalidate_pdf_artifact(updated_quote)
         if not commit:

--- a/backend/app/features/quotes/extraction_outcomes.py
+++ b/backend/app/features/quotes/extraction_outcomes.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from typing import Literal
 from uuid import UUID
 
-from app.features.quotes.schemas import ExtractionResult
+from app.features.quotes.schemas import ExtractionResult, PricingHints
 from app.integrations.extraction import is_retryable_extraction_error
 from app.shared.event_logger import log_event
 
@@ -55,8 +55,11 @@ def build_degraded_extraction_result(
     """Build a degraded sentinel result that still preserves user transcript work."""
     return ExtractionResult(
         transcript=transcript,
+        pipeline_version="v2",
         line_items=[],
-        total=None,
+        pricing_hints=PricingHints(),
+        customer_notes_suggestion=None,
+        unresolved_segments=[],
         confidence_notes=[],
         extraction_tier=EXTRACTION_TIER_DEGRADED,
         extraction_degraded_reason_code=reason_code,

--- a/backend/app/features/quotes/models.py
+++ b/backend/app/features/quotes/models.py
@@ -8,6 +8,7 @@ from enum import StrEnum
 from uuid import UUID, uuid4
 
 import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.core.database import Base
@@ -90,6 +91,10 @@ class Document(Base):
         sa.String(64),
         nullable=True,
     )
+    extraction_review_metadata: Mapped[dict[str, object] | None] = mapped_column(
+        JSONB,
+        nullable=True,
+    )
     total_amount: Mapped[Decimal | None] = mapped_column(sa.Numeric(10, 2), nullable=True)
     tax_rate: Mapped[Decimal | None] = mapped_column(sa.Numeric(5, 4), nullable=True)
     discount_type: Mapped[str | None] = mapped_column(sa.String(7), nullable=True)
@@ -167,6 +172,12 @@ class LineItem(Base):
     description: Mapped[str] = mapped_column(sa.Text, nullable=False)
     details: Mapped[str | None] = mapped_column(sa.Text, nullable=True)
     price: Mapped[Decimal | None] = mapped_column(sa.Numeric(10, 2), nullable=True)
+    flagged: Mapped[bool] = mapped_column(
+        sa.Boolean,
+        nullable=False,
+        server_default=sa.text("false"),
+    )
+    flag_reason: Mapped[str | None] = mapped_column(sa.Text, nullable=True)
     sort_order: Mapped[int] = mapped_column(sa.Integer, nullable=False, default=0)
     created_at: Mapped[datetime] = mapped_column(
         sa.DateTime(timezone=True),

--- a/backend/app/features/quotes/repository.py
+++ b/backend/app/features/quotes/repository.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import UTC, date, datetime, tzinfo
 from decimal import Decimal
-from typing import cast
+from typing import Any, cast
 from uuid import UUID
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
@@ -135,6 +135,7 @@ class QuoteDetailRow:
     transcript: str
     extraction_tier: str | None
     extraction_degraded_reason_code: str | None
+    extraction_review_metadata: dict[str, Any] | None
     total_amount: Decimal | None
     tax_rate: Decimal | None
     discount_type: str | None
@@ -341,6 +342,7 @@ class QuoteRepository:
             transcript=document.transcript,
             extraction_tier=document.extraction_tier,
             extraction_degraded_reason_code=document.extraction_degraded_reason_code,
+            extraction_review_metadata=document.extraction_review_metadata,
             total_amount=document.total_amount,
             tax_rate=document.tax_rate,
             discount_type=document.discount_type,
@@ -619,6 +621,7 @@ class QuoteRepository:
         source_type: str,
         extraction_tier: str | None = None,
         extraction_degraded_reason_code: str | None = None,
+        extraction_review_metadata: dict[str, Any] | None = None,
     ) -> Document:
         """Create a quote and optional line items for the owning user."""
         next_sequence = await self.get_next_doc_sequence_for_type(
@@ -636,6 +639,7 @@ class QuoteRepository:
             transcript=transcript,
             extraction_tier=extraction_tier,
             extraction_degraded_reason_code=extraction_degraded_reason_code,
+            extraction_review_metadata=extraction_review_metadata,
             total_amount=_to_decimal(total_amount),
             tax_rate=_to_decimal(tax_rate),
             discount_type=discount_type,
@@ -720,12 +724,15 @@ class QuoteRepository:
         line_items: list[LineItemDraft],
         extraction_tier: str | None = None,
         extraction_degraded_reason_code: str | None = None,
+        extraction_review_metadata: dict[str, Any] | None = None,
     ) -> Document:
         """Append extracted line items while preserving existing rows and order."""
         document.transcript = transcript
         document.total_amount = _to_decimal(total_amount)
         document.extraction_tier = extraction_tier
         document.extraction_degraded_reason_code = extraction_degraded_reason_code
+        if extraction_review_metadata is not None:
+            document.extraction_review_metadata = extraction_review_metadata
 
         next_sort_order = len(document.line_items)
         for index, item in enumerate(line_items):
@@ -735,6 +742,8 @@ class QuoteRepository:
                     description=item.description,
                     details=item.details,
                     price=_to_decimal(item.price),
+                    flagged=item.flagged,
+                    flag_reason=item.flag_reason,
                     sort_order=next_sort_order + index,
                 )
             )
@@ -843,6 +852,8 @@ class QuoteRepository:
                     description=item.description,
                     details=item.details,
                     price=_to_decimal(item.price),
+                    flagged=item.flagged,
+                    flag_reason=item.flag_reason,
                     sort_order=index,
                 )
             )

--- a/backend/app/features/quotes/review_metadata.py
+++ b/backend/app/features/quotes/review_metadata.py
@@ -1,0 +1,147 @@
+"""Helpers for extraction review sidecar metadata."""
+
+from __future__ import annotations
+
+from hashlib import sha256
+from typing import Literal, cast
+
+from app.features.quotes.schemas import (
+    ExtractionResult,
+    ExtractionReviewHiddenDetails,
+    ExtractionReviewMetadataV1,
+    ExtractionReviewState,
+    ExtractionReviewUnresolvedSegment,
+    NotesSeededFieldMetadata,
+    PlacementConfidence,
+    PricingFieldName,
+    PricingSeededFieldMetadata,
+    PricingSeededFieldsMetadata,
+    SeededFieldsMetadata,
+)
+
+
+def normalize_extraction_review_metadata(
+    value: object | None,
+    *,
+    extraction_degraded_reason_code: str | None,
+) -> ExtractionReviewMetadataV1:
+    """Deserialize nullable sidecar payloads to safe defaults."""
+    return ExtractionReviewMetadataV1.model_validate_with_defaults(
+        value,
+        extraction_degraded_reason_code=extraction_degraded_reason_code,
+    )
+
+
+def build_extraction_review_metadata(
+    extraction_result: ExtractionResult,
+    *,
+    seeded_notes: bool,
+    seeded_notes_confidence: PlacementConfidence | None,
+    seeded_notes_source: str | None,
+    seeded_pricing_fields: set[PricingFieldName],
+    existing_metadata: ExtractionReviewMetadataV1 | None = None,
+) -> ExtractionReviewMetadataV1:
+    """Build or merge sidecar metadata for one extraction persistence write."""
+    previous = existing_metadata or ExtractionReviewMetadataV1()
+    notes_seeded_source = _normalize_notes_seeded_source(seeded_notes_source)
+
+    notes_seeded = previous.seeded_fields.notes.seeded or seeded_notes
+    notes_confidence = (
+        previous.seeded_fields.notes.confidence
+        if previous.seeded_fields.notes.confidence is not None
+        else seeded_notes_confidence
+    )
+    if seeded_notes and seeded_notes_confidence is not None:
+        notes_confidence = seeded_notes_confidence
+
+    notes_source = previous.seeded_fields.notes.source
+    if notes_source is None and notes_seeded_source is not None:
+        notes_source = notes_seeded_source
+    elif seeded_notes and notes_seeded_source is not None:
+        notes_source = notes_seeded_source
+
+    pricing_seeded = previous.seeded_fields.pricing
+    merged_pricing = PricingSeededFieldsMetadata(
+        explicit_total=_merge_pricing_seed(
+            pricing_seeded.explicit_total,
+            seed_now="explicit_total" in seeded_pricing_fields,
+        ),
+        deposit_amount=_merge_pricing_seed(
+            pricing_seeded.deposit_amount,
+            seed_now="deposit_amount" in seeded_pricing_fields,
+        ),
+        tax_rate=_merge_pricing_seed(
+            pricing_seeded.tax_rate,
+            seed_now="tax_rate" in seeded_pricing_fields,
+        ),
+        discount=_merge_pricing_seed(
+            pricing_seeded.discount,
+            seed_now="discount" in seeded_pricing_fields,
+        ),
+    )
+
+    hidden_details = ExtractionReviewHiddenDetails(
+        unresolved_segments=[
+            ExtractionReviewUnresolvedSegment(
+                id=_deterministic_hidden_id(
+                    "unresolved",
+                    segment.source,
+                    segment.confidence,
+                    segment.raw_text,
+                ),
+                raw_text=segment.raw_text,
+                confidence=segment.confidence,
+                source=segment.source,
+            )
+            for segment in extraction_result.unresolved_segments
+        ],
+        append_suggestions=list(previous.hidden_details.append_suggestions),
+        confidence_notes=list(extraction_result.confidence_notes),
+    )
+
+    return ExtractionReviewMetadataV1(
+        pipeline_version=extraction_result.pipeline_version,
+        review_state=ExtractionReviewState(
+            notes_pending=previous.review_state.notes_pending or seeded_notes,
+            pricing_pending=(previous.review_state.pricing_pending or bool(seeded_pricing_fields)),
+        ),
+        seeded_fields=SeededFieldsMetadata(
+            notes=NotesSeededFieldMetadata(
+                seeded=notes_seeded,
+                confidence=notes_confidence,
+                source=notes_source,
+            ),
+            pricing=merged_pricing,
+        ),
+        hidden_details=hidden_details,
+        extraction_degraded_reason_code=extraction_result.extraction_degraded_reason_code,
+    )
+
+
+def _merge_pricing_seed(
+    previous: PricingSeededFieldMetadata,
+    *,
+    seed_now: bool,
+) -> PricingSeededFieldMetadata:
+    if previous.seeded or seed_now:
+        return PricingSeededFieldMetadata(seeded=True, source="explicit_pricing_phrase")
+    return PricingSeededFieldMetadata(seeded=False, source=previous.source)
+
+
+def _normalize_notes_seeded_source(
+    value: str | None,
+) -> Literal["explicit_notes_section", "derived", "leftover_classification"] | None:
+    if value in {"explicit_notes_section", "derived", "leftover_classification"}:
+        return cast(
+            Literal["explicit_notes_section", "derived", "leftover_classification"],
+            value,
+        )
+    if value is None:
+        return None
+    return "derived"
+
+
+def _deterministic_hidden_id(*parts: str) -> str:
+    normalized = "|".join(part.strip().casefold() for part in parts)
+    digest = sha256(normalized.encode("utf-8")).hexdigest()[:16]
+    return f"h:{digest}"

--- a/backend/app/features/quotes/review_metadata.py
+++ b/backend/app/features/quotes/review_metadata.py
@@ -96,7 +96,11 @@ def build_extraction_review_metadata(
             for segment in extraction_result.unresolved_segments
         ],
         append_suggestions=list(previous.hidden_details.append_suggestions),
-        confidence_notes=list(extraction_result.confidence_notes),
+        confidence_notes=(
+            list(extraction_result.confidence_notes)
+            if extraction_result.confidence_notes
+            else list(previous.hidden_details.confidence_notes)
+        ),
     )
 
     return ExtractionReviewMetadataV1(

--- a/backend/app/features/quotes/schemas.py
+++ b/backend/app/features/quotes/schemas.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from datetime import date, datetime
-from typing import Annotated, Literal
+from typing import Annotated, Any, Literal
 from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
@@ -37,13 +37,12 @@ class LineItemDraft(BaseModel):
     description: str = Field(min_length=1, max_length=LINE_ITEM_DESCRIPTION_MAX_CHARS)
     details: str | None = Field(default=None, max_length=LINE_ITEM_DETAILS_MAX_CHARS)
     price: float | None = None
+    flagged: bool = False
+    flag_reason: str | None = None
 
 
 class LineItemExtracted(LineItemDraft):
     """Extraction-only line item metadata used during review."""
-
-    flagged: bool = False
-    flag_reason: str | None = None
 
 
 class PreparedCaptureInput(BaseModel):
@@ -177,42 +176,165 @@ class ExtractionResultV2(BaseModel):
     extraction_tier: Literal["primary", "degraded"] = "primary"
     extraction_degraded_reason_code: str | None = None
 
-    def to_v1_result(self) -> ExtractionResult:
-        """Project the internal V2 payload onto the existing V1 contract."""
-        return ExtractionResult(
-            transcript=self.transcript,
-            line_items=[
-                LineItemExtracted(
-                    description=item.description,
-                    details=item.details,
-                    price=item.price,
-                    flagged=item.flagged,
-                    flag_reason=item.flag_reason,
-                )
-                for item in self.line_items
-            ],
-            total=self.pricing_hints.explicit_total,
-            confidence_notes=self.confidence_notes,
-            extraction_tier=self.extraction_tier,
-            extraction_degraded_reason_code=self.extraction_degraded_reason_code,
-        )
+
+class ExtractionResult(ExtractionResultV2):
+    """Structured extraction output returned from extraction endpoints.
+
+    Backward compatibility shim:
+    legacy callers/tests may still pass `total`, which maps to
+    `pricing_hints.explicit_total`.
+    """
+
+    @model_validator(mode="before")
+    @classmethod
+    def _map_legacy_total_field(cls, value: Any) -> Any:
+        if not isinstance(value, dict):
+            return value
+        payload = dict(value)
+        if "total" in payload:
+            total = payload.pop("total", None)
+            pricing_hints = payload.get("pricing_hints")
+            if not isinstance(pricing_hints, dict):
+                pricing_hints = {}
+            pricing_hints = dict(pricing_hints)
+            pricing_hints.setdefault("explicit_total", total)
+            payload["pricing_hints"] = pricing_hints
+
+        legacy_line_items = payload.get("line_items")
+        if isinstance(legacy_line_items, list):
+            normalized_items: list[dict[str, Any]] = []
+            for candidate in legacy_line_items:
+                item_payload: dict[str, Any] | None = None
+                if isinstance(candidate, dict):
+                    item_payload = dict(candidate)
+                else:
+                    try:
+                        dumped = candidate.model_dump(mode="json")
+                    except AttributeError:
+                        dumped = None
+                    if isinstance(dumped, dict):
+                        item_payload = dict(dumped)
+                if item_payload is None:
+                    continue
+                if not item_payload.get("raw_text"):
+                    item_payload["raw_text"] = (
+                        item_payload.get("details")
+                        or item_payload.get("description")
+                        or "line item"
+                    )
+                item_payload.setdefault("confidence", "medium")
+                normalized_items.append(item_payload)
+            payload["line_items"] = normalized_items
+        return payload
+
+    @property
+    def total(self) -> float | None:
+        """Compatibility accessor for legacy internal callers/tests."""
+        return self.pricing_hints.explicit_total
 
 
-class ExtractionResult(BaseModel):
-    """Structured extraction output returned from convert-notes."""
+PricingFieldName = Literal["explicit_total", "deposit_amount", "tax_rate", "discount"]
 
-    transcript: str = Field(min_length=1, max_length=EXTRACTION_TRANSCRIPT_MAX_CHARS)
-    line_items: list[LineItemExtracted] = Field(
-        default_factory=list,
-        max_length=DOCUMENT_LINE_ITEMS_MAX_ITEMS,
-    )
-    total: float | None = None
+
+class ExtractionReviewState(BaseModel):
+    """Visible grouped extraction review state."""
+
+    notes_pending: bool = False
+    pricing_pending: bool = False
+
+
+class NotesSeededFieldMetadata(BaseModel):
+    """Review metadata for notes field seeding provenance."""
+
+    seeded: bool = False
+    confidence: PlacementConfidence | None = None
+    source: Literal["explicit_notes_section", "derived", "leftover_classification"] | None = None
+
+
+class PricingSeededFieldMetadata(BaseModel):
+    """Review metadata for one pricing field seeding provenance."""
+
+    seeded: bool = False
+    source: Literal["explicit_pricing_phrase"] | None = None
+
+
+class PricingSeededFieldsMetadata(BaseModel):
+    """Grouped pricing field provenance."""
+
+    explicit_total: PricingSeededFieldMetadata = Field(default_factory=PricingSeededFieldMetadata)
+    deposit_amount: PricingSeededFieldMetadata = Field(default_factory=PricingSeededFieldMetadata)
+    tax_rate: PricingSeededFieldMetadata = Field(default_factory=PricingSeededFieldMetadata)
+    discount: PricingSeededFieldMetadata = Field(default_factory=PricingSeededFieldMetadata)
+
+
+class SeededFieldsMetadata(BaseModel):
+    """Grouped seeded-field metadata for V2 extraction hydration."""
+
+    notes: NotesSeededFieldMetadata = Field(default_factory=NotesSeededFieldMetadata)
+    pricing: PricingSeededFieldsMetadata = Field(default_factory=PricingSeededFieldsMetadata)
+
+
+class ExtractionReviewAppendSuggestion(BaseModel):
+    """Hidden append suggestion persisted in sidecar metadata."""
+
+    id: str
+    kind: Literal["note", "pricing"]
+    raw_text: str = Field(min_length=1, max_length=EXTRACTION_TRANSCRIPT_MAX_CHARS)
+    confidence: Literal["medium", "low"]
+    source: Literal["append_capture"] = "append_capture"
+    pricing_field: PricingFieldName | None = None
+
+
+class ExtractionReviewUnresolvedSegment(BaseModel):
+    """Hidden unresolved segment persisted in sidecar metadata."""
+
+    id: str
+    raw_text: str = Field(min_length=1, max_length=EXTRACTION_TRANSCRIPT_MAX_CHARS)
+    confidence: Literal["medium", "low"]
+    source: UnresolvedSegmentSource
+
+
+class ExtractionReviewHiddenDetails(BaseModel):
+    """Hidden extraction details shown in Capture Details surfaces."""
+
+    unresolved_segments: list[ExtractionReviewUnresolvedSegment] = Field(default_factory=list)
+    append_suggestions: list[ExtractionReviewAppendSuggestion] = Field(default_factory=list)
     confidence_notes: list[Annotated[str, Field(max_length=CONFIDENCE_NOTE_MAX_CHARS)]] = Field(
         default_factory=list,
         max_length=CONFIDENCE_NOTES_MAX_ITEMS,
     )
-    extraction_tier: Literal["primary", "degraded"] = "primary"
+
+
+class ExtractionReviewMetadataV1(BaseModel):
+    """Sidecar metadata persisted for V2 extraction review behavior."""
+
+    pipeline_version: Literal["v2"] = "v2"
+    review_state: ExtractionReviewState = Field(default_factory=ExtractionReviewState)
+    seeded_fields: SeededFieldsMetadata = Field(default_factory=SeededFieldsMetadata)
+    hidden_details: ExtractionReviewHiddenDetails = Field(
+        default_factory=ExtractionReviewHiddenDetails
+    )
     extraction_degraded_reason_code: str | None = None
+
+    @classmethod
+    def model_validate_with_defaults(
+        cls,
+        value: object | None,
+        *,
+        extraction_degraded_reason_code: str | None = None,
+    ) -> ExtractionReviewMetadataV1:
+        """Deserialize nullable sidecar payloads to a safe default object."""
+        if value is None:
+            return cls(extraction_degraded_reason_code=extraction_degraded_reason_code)
+        metadata = cls.model_validate(value)
+        if (
+            metadata.extraction_degraded_reason_code is None
+            and extraction_degraded_reason_code is not None
+        ):
+            return metadata.model_copy(
+                update={"extraction_degraded_reason_code": extraction_degraded_reason_code}
+            )
+        return metadata
 
 
 class PersistedExtractionResponse(ExtractionResult):
@@ -302,6 +424,8 @@ class LineItemResponse(BaseModel):
     description: str
     details: str | None
     price: float | None
+    flagged: bool = False
+    flag_reason: str | None = None
     sort_order: int
 
 
@@ -395,6 +519,7 @@ class QuoteDetailResponse(QuoteResponse):
     can_reassign_customer: bool
     linked_invoice: LinkedInvoiceResponse | None
     pdf_artifact: PdfArtifactResponse
+    extraction_review_metadata: ExtractionReviewMetadataV1
 
 
 class PublicQuoteResponse(BaseModel):

--- a/backend/app/features/quotes/service.py
+++ b/backend/app/features/quotes/service.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 from datetime import datetime
-from typing import Literal, Protocol, cast
+from typing import Any, Literal, Protocol, cast
 from uuid import UUID
 
 from arq.connections import ArqRedis
@@ -118,6 +118,7 @@ class QuoteRepositoryProtocol(Protocol):
         source_type: str,
         extraction_tier: str | None = None,
         extraction_degraded_reason_code: str | None = None,
+        extraction_review_metadata: dict[str, Any] | None = None,
     ) -> Document: ...
 
     async def update(
@@ -157,6 +158,7 @@ class QuoteRepositoryProtocol(Protocol):
         line_items: list[LineItemDraft],
         extraction_tier: str | None = None,
         extraction_degraded_reason_code: str | None = None,
+        extraction_review_metadata: dict[str, Any] | None = None,
     ) -> Document: ...
 
     async def delete(self, document_id: UUID) -> None: ...

--- a/backend/app/features/quotes/tests/support/mocks.py
+++ b/backend/app/features/quotes/tests/support/mocks.py
@@ -5,7 +5,12 @@ from types import SimpleNamespace
 from typing import TypedDict
 
 from app.features.quotes.repository import QuoteRenderContext
-from app.features.quotes.schemas import ExtractionResult, LineItemExtracted, PreparedCaptureInput
+from app.features.quotes.schemas import (
+    ExtractionResult,
+    LineItemExtractedV2,
+    PreparedCaptureInput,
+    PricingHints,
+)
 from app.integrations.audio import AudioClip, AudioError
 from app.integrations.email import EmailConfigurationError, EmailMessage, EmailSendError
 from app.integrations.extraction import ExtractionError
@@ -26,28 +31,32 @@ class _MockExtractionIntegration:
             return ExtractionResult(
                 transcript=normalized_notes,
                 line_items=[
-                    LineItemExtracted(
+                    LineItemExtractedV2(
+                        raw_text="Brown mulch 5 yards 120",
                         description="Brown mulch",
                         details="5 yards",
                         price=120,
                         flagged=True,
                         flag_reason="Unit or price sounds inconsistent with the transcript",
+                        confidence="medium",
                     )
                 ],
-                total=120,
+                pricing_hints=PricingHints(explicit_total=120),
                 confidence_notes=[],
             )
 
         return ExtractionResult(
             transcript=normalized_notes,
             line_items=[
-                LineItemExtracted(
+                LineItemExtractedV2(
+                    raw_text="Brown mulch 5 yards 120",
                     description="Brown mulch",
                     details="5 yards",
                     price=120,
+                    confidence="medium",
                 )
             ],
-            total=120,
+            pricing_hints=PricingHints(explicit_total=120),
             confidence_notes=[],
         )
 

--- a/backend/app/features/quotes/tests/test_creation_service.py
+++ b/backend/app/features/quotes/tests/test_creation_service.py
@@ -16,7 +16,8 @@ from app.features.quotes.creation.service import (
 from app.features.quotes.models import Document
 from app.features.quotes.schemas import (
     ExtractionResult,
-    LineItemExtracted,
+    LineItemExtractedV2,
+    PricingHints,
     QuoteCreateRequest,
 )
 
@@ -99,13 +100,15 @@ async def test_create_extracted_draft_commit_false_skips_commit() -> None:
     extraction_result = ExtractionResult(
         transcript="mulch the front beds",
         line_items=[
-            LineItemExtracted(
+            LineItemExtractedV2(
+                raw_text="mulch the front beds",
                 description="Brown mulch",
                 details="5 yards",
                 price=120,
+                confidence="medium",
             )
         ],
-        total=120,
+        pricing_hints=PricingHints(explicit_total=120),
         confidence_notes=[],
     )
 

--- a/backend/app/features/quotes/tests/test_extraction_scorer.py
+++ b/backend/app/features/quotes/tests/test_extraction_scorer.py
@@ -4,7 +4,11 @@ from __future__ import annotations
 
 import pytest
 
-from app.features.quotes.schemas import ExtractionResult, LineItemExtracted
+from app.features.quotes.schemas import (
+    ExtractionResult,
+    LineItemExtractedV2,
+    PricingHints,
+)
 from app.features.quotes.tests.scoring import extraction_scorer as scorer_module
 from app.features.quotes.tests.scoring.extraction_scorer import (
     CaseScore,
@@ -26,18 +30,20 @@ def _item(
     details: str | None = None,
     flagged: bool = False,
     flag_reason: str | None = None,
-) -> LineItemExtracted:
-    return LineItemExtracted(
+) -> LineItemExtractedV2:
+    return LineItemExtractedV2(
+        raw_text=f"{description} {details or ''}".strip() or description,
         description=description,
         price=price,
         details=details,
         flagged=flagged,
         flag_reason=flag_reason,
+        confidence="medium",
     )
 
 
 def _result(
-    line_items: list[LineItemExtracted],
+    line_items: list[LineItemExtractedV2],
     *,
     total: float | None = None,
     confidence_notes: list[str] | None = None,
@@ -45,7 +51,7 @@ def _result(
     return ExtractionResult(
         transcript="unit test transcript",
         line_items=line_items,
-        total=total,
+        pricing_hints=PricingHints(explicit_total=total),
         confidence_notes=confidence_notes or [],
     )
 

--- a/backend/app/features/quotes/tests/test_quote_append_extraction.py
+++ b/backend/app/features/quotes/tests/test_quote_append_extraction.py
@@ -13,7 +13,12 @@ from app.core.config import get_settings
 from app.features.jobs.models import JobRecord, JobType
 from app.features.jobs.repository import JobRepository
 from app.features.quotes.models import Document
-from app.features.quotes.schemas import ExtractionResult
+from app.features.quotes.schemas import (
+    ExtractionResult,
+    ExtractionReviewMetadataV1,
+    LineItemExtractedV2,
+    PricingHints,
+)
 from app.features.quotes.service import QuoteService, QuoteServiceError
 from app.features.quotes.tests import test_quotes as quotes_test_module
 from app.features.quotes.tests.support.helpers import (
@@ -131,6 +136,62 @@ async def test_append_extraction_sync_appends_line_items_and_merges_transcript_e
     assert "- first follow-up request" in payload["transcript"]
     assert "- second follow-up request" in payload["transcript"]
     assert "Added later (2):" not in payload["transcript"]
+
+
+async def test_append_extraction_preserves_existing_confidence_notes_when_new_notes_empty(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def _extract_without_confidence_notes(self, notes: str) -> ExtractionResult:  # noqa: ANN001
+        del self, notes
+        return ExtractionResult(
+            transcript="append without confidence notes",
+            line_items=[
+                LineItemExtractedV2(
+                    raw_text="Added labor 15",
+                    description="Added labor",
+                    details=None,
+                    price=15,
+                    confidence="medium",
+                )
+            ],
+            pricing_hints=PricingHints(explicit_total=15),
+            confidence_notes=[],
+        )
+
+    monkeypatch.setattr(
+        _MockExtractionIntegration,
+        "extract",
+        _extract_without_confidence_notes,
+    )
+
+    csrf_token = await _register_and_login(client, _credentials())
+    customer_id = await _create_customer(client, csrf_token)
+    quote = await _create_quote(client, csrf_token, customer_id)
+    quote_id = UUID(quote["id"])
+    app.state.arq_pool = None
+
+    persisted_quote = await db_session.get(Document, quote_id)
+    assert persisted_quote is not None
+    persisted_quote.extraction_review_metadata = ExtractionReviewMetadataV1(
+        hidden_details={"confidence_notes": ["keep existing confidence note"]},
+    ).model_dump(mode="json")
+    await db_session.commit()
+
+    append_response = await client.post(
+        f"/api/quotes/{quote_id}/append-extraction",
+        files=[("notes", (None, "append this follow-up"))],
+        headers={"X-CSRF-Token": csrf_token},
+    )
+    assert append_response.status_code == 200
+
+    detail_response = await client.get(f"/api/quotes/{quote_id}")
+    assert detail_response.status_code == 200
+    detail_payload = detail_response.json()
+    assert detail_payload["extraction_review_metadata"]["hidden_details"]["confidence_notes"] == [
+        "keep existing confidence note"
+    ]
 
 
 async def test_append_extraction_sync_cleans_obsolete_pdf_artifact_after_commit(

--- a/backend/app/features/quotes/tests/test_quote_append_extraction.py
+++ b/backend/app/features/quotes/tests/test_quote_append_extraction.py
@@ -15,6 +15,7 @@ from app.features.jobs.repository import JobRepository
 from app.features.quotes.models import Document
 from app.features.quotes.schemas import (
     ExtractionResult,
+    ExtractionReviewHiddenDetails,
     ExtractionReviewMetadataV1,
     LineItemExtractedV2,
     PricingHints,
@@ -175,7 +176,9 @@ async def test_append_extraction_preserves_existing_confidence_notes_when_new_no
     persisted_quote = await db_session.get(Document, quote_id)
     assert persisted_quote is not None
     persisted_quote.extraction_review_metadata = ExtractionReviewMetadataV1(
-        hidden_details={"confidence_notes": ["keep existing confidence note"]},
+        hidden_details=ExtractionReviewHiddenDetails(
+            confidence_notes=["keep existing confidence note"]
+        ),
     ).model_dump(mode="json")
     await db_session.commit()
 

--- a/backend/app/features/quotes/tests/test_quote_crud.py
+++ b/backend/app/features/quotes/tests/test_quote_crud.py
@@ -81,7 +81,7 @@ async def test_quote_crud_happy_path_with_ordering_and_line_item_replacement(
             "title": "  Front Bed Refresh  ",
             "transcript": extraction_payload["transcript"],
             "line_items": extraction_payload["line_items"],
-            "total_amount": extraction_payload["total"],
+            "total_amount": extraction_payload["pricing_hints"]["explicit_total"],
             "notes": "Please review within 7 days",
             "source_type": "text",
         },
@@ -487,7 +487,9 @@ async def test_update_quote_replaces_line_items_when_provided(
             "id": payload["line_items"][0]["id"],
             "description": "Premium mulch refresh",
             "details": "6 yards",
-            "price": 180,
+            "price": 180.0,
+            "flagged": False,
+            "flag_reason": None,
             "sort_order": 0,
         }
     ]

--- a/backend/app/features/quotes/tests/test_quote_crud.py
+++ b/backend/app/features/quotes/tests/test_quote_crud.py
@@ -239,6 +239,7 @@ async def test_create_quote_returns_404_for_nonexistent_customer(
 
 async def test_create_manual_draft_without_customer_persists_empty_draft_and_logs_manual_event(
     client: AsyncClient,
+    db_session: AsyncSession,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     emitted_events: list[dict[str, str]] = []
@@ -266,11 +267,24 @@ async def test_create_manual_draft_without_customer_persists_empty_draft_and_log
     assert payload["line_items"] == []
     assert payload["total_amount"] is None
 
+    persisted_quote = await db_session.get(Document, UUID(payload["id"]))
+    assert persisted_quote is not None
+    assert persisted_quote.extraction_review_metadata is None
+
     detail_response = await client.get(f"/api/quotes/{payload['id']}")
     assert detail_response.status_code == 200
     detail_payload = detail_response.json()
     assert detail_payload["extraction_tier"] is None
     assert detail_payload["extraction_degraded_reason_code"] is None
+    assert detail_payload["extraction_review_metadata"]["review_state"] == {
+        "notes_pending": False,
+        "pricing_pending": False,
+    }
+    assert detail_payload["extraction_review_metadata"]["hidden_details"] == {
+        "unresolved_segments": [],
+        "append_suggestions": [],
+        "confidence_notes": [],
+    }
 
     quote_event_names = [
         event["event"] for event in emitted_events if event.get("quote_id") == payload["id"]

--- a/backend/app/features/quotes/tests/test_quote_extraction.py
+++ b/backend/app/features/quotes/tests/test_quote_extraction.py
@@ -16,7 +16,7 @@ from app.features.jobs.models import JobRecord, JobStatus, JobType
 from app.features.jobs.repository import JobRepository
 from app.features.quotes.extraction_service import ExtractionService
 from app.features.quotes.models import Document, QuoteStatus
-from app.features.quotes.schemas import ExtractionResult, PreparedCaptureInput
+from app.features.quotes.schemas import ExtractionResult, PreparedCaptureInput, PricingHints
 from app.features.quotes.service import QuoteService, QuoteServiceError
 from app.features.quotes.tests import test_quotes as quotes_test_module
 from app.features.quotes.tests.support.helpers import (
@@ -754,7 +754,7 @@ async def test_convert_notes_rejects_when_concurrency_limit_is_exhausted(
             return ExtractionResult(
                 transcript=notes.transcript,
                 line_items=[],
-                total=None,
+                pricing_hints=PricingHints(),
                 confidence_notes=[],
             )
 

--- a/backend/app/features/quotes/tests/test_quote_to_invoice.py
+++ b/backend/app/features/quotes/tests/test_quote_to_invoice.py
@@ -435,7 +435,9 @@ async def test_convert_quote_to_invoice_rejects_duplicates_and_patch_preserves_s
             "description": "Final walkthrough",
             "details": "Touch-up and cleanup",
             "id": patched_invoice["line_items"][0]["id"],
-            "price": 90,
+            "price": 90.0,
+            "flagged": False,
+            "flag_reason": None,
             "sort_order": 0,
         }
     ]

--- a/backend/app/integrations/extraction.py
+++ b/backend/app/integrations/extraction.py
@@ -414,7 +414,7 @@ class ExtractionIntegration:
         try:
             validated_result_v2 = ExtractionResultV2.model_validate(payload)
             guarded_result_v2 = _apply_semantic_guard_rules(validated_result_v2)
-            result = guarded_result_v2.to_v1_result()
+            result = ExtractionResult.model_validate(guarded_result_v2.model_dump(mode="json"))
             _log_result_trace(
                 result=result,
                 invocation_tier=tier.tier,
@@ -555,7 +555,7 @@ class ExtractionIntegration:
                 raw_tool_payload=repair_payload,
             )
             guarded_result_v2 = _apply_semantic_guard_rules(repaired_result_v2)
-            result = guarded_result_v2.to_v1_result()
+            result = ExtractionResult.model_validate(guarded_result_v2.model_dump(mode="json"))
             _log_result_trace(
                 result=result,
                 invocation_tier=tier.tier,
@@ -915,7 +915,7 @@ def _log_result_trace(
         extraction_degraded_reason_code=result.extraction_degraded_reason_code,
         line_item_count=len(result.line_items),
         confidence_note_count=len(result.confidence_notes),
-        total_present=result.total is not None,
+        total_present=result.pricing_hints.explicit_total is not None,
         raw_transcript=result.transcript,
         raw_tool_payload=result.model_dump(mode="json"),
     )
@@ -956,8 +956,11 @@ def _compact_validation_errors(error: ValidationError) -> list[str]:
 def _build_validation_repair_failed_result(*, transcript: str) -> ExtractionResult:
     return ExtractionResult(
         transcript=transcript,
+        pipeline_version="v2",
         line_items=[],
-        total=None,
+        pricing_hints=PricingHints(),
+        customer_notes_suggestion=None,
+        unresolved_segments=[],
         confidence_notes=[],
         extraction_tier="degraded",
         extraction_degraded_reason_code=EXTRACTION_DEGRADED_REASON_VALIDATION_REPAIR_FAILED,

--- a/backend/app/worker/tests/test_job_registry.py
+++ b/backend/app/worker/tests/test_job_registry.py
@@ -11,7 +11,7 @@ from app.features.auth.models import User
 from app.features.jobs.models import JobRecord, JobStatus, JobType
 from app.features.jobs.repository import JobRepository
 from app.features.quotes.models import Document
-from app.features.quotes.schemas import ExtractionResult, PreparedCaptureInput
+from app.features.quotes.schemas import ExtractionResult, PreparedCaptureInput, PricingHints
 from app.features.quotes.service import QuoteServiceError
 from app.integrations.extraction import ExtractionCallMetadata, ExtractionError
 from app.shared import event_logger, observability
@@ -333,7 +333,7 @@ class _SuccessfulExtractionIntegration:
         return ExtractionResult(
             transcript=transcript,
             line_items=[],
-            total=None,
+            pricing_hints=PricingHints(),
             confidence_notes=[],
         )
 
@@ -349,7 +349,7 @@ class _CaptureInputExtractionIntegration:
         return ExtractionResult(
             transcript=transcript,
             line_items=[],
-            total=None,
+            pricing_hints=PricingHints(),
             confidence_notes=[],
         )
 
@@ -374,7 +374,7 @@ class _ValidationRepairFailedExtractionIntegration:
         return ExtractionResult(
             transcript=transcript,
             line_items=[],
-            total=None,
+            pricing_hints=PricingHints(),
             confidence_notes=[],
             extraction_tier="degraded",
             extraction_degraded_reason_code="validation_repair_failed",

--- a/frontend/src/features/quotes/components/CaptureScreen.tsx
+++ b/frontend/src/features/quotes/components/CaptureScreen.tsx
@@ -17,12 +17,11 @@ import {
   resolveCaptureLaunchOrigin,
 } from "@/features/quotes/utils/workflowNavigation";
 import {
-  readQuoteConfidenceNotes,
   writeQuoteConfidenceNotes,
 } from "@/features/quotes/utils/reviewConfidenceNotes";
 import { useVoiceCapture } from "@/features/quotes/hooks/useVoiceCapture";
 import { quoteService } from "@/features/quotes/services/quoteService";
-import type { ExtractionResult, QuoteSourceType } from "@/features/quotes/types/quote.types";
+import type { QuoteDetail, QuoteSourceType } from "@/features/quotes/types/quote.types";
 import { Button } from "@/shared/components/Button";
 import { ConfirmModal } from "@/shared/components/ConfirmModal";
 import { ScreenFooter } from "@/shared/components/ScreenFooter";
@@ -110,46 +109,51 @@ export function CaptureScreen(): React.ReactElement {
     };
   }, []);
 
-  function applyDraft(
+  function applyDraftFromQuoteDetail(
     sourceType: QuoteSourceType,
-    extraction: ExtractionResult,
+    quoteDetail: QuoteDetail,
     quoteId: string,
   ): void {
-    writeQuoteConfidenceNotes(quoteId, extraction.confidence_notes);
+    const confidenceNotes =
+      quoteDetail.extraction_review_metadata?.hidden_details.confidence_notes ?? [];
+    writeQuoteConfidenceNotes(quoteId, confidenceNotes);
     setDraft({
       quoteId,
-      customerId: customerId ?? "",
+      customerId: quoteDetail.customer_id ?? customerId ?? "",
       launchOrigin,
       title: "",
-      transcript: extraction.transcript,
-      lineItems: extraction.line_items.map((lineItem) => ({
+      transcript: quoteDetail.transcript,
+      lineItems: quoteDetail.line_items.map((lineItem) => ({
         description: lineItem.description,
         details: lineItem.details,
         price: lineItem.price,
         flagged: lineItem.flagged,
         flagReason: lineItem.flag_reason,
       })),
-      total: extraction.total,
-      taxRate: null,
-      discountType: null,
-      discountValue: null,
-      depositAmount: null,
-      confidenceNotes: extraction.confidence_notes,
-      notes: "",
+      total: quoteDetail.total_amount,
+      taxRate: quoteDetail.tax_rate,
+      discountType: quoteDetail.discount_type,
+      discountValue: quoteDetail.discount_value,
+      depositAmount: quoteDetail.deposit_amount,
+      confidenceNotes,
+      notes: quoteDetail.notes ?? "",
       sourceType,
     });
   }
 
-  function applyAppendResult(
+  async function hydrateFromPersistedQuote(
     quoteId: string,
-    extraction: ExtractionResult,
-  ): void {
-    const existingNotes = readQuoteConfidenceNotes(quoteId);
-    const nextNotes =
-      extraction.confidence_notes.length > 0
-        ? extraction.confidence_notes
-        : existingNotes;
-    writeQuoteConfidenceNotes(quoteId, nextNotes);
+    sourceType: QuoteSourceType,
+    appendMode: boolean,
+  ): Promise<void> {
+    const persistedQuote = await quoteService.getQuote(quoteId);
+    const confidenceNotes =
+      persistedQuote.extraction_review_metadata?.hidden_details.confidence_notes ?? [];
+    writeQuoteConfidenceNotes(quoteId, confidenceNotes);
+    if (appendMode) {
+      return;
+    }
+    applyDraftFromQuoteDetail(sourceType, persistedQuote, quoteId);
   }
 
   function navigateToReview(quoteId: string): void {
@@ -213,11 +217,7 @@ export function CaptureScreen(): React.ReactElement {
       }
       const sourceType: QuoteSourceType = clips.length > 0 ? "voice" : "text";
       if (extraction.type === "sync") {
-        if (isAppendMode) {
-          applyAppendResult(extraction.quoteId, extraction.result);
-        } else {
-          applyDraft(sourceType, extraction.result, extraction.quoteId);
-        }
+        await hydrateFromPersistedQuote(extraction.quoteId, sourceType, isAppendMode);
         navigateToReview(extraction.quoteId);
         return;
       }
@@ -281,11 +281,7 @@ export function CaptureScreen(): React.ReactElement {
             "Extraction completed without a result. Please try again.",
           );
         }
-        if (appendMode) {
-          applyAppendResult(job.quote_id, job.extraction_result);
-        } else {
-          applyDraft(sourceType, job.extraction_result, job.quote_id);
-        }
+        await hydrateFromPersistedQuote(job.quote_id, sourceType, appendMode);
         navigateToReview(job.quote_id);
         return;
       }

--- a/frontend/src/features/quotes/components/reviewScreenUtils.ts
+++ b/frontend/src/features/quotes/components/reviewScreenUtils.ts
@@ -44,6 +44,8 @@ export function buildLineItemSubmitState(lineItems: LineItemDraftWithFlags[]): {
       description: lineItem.description,
       details: lineItem.details,
       price: lineItem.price,
+      flagged: lineItem.flagged,
+      flag_reason: lineItem.flagReason ?? null,
     }));
   const lineItemSum = normalizedLineItems.reduce((runningTotal, lineItem) => {
     if (lineItem.price === null) {

--- a/frontend/src/features/quotes/hooks/persistedDocumentDraft.ts
+++ b/frontend/src/features/quotes/hooks/persistedDocumentDraft.ts
@@ -180,6 +180,8 @@ export function mapQuoteToEditDraft(quote: QuoteDetail): DocumentEditDraft {
       description: item.description,
       details: item.details,
       price: item.price,
+      flagged: item.flagged,
+      flagReason: item.flag_reason,
     })),
     total: breakdown.subtotal ?? quote.total_amount,
     taxRate: quote.tax_rate,

--- a/frontend/src/features/quotes/services/quoteService.ts
+++ b/frontend/src/features/quotes/services/quoteService.ts
@@ -85,17 +85,11 @@ async function submitExtraction(
   }
 
   const persistedExtraction = response.data as PersistedExtractionPayload;
+  const { quote_id: quoteId, ...result } = persistedExtraction;
   return {
     type: "sync",
-    quoteId: persistedExtraction.quote_id,
-    result: {
-      transcript: persistedExtraction.transcript,
-      line_items: persistedExtraction.line_items,
-      total: persistedExtraction.total,
-      confidence_notes: persistedExtraction.confidence_notes,
-      extraction_tier: persistedExtraction.extraction_tier,
-      extraction_degraded_reason_code: persistedExtraction.extraction_degraded_reason_code,
-    },
+    quoteId,
+    result,
   };
 }
 

--- a/frontend/src/features/quotes/tests/CaptureScreen.test.tsx
+++ b/frontend/src/features/quotes/tests/CaptureScreen.test.tsx
@@ -7,7 +7,11 @@ import { useQuoteDraft } from "@/features/quotes/hooks/useQuoteDraft";
 import { HOME_ROUTE } from "@/features/quotes/utils/workflowNavigation";
 import { useVoiceCapture, type VoiceClip } from "@/features/quotes/hooks/useVoiceCapture";
 import { quoteService } from "@/features/quotes/services/quoteService";
-import type { ExtractionResult, JobStatusResponse } from "@/features/quotes/types/quote.types";
+import type {
+  ExtractionResult,
+  JobStatusResponse,
+  QuoteDetail,
+} from "@/features/quotes/types/quote.types";
 import { jobService } from "@/shared/lib/jobService";
 import {
   MAX_AUDIO_CLIPS_PER_REQUEST,
@@ -69,19 +73,96 @@ const mockedJobService = vi.mocked(jobService);
 
 const extractionFixture: ExtractionResult = {
   transcript: "5 yards brown mulch",
+  pipeline_version: "v2",
   line_items: [
     {
+      raw_text: "5 yards brown mulch",
       description: "Brown mulch",
       details: "5 yards",
       price: 120,
       flagged: true,
       flag_reason: "Unit phrasing may be ambiguous",
+      confidence: "medium",
     },
   ],
-  total: 120,
+  pricing_hints: {
+    explicit_total: 120,
+    deposit_amount: null,
+    tax_rate: null,
+    discount_type: null,
+    discount_value: null,
+  },
+  customer_notes_suggestion: null,
+  unresolved_segments: [],
   confidence_notes: [],
   extraction_tier: "primary",
   extraction_degraded_reason_code: null,
+};
+
+const quoteDetailFixture: QuoteDetail = {
+  id: "quote-1",
+  customer_id: "cust-1",
+  extraction_tier: "primary",
+  extraction_degraded_reason_code: null,
+  extraction_review_metadata: {
+    pipeline_version: "v2",
+    review_state: {
+      notes_pending: false,
+      pricing_pending: false,
+    },
+    seeded_fields: {
+      notes: { seeded: false, confidence: null, source: null },
+      pricing: {
+        explicit_total: { seeded: true, source: "explicit_pricing_phrase" },
+        deposit_amount: { seeded: false, source: null },
+        tax_rate: { seeded: false, source: null },
+        discount: { seeded: false, source: null },
+      },
+    },
+    hidden_details: {
+      unresolved_segments: [],
+      append_suggestions: [],
+      confidence_notes: [],
+    },
+    extraction_degraded_reason_code: null,
+  },
+  customer_name: null,
+  customer_email: null,
+  customer_phone: null,
+  doc_number: "Q-001",
+  title: null,
+  status: "draft",
+  source_type: "text",
+  transcript: extractionFixture.transcript,
+  total_amount: 120,
+  tax_rate: null,
+  discount_type: null,
+  discount_value: null,
+  deposit_amount: null,
+  notes: null,
+  shared_at: null,
+  share_token: null,
+  has_active_share: false,
+  linked_invoice: null,
+  pdf_artifact: {
+    status: "missing",
+    job_id: null,
+    download_url: null,
+    terminal_error: null,
+  },
+  line_items: [
+    {
+      id: "line-1",
+      description: "Brown mulch",
+      details: "5 yards",
+      price: 120,
+      flagged: true,
+      flag_reason: "Unit phrasing may be ambiguous",
+      sort_order: 0,
+    },
+  ],
+  created_at: "2026-03-20T00:00:00.000Z",
+  updated_at: "2026-03-20T00:00:00.000Z",
 };
 
 const clipFixture: VoiceClip = {
@@ -160,6 +241,7 @@ beforeEach(() => {
   mockVoiceCapture();
   mockedQuoteService.extract.mockResolvedValue({ type: "sync", quoteId: "quote-1", result: extractionFixture });
   mockedQuoteService.appendExtraction.mockReset();
+  mockedQuoteService.getQuote.mockResolvedValue(quoteDetailFixture);
   mockedQuoteService.createManualDraft.mockResolvedValue({
     id: "quote-manual-1",
     customer_id: "cust-1",
@@ -527,7 +609,18 @@ describe("CaptureScreen", () => {
       quoteId: "quote-1",
       result: {
         ...extractionFixture,
-        confidence_notes: ["New note"],
+        confidence_notes: ["Ignored because hydration now reads persisted sidecar"],
+      },
+    });
+    mockedQuoteService.getQuote.mockResolvedValueOnce({
+      ...quoteDetailFixture,
+      extraction_review_metadata: {
+        ...quoteDetailFixture.extraction_review_metadata!,
+        hidden_details: {
+          unresolved_segments: [],
+          append_suggestions: [],
+          confidence_notes: ["New note"],
+        },
       },
     });
     renderScreen({
@@ -565,6 +658,11 @@ describe("CaptureScreen", () => {
         quote_id: "quote-home",
       }),
     );
+    mockedQuoteService.getQuote.mockResolvedValueOnce({
+      ...quoteDetailFixture,
+      id: "quote-home",
+      customer_id: null,
+    });
     renderScreen({ pathname: "/quotes/capture", customerId: null });
 
     fireEvent.change(screen.getByLabelText(/written description/i), {

--- a/frontend/src/features/quotes/tests/quoteService.extract.test.ts
+++ b/frontend/src/features/quotes/tests/quoteService.extract.test.ts
@@ -13,6 +13,24 @@ const mockedRequestWithMetadata = vi.mocked(requestWithMetadata);
 const mockedRequest = vi.mocked(request);
 
 describe("quoteService.extract", () => {
+  const extractionPayload = {
+    transcript: "typed note only",
+    pipeline_version: "v2" as const,
+    line_items: [],
+    pricing_hints: {
+      explicit_total: null,
+      deposit_amount: null,
+      tax_rate: null,
+      discount_type: null,
+      discount_value: null,
+    },
+    customer_notes_suggestion: null,
+    unresolved_segments: [],
+    confidence_notes: [],
+    extraction_tier: "primary" as const,
+    extraction_degraded_reason_code: null,
+  };
+
   afterEach(() => {
     mockedRequestWithMetadata.mockReset();
     mockedRequest.mockReset();
@@ -57,10 +75,7 @@ describe("quoteService.extract", () => {
       status: 200,
       data: {
         quote_id: "quote-11",
-        transcript: "typed note only",
-        line_items: [],
-        total: null,
-        confidence_notes: [],
+        ...extractionPayload,
       },
     });
 
@@ -69,12 +84,7 @@ describe("quoteService.extract", () => {
     expect(result).toEqual({
       type: "sync",
       quoteId: "quote-11",
-      result: {
-        transcript: "typed note only",
-        line_items: [],
-        total: null,
-        confidence_notes: [],
-      },
+      result: extractionPayload,
     });
 
     const [, options] = mockedRequestWithMetadata.mock.calls[0] ?? [];
@@ -88,10 +98,8 @@ describe("quoteService.extract", () => {
       status: 200,
       data: {
         quote_id: "quote-22",
+        ...extractionPayload,
         transcript: "clips only",
-        line_items: [],
-        total: null,
-        confidence_notes: [],
       },
     });
 
@@ -112,10 +120,8 @@ describe("quoteService.extract", () => {
       status: 200,
       data: {
         quote_id: "quote-22",
+        ...extractionPayload,
         transcript: "append transcript",
-        line_items: [],
-        total: null,
-        confidence_notes: [],
       },
     });
 
@@ -127,10 +133,8 @@ describe("quoteService.extract", () => {
       type: "sync",
       quoteId: "quote-22",
       result: {
+        ...extractionPayload,
         transcript: "append transcript",
-        line_items: [],
-        total: null,
-        confidence_notes: [],
       },
     });
 

--- a/frontend/src/features/quotes/types/quote.types.ts
+++ b/frontend/src/features/quotes/types/quote.types.ts
@@ -5,9 +5,13 @@ export interface LineItemDraft {
   description: string;
   details: string | null;
   price: number | null;
+  flagged?: boolean;
+  flag_reason?: string | null;
 }
 
 export interface LineItemExtracted extends LineItemDraft {
+  raw_text?: string;
+  confidence?: PlacementConfidence;
   flagged?: boolean;
   flag_reason?: string | null;
 }
@@ -17,10 +21,39 @@ export interface LineItemDraftWithFlags extends LineItemDraft {
   flagReason?: string | null;
 }
 
+export type PlacementConfidence = "high" | "medium" | "low";
+export type UnresolvedSegmentSource =
+  | "leftover_classification"
+  | "typed_conflict"
+  | "transcript_conflict";
+
+export interface PricingHints {
+  explicit_total: number | null;
+  deposit_amount: number | null;
+  tax_rate: number | null;
+  discount_type: DiscountType | null;
+  discount_value: number | null;
+}
+
+export interface ExtractionSuggestion {
+  text: string;
+  confidence: PlacementConfidence;
+  source: UnresolvedSegmentSource;
+}
+
+export interface UnresolvedSegment {
+  raw_text: string;
+  confidence: "medium" | "low";
+  source: UnresolvedSegmentSource;
+}
+
 export interface ExtractionResult {
   transcript: string;
+  pipeline_version: "v2";
   line_items: LineItemExtracted[];
-  total: number | null;
+  pricing_hints: PricingHints;
+  customer_notes_suggestion: ExtractionSuggestion | null;
+  unresolved_segments: UnresolvedSegment[];
   confidence_notes: string[];
   extraction_tier: ExtractionTier;
   extraction_degraded_reason_code: string | null;
@@ -65,6 +98,8 @@ export interface LineItem {
   description: string;
   details: string | null;
   price: number | null;
+  flagged?: boolean;
+  flag_reason?: string | null;
   sort_order: number;
 }
 
@@ -121,6 +156,7 @@ export interface QuoteDetail extends Quote {
   has_active_share: boolean;
   extraction_tier: ExtractionTier | null;
   extraction_degraded_reason_code: string | null;
+  extraction_review_metadata?: ExtractionReviewMetadata;
   customer_name: string | null;
   customer_email: string | null;
   customer_phone: string | null;
@@ -128,6 +164,56 @@ export interface QuoteDetail extends Quote {
   can_reassign_customer?: boolean;
   linked_invoice: LinkedInvoiceSummary | null;
   pdf_artifact: PdfArtifact;
+}
+
+export interface ExtractionReviewState {
+  notes_pending: boolean;
+  pricing_pending: boolean;
+}
+
+export interface NotesSeededFieldMetadata {
+  seeded: boolean;
+  confidence: PlacementConfidence | null;
+  source: "explicit_notes_section" | "derived" | "leftover_classification" | null;
+}
+
+export interface PricingSeededFieldMetadata {
+  seeded: boolean;
+  source: "explicit_pricing_phrase" | null;
+}
+
+export interface ExtractionReviewHiddenDetails {
+  unresolved_segments: Array<{
+    id: string;
+    raw_text: string;
+    confidence: "medium" | "low";
+    source: UnresolvedSegmentSource;
+  }>;
+  append_suggestions: Array<{
+    id: string;
+    kind: "note" | "pricing";
+    raw_text: string;
+    confidence: "medium" | "low";
+    source: "append_capture";
+    pricing_field?: "explicit_total" | "deposit_amount" | "tax_rate" | "discount" | null;
+  }>;
+  confidence_notes: string[];
+}
+
+export interface ExtractionReviewMetadata {
+  pipeline_version: "v2";
+  review_state: ExtractionReviewState;
+  seeded_fields: {
+    notes: NotesSeededFieldMetadata;
+    pricing: {
+      explicit_total: PricingSeededFieldMetadata;
+      deposit_amount: PricingSeededFieldMetadata;
+      tax_rate: PricingSeededFieldMetadata;
+      discount: PricingSeededFieldMetadata;
+    };
+  };
+  hidden_details: ExtractionReviewHiddenDetails;
+  extraction_degraded_reason_code: string | null;
 }
 
 export interface QuoteListItem {


### PR DESCRIPTION
## Summary
- migrate quote extraction API/data contracts from V1 to V2 across backend schemas, extraction outcomes, and frontend quote service/types
- add `documents.extraction_review_metadata` sidecar persistence and thread-safe defaults in quote detail serialization
- seed notes/pricing/document totals directly into persisted quote draft fields, and persist line-item `flagged` / `flag_reason`
- update capture hydration to reseed review draft from persisted quote detail + sidecar after extraction completion
- add DB migration for sidecar + line-item flags and update targeted tests for the V2 response/behavior

## Verification
- `cd backend && .venv/bin/ruff check . --cache-dir .ruff_cache && .venv/bin/ruff format --check .`
- `cd backend && .venv/bin/pytest app/features/quotes/tests/test_extraction.py app/features/quotes/tests/test_extraction_service.py app/features/quotes/tests/test_quote_extraction.py app/features/quotes/tests/test_quote_append_extraction.py -v -m "not live and not extraction_eval and not extraction_quality" -o cache_dir=.pytest_cache`
- `cd frontend && ./node_modules/.bin/tsc --noEmit && ./node_modules/.bin/eslint src/features/quotes && ./node_modules/.bin/vitest run src/features/quotes`
- `make verify`

Closes #396