### PR TITLE
Task #398: Append behavior + hidden-item lifecycle

### DIFF
--- a/backend/app/features/quotes/api.py
+++ b/backend/app/features/quotes/api.py
@@ -43,6 +43,8 @@ from app.features.quotes.schemas import (
     ConvertNotesRequest,
     DiscountType,
     ExtractionResult,
+    ExtractionReviewMetadataUpdateRequest,
+    ExtractionReviewMetadataV1,
     LineItemResponse,
     LinkedInvoiceResponse,
     ManualDraftCreateRequest,
@@ -555,6 +557,28 @@ async def get_quote(
             extraction_degraded_reason_code=quote.extraction_degraded_reason_code,
         ),
     )
+
+
+@router.patch(
+    "/{quote_id}/extraction-review-metadata",
+    response_model=ExtractionReviewMetadataV1,
+    dependencies=[Depends(require_csrf)],
+)
+async def update_extraction_review_metadata(
+    quote_id: UUID,
+    payload: ExtractionReviewMetadataUpdateRequest,
+    user: Annotated[User, Depends(get_current_user)],
+    quote_service: Annotated[QuoteService, Depends(get_quote_service)],
+) -> ExtractionReviewMetadataV1:
+    """Mutate one quote extraction review sidecar payload."""
+    try:
+        return await quote_service.update_extraction_review_metadata(
+            user,
+            quote_id,
+            payload,
+        )
+    except QuoteServiceError as exc:
+        raise HTTPException(status_code=exc.status_code, detail=exc.detail) from exc
 
 
 @router.patch(

--- a/backend/app/features/quotes/extraction_append/service.py
+++ b/backend/app/features/quotes/extraction_append/service.py
@@ -4,17 +4,23 @@ from __future__ import annotations
 
 import re
 from collections.abc import Awaitable, Callable, Sequence
-from typing import Protocol
+from typing import Literal, Protocol
 from uuid import UUID
 
 from app.features.quotes.errors import QuoteServiceError
 from app.features.quotes.extraction_outcomes import classify_extraction_result
 from app.features.quotes.models import Document, QuoteStatus
 from app.features.quotes.review_metadata import (
+    build_append_suggestion,
     build_extraction_review_metadata,
     normalize_extraction_review_metadata,
 )
-from app.features.quotes.schemas import ExtractionResult, LineItemDraft
+from app.features.quotes.schemas import (
+    ExtractionResult,
+    ExtractionReviewAppendSuggestion,
+    LineItemDraft,
+    PricingFieldName,
+)
 from app.shared.pricing import (
     PricingValidationError,
     derive_document_subtotal_from_line_items,
@@ -49,6 +55,17 @@ class QuoteExtractionAppendRepositoryProtocol(Protocol):
         document: Document,
         transcript: str,
         total_amount: float | None,
+        update_total_amount: bool,
+        notes: str | None,
+        update_notes: bool,
+        tax_rate: float | None,
+        update_tax_rate: bool,
+        discount_type: str | None,
+        update_discount_type: bool,
+        discount_value: float | None,
+        update_discount_value: bool,
+        deposit_amount: float | None,
+        update_deposit_amount: bool,
         line_items: list[LineItemDraft],
         extraction_tier: str | None = None,
         extraction_degraded_reason_code: str | None = None,
@@ -98,6 +115,31 @@ class QuoteExtractionAppendService:
     ) -> tuple[Document, ExtractionResult]:
         """Append extraction output and commit cleanup only when `commit=True`."""
         quote = await self.ensure_quote_appendable(user_id=user_id, quote_id=quote_id)
+        append_suggestions = _resolve_append_suggestions(
+            quote=quote,
+            extraction_result=extraction_result,
+        )
+        (
+            next_notes,
+            update_notes,
+        ) = _resolve_next_notes_for_append(quote=quote, extraction_result=extraction_result)
+        (
+            next_discount_type,
+            next_discount_value,
+            update_discount_type,
+            update_discount_value,
+            seeded_discount,
+        ) = _resolve_discount_for_append(quote=quote, extraction_result=extraction_result)
+        (
+            next_tax_rate,
+            update_tax_rate,
+            seeded_tax_rate,
+        ) = _resolve_tax_rate_for_append(quote=quote, extraction_result=extraction_result)
+        (
+            next_deposit_amount,
+            update_deposit_amount,
+            seeded_deposit_amount,
+        ) = _resolve_deposit_amount_for_append(quote=quote, extraction_result=extraction_result)
         appended_line_items = [
             LineItemDraft(
                 description=item.description,
@@ -126,43 +168,104 @@ class QuoteExtractionAppendService:
         )
         current_subtotal = resolve_document_subtotal_for_edit(
             total_amount=quote.total_amount,
-            discount_type=quote.discount_type,
-            discount_value=quote.discount_value,
-            tax_rate=quote.tax_rate,
-            deposit_amount=quote.deposit_amount,
+            discount_type=next_discount_type,
+            discount_value=next_discount_value,
+            tax_rate=next_tax_rate,
+            deposit_amount=next_deposit_amount,
             line_items=merged_line_items,
         )
+        next_total_input = _resolve_total_amount_for_append(
+            quote=quote,
+            extraction_result=extraction_result,
+            line_items_define_subtotal=line_items_define_subtotal,
+            derived_line_item_subtotal=derived_line_item_subtotal,
+            current_subtotal=current_subtotal,
+        )
         validated_pricing = _validate_document_pricing_for_append(
-            total_amount=(
-                derived_line_item_subtotal if line_items_define_subtotal else current_subtotal
-            ),
+            total_amount=next_total_input,
             line_items=merged_line_items,
-            discount_type=quote.discount_type,
-            discount_value=document_field_float_or_none(quote.discount_value),
-            tax_rate=document_field_float_or_none(quote.tax_rate),
-            deposit_amount=document_field_float_or_none(quote.deposit_amount),
+            discount_type=next_discount_type,
+            discount_value=next_discount_value,
+            tax_rate=next_tax_rate,
+            deposit_amount=next_deposit_amount,
         )
 
         next_transcript = _merge_append_transcript(
             current_transcript=quote.transcript,
             appended_transcript=extraction_result.transcript,
         )
+        validated_total_amount = document_field_float_or_none(validated_pricing.total_amount)
+        validated_tax_rate = document_field_float_or_none(validated_pricing.tax_rate)
+        validated_discount_value = document_field_float_or_none(validated_pricing.discount_value)
+        validated_deposit_amount = document_field_float_or_none(validated_pricing.deposit_amount)
+        seeded_pricing_fields: set[PricingFieldName] = set()
+        if (
+            seeded_discount
+            and validated_pricing.discount_type is not None
+            and validated_discount_value is not None
+        ):
+            seeded_pricing_fields.add("discount")
+        if seeded_tax_rate and validated_tax_rate is not None:
+            seeded_pricing_fields.add("tax_rate")
+        if seeded_deposit_amount and validated_deposit_amount is not None:
+            seeded_pricing_fields.add("deposit_amount")
+        if (
+            extraction_result.pricing_hints.explicit_total is not None
+            and quote.total_amount is None
+            and not line_items_define_subtotal
+            and validated_total_amount is not None
+        ):
+            seeded_pricing_fields.add("explicit_total")
+
         extraction_metadata = classify_extraction_result(extraction_result)
         merged_review_metadata = build_extraction_review_metadata(
             extraction_result,
-            seeded_notes=False,
-            seeded_notes_confidence=None,
-            seeded_notes_source=None,
-            seeded_pricing_fields=set(),
+            seeded_notes=update_notes,
+            seeded_notes_confidence=(
+                extraction_result.customer_notes_suggestion.confidence
+                if extraction_result.customer_notes_suggestion is not None
+                else None
+            ),
+            seeded_notes_source=(
+                extraction_result.customer_notes_suggestion.source
+                if extraction_result.customer_notes_suggestion is not None
+                else None
+            ),
+            seeded_pricing_fields=seeded_pricing_fields,
             existing_metadata=normalize_extraction_review_metadata(
                 quote.extraction_review_metadata,
                 extraction_degraded_reason_code=quote.extraction_degraded_reason_code,
             ),
+            append_suggestions=append_suggestions,
         )
         updated_quote = await self._repository.append_extraction(
             document=quote,
             transcript=next_transcript,
-            total_amount=document_field_float_or_none(validated_pricing.total_amount),
+            total_amount=validated_total_amount,
+            update_total_amount=(
+                validated_total_amount != document_field_float_or_none(quote.total_amount)
+            ),
+            notes=next_notes,
+            update_notes=update_notes,
+            tax_rate=validated_tax_rate,
+            update_tax_rate=(
+                update_tax_rate
+                and validated_tax_rate != document_field_float_or_none(quote.tax_rate)
+            ),
+            discount_type=validated_pricing.discount_type,
+            update_discount_type=(
+                update_discount_type and validated_pricing.discount_type != quote.discount_type
+            ),
+            discount_value=validated_discount_value,
+            update_discount_value=(
+                update_discount_value
+                and validated_discount_value != document_field_float_or_none(quote.discount_value)
+            ),
+            deposit_amount=validated_deposit_amount,
+            update_deposit_amount=(
+                update_deposit_amount
+                and validated_deposit_amount != document_field_float_or_none(quote.deposit_amount)
+            ),
             line_items=appended_line_items,
             extraction_tier=extraction_metadata.tier,
             extraction_degraded_reason_code=extraction_metadata.degraded_reason_code,
@@ -250,3 +353,182 @@ def _extract_append_entries(transcript: str) -> list[str]:
         if line:
             entries.append(line)
     return entries
+
+
+def _resolve_append_suggestions(
+    *,
+    quote: Document,
+    extraction_result: ExtractionResult,
+) -> list[ExtractionReviewAppendSuggestion]:
+    append_suggestions: list[ExtractionReviewAppendSuggestion] = []
+    notes_suggestion = extraction_result.customer_notes_suggestion
+    if notes_suggestion is not None and _is_populated_text(quote.notes):
+        normalized_text = notes_suggestion.text.strip()
+        if normalized_text:
+            append_suggestions.append(
+                build_append_suggestion(
+                    kind="note",
+                    raw_text=normalized_text,
+                    confidence=_normalize_append_confidence(notes_suggestion.confidence),
+                )
+            )
+
+    pricing_hints = extraction_result.pricing_hints
+    if pricing_hints.explicit_total is not None and quote.total_amount is not None:
+        append_suggestions.append(
+            _build_pricing_append_suggestion(
+                pricing_field="explicit_total",
+                value=pricing_hints.explicit_total,
+            )
+        )
+    if pricing_hints.deposit_amount is not None and quote.deposit_amount is not None:
+        append_suggestions.append(
+            _build_pricing_append_suggestion(
+                pricing_field="deposit_amount",
+                value=pricing_hints.deposit_amount,
+            )
+        )
+    if pricing_hints.tax_rate is not None and quote.tax_rate is not None:
+        append_suggestions.append(
+            _build_pricing_append_suggestion(
+                pricing_field="tax_rate",
+                value=pricing_hints.tax_rate,
+            )
+        )
+    if (
+        pricing_hints.discount_type is not None
+        and pricing_hints.discount_value is not None
+        and _is_discount_populated(
+            discount_type=quote.discount_type,
+            discount_value=document_field_float_or_none(quote.discount_value),
+        )
+    ):
+        append_suggestions.append(
+            build_append_suggestion(
+                kind="pricing",
+                raw_text=(
+                    f"Discount ({pricing_hints.discount_type}) {pricing_hints.discount_value:g}"
+                ),
+                confidence="medium",
+                pricing_field="discount",
+            )
+        )
+
+    return append_suggestions
+
+
+def _resolve_next_notes_for_append(
+    *,
+    quote: Document,
+    extraction_result: ExtractionResult,
+) -> tuple[str | None, bool]:
+    suggestion = extraction_result.customer_notes_suggestion
+    if suggestion is None:
+        return quote.notes, False
+    normalized_text = suggestion.text.strip()
+    if not normalized_text or _is_populated_text(quote.notes):
+        return quote.notes, False
+    return normalized_text, normalized_text != (quote.notes or "")
+
+
+def _resolve_discount_for_append(
+    *,
+    quote: Document,
+    extraction_result: ExtractionResult,
+) -> tuple[str | None, float | None, bool, bool, bool]:
+    discount_type = extraction_result.pricing_hints.discount_type
+    discount_value = extraction_result.pricing_hints.discount_value
+    if discount_type is None or discount_value is None:
+        return (
+            quote.discount_type,
+            document_field_float_or_none(quote.discount_value),
+            False,
+            False,
+            False,
+        )
+    if _is_discount_populated(
+        discount_type=quote.discount_type,
+        discount_value=document_field_float_or_none(quote.discount_value),
+    ):
+        return (
+            quote.discount_type,
+            document_field_float_or_none(quote.discount_value),
+            False,
+            False,
+            False,
+        )
+    return discount_type, discount_value, True, True, True
+
+
+def _resolve_tax_rate_for_append(
+    *,
+    quote: Document,
+    extraction_result: ExtractionResult,
+) -> tuple[float | None, bool, bool]:
+    if extraction_result.pricing_hints.tax_rate is None or quote.tax_rate is not None:
+        return document_field_float_or_none(quote.tax_rate), False, False
+    return extraction_result.pricing_hints.tax_rate, True, True
+
+
+def _resolve_deposit_amount_for_append(
+    *,
+    quote: Document,
+    extraction_result: ExtractionResult,
+) -> tuple[float | None, bool, bool]:
+    if extraction_result.pricing_hints.deposit_amount is None or quote.deposit_amount is not None:
+        return document_field_float_or_none(quote.deposit_amount), False, False
+    return extraction_result.pricing_hints.deposit_amount, True, True
+
+
+def _resolve_total_amount_for_append(
+    *,
+    quote: Document,
+    extraction_result: ExtractionResult,
+    line_items_define_subtotal: bool,
+    derived_line_item_subtotal: float | None,
+    current_subtotal: float | None,
+) -> float | None:
+    if line_items_define_subtotal:
+        return derived_line_item_subtotal
+    if quote.total_amount is None and extraction_result.pricing_hints.explicit_total is not None:
+        return extraction_result.pricing_hints.explicit_total
+    return current_subtotal
+
+
+def _is_populated_text(value: str | None) -> bool:
+    return value is not None and value.strip() != ""
+
+
+def _is_discount_populated(
+    *,
+    discount_type: str | None,
+    discount_value: float | None,
+) -> bool:
+    return discount_type is not None or discount_value is not None
+
+
+def _build_pricing_append_suggestion(
+    *,
+    pricing_field: PricingFieldName,
+    value: float,
+) -> ExtractionReviewAppendSuggestion:
+    label = {
+        "explicit_total": "Total",
+        "deposit_amount": "Deposit",
+        "tax_rate": "Tax rate",
+        "discount": "Discount",
+    }[pricing_field]
+    return build_append_suggestion(
+        kind="pricing",
+        raw_text=f"{label} {value:g}",
+        confidence="medium",
+        pricing_field=pricing_field,
+    )
+
+
+def _normalize_append_confidence(
+    confidence: str,
+) -> Literal["medium", "low"]:
+    if confidence == "low":
+        return "low"
+    return "medium"

--- a/backend/app/features/quotes/mutation/service.py
+++ b/backend/app/features/quotes/mutation/service.py
@@ -327,13 +327,13 @@ class QuoteMutationService:
             metadata,
             dismiss_hidden_item=data.dismiss_hidden_item,
             review_hidden_item=data.review_hidden_item,
-            clear_notes_pending=bool(
+            clear_notes_pending=(
                 data.clear_review_state is not None
-                and data.clear_review_state.notes_pending is not None
+                and data.clear_review_state.notes_pending is True
             ),
-            clear_pricing_pending=bool(
+            clear_pricing_pending=(
                 data.clear_review_state is not None
-                and data.clear_review_state.pricing_pending is not None
+                and data.clear_review_state.pricing_pending is True
             ),
         )
         if next_metadata.model_dump(mode="json") != metadata.model_dump(mode="json"):

--- a/backend/app/features/quotes/mutation/service.py
+++ b/backend/app/features/quotes/mutation/service.py
@@ -11,7 +11,17 @@ from sqlalchemy.exc import IntegrityError
 
 from app.features.quotes.errors import QuoteServiceError
 from app.features.quotes.models import Document, QuoteStatus
-from app.features.quotes.schemas import LineItemDraft, QuoteUpdateRequest
+from app.features.quotes.review_metadata import (
+    apply_hidden_detail_lifecycle_updates,
+    clear_append_suggestions_for_manual_edits,
+    normalize_extraction_review_metadata,
+)
+from app.features.quotes.schemas import (
+    ExtractionReviewMetadataUpdateRequest,
+    ExtractionReviewMetadataV1,
+    LineItemDraft,
+    QuoteUpdateRequest,
+)
 from app.shared.event_logger import log_event
 from app.shared.pricing import (
     PricingValidationError,
@@ -71,6 +81,15 @@ class QuoteMutationRepositoryProtocol(Protocol):
         update_notes: bool,
         line_items: list[LineItemDraft] | None,
         replace_line_items: bool,
+        extraction_review_metadata: dict[str, object] | None = None,
+        update_extraction_review_metadata: bool = False,
+    ) -> Document: ...
+
+    async def update_extraction_review_metadata(
+        self,
+        *,
+        document: Document,
+        extraction_review_metadata: dict[str, object],
     ) -> Document: ...
 
     async def invalidate_pdf_artifact(self, document: Document) -> str | None: ...
@@ -185,19 +204,44 @@ class QuoteMutationService:
                 else document_field_float_or_none(quote.deposit_amount)
             ),
         )
+        next_total_amount = document_field_float_or_none(current_pricing.total_amount)
+        next_tax_rate = document_field_float_or_none(current_pricing.tax_rate)
+        next_discount_type = current_pricing.discount_type
+        next_discount_value = document_field_float_or_none(current_pricing.discount_value)
+        next_deposit_amount = document_field_float_or_none(current_pricing.deposit_amount)
+        next_notes = data.notes if "notes" in data.model_fields_set else quote.notes
+        notes_changed = "notes" in data.model_fields_set and _normalized_optional_text(
+            next_notes
+        ) != _normalized_optional_text(quote.notes)
+        pricing_changed = any(
+            (
+                next_total_amount != document_field_float_or_none(quote.total_amount),
+                next_tax_rate != document_field_float_or_none(quote.tax_rate),
+                next_discount_type != quote.discount_type,
+                next_discount_value != document_field_float_or_none(quote.discount_value),
+                next_deposit_amount != document_field_float_or_none(quote.deposit_amount),
+            )
+        )
+        next_extraction_review_metadata, update_extraction_review_metadata = (
+            _resolve_next_extraction_review_metadata_for_update(
+                quote=quote,
+                notes_changed=notes_changed,
+                pricing_changed=pricing_changed,
+            )
+        )
         rendered_fields_changed = (
             _quote_render_inputs_changed(
                 quote=quote,
                 update_fields=data.model_fields_set,
                 next_customer_id=next_customer_id,
                 next_line_items=next_line_items,
-                next_total_amount=document_field_float_or_none(current_pricing.total_amount),
-                next_tax_rate=document_field_float_or_none(current_pricing.tax_rate),
-                next_discount_type=current_pricing.discount_type,
-                next_discount_value=document_field_float_or_none(current_pricing.discount_value),
-                next_deposit_amount=document_field_float_or_none(current_pricing.deposit_amount),
+                next_total_amount=next_total_amount,
+                next_tax_rate=next_tax_rate,
+                next_discount_type=next_discount_type,
+                next_discount_value=next_discount_value,
+                next_deposit_amount=next_deposit_amount,
                 next_title=data.title if "title" in data.model_fields_set else quote.title,
-                next_notes=data.notes if "notes" in data.model_fields_set else quote.notes,
+                next_notes=next_notes,
             )
             or doc_type_changed
         )
@@ -211,30 +255,33 @@ class QuoteMutationService:
                 update_title="title" in data.model_fields_set,
                 transcript=data.transcript,
                 update_transcript="transcript" in data.model_fields_set,
-                total_amount=document_field_float_or_none(current_pricing.total_amount),
+                total_amount=next_total_amount,
                 update_total_amount="total_amount" in data.model_fields_set
                 or ("line_items" in data.model_fields_set and line_items_define_subtotal)
                 or "discount_type" in data.model_fields_set
                 or "discount_value" in data.model_fields_set
                 or "tax_rate" in data.model_fields_set,
-                tax_rate=document_field_float_or_none(current_pricing.tax_rate),
+                tax_rate=next_tax_rate,
                 update_tax_rate="tax_rate" in data.model_fields_set,
-                discount_type=current_pricing.discount_type,
+                discount_type=next_discount_type,
                 update_discount_type=(
                     "discount_type" in data.model_fields_set
-                    or (
-                        "discount_value" in data.model_fields_set
-                        and current_pricing.discount_type is None
-                    )
+                    or ("discount_value" in data.model_fields_set and next_discount_type is None)
                 ),
-                discount_value=document_field_float_or_none(current_pricing.discount_value),
+                discount_value=next_discount_value,
                 update_discount_value="discount_value" in data.model_fields_set,
-                deposit_amount=document_field_float_or_none(current_pricing.deposit_amount),
+                deposit_amount=next_deposit_amount,
                 update_deposit_amount="deposit_amount" in data.model_fields_set,
                 notes=data.notes,
                 update_notes="notes" in data.model_fields_set,
                 line_items=data.line_items,
                 replace_line_items="line_items" in data.model_fields_set,
+                extraction_review_metadata=(
+                    next_extraction_review_metadata.model_dump(mode="json")
+                    if next_extraction_review_metadata is not None
+                    else None
+                ),
+                update_extraction_review_metadata=update_extraction_review_metadata,
             )
             obsolete_artifact_path = None
             if rendered_fields_changed:
@@ -259,6 +306,46 @@ class QuoteMutationService:
             customer_id=updated_quote.customer_id,
         )
         return await self._repository.refresh(updated_quote)
+
+    async def update_extraction_review_metadata(
+        self,
+        *,
+        user_id: UUID,
+        quote_id: UUID,
+        data: ExtractionReviewMetadataUpdateRequest,
+    ) -> ExtractionReviewMetadataV1:
+        """Mutate only extraction review sidecar metadata for one quote."""
+        quote = await self._repository.get_by_id(quote_id, user_id)
+        if quote is None:
+            raise QuoteServiceError(detail="Not found", status_code=404)
+
+        metadata = normalize_extraction_review_metadata(
+            quote.extraction_review_metadata,
+            extraction_degraded_reason_code=quote.extraction_degraded_reason_code,
+        )
+        next_metadata = apply_hidden_detail_lifecycle_updates(
+            metadata,
+            dismiss_hidden_item=data.dismiss_hidden_item,
+            review_hidden_item=data.review_hidden_item,
+            clear_notes_pending=bool(
+                data.clear_review_state is not None
+                and data.clear_review_state.notes_pending is not None
+            ),
+            clear_pricing_pending=bool(
+                data.clear_review_state is not None
+                and data.clear_review_state.pricing_pending is not None
+            ),
+        )
+        if next_metadata.model_dump(mode="json") != metadata.model_dump(mode="json"):
+            await self._repository.update_extraction_review_metadata(
+                document=quote,
+                extraction_review_metadata=next_metadata.model_dump(mode="json"),
+            )
+            await self._repository.commit()
+        return normalize_extraction_review_metadata(
+            quote.extraction_review_metadata,
+            extraction_degraded_reason_code=quote.extraction_degraded_reason_code,
+        )
 
     async def _apply_doc_type_transition(
         self,
@@ -351,6 +438,36 @@ class QuoteMutationService:
             )
 
         return requested_customer_id
+
+
+def _resolve_next_extraction_review_metadata_for_update(
+    *,
+    quote: Document,
+    notes_changed: bool,
+    pricing_changed: bool,
+) -> tuple[ExtractionReviewMetadataV1 | None, bool]:
+    if not notes_changed and not pricing_changed:
+        return None, False
+
+    metadata = normalize_extraction_review_metadata(
+        getattr(quote, "extraction_review_metadata", None),
+        extraction_degraded_reason_code=getattr(quote, "extraction_degraded_reason_code", None),
+    )
+    cleared_metadata = clear_append_suggestions_for_manual_edits(
+        metadata,
+        notes_changed=notes_changed,
+        pricing_changed=pricing_changed,
+    )
+    if cleared_metadata.model_dump(mode="json") == metadata.model_dump(mode="json"):
+        return None, False
+    return cleared_metadata, True
+
+
+def _normalized_optional_text(value: str | None) -> str | None:
+    if value is None:
+        return None
+    normalized = value.strip()
+    return normalized or None
 
 
 def _is_doc_sequence_collision(exc: IntegrityError) -> bool:

--- a/backend/app/features/quotes/repository.py
+++ b/backend/app/features/quotes/repository.py
@@ -686,6 +686,8 @@ class QuoteRepository:
         update_notes: bool,
         line_items: list[LineItemDraft] | None,
         replace_line_items: bool,
+        extraction_review_metadata: dict[str, Any] | None = None,
+        update_extraction_review_metadata: bool = False,
     ) -> Document:
         """Apply partial quote updates and optional full line-item replacement."""
         if update_customer_id:
@@ -706,6 +708,8 @@ class QuoteRepository:
             document.deposit_amount = _to_decimal(deposit_amount)
         if update_notes:
             document.notes = notes
+        if update_extraction_review_metadata:
+            document.extraction_review_metadata = extraction_review_metadata
 
         if replace_line_items and line_items is not None:
             await self._replace_line_items(document.id, line_items)
@@ -721,6 +725,17 @@ class QuoteRepository:
         document: Document,
         transcript: str,
         total_amount: float | None,
+        update_total_amount: bool,
+        notes: str | None,
+        update_notes: bool,
+        tax_rate: float | None,
+        update_tax_rate: bool,
+        discount_type: str | None,
+        update_discount_type: bool,
+        discount_value: float | None,
+        update_discount_value: bool,
+        deposit_amount: float | None,
+        update_deposit_amount: bool,
         line_items: list[LineItemDraft],
         extraction_tier: str | None = None,
         extraction_degraded_reason_code: str | None = None,
@@ -728,7 +743,18 @@ class QuoteRepository:
     ) -> Document:
         """Append extracted line items while preserving existing rows and order."""
         document.transcript = transcript
-        document.total_amount = _to_decimal(total_amount)
+        if update_total_amount:
+            document.total_amount = _to_decimal(total_amount)
+        if update_notes:
+            document.notes = notes
+        if update_tax_rate:
+            document.tax_rate = _to_decimal(tax_rate)
+        if update_discount_type:
+            document.discount_type = discount_type
+        if update_discount_value:
+            document.discount_value = _to_decimal(discount_value)
+        if update_deposit_amount:
+            document.deposit_amount = _to_decimal(deposit_amount)
         document.extraction_tier = extraction_tier
         document.extraction_degraded_reason_code = extraction_degraded_reason_code
         if extraction_review_metadata is not None:
@@ -751,6 +777,18 @@ class QuoteRepository:
         await self._session.flush()
         await self._session.refresh(document)
         await self._session.refresh(document, attribute_names=["line_items"])
+        return document
+
+    async def update_extraction_review_metadata(
+        self,
+        *,
+        document: Document,
+        extraction_review_metadata: dict[str, Any],
+    ) -> Document:
+        """Persist one sidecar-only extraction review metadata mutation."""
+        document.extraction_review_metadata = extraction_review_metadata
+        await self._session.flush()
+        await self._session.refresh(document)
         return document
 
     async def has_linked_invoice(

--- a/backend/app/features/quotes/review_metadata.py
+++ b/backend/app/features/quotes/review_metadata.py
@@ -2,15 +2,18 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping, Sequence
 from hashlib import sha256
 from typing import Literal, cast
 
 from app.features.quotes.schemas import (
     ExtractionResult,
+    ExtractionReviewAppendSuggestion,
     ExtractionReviewHiddenDetails,
     ExtractionReviewMetadataV1,
     ExtractionReviewState,
     ExtractionReviewUnresolvedSegment,
+    HiddenItemState,
     NotesSeededFieldMetadata,
     PlacementConfidence,
     PricingFieldName,
@@ -40,6 +43,7 @@ def build_extraction_review_metadata(
     seeded_notes_source: str | None,
     seeded_pricing_fields: set[PricingFieldName],
     existing_metadata: ExtractionReviewMetadataV1 | None = None,
+    append_suggestions: Sequence[ExtractionReviewAppendSuggestion] | None = None,
 ) -> ExtractionReviewMetadataV1:
     """Build or merge sidecar metadata for one extraction persistence write."""
     previous = existing_metadata or ExtractionReviewMetadataV1()
@@ -80,28 +84,28 @@ def build_extraction_review_metadata(
         ),
     )
 
+    unresolved_segments = _dedupe_unresolved_segments(extraction_result)
+    merged_append_suggestions, incoming_append_ids = _merge_append_suggestions(
+        previous_suggestions=previous.hidden_details.append_suggestions,
+        incoming_suggestions=append_suggestions or [],
+    )
     hidden_details = ExtractionReviewHiddenDetails(
-        unresolved_segments=[
-            ExtractionReviewUnresolvedSegment(
-                id=_deterministic_hidden_id(
-                    "unresolved",
-                    segment.source,
-                    segment.confidence,
-                    segment.raw_text,
-                ),
-                raw_text=segment.raw_text,
-                confidence=segment.confidence,
-                source=segment.source,
-            )
-            for segment in extraction_result.unresolved_segments
-        ],
-        append_suggestions=list(previous.hidden_details.append_suggestions),
+        unresolved_segments=unresolved_segments,
+        append_suggestions=merged_append_suggestions,
         confidence_notes=(
             list(extraction_result.confidence_notes)
             if extraction_result.confidence_notes
             else list(previous.hidden_details.confidence_notes)
         ),
     )
+    current_hidden_item_ids = {
+        *[item.id for item in unresolved_segments],
+        *[item.id for item in merged_append_suggestions],
+    }
+    resurfaced_hidden_item_ids = {
+        *[item.id for item in unresolved_segments],
+        *incoming_append_ids,
+    }
 
     return ExtractionReviewMetadataV1(
         pipeline_version=extraction_result.pipeline_version,
@@ -118,6 +122,11 @@ def build_extraction_review_metadata(
             pricing=merged_pricing,
         ),
         hidden_details=hidden_details,
+        hidden_detail_state=_build_hidden_detail_state(
+            previous_state=previous.hidden_detail_state,
+            current_item_ids=current_hidden_item_ids,
+            resurfaced_item_ids=resurfaced_hidden_item_ids,
+        ),
         extraction_degraded_reason_code=extraction_result.extraction_degraded_reason_code,
     )
 
@@ -130,6 +139,116 @@ def _merge_pricing_seed(
     if previous.seeded or seed_now:
         return PricingSeededFieldMetadata(seeded=True, source="explicit_pricing_phrase")
     return PricingSeededFieldMetadata(seeded=False, source=previous.source)
+
+
+def build_append_suggestion(
+    *,
+    kind: Literal["note", "pricing"],
+    raw_text: str,
+    confidence: Literal["medium", "low"],
+    pricing_field: PricingFieldName | None = None,
+) -> ExtractionReviewAppendSuggestion:
+    """Build one deterministic append suggestion payload."""
+    normalized_raw_text = raw_text.strip()
+    suffix = pricing_field if pricing_field is not None else "none"
+    return ExtractionReviewAppendSuggestion(
+        id=build_hidden_item_id("append", kind, suffix, normalized_raw_text),
+        kind=kind,
+        raw_text=normalized_raw_text,
+        confidence=confidence,
+        source="append_capture",
+        pricing_field=pricing_field,
+    )
+
+
+def clear_append_suggestions_for_manual_edits(
+    metadata: ExtractionReviewMetadataV1,
+    *,
+    notes_changed: bool,
+    pricing_changed: bool,
+) -> ExtractionReviewMetadataV1:
+    """Clear related append suggestions/review groups after real manual edits."""
+    if not notes_changed and not pricing_changed:
+        return metadata
+
+    filtered_append_suggestions = [
+        item
+        for item in metadata.hidden_details.append_suggestions
+        if not (
+            (notes_changed and item.kind == "note") or (pricing_changed and item.kind == "pricing")
+        )
+    ]
+    updated_review_state = metadata.review_state.model_copy(
+        update={
+            "notes_pending": (False if notes_changed else metadata.review_state.notes_pending),
+            "pricing_pending": (
+                False if pricing_changed else metadata.review_state.pricing_pending
+            ),
+        }
+    )
+    updated_hidden_details = metadata.hidden_details.model_copy(
+        update={"append_suggestions": filtered_append_suggestions}
+    )
+    return metadata.model_copy(
+        update={
+            "review_state": updated_review_state,
+            "hidden_details": updated_hidden_details,
+        }
+    )
+
+
+def apply_hidden_detail_lifecycle_updates(
+    metadata: ExtractionReviewMetadataV1,
+    *,
+    dismiss_hidden_item: str | None = None,
+    review_hidden_item: str | None = None,
+    clear_notes_pending: bool = False,
+    clear_pricing_pending: bool = False,
+) -> ExtractionReviewMetadataV1:
+    """Apply sidecar lifecycle/review-state mutations from PATCH operations."""
+    if not any(
+        (
+            dismiss_hidden_item is not None,
+            review_hidden_item is not None,
+            clear_notes_pending,
+            clear_pricing_pending,
+        )
+    ):
+        return metadata
+
+    next_state: dict[str, HiddenItemState] = {
+        item_id: value.model_copy(deep=True)
+        for item_id, value in metadata.hidden_detail_state.items()
+    }
+    if review_hidden_item is not None:
+        previous = next_state.get(review_hidden_item, HiddenItemState())
+        next_state[review_hidden_item] = HiddenItemState(
+            reviewed=True,
+            dismissed=previous.dismissed,
+        )
+    if dismiss_hidden_item is not None:
+        previous = next_state.get(dismiss_hidden_item, HiddenItemState())
+        next_state[dismiss_hidden_item] = HiddenItemState(
+            reviewed=previous.reviewed,
+            dismissed=True,
+        )
+
+    updated_review_state = metadata.review_state.model_copy(
+        update={
+            "notes_pending": (
+                False if clear_notes_pending else metadata.review_state.notes_pending
+            ),
+            "pricing_pending": (
+                False if clear_pricing_pending else metadata.review_state.pricing_pending
+            ),
+        }
+    )
+    return metadata.model_copy(
+        update={
+            "hidden_detail_state": next_state,
+            "review_state": updated_review_state,
+        }
+    )
 
 
 def _normalize_notes_seeded_source(
@@ -145,7 +264,66 @@ def _normalize_notes_seeded_source(
     return "derived"
 
 
-def _deterministic_hidden_id(*parts: str) -> str:
+def build_hidden_item_id(*parts: str) -> str:
+    """Build a deterministic hidden-item id from normalized content parts."""
     normalized = "|".join(part.strip().casefold() for part in parts)
     digest = sha256(normalized.encode("utf-8")).hexdigest()[:16]
     return f"h:{digest}"
+
+
+def _build_hidden_detail_state(
+    *,
+    previous_state: Mapping[str, HiddenItemState],
+    current_item_ids: set[str],
+    resurfaced_item_ids: set[str],
+) -> dict[str, HiddenItemState]:
+    merged: dict[str, HiddenItemState] = {
+        item_id: state.model_copy(deep=True) for item_id, state in previous_state.items()
+    }
+    for item_id in current_item_ids:
+        previous = merged.get(item_id, HiddenItemState())
+        if item_id in resurfaced_item_ids:
+            merged[item_id] = HiddenItemState()
+            continue
+        merged[item_id] = HiddenItemState(
+            reviewed=previous.reviewed,
+            dismissed=previous.dismissed,
+        )
+    return merged
+
+
+def _dedupe_unresolved_segments(
+    extraction_result: ExtractionResult,
+) -> list[ExtractionReviewUnresolvedSegment]:
+    deduped: dict[str, ExtractionReviewUnresolvedSegment] = {}
+    for segment in extraction_result.unresolved_segments:
+        hidden_id = build_hidden_item_id(
+            "unresolved",
+            segment.source,
+            segment.confidence,
+            segment.raw_text,
+        )
+        if hidden_id in deduped:
+            continue
+        deduped[hidden_id] = ExtractionReviewUnresolvedSegment(
+            id=hidden_id,
+            raw_text=segment.raw_text,
+            confidence=segment.confidence,
+            source=segment.source,
+        )
+    return list(deduped.values())
+
+
+def _merge_append_suggestions(
+    *,
+    previous_suggestions: Sequence[ExtractionReviewAppendSuggestion],
+    incoming_suggestions: Sequence[ExtractionReviewAppendSuggestion],
+) -> tuple[list[ExtractionReviewAppendSuggestion], set[str]]:
+    merged: dict[str, ExtractionReviewAppendSuggestion] = {
+        item.id: item for item in previous_suggestions
+    }
+    incoming_ids: set[str] = set()
+    for item in incoming_suggestions:
+        merged[item.id] = item
+        incoming_ids.add(item.id)
+    return list(merged.values()), incoming_ids

--- a/backend/app/features/quotes/schemas.py
+++ b/backend/app/features/quotes/schemas.py
@@ -426,8 +426,8 @@ class QuoteUpdateRequest(BaseModel):
 class ExtractionReviewStateClearRequest(BaseModel):
     """Request payload for clearing grouped extraction review state flags."""
 
-    notes_pending: bool | None = None
-    pricing_pending: bool | None = None
+    notes_pending: Literal[True] | None = None
+    pricing_pending: Literal[True] | None = None
 
     @model_validator(mode="after")
     def validate_has_target(self) -> ExtractionReviewStateClearRequest:

--- a/backend/app/features/quotes/schemas.py
+++ b/backend/app/features/quotes/schemas.py
@@ -305,6 +305,13 @@ class ExtractionReviewHiddenDetails(BaseModel):
     )
 
 
+class HiddenItemState(BaseModel):
+    """Lifecycle state persisted for one hidden extraction item."""
+
+    reviewed: bool = False
+    dismissed: bool = False
+
+
 class ExtractionReviewMetadataV1(BaseModel):
     """Sidecar metadata persisted for V2 extraction review behavior."""
 
@@ -314,6 +321,7 @@ class ExtractionReviewMetadataV1(BaseModel):
     hidden_details: ExtractionReviewHiddenDetails = Field(
         default_factory=ExtractionReviewHiddenDetails
     )
+    hidden_detail_state: dict[str, HiddenItemState] = Field(default_factory=dict)
     extraction_degraded_reason_code: str | None = None
 
     @classmethod
@@ -412,6 +420,40 @@ class QuoteUpdateRequest(BaseModel):
             raise ValueError("doc_type cannot be null")
         if "due_date" in self.model_fields_set and self.due_date is None:
             raise ValueError("due_date cannot be null")
+        return self
+
+
+class ExtractionReviewStateClearRequest(BaseModel):
+    """Request payload for clearing grouped extraction review state flags."""
+
+    notes_pending: bool | None = None
+    pricing_pending: bool | None = None
+
+    @model_validator(mode="after")
+    def validate_has_target(self) -> ExtractionReviewStateClearRequest:
+        if self.notes_pending is None and self.pricing_pending is None:
+            raise ValueError("clear_review_state must include notes_pending or pricing_pending")
+        return self
+
+
+class ExtractionReviewMetadataUpdateRequest(BaseModel):
+    """Sidecar-only mutation payload for hidden-item lifecycle and review state."""
+
+    dismiss_hidden_item: str | None = Field(default=None, min_length=1)
+    review_hidden_item: str | None = Field(default=None, min_length=1)
+    clear_review_state: ExtractionReviewStateClearRequest | None = None
+
+    @model_validator(mode="after")
+    def validate_has_mutation(self) -> ExtractionReviewMetadataUpdateRequest:
+        has_action = any(
+            (
+                self.dismiss_hidden_item is not None,
+                self.review_hidden_item is not None,
+                self.clear_review_state is not None,
+            )
+        )
+        if not has_action:
+            raise ValueError("At least one extraction review metadata mutation is required")
         return self
 
 

--- a/backend/app/features/quotes/service.py
+++ b/backend/app/features/quotes/service.py
@@ -30,6 +30,8 @@ from app.features.quotes.repository import (
 )
 from app.features.quotes.schemas import (
     ExtractionResult,
+    ExtractionReviewMetadataUpdateRequest,
+    ExtractionReviewMetadataV1,
     LineItemDraft,
     QuoteCreateRequest,
     QuoteUpdateRequest,
@@ -145,6 +147,8 @@ class QuoteRepositoryProtocol(Protocol):
         update_notes: bool,
         line_items: list[LineItemDraft] | None,
         replace_line_items: bool,
+        extraction_review_metadata: dict[str, Any] | None = None,
+        update_extraction_review_metadata: bool = False,
     ) -> Document: ...
 
     async def invalidate_pdf_artifact(self, document: Document) -> str | None: ...
@@ -155,10 +159,28 @@ class QuoteRepositoryProtocol(Protocol):
         document: Document,
         transcript: str,
         total_amount: float | None,
+        update_total_amount: bool,
+        notes: str | None,
+        update_notes: bool,
+        tax_rate: float | None,
+        update_tax_rate: bool,
+        discount_type: str | None,
+        update_discount_type: bool,
+        discount_value: float | None,
+        update_discount_value: bool,
+        deposit_amount: float | None,
+        update_deposit_amount: bool,
         line_items: list[LineItemDraft],
         extraction_tier: str | None = None,
         extraction_degraded_reason_code: str | None = None,
         extraction_review_metadata: dict[str, Any] | None = None,
+    ) -> Document: ...
+
+    async def update_extraction_review_metadata(
+        self,
+        *,
+        document: Document,
+        extraction_review_metadata: dict[str, Any],
     ) -> Document: ...
 
     async def delete(self, document_id: UUID) -> None: ...
@@ -323,6 +345,19 @@ class QuoteService:
     ) -> Document:
         """Delegate quote patch behavior to the mutation lifecycle slice."""
         return await self._mutation_service.update_quote(
+            user_id=_resolve_user_id(user),
+            quote_id=quote_id,
+            data=data,
+        )
+
+    async def update_extraction_review_metadata(
+        self,
+        user: User,
+        quote_id: UUID,
+        data: ExtractionReviewMetadataUpdateRequest,
+    ) -> ExtractionReviewMetadataV1:
+        """Delegate sidecar-only extraction review metadata updates."""
+        return await self._mutation_service.update_extraction_review_metadata(
             user_id=_resolve_user_id(user),
             quote_id=quote_id,
             data=data,

--- a/backend/app/features/quotes/tests/test_extraction.py
+++ b/backend/app/features/quotes/tests/test_extraction.py
@@ -12,6 +12,7 @@ import httpx
 import pytest
 
 import app.integrations.extraction as extraction_module
+from app.features.quotes.review_metadata import build_hidden_item_id
 from app.features.quotes.schemas import PreparedCaptureInput
 from app.features.quotes.tests.fixtures.transcripts import TRANSCRIPTS
 from app.integrations.extraction import (
@@ -678,6 +679,15 @@ async def test_tool_schema_line_items_include_optional_flag_fields() -> None:
     assert "flag_reason" not in line_item_schema["required"]
     assert "raw_text" in line_item_schema["required"]
     assert "confidence" in line_item_schema["required"]
+
+
+async def test_hidden_item_id_is_deterministic_and_distinguishes_content() -> None:
+    first = build_hidden_item_id("append", "note", "none", "Gate code 1942")
+    second = build_hidden_item_id(" append ", "NOTE", "none", " gate code 1942 ")
+    different = build_hidden_item_id("append", "note", "none", "Gate code 7788")
+
+    assert first == second
+    assert first != different
 
 
 @pytest.mark.parametrize("fixture_name", sorted(TRANSCRIPTS))

--- a/backend/app/features/quotes/tests/test_quote_append_extraction.py
+++ b/backend/app/features/quotes/tests/test_quote_append_extraction.py
@@ -379,6 +379,51 @@ async def test_patch_extraction_review_metadata_updates_sidecar_only(
     }
 
 
+async def test_patch_extraction_review_metadata_marks_hidden_item_reviewed(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    csrf_token = await _register_and_login(client, _credentials())
+    customer_id = await _create_customer(client, csrf_token)
+    quote = await _create_quote(client, csrf_token, customer_id)
+    quote_id = UUID(quote["id"])
+
+    persisted_quote = await db_session.get(Document, quote_id)
+    assert persisted_quote is not None
+    persisted_quote.extraction_review_metadata = ExtractionReviewMetadataV1(
+        hidden_details=ExtractionReviewHiddenDetails(
+            unresolved_segments=[
+                {
+                    "id": "unresolved-1",
+                    "raw_text": "Confirm edging scope",
+                    "confidence": "low",
+                    "source": "leftover_classification",
+                }
+            ]
+        ),
+    ).model_dump(mode="json")
+    await db_session.commit()
+
+    patch_response = await client.patch(
+        f"/api/quotes/{quote_id}/extraction-review-metadata",
+        json={"review_hidden_item": "unresolved-1"},
+        headers={"X-CSRF-Token": csrf_token},
+    )
+    assert patch_response.status_code == 200
+    assert patch_response.json()["hidden_detail_state"]["unresolved-1"] == {
+        "reviewed": True,
+        "dismissed": False,
+    }
+
+    detail_response = await client.get(f"/api/quotes/{quote_id}")
+    assert detail_response.status_code == 200
+    payload = detail_response.json()
+    assert payload["extraction_review_metadata"]["hidden_detail_state"]["unresolved-1"] == {
+        "reviewed": True,
+        "dismissed": False,
+    }
+
+
 async def test_quote_patch_clears_related_append_suggestions_on_real_field_edits(
     client: AsyncClient,
     db_session: AsyncSession,

--- a/backend/app/features/quotes/tests/test_quote_append_extraction.py
+++ b/backend/app/features/quotes/tests/test_quote_append_extraction.py
@@ -13,10 +13,15 @@ from app.core.config import get_settings
 from app.features.jobs.models import JobRecord, JobType
 from app.features.jobs.repository import JobRepository
 from app.features.quotes.models import Document
+from app.features.quotes.review_metadata import build_hidden_item_id
 from app.features.quotes.schemas import (
     ExtractionResult,
+    ExtractionReviewAppendSuggestion,
     ExtractionReviewHiddenDetails,
     ExtractionReviewMetadataV1,
+    ExtractionReviewState,
+    ExtractionSuggestion,
+    HiddenItemState,
     LineItemExtractedV2,
     PricingHints,
 )
@@ -139,6 +144,135 @@ async def test_append_extraction_sync_appends_line_items_and_merges_transcript_e
     assert "Added later (2):" not in payload["transcript"]
 
 
+async def test_append_extraction_keeps_populated_notes_and_total_and_records_append_suggestions(
+    client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def _extract_blocked_append_fields(self, notes: str) -> ExtractionResult:  # noqa: ANN001
+        del self, notes
+        return ExtractionResult(
+            transcript="append blocked fields",
+            line_items=[],
+            pricing_hints=PricingHints(explicit_total=999),
+            customer_notes_suggestion=ExtractionSuggestion(
+                text="Add driveway gate code",
+                confidence="medium",
+                source="leftover_classification",
+            ),
+            confidence_notes=[],
+        )
+
+    monkeypatch.setattr(
+        _MockExtractionIntegration,
+        "extract",
+        _extract_blocked_append_fields,
+    )
+
+    csrf_token = await _register_and_login(client, _credentials())
+    customer_id = await _create_customer(client, csrf_token)
+    quote = await _create_quote(client, csrf_token, customer_id)
+    quote_id = quote["id"]
+    app.state.arq_pool = None
+
+    append_response = await client.post(
+        f"/api/quotes/{quote_id}/append-extraction",
+        files=[("notes", (None, "append blocked fields"))],
+        headers={"X-CSRF-Token": csrf_token},
+    )
+    assert append_response.status_code == 200
+
+    detail_response = await client.get(f"/api/quotes/{quote_id}")
+    assert detail_response.status_code == 200
+    payload = detail_response.json()
+    assert payload["notes"] == "Original note"
+    assert payload["total_amount"] == 55
+    append_suggestions = payload["extraction_review_metadata"]["hidden_details"][
+        "append_suggestions"
+    ]
+    assert append_suggestions == [
+        {
+            "id": append_suggestions[0]["id"],
+            "kind": "note",
+            "raw_text": "Add driveway gate code",
+            "confidence": "medium",
+            "source": "append_capture",
+            "pricing_field": None,
+        },
+        {
+            "id": append_suggestions[1]["id"],
+            "kind": "pricing",
+            "raw_text": "Total 999",
+            "confidence": "medium",
+            "source": "append_capture",
+            "pricing_field": "explicit_total",
+        },
+    ]
+
+
+async def test_append_extraction_resurfaces_previously_dismissed_matching_suggestion(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    suggestion_text = "Add driveway gate code"
+    suggestion_id = build_hidden_item_id("append", "note", "none", suggestion_text)
+
+    async def _extract_blocked_note(self, notes: str) -> ExtractionResult:  # noqa: ANN001
+        del self, notes
+        return ExtractionResult(
+            transcript="append blocked note",
+            line_items=[],
+            pricing_hints=PricingHints(),
+            customer_notes_suggestion=ExtractionSuggestion(
+                text=suggestion_text,
+                confidence="low",
+                source="leftover_classification",
+            ),
+            confidence_notes=[],
+        )
+
+    monkeypatch.setattr(
+        _MockExtractionIntegration,
+        "extract",
+        _extract_blocked_note,
+    )
+
+    csrf_token = await _register_and_login(client, _credentials())
+    customer_id = await _create_customer(client, csrf_token)
+    quote = await _create_quote(client, csrf_token, customer_id)
+    quote_id = UUID(quote["id"])
+    app.state.arq_pool = None
+
+    persisted_quote = await db_session.get(Document, quote_id)
+    assert persisted_quote is not None
+    persisted_quote.extraction_review_metadata = ExtractionReviewMetadataV1(
+        hidden_details=ExtractionReviewHiddenDetails(
+            append_suggestions=[
+                ExtractionReviewAppendSuggestion(
+                    id=suggestion_id,
+                    kind="note",
+                    raw_text=suggestion_text,
+                    confidence="low",
+                )
+            ]
+        ),
+        hidden_detail_state={suggestion_id: HiddenItemState(reviewed=True, dismissed=True)},
+    ).model_dump(mode="json")
+    await db_session.commit()
+
+    append_response = await client.post(
+        f"/api/quotes/{quote_id}/append-extraction",
+        files=[("notes", (None, "append blocked note"))],
+        headers={"X-CSRF-Token": csrf_token},
+    )
+    assert append_response.status_code == 200
+
+    detail_response = await client.get(f"/api/quotes/{quote_id}")
+    assert detail_response.status_code == 200
+    hidden_state = detail_response.json()["extraction_review_metadata"]["hidden_detail_state"]
+    assert hidden_state[suggestion_id] == {"reviewed": False, "dismissed": False}
+
+
 async def test_append_extraction_preserves_existing_confidence_notes_when_new_notes_empty(
     client: AsyncClient,
     db_session: AsyncSession,
@@ -195,6 +329,128 @@ async def test_append_extraction_preserves_existing_confidence_notes_when_new_no
     assert detail_payload["extraction_review_metadata"]["hidden_details"]["confidence_notes"] == [
         "keep existing confidence note"
     ]
+
+
+async def test_patch_extraction_review_metadata_updates_sidecar_only(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    csrf_token = await _register_and_login(client, _credentials())
+    customer_id = await _create_customer(client, csrf_token)
+    quote = await _create_quote(client, csrf_token, customer_id)
+    quote_id = UUID(quote["id"])
+
+    persisted_quote = await db_session.get(Document, quote_id)
+    assert persisted_quote is not None
+    persisted_quote.extraction_review_metadata = ExtractionReviewMetadataV1(
+        hidden_details=ExtractionReviewHiddenDetails(
+            append_suggestions=[
+                ExtractionReviewAppendSuggestion(
+                    id="append-note-1",
+                    kind="note",
+                    raw_text="Add mulch color confirmation",
+                    confidence="medium",
+                )
+            ]
+        ),
+    ).model_dump(mode="json")
+    await db_session.commit()
+
+    patch_response = await client.patch(
+        f"/api/quotes/{quote_id}/extraction-review-metadata",
+        json={"dismiss_hidden_item": "append-note-1"},
+        headers={"X-CSRF-Token": csrf_token},
+    )
+    assert patch_response.status_code == 200
+    assert patch_response.json()["hidden_detail_state"]["append-note-1"] == {
+        "reviewed": False,
+        "dismissed": True,
+    }
+
+    detail_response = await client.get(f"/api/quotes/{quote_id}")
+    assert detail_response.status_code == 200
+    payload = detail_response.json()
+    assert payload["notes"] == "Original note"
+    assert payload["total_amount"] == 55
+    assert payload["line_items"][0]["description"] == "line item"
+    assert payload["extraction_review_metadata"]["hidden_detail_state"]["append-note-1"] == {
+        "reviewed": False,
+        "dismissed": True,
+    }
+
+
+async def test_quote_patch_clears_related_append_suggestions_on_real_field_edits(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    csrf_token = await _register_and_login(client, _credentials())
+    customer_id = await _create_customer(client, csrf_token)
+    quote = await _create_quote(client, csrf_token, customer_id)
+    quote_id = UUID(quote["id"])
+
+    persisted_quote = await db_session.get(Document, quote_id)
+    assert persisted_quote is not None
+    persisted_quote.extraction_review_metadata = ExtractionReviewMetadataV1(
+        review_state=ExtractionReviewState(
+            notes_pending=True,
+            pricing_pending=True,
+        ),
+        hidden_details=ExtractionReviewHiddenDetails(
+            unresolved_segments=[],
+            append_suggestions=[
+                ExtractionReviewAppendSuggestion(
+                    id="append-note-1",
+                    kind="note",
+                    raw_text="Add customer gate code",
+                    confidence="medium",
+                ),
+                ExtractionReviewAppendSuggestion(
+                    id="append-pricing-1",
+                    kind="pricing",
+                    raw_text="Total 120",
+                    confidence="medium",
+                    pricing_field="explicit_total",
+                ),
+            ],
+            confidence_notes=[],
+        ),
+    ).model_dump(mode="json")
+    await db_session.commit()
+
+    note_update_response = await client.patch(
+        f"/api/quotes/{quote_id}",
+        json={"notes": "Updated customer notes"},
+        headers={"X-CSRF-Token": csrf_token},
+    )
+    assert note_update_response.status_code == 200
+
+    first_detail_response = await client.get(f"/api/quotes/{quote_id}")
+    assert first_detail_response.status_code == 200
+    first_metadata = first_detail_response.json()["extraction_review_metadata"]
+    assert first_metadata["review_state"] == {"notes_pending": False, "pricing_pending": True}
+    assert first_metadata["hidden_details"]["append_suggestions"] == [
+        {
+            "id": "append-pricing-1",
+            "kind": "pricing",
+            "raw_text": "Total 120",
+            "confidence": "medium",
+            "source": "append_capture",
+            "pricing_field": "explicit_total",
+        }
+    ]
+
+    pricing_update_response = await client.patch(
+        f"/api/quotes/{quote_id}",
+        json={"total_amount": 88},
+        headers={"X-CSRF-Token": csrf_token},
+    )
+    assert pricing_update_response.status_code == 200
+
+    second_detail_response = await client.get(f"/api/quotes/{quote_id}")
+    assert second_detail_response.status_code == 200
+    second_metadata = second_detail_response.json()["extraction_review_metadata"]
+    assert second_metadata["review_state"] == {"notes_pending": False, "pricing_pending": False}
+    assert second_metadata["hidden_details"]["append_suggestions"] == []
 
 
 async def test_append_extraction_sync_cleans_obsolete_pdf_artifact_after_commit(

--- a/backend/app/features/quotes/tests/test_quote_append_extraction.py
+++ b/backend/app/features/quotes/tests/test_quote_append_extraction.py
@@ -20,6 +20,7 @@ from app.features.quotes.schemas import (
     ExtractionReviewHiddenDetails,
     ExtractionReviewMetadataV1,
     ExtractionReviewState,
+    ExtractionReviewUnresolvedSegment,
     ExtractionSuggestion,
     HiddenItemState,
     LineItemExtractedV2,
@@ -393,12 +394,12 @@ async def test_patch_extraction_review_metadata_marks_hidden_item_reviewed(
     persisted_quote.extraction_review_metadata = ExtractionReviewMetadataV1(
         hidden_details=ExtractionReviewHiddenDetails(
             unresolved_segments=[
-                {
-                    "id": "unresolved-1",
-                    "raw_text": "Confirm edging scope",
-                    "confidence": "low",
-                    "source": "leftover_classification",
-                }
+                ExtractionReviewUnresolvedSegment(
+                    id="unresolved-1",
+                    raw_text="Confirm edging scope",
+                    confidence="low",
+                    source="leftover_classification",
+                )
             ]
         ),
     ).model_dump(mode="json")

--- a/frontend/src/features/quotes/components/CaptureDetailsSheet.tsx
+++ b/frontend/src/features/quotes/components/CaptureDetailsSheet.tsx
@@ -1,12 +1,16 @@
 import * as Dialog from "@radix-ui/react-dialog";
 
-import type { ExtractionReviewHiddenDetails } from "@/features/quotes/types/quote.types";
+import type { ExtractionReviewHiddenDetails, HiddenItemState } from "@/features/quotes/types/quote.types";
 
 interface CaptureDetailsSheetProps {
   open: boolean;
   onClose: () => void;
   transcript: string;
   hiddenDetails?: ExtractionReviewHiddenDetails;
+  hiddenDetailState?: Record<string, HiddenItemState>;
+  onReviewHiddenItem?: (itemId: string) => Promise<void> | void;
+  onDismissHiddenItem?: (itemId: string) => Promise<void> | void;
+  isMutating?: boolean;
 }
 
 function formatPricingField(
@@ -41,10 +45,20 @@ export function CaptureDetailsSheet({
   onClose,
   transcript,
   hiddenDetails,
+  hiddenDetailState,
+  onReviewHiddenItem,
+  onDismissHiddenItem,
+  isMutating = false,
 }: CaptureDetailsSheetProps): React.ReactElement {
   const appendSuggestions = hiddenDetails?.append_suggestions ?? [];
   const unresolvedSegments = hiddenDetails?.unresolved_segments ?? [];
   const confidenceNotes = hiddenDetails?.confidence_notes ?? [];
+  const visibleAppendSuggestions = appendSuggestions.filter(
+    (suggestion) => !hiddenDetailState?.[suggestion.id]?.dismissed,
+  );
+  const visibleUnresolvedSegments = unresolvedSegments.filter(
+    (segment) => !hiddenDetailState?.[segment.id]?.dismissed,
+  );
 
   return (
     <Dialog.Root open={open} onOpenChange={(nextOpen) => { if (!nextOpen) onClose(); }}>
@@ -67,10 +81,11 @@ export function CaptureDetailsSheet({
                 <h3 className="text-[0.6875rem] font-bold uppercase tracking-widest text-outline">
                   New Suggestions From Latest Capture
                 </h3>
-                {appendSuggestions.length === 0 ? renderEmptySection("No new suggestions from the latest capture.") : (
+                {visibleAppendSuggestions.length === 0 ? renderEmptySection("No new suggestions from the latest capture.") : (
                   <ul className="space-y-2">
-                    {appendSuggestions.map((suggestion) => {
+                    {visibleAppendSuggestions.map((suggestion) => {
                       const pricingField = formatPricingField(suggestion.pricing_field);
+                      const itemState = hiddenDetailState?.[suggestion.id];
                       return (
                         <li
                           key={suggestion.id}
@@ -81,6 +96,30 @@ export function CaptureDetailsSheet({
                             {pricingField ? ` (${pricingField})` : ""}
                           </p>
                           <p className="mt-1 whitespace-pre-wrap text-on-surface-variant">{suggestion.raw_text}</p>
+                          <div className="mt-3 flex items-center gap-2">
+                            {itemState?.reviewed ? (
+                              <span className="rounded-full bg-success/10 px-2 py-0.5 text-[0.6875rem] font-semibold uppercase tracking-wide text-success">
+                                Reviewed
+                              </span>
+                            ) : (
+                              <button
+                                type="button"
+                                className="rounded-md border border-outline-variant/40 px-2 py-1 text-[0.6875rem] font-semibold uppercase tracking-wide text-on-surface-variant transition-colors hover:bg-surface-container-lowest disabled:cursor-not-allowed disabled:opacity-60"
+                                disabled={isMutating || !onReviewHiddenItem}
+                                onClick={() => { void onReviewHiddenItem?.(suggestion.id); }}
+                              >
+                                Mark reviewed
+                              </button>
+                            )}
+                            <button
+                              type="button"
+                              className="rounded-md border border-outline-variant/40 px-2 py-1 text-[0.6875rem] font-semibold uppercase tracking-wide text-on-surface-variant transition-colors hover:bg-surface-container-lowest disabled:cursor-not-allowed disabled:opacity-60"
+                              disabled={isMutating || !onDismissHiddenItem}
+                              onClick={() => { void onDismissHiddenItem?.(suggestion.id); }}
+                            >
+                              Dismiss
+                            </button>
+                          </div>
                         </li>
                       );
                     })}
@@ -92,19 +131,46 @@ export function CaptureDetailsSheet({
                 <h3 className="text-[0.6875rem] font-bold uppercase tracking-widest text-outline">
                   Unresolved Capture Details
                 </h3>
-                {unresolvedSegments.length === 0 ? renderEmptySection("No unresolved capture details.") : (
+                {visibleUnresolvedSegments.length === 0 ? renderEmptySection("No unresolved capture details.") : (
                   <ul className="space-y-2">
-                    {unresolvedSegments.map((segment) => (
-                      <li
-                        key={segment.id}
-                        className="rounded-lg border border-outline-variant/30 bg-surface-container-high p-3 text-sm text-on-surface"
-                      >
-                        <p className="font-semibold">
-                          {segment.source.replaceAll("_", " ")}
-                        </p>
-                        <p className="mt-1 whitespace-pre-wrap text-on-surface-variant">{segment.raw_text}</p>
-                      </li>
-                    ))}
+                    {visibleUnresolvedSegments.map((segment) => {
+                      const itemState = hiddenDetailState?.[segment.id];
+                      return (
+                        <li
+                          key={segment.id}
+                          className="rounded-lg border border-outline-variant/30 bg-surface-container-high p-3 text-sm text-on-surface"
+                        >
+                          <p className="font-semibold">
+                            {segment.source.replaceAll("_", " ")}
+                          </p>
+                          <p className="mt-1 whitespace-pre-wrap text-on-surface-variant">{segment.raw_text}</p>
+                          <div className="mt-3 flex items-center gap-2">
+                            {itemState?.reviewed ? (
+                              <span className="rounded-full bg-success/10 px-2 py-0.5 text-[0.6875rem] font-semibold uppercase tracking-wide text-success">
+                                Reviewed
+                              </span>
+                            ) : (
+                              <button
+                                type="button"
+                                className="rounded-md border border-outline-variant/40 px-2 py-1 text-[0.6875rem] font-semibold uppercase tracking-wide text-on-surface-variant transition-colors hover:bg-surface-container-lowest disabled:cursor-not-allowed disabled:opacity-60"
+                                disabled={isMutating || !onReviewHiddenItem}
+                                onClick={() => { void onReviewHiddenItem?.(segment.id); }}
+                              >
+                                Mark reviewed
+                              </button>
+                            )}
+                            <button
+                              type="button"
+                              className="rounded-md border border-outline-variant/40 px-2 py-1 text-[0.6875rem] font-semibold uppercase tracking-wide text-on-surface-variant transition-colors hover:bg-surface-container-lowest disabled:cursor-not-allowed disabled:opacity-60"
+                              disabled={isMutating || !onDismissHiddenItem}
+                              onClick={() => { void onDismissHiddenItem?.(segment.id); }}
+                            >
+                              Dismiss
+                            </button>
+                          </div>
+                        </li>
+                      );
+                    })}
                   </ul>
                 )}
               </section>

--- a/frontend/src/features/quotes/components/DocumentEditScreenView.tsx
+++ b/frontend/src/features/quotes/components/DocumentEditScreenView.tsx
@@ -4,7 +4,7 @@ import { ReviewFormContent } from "@/features/quotes/components/ReviewFormConten
 import { isInvoiceDocument } from "@/features/quotes/components/documentEditUtils";
 import type { ReviewLineItemSheetState } from "@/features/quotes/components/reviewLineItemSheetState";
 import { type DocumentEditDraft, type PersistedEditableDocument } from "@/features/quotes/hooks/usePersistedReview";
-import type { ExtractionReviewHiddenDetails, ExtractionTier, LineItemDraftWithFlags } from "@/features/quotes/types/quote.types";
+import type { ExtractionReviewHiddenDetails, ExtractionTier, HiddenItemState, LineItemDraftWithFlags } from "@/features/quotes/types/quote.types";
 import { HOME_ROUTE } from "@/features/quotes/utils/workflowNavigation";
 import { WorkflowScreenHeader } from "@/shared/components/WorkflowScreenHeader";
 
@@ -24,8 +24,10 @@ interface DocumentEditScreenViewProps {
   extractionTier: ExtractionTier | null;
   extractionDegradedReasonCode: string | null;
   hiddenDetails?: ExtractionReviewHiddenDetails;
+  hiddenDetailState?: Record<string, HiddenItemState>;
   lineItemSum: number;
   suggestedTaxRate: number | null;
+  isMutatingHiddenItems: boolean;
   isTypeSelectorLocked: boolean;
   isAssignmentSheetOpen: boolean;
   lineItemSheetState: ReviewLineItemSheetState | null;
@@ -49,6 +51,8 @@ interface DocumentEditScreenViewProps {
   onDiscountValueChange: (nextDiscountValue: number | null) => void;
   onDepositAmountChange: (nextDepositAmount: number | null) => void;
   onNotesChange: (nextNotes: string) => void;
+  onReviewHiddenItem: (itemId: string) => Promise<void>;
+  onDismissHiddenItem: (itemId: string) => Promise<void>;
   onSaveDraft: () => void;
   onPrimaryAction: () => void;
   onCloseAssignment: () => void;
@@ -79,8 +83,10 @@ export function DocumentEditScreenView({
   extractionTier,
   extractionDegradedReasonCode,
   hiddenDetails,
+  hiddenDetailState,
   lineItemSum,
   suggestedTaxRate,
+  isMutatingHiddenItems,
   isTypeSelectorLocked,
   isAssignmentSheetOpen,
   lineItemSheetState,
@@ -104,6 +110,8 @@ export function DocumentEditScreenView({
   onDiscountValueChange,
   onDepositAmountChange,
   onNotesChange,
+  onReviewHiddenItem,
+  onDismissHiddenItem,
   onSaveDraft,
   onPrimaryAction,
   onCloseAssignment,
@@ -146,8 +154,10 @@ export function DocumentEditScreenView({
         extractionTier={extractionTier}
         extractionDegradedReasonCode={extractionDegradedReasonCode}
         hiddenDetails={hiddenDetails}
+        hiddenDetailState={hiddenDetailState}
         lineItemSum={lineItemSum}
         suggestedTaxRate={suggestedTaxRate}
+        isMutatingHiddenItems={isMutatingHiddenItems}
         onDocumentTypeChange={onDocumentTypeChange}
         onDueDateChange={onDueDateChange}
         onRequestAssignment={onOpenAssignment}
@@ -161,6 +171,8 @@ export function DocumentEditScreenView({
         onDiscountValueChange={onDiscountValueChange}
         onDepositAmountChange={onDepositAmountChange}
         onNotesChange={onNotesChange}
+        onReviewHiddenItem={onReviewHiddenItem}
+        onDismissHiddenItem={onDismissHiddenItem}
       />
 
       <ReviewActionFooter

--- a/frontend/src/features/quotes/components/ReviewFormContent.tsx
+++ b/frontend/src/features/quotes/components/ReviewFormContent.tsx
@@ -5,7 +5,7 @@ import { ReviewCustomerRow } from "@/features/quotes/components/ReviewCustomerRo
 import { ReviewDocumentTypeSelector, type ReviewDocumentType } from "@/features/quotes/components/ReviewDocumentTypeSelector";
 import { ReviewLineItemsSection } from "@/features/quotes/components/ReviewLineItemsSection";
 import { TotalAmountSection } from "@/features/quotes/components/TotalAmountSection";
-import type { ExtractionReviewHiddenDetails, ExtractionTier } from "@/features/quotes/types/quote.types";
+import type { ExtractionReviewHiddenDetails, ExtractionTier, HiddenItemState } from "@/features/quotes/types/quote.types";
 import { FeedbackMessage } from "@/shared/components/FeedbackMessage";
 import {
   DOCUMENT_NOTES_MAX_CHARS,
@@ -58,8 +58,10 @@ interface ReviewFormContentProps {
   extractionTier: ExtractionTier | null;
   extractionDegradedReasonCode: string | null;
   hiddenDetails?: ExtractionReviewHiddenDetails;
+  hiddenDetailState?: Record<string, HiddenItemState>;
   lineItemSum: number;
   suggestedTaxRate: number | null;
+  isMutatingHiddenItems: boolean;
   onDocumentTypeChange: (nextType: ReviewDocumentType) => void;
   onDueDateChange: (nextDueDate: string) => void;
   onRequestAssignment: () => void;
@@ -73,6 +75,8 @@ interface ReviewFormContentProps {
   onDiscountValueChange: (nextDiscountValue: number | null) => void;
   onDepositAmountChange: (nextDepositAmount: number | null) => void;
   onNotesChange: (nextNotes: string) => void;
+  onReviewHiddenItem: (itemId: string) => Promise<void>;
+  onDismissHiddenItem: (itemId: string) => Promise<void>;
 }
 
 export function ReviewFormContent({
@@ -92,8 +96,10 @@ export function ReviewFormContent({
   extractionTier,
   extractionDegradedReasonCode,
   hiddenDetails,
+  hiddenDetailState,
   lineItemSum,
   suggestedTaxRate,
+  isMutatingHiddenItems,
   onDocumentTypeChange,
   onDueDateChange,
   onRequestAssignment,
@@ -107,16 +113,24 @@ export function ReviewFormContent({
   onDiscountValueChange,
   onDepositAmountChange,
   onNotesChange,
+  onReviewHiddenItem,
+  onDismissHiddenItem,
 }: ReviewFormContentProps): React.ReactElement {
   const [isCaptureDetailsOpen, setIsCaptureDetailsOpen] = useState(false);
   const showDueDateField = documentType === "invoice";
   const showQuoteOnlySections = documentType === "quote";
   const showSevereDegradedMarker = extractionTier === "degraded"
     && draft.lineItems.length === 0;
+  const hasVisibleAppendSuggestions = Boolean(
+    hiddenDetails?.append_suggestions.some((suggestion) => !hiddenDetailState?.[suggestion.id]?.dismissed),
+  );
+  const hasVisibleUnresolvedSegments = Boolean(
+    hiddenDetails?.unresolved_segments.some((segment) => !hiddenDetailState?.[segment.id]?.dismissed),
+  );
   const hasHiddenActionableItems = Boolean(
     hiddenDetails
-      && (hiddenDetails.append_suggestions.length > 0
-        || hiddenDetails.unresolved_segments.length > 0
+      && (hasVisibleAppendSuggestions
+        || hasVisibleUnresolvedSegments
         || hiddenDetails.confidence_notes.length > 0),
   );
 
@@ -294,6 +308,10 @@ export function ReviewFormContent({
           onClose={() => setIsCaptureDetailsOpen(false)}
           transcript={draft.transcript ?? ""}
           hiddenDetails={hiddenDetails}
+          hiddenDetailState={hiddenDetailState}
+          onReviewHiddenItem={onReviewHiddenItem}
+          onDismissHiddenItem={onDismissHiddenItem}
+          isMutating={isMutatingHiddenItems}
         />
       ) : null}
     </form>

--- a/frontend/src/features/quotes/components/ReviewScreen.tsx
+++ b/frontend/src/features/quotes/components/ReviewScreen.tsx
@@ -4,6 +4,7 @@ import { useBeforeUnload, useLocation, useNavigate, useParams } from "react-rout
 import { profileService } from "@/features/profile/services/profileService";
 import { DocumentEditScreenView } from "@/features/quotes/components/DocumentEditScreenView";
 import { buildDefaultInvoiceDueDate, buildDocumentSnapshotKey, buildSaveValidationMessage, isInvoiceDocument, persistDocumentDraft } from "@/features/quotes/components/documentEditUtils";
+import { useHiddenDetailLifecycle } from "@/features/quotes/hooks/useHiddenDetailLifecycle";
 import { applyLineItemSheetDelete, applyLineItemSheetSave, resolveLineItemSheetInitialItem, type ReviewLineItemSheetState } from "@/features/quotes/components/reviewLineItemSheetState";
 import { buildLineItemSubmitState, EMPTY_LINE_ITEM } from "@/features/quotes/components/reviewScreenUtils";
 import { usePersistedReview } from "@/features/quotes/hooks/usePersistedReview";
@@ -78,6 +79,17 @@ export function DocumentEditScreen(): React.ReactElement {
     }
     return JSON.stringify(buildDraftSnapshot(draft));
   }, [draft]);
+  const documentId = id ?? "";
+  const {
+    isMutatingHiddenItems,
+    reviewHiddenItem,
+    dismissHiddenItem,
+  } = useHiddenDetailLifecycle({
+    canMutate: Boolean(document && !isInvoiceDocument(document)),
+    documentId,
+    refreshDocument: async () => refreshDocument(),
+    setSaveError,
+  });
   useEffect(() => {
     if (!id) {
       return;
@@ -88,13 +100,11 @@ export function DocumentEditScreen(): React.ReactElement {
     if (!id || !locationState.reseedDraft || hasAppliedReseedFromLocation) {
       return;
     }
-
     setHasAppliedReseedFromLocation(true);
     void refreshDocument({ reseedDraft: true }).catch(() => {
       // Existing load/save error messaging covers failed refreshes.
     });
   }, [hasAppliedReseedFromLocation, id, locationState.reseedDraft, refreshDocument]);
-
   useEffect(() => {
     if (!document || !draft || !currentSnapshotKey) {
       return;
@@ -133,24 +143,19 @@ export function DocumentEditScreen(): React.ReactElement {
     if (!hasUnsavedChanges) {
       return;
     }
-
     event.preventDefault();
     event.returnValue = "";
   });
-
   function requestNavigation(target: { to: string; replace?: boolean }): void {
     if (!hasUnsavedChanges) {
       navigate(target.to, { replace: target.replace });
       return;
     }
-
     setPendingNavigationTarget(target);
     setShowLeaveWarning(true);
   }
-
   function handleLeaveConfirm(): void {
     setShowLeaveWarning(false);
-
     if (pendingNavigationTarget) {
       const nextTarget = pendingNavigationTarget;
       setPendingNavigationTarget(null);
@@ -163,7 +168,6 @@ export function DocumentEditScreen(): React.ReactElement {
     setShowLeaveWarning(false);
     setPendingNavigationTarget(null);
   }
-
   if (!id) {
     return (
       <main className="min-h-screen bg-background px-4 pt-20">
@@ -172,7 +176,6 @@ export function DocumentEditScreen(): React.ReactElement {
     );
   }
 
-  const documentId = id;
   const activeDocumentType = draft?.docType ?? (document && isInvoiceDocument(document) ? "invoice" : "quote");
   const shouldUseQuoteListBackTarget = locationState.origin === "preview" && requiresCustomerAssignment;
   const invoiceBackTarget = `/invoices/${documentId}`;
@@ -185,7 +188,6 @@ export function DocumentEditScreen(): React.ReactElement {
     : (shouldUseQuoteListBackTarget
       ? "Back to quotes"
       : (locationState.origin === "preview" ? "Back to preview" : "Back to quotes"));
-
   if (isLoadingDocument || !draft) {
     return (
       <main className="min-h-screen bg-background px-4 pt-20">
@@ -205,7 +207,6 @@ export function DocumentEditScreen(): React.ReactElement {
   }
   const activeDocument = document;
   const activeDraft = draft;
-
   const {
     hasInvalidLineItems,
     lineItemsForSubmit,
@@ -214,6 +215,7 @@ export function DocumentEditScreen(): React.ReactElement {
   const extractionReviewMetadata = !isInvoiceDocument(activeDocument)
     ? activeDocument.extraction_review_metadata
     : undefined;
+  const hiddenDetailState = extractionReviewMetadata?.hidden_detail_state;
   const notesReviewPending = activeDraft.docType === "quote"
     && Boolean(extractionReviewMetadata?.review_state.notes_pending);
   const pricingReviewPending = activeDraft.docType === "quote"
@@ -223,12 +225,10 @@ export function DocumentEditScreen(): React.ReactElement {
   const lineItemSheetInitialItem = lineItemSheetState
     ? resolveLineItemSheetInitialItem(activeDraft, lineItemSheetState, EMPTY_LINE_ITEM)
     : EMPTY_LINE_ITEM;
-
   async function tryAutoSaveDraft(): Promise<void> {
     if (activeDraft.docType !== "quote") {
       return;
     }
-
     const validationMessage = buildSaveValidationMessage({
       draft: activeDraft,
       lineItemsForSubmit,
@@ -237,7 +237,6 @@ export function DocumentEditScreen(): React.ReactElement {
     if (validationMessage) {
       return;
     }
-
     try {
       await persistDocumentDraft({
         document: activeDocument,
@@ -254,9 +253,7 @@ export function DocumentEditScreen(): React.ReactElement {
     if (isAddVoiceNoteInFlightRef.current) {
       return;
     }
-
     isAddVoiceNoteInFlightRef.current = true;
-
     try {
       await tryAutoSaveDraft();
       navigate(`/quotes/${documentId}/review/append-capture`, {
@@ -270,7 +267,6 @@ export function DocumentEditScreen(): React.ReactElement {
   async function saveDraft(nextAction: "save" | "continue"): Promise<void> {
     setSaveError(null);
     setToastMessage(null);
-
     const validationMessage = buildSaveValidationMessage({
       draft: activeDraft,
       lineItemsForSubmit,
@@ -280,9 +276,7 @@ export function DocumentEditScreen(): React.ReactElement {
       setSaveError(validationMessage ?? "Unable to save quote.");
       return;
     }
-
     setSubmitAction(nextAction);
-
     try {
       await persistDocumentDraft({
         document: activeDocument,
@@ -303,11 +297,9 @@ export function DocumentEditScreen(): React.ReactElement {
           navigate(`/invoices/${documentId}`, { replace: true });
           return;
         }
-
         navigate(`/quotes/${documentId}/preview`, { replace: true });
         return;
       }
-
       setToastMessage("Draft saved.");
     } catch (error) {
       const message = error instanceof Error ? error.message : "Unable to save quote";
@@ -321,9 +313,7 @@ export function DocumentEditScreen(): React.ReactElement {
     if (isInvoiceDocument(activeDocument)) {
       return;
     }
-
     setIsAssigningCustomer(true);
-
     try {
       await quoteService.updateQuote(documentId, { customer_id: customerId });
       await refreshDocument();
@@ -334,7 +324,6 @@ export function DocumentEditScreen(): React.ReactElement {
       setIsAssigningCustomer(false);
     }
   }
-
   return (
     <DocumentEditScreenView
       document={activeDocument}
@@ -352,8 +341,10 @@ export function DocumentEditScreen(): React.ReactElement {
       extractionTier={!isInvoiceDocument(activeDocument) ? activeDocument.extraction_tier : null}
       extractionDegradedReasonCode={!isInvoiceDocument(activeDocument) ? activeDocument.extraction_degraded_reason_code : null}
       hiddenDetails={extractionReviewMetadata?.hidden_details}
+      hiddenDetailState={hiddenDetailState}
       lineItemSum={lineItemSum}
       suggestedTaxRate={suggestedTaxRate}
+      isMutatingHiddenItems={isMutatingHiddenItems}
       isTypeSelectorLocked={isTypeSelectorLocked}
       isAssignmentSheetOpen={isAssignmentSheetOpen}
       lineItemSheetState={lineItemSheetState}
@@ -408,6 +399,8 @@ export function DocumentEditScreen(): React.ReactElement {
       onDiscountValueChange={(nextDiscountValue) => { setToastMessage(null); setDraft((currentDraft) => ({ ...currentDraft, discountValue: nextDiscountValue })); }}
       onDepositAmountChange={(nextDepositAmount) => { setToastMessage(null); setDraft((currentDraft) => ({ ...currentDraft, depositAmount: nextDepositAmount })); }}
       onNotesChange={(nextNotes) => { setToastMessage(null); setDraft((currentDraft) => ({ ...currentDraft, notes: nextNotes })); }}
+      onReviewHiddenItem={reviewHiddenItem}
+      onDismissHiddenItem={dismissHiddenItem}
       onSaveDraft={() => { void saveDraft("save"); }}
       onPrimaryAction={() => {
         if (activeDraft.docType === "quote" && (notesReviewPending || pricingReviewPending)) {

--- a/frontend/src/features/quotes/hooks/useHiddenDetailLifecycle.ts
+++ b/frontend/src/features/quotes/hooks/useHiddenDetailLifecycle.ts
@@ -1,0 +1,67 @@
+import { useCallback, useState } from "react";
+
+import { quoteService } from "@/features/quotes/services/quoteService";
+import type { ExtractionReviewMetadataUpdateRequest } from "@/features/quotes/types/quote.types";
+
+interface UseHiddenDetailLifecycleParams {
+  canMutate: boolean;
+  documentId: string;
+  refreshDocument: () => Promise<unknown>;
+  setSaveError: (message: string | null) => void;
+}
+
+interface HiddenDetailLifecycleActions {
+  isMutatingHiddenItems: boolean;
+  reviewHiddenItem: (itemId: string) => Promise<void>;
+  dismissHiddenItem: (itemId: string) => Promise<void>;
+}
+
+export function useHiddenDetailLifecycle({
+  canMutate,
+  documentId,
+  refreshDocument,
+  setSaveError,
+}: UseHiddenDetailLifecycleParams): HiddenDetailLifecycleActions {
+  const [isMutatingHiddenItems, setIsMutatingHiddenItems] = useState(false);
+
+  const mutateExtractionReviewMetadata = useCallback(
+    async (payload: ExtractionReviewMetadataUpdateRequest): Promise<void> => {
+      if (!canMutate || !documentId) {
+        return;
+      }
+
+      setIsMutatingHiddenItems(true);
+      setSaveError(null);
+      try {
+        await quoteService.updateExtractionReviewMetadata(documentId, payload);
+        await refreshDocument();
+      } catch (error) {
+        const message = error instanceof Error ? error.message : "Unable to update capture details";
+        setSaveError(message);
+      } finally {
+        setIsMutatingHiddenItems(false);
+      }
+    },
+    [canMutate, documentId, refreshDocument, setSaveError],
+  );
+
+  const reviewHiddenItem = useCallback(
+    async (itemId: string): Promise<void> => {
+      await mutateExtractionReviewMetadata({ review_hidden_item: itemId });
+    },
+    [mutateExtractionReviewMetadata],
+  );
+
+  const dismissHiddenItem = useCallback(
+    async (itemId: string): Promise<void> => {
+      await mutateExtractionReviewMetadata({ dismiss_hidden_item: itemId });
+    },
+    [mutateExtractionReviewMetadata],
+  );
+
+  return {
+    isMutatingHiddenItems,
+    reviewHiddenItem,
+    dismissHiddenItem,
+  };
+}

--- a/frontend/src/features/quotes/services/quoteService.ts
+++ b/frontend/src/features/quotes/services/quoteService.ts
@@ -1,6 +1,8 @@
 import type { Invoice } from "@/features/invoices/types/invoice.types";
 import type {
   ExtractionResult,
+  ExtractionReviewMetadata,
+  ExtractionReviewMetadataUpdateRequest,
   JobStatusResponse,
   Quote,
   QuoteDetail,
@@ -134,6 +136,19 @@ function updateQuote(id: string, data: QuoteUpdateRequest): Promise<Quote> {
   });
 }
 
+function updateExtractionReviewMetadata(
+  id: string,
+  data: ExtractionReviewMetadataUpdateRequest,
+): Promise<ExtractionReviewMetadata> {
+  return request<ExtractionReviewMetadata>(
+    `/api/quotes/${id}/extraction-review-metadata`,
+    {
+      method: "PATCH",
+      body: data,
+    },
+  );
+}
+
 function deleteQuote(id: string): Promise<void> {
   // 204 No Content responses parse as null before we normalize back to void.
   return request<null>(`/api/quotes/${id}`, {
@@ -197,6 +212,7 @@ export const quoteService = {
   listQuotes,
   getQuote,
   updateQuote,
+  updateExtractionReviewMetadata,
   deleteQuote,
   generatePdf,
   shareQuote,

--- a/frontend/src/features/quotes/tests/CaptureScreen.test.tsx
+++ b/frontend/src/features/quotes/tests/CaptureScreen.test.tsx
@@ -124,6 +124,7 @@ const quoteDetailFixture: QuoteDetail = {
       append_suggestions: [],
       confidence_notes: [],
     },
+    hidden_detail_state: {},
     extraction_degraded_reason_code: null,
   },
   customer_name: null,
@@ -617,6 +618,7 @@ describe("CaptureScreen", () => {
           append_suggestions: [],
           confidence_notes: ["New note"],
         },
+        hidden_detail_state: {},
       },
     });
     renderScreen({

--- a/frontend/src/features/quotes/tests/ReviewScreen.test.tsx
+++ b/frontend/src/features/quotes/tests/ReviewScreen.test.tsx
@@ -40,6 +40,7 @@ vi.mock("@/features/quotes/hooks/usePersistedReview", async () => {
 vi.mock("@/features/quotes/services/quoteService", () => ({
   quoteService: {
     updateQuote: vi.fn(),
+    updateExtractionReviewMetadata: vi.fn(),
   },
 }));
 
@@ -101,6 +102,7 @@ function makeQuote(overrides: Partial<QuoteDetail> = {}): QuoteDetail {
         append_suggestions: [],
         confidence_notes: [],
       },
+      hidden_detail_state: {},
       extraction_degraded_reason_code: null,
     },
     shared_at: null,
@@ -242,6 +244,29 @@ beforeEach(() => {
   mockedQuoteService.updateQuote.mockResolvedValue({
     id: "doc-1",
   } as never);
+  mockedQuoteService.updateExtractionReviewMetadata.mockResolvedValue({
+    pipeline_version: "v2",
+    review_state: {
+      notes_pending: false,
+      pricing_pending: false,
+    },
+    seeded_fields: {
+      notes: { seeded: false, confidence: null, source: null },
+      pricing: {
+        explicit_total: { seeded: false, source: null },
+        deposit_amount: { seeded: false, source: null },
+        tax_rate: { seeded: false, source: null },
+        discount: { seeded: false, source: null },
+      },
+    },
+    hidden_details: {
+      unresolved_segments: [],
+      append_suggestions: [],
+      confidence_notes: [],
+    },
+    hidden_detail_state: {},
+    extraction_degraded_reason_code: null,
+  });
   mockedInvoiceService.updateInvoice.mockResolvedValue({
     id: "doc-1",
   } as never);
@@ -470,6 +495,39 @@ describe("DocumentEditScreen", () => {
     expect(section2.compareDocumentPosition(section3)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
     expect(section3.compareDocumentPosition(section4)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
     expect(screen.getByText("Original capture transcript text.")).toBeInTheDocument();
+  });
+
+  it("persists dismiss actions for hidden items through sidecar metadata patch", async () => {
+    renderScreen({
+      document: makeQuote({
+        extraction_review_metadata: {
+          ...makeQuote().extraction_review_metadata!,
+          hidden_details: {
+            append_suggestions: [
+              {
+                id: "append-1",
+                kind: "note",
+                raw_text: "Add gate latch note",
+                confidence: "low",
+                source: "append_capture",
+              },
+            ],
+            unresolved_segments: [],
+            confidence_notes: [],
+          },
+          hidden_detail_state: {},
+        },
+      }),
+    });
+
+    fireEvent.click(await screen.findByRole("button", { name: /capture details/i }));
+    fireEvent.click(screen.getByRole("button", { name: /dismiss/i }));
+
+    await waitFor(() => {
+      expect(mockedQuoteService.updateExtractionReviewMetadata).toHaveBeenCalledWith("doc-1", {
+        dismiss_hidden_item: "append-1",
+      });
+    });
   });
 
   it("locks type selector after sharing", async () => {

--- a/frontend/src/features/quotes/types/quote.types.ts
+++ b/frontend/src/features/quotes/types/quote.types.ts
@@ -226,8 +226,8 @@ export interface ExtractionReviewMetadataUpdateRequest {
   dismiss_hidden_item?: string;
   review_hidden_item?: string;
   clear_review_state?: {
-    notes_pending?: boolean;
-    pricing_pending?: boolean;
+    notes_pending?: true;
+    pricing_pending?: true;
   };
 }
 

--- a/frontend/src/features/quotes/types/quote.types.ts
+++ b/frontend/src/features/quotes/types/quote.types.ts
@@ -200,6 +200,11 @@ export interface ExtractionReviewHiddenDetails {
   confidence_notes: string[];
 }
 
+export interface HiddenItemState {
+  reviewed: boolean;
+  dismissed: boolean;
+}
+
 export interface ExtractionReviewMetadata {
   pipeline_version: "v2";
   review_state: ExtractionReviewState;
@@ -213,7 +218,17 @@ export interface ExtractionReviewMetadata {
     };
   };
   hidden_details: ExtractionReviewHiddenDetails;
+  hidden_detail_state: Record<string, HiddenItemState>;
   extraction_degraded_reason_code: string | null;
+}
+
+export interface ExtractionReviewMetadataUpdateRequest {
+  dismiss_hidden_item?: string;
+  review_hidden_item?: string;
+  clear_review_state?: {
+    notes_pending?: boolean;
+    pricing_pending?: boolean;
+  };
 }
 
 export interface QuoteListItem {


### PR DESCRIPTION
## Summary
- implement conservative append for notes/pricing: seed only when target fields are empty and create deterministic hidden append suggestions when populated fields are protected
- add sidecar lifecycle support with `hidden_detail_state`, deterministic hidden-item ids, and `PATCH /api/quotes/{id}/extraction-review-metadata` for review/dismiss and grouped review-state clear operations
- clear related append suggestions + grouped review-state server-side on real notes/pricing value changes through normal quote PATCH
- wire frontend Capture Details to lifecycle state and sidecar PATCH mutations (review/dismiss actions), including hidden-item filtering by dismissed state
- add backend/frontend test coverage for append protection, suggestion persistence/resurfacing, sidecar patch behavior, deterministic ids, and review-screen lifecycle actions

## Verification
- `cd backend && .venv/bin/ruff check . --cache-dir .ruff_cache && .venv/bin/ruff format --check .`
- `cd backend && .venv/bin/pytest app/features/quotes/tests/test_quote_append_extraction.py app/features/quotes/tests/test_extraction.py app/features/quotes/tests/test_extraction_service.py -v -m "not live and not extraction_eval and not extraction_quality" -o cache_dir=.pytest_cache`
- `cd frontend && ./node_modules/.bin/tsc --noEmit && ./node_modules/.bin/eslint src/features/quotes && ./node_modules/.bin/vitest run src/features/quotes`
- `make verify`

Closes #398