### PR TITLE
Task #399: harden extraction eval matrix and review transcript safeguards

### DIFF
--- a/backend/app/features/quotes/tests/fixtures/extraction_eval_cases.py
+++ b/backend/app/features/quotes/tests/fixtures/extraction_eval_cases.py
@@ -15,6 +15,44 @@ _SEMANTIC_EMPTY_LINE_ITEMS_ABOVE_TRANSCRIPT = (
     "Clean gutters flush drains sweep roof patch fascia trim shrubs edge beds "
     "check lights and confirm full work schedule tomorrow morning."
 )
+_TYPED_LANDSCAPING_TRANSCRIPT = (
+    "Install 5 yards of brown mulch at 45 per yard, edge the front beds for 80, "
+    "and flush the drip line for 60. Total should be 365."
+)
+_VOICE_EQUIVALENT_TRANSCRIPT = (
+    "Spoken capture: install five yards of brown mulch at forty-five per yard, "
+    "edge the front beds for eighty, and flush the drip line for sixty. "
+    "Total should be three hundred sixty-five."
+)
+_MIXED_VOICE_TEXT_RAW_TRANSCRIPT = (
+    "Install five yards of brown mulch at forty-five per yard and edge the front beds for eighty."
+)
+_MIXED_VOICE_TEXT_RAW_TYPED_NOTES = (
+    "Add drip-line flush for 60. Typed follow-up says skip edging on one side; "
+    "confirm with customer."
+)
+_MIXED_VOICE_TEXT_TRANSCRIPT = (
+    f"{_MIXED_VOICE_TEXT_RAW_TRANSCRIPT}\n\n{_MIXED_VOICE_TEXT_RAW_TYPED_NOTES}"
+)
+_APPEND_CAPTURE_TRANSCRIPT = (
+    "Original capture: install two floodlights at 180 each.\n\n"
+    "Added later:\n"
+    "- include driveway edging for 95"
+)
+_EXPLICIT_PRICING_RULE_TRANSCRIPT = (
+    "Patio and drainage scope: seal patio for 260 and clear drainage line for 180. "
+    "Pricing notes: deposit 150, tax 6.5 percent, discount 10 percent, total 459.95."
+)
+_TYPED_TRANSCRIPT_CONFLICT_TRANSCRIPT = (
+    "Transcript says seal patio for 260 and clear drainage line for 180. "
+    "Typed note says skip drainage if the patio budget is tight."
+)
+
+_UNRESOLVED_SEGMENT_SOURCE = Literal[
+    "leftover_classification",
+    "typed_conflict",
+    "transcript_conflict",
+]
 
 
 @dataclass(frozen=True, slots=True)
@@ -27,11 +65,17 @@ class ExtractionEvalCase:
     expected_models: tuple[str, ...]
     expected_invocation_tier: Literal["primary", "fallback"]
     expect_total_matches_priced_sum: bool
+    source_type: Literal["text", "voice", "voice+text"] = "text"
+    raw_typed_notes: str | None = None
+    raw_transcript: str | None = None
     expect_extraction_tier: Literal["primary", "degraded"] | None = None
     expect_degraded_reason_code: str | None = None
     expect_line_item_count_min: int | None = None
     expect_line_item_count_max: int | None = None
     expect_confidence_note_substrings: tuple[str, ...] = ()
+    expect_pricing_hints: dict[str, float | str | None] | None = None
+    expect_unresolved_segment_sources: tuple[_UNRESOLVED_SEGMENT_SOURCE, ...] = ()
+    expect_customer_notes_source: _UNRESOLVED_SEGMENT_SOURCE | None = None
     expect_all_line_items_flagged: bool | None = None
     expect_flag_reason_substrings: tuple[str, ...] = ()
     expect_repair_attempted: bool | None = None
@@ -124,6 +168,309 @@ EXTRACTION_EVAL_CASES: tuple[ExtractionEvalCase, ...] = (
         expect_repair_attempted=False,
         expect_repair_outcome="not_attempted",
         human_notes="Fallback invocation should remain quote-facing primary when usable.",
+    ),
+    ExtractionEvalCase(
+        name="typed_landscaping_capture_with_explicit_total",
+        transcript=_TYPED_LANDSCAPING_TRANSCRIPT,
+        provider_events=(
+            {
+                "type": "tool_use",
+                "input": {
+                    "transcript": _TYPED_LANDSCAPING_TRANSCRIPT,
+                    "line_items": [
+                        {
+                            "description": "Brown mulch",
+                            "details": "5 yards",
+                            "price": 225,
+                        },
+                        {
+                            "description": "Edge front beds",
+                            "details": None,
+                            "price": 80,
+                        },
+                        {
+                            "description": "Flush drip line",
+                            "details": None,
+                            "price": 60,
+                        },
+                    ],
+                    "pricing_hints": {
+                        "explicit_total": 365,
+                    },
+                    "confidence_notes": [],
+                },
+            },
+        ),
+        expected_models=("primary-model",),
+        expected_invocation_tier="primary",
+        expect_total_matches_priced_sum=True,
+        expect_extraction_tier="primary",
+        expect_line_item_count_min=3,
+        expect_line_item_count_max=3,
+        expect_pricing_hints={"explicit_total": 365},
+        expect_repair_attempted=False,
+        expect_repair_outcome="not_attempted",
+        human_notes="Typed-only landscaping capture should preserve explicit quantity math.",
+    ),
+    ExtractionEvalCase(
+        name="voice_only_landscaping_capture_spoken_equivalent",
+        transcript=_VOICE_EQUIVALENT_TRANSCRIPT,
+        provider_events=(
+            {
+                "type": "tool_use",
+                "input": {
+                    "transcript": _VOICE_EQUIVALENT_TRANSCRIPT,
+                    "line_items": [
+                        {
+                            "description": "Brown mulch",
+                            "details": "5 yards",
+                            "price": 225,
+                        },
+                        {
+                            "description": "Edge front beds",
+                            "details": None,
+                            "price": 80,
+                        },
+                        {
+                            "description": "Flush drip line",
+                            "details": None,
+                            "price": 60,
+                        },
+                    ],
+                    "pricing_hints": {"explicit_total": 365},
+                    "confidence_notes": [],
+                },
+            },
+        ),
+        expected_models=("primary-model",),
+        expected_invocation_tier="primary",
+        expect_total_matches_priced_sum=True,
+        source_type="voice",
+        raw_transcript=_VOICE_EQUIVALENT_TRANSCRIPT,
+        expect_extraction_tier="primary",
+        expect_line_item_count_min=3,
+        expect_line_item_count_max=3,
+        expect_pricing_hints={"explicit_total": 365},
+        expect_repair_attempted=False,
+        expect_repair_outcome="not_attempted",
+        human_notes="Voice-only equivalent should retain the same pricing structure.",
+    ),
+    ExtractionEvalCase(
+        name="mixed_voice_text_capture_with_typed_vs_transcript_conflict",
+        transcript=_MIXED_VOICE_TEXT_TRANSCRIPT,
+        provider_events=(
+            {
+                "type": "tool_use",
+                "input": {
+                    "transcript": _MIXED_VOICE_TEXT_TRANSCRIPT,
+                    "line_items": [
+                        {
+                            "description": "Brown mulch",
+                            "details": "5 yards",
+                            "price": 225,
+                        },
+                        {
+                            "description": "Edge front beds",
+                            "details": None,
+                            "price": 80,
+                        },
+                        {
+                            "description": "Flush drip line",
+                            "details": None,
+                            "price": 60,
+                        },
+                    ],
+                    "pricing_hints": {"explicit_total": 365},
+                    "customer_notes_suggestion": {
+                        "text": (
+                            "Typed follow-up conflicts with transcript scope; "
+                            "confirm edging details."
+                        ),
+                        "confidence": "low",
+                        "source": "typed_conflict",
+                    },
+                    "unresolved_segments": [
+                        {
+                            "raw_text": "Typed follow-up says skip edging on one side.",
+                            "confidence": "low",
+                            "source": "typed_conflict",
+                        },
+                        {
+                            "raw_text": "Transcript includes edging for full front beds.",
+                            "confidence": "medium",
+                            "source": "transcript_conflict",
+                        },
+                    ],
+                    "confidence_notes": [
+                        "Typed and transcript conflict on edging scope; "
+                        "operator confirmation required."
+                    ],
+                },
+            },
+        ),
+        expected_models=("primary-model",),
+        expected_invocation_tier="primary",
+        expect_total_matches_priced_sum=True,
+        source_type="voice+text",
+        raw_typed_notes=_MIXED_VOICE_TEXT_RAW_TYPED_NOTES,
+        raw_transcript=_MIXED_VOICE_TEXT_RAW_TRANSCRIPT,
+        expect_extraction_tier="primary",
+        expect_line_item_count_min=3,
+        expect_line_item_count_max=3,
+        expect_confidence_note_substrings=("conflict on edging scope",),
+        expect_pricing_hints={"explicit_total": 365},
+        expect_unresolved_segment_sources=("typed_conflict", "transcript_conflict"),
+        expect_customer_notes_source="typed_conflict",
+        expect_repair_attempted=False,
+        expect_repair_outcome="not_attempted",
+        human_notes=(
+            "Mixed capture should retain provenance and preserve typed/transcript conflicts."
+        ),
+    ),
+    ExtractionEvalCase(
+        name="append_capture_follow_up_transcript_sample",
+        transcript=_APPEND_CAPTURE_TRANSCRIPT,
+        provider_events=(
+            {
+                "type": "tool_use",
+                "input": {
+                    "transcript": _APPEND_CAPTURE_TRANSCRIPT,
+                    "line_items": [
+                        {
+                            "description": "Floodlights",
+                            "details": "2 units",
+                            "price": 360,
+                        },
+                        {
+                            "description": "Driveway edging",
+                            "details": None,
+                            "price": 95,
+                        },
+                    ],
+                    "pricing_hints": {"explicit_total": 455},
+                    "confidence_notes": [
+                        "Append capture added a new line item after the initial transcript."
+                    ],
+                },
+            },
+        ),
+        expected_models=("primary-model",),
+        expected_invocation_tier="primary",
+        expect_total_matches_priced_sum=True,
+        expect_extraction_tier="primary",
+        expect_line_item_count_min=2,
+        expect_line_item_count_max=2,
+        expect_confidence_note_substrings=("append capture added",),
+        expect_pricing_hints={"explicit_total": 455},
+        expect_repair_attempted=False,
+        expect_repair_outcome="not_attempted",
+        human_notes="Append-style transcript section should remain deterministic in eval fixtures.",
+    ),
+    ExtractionEvalCase(
+        name="explicit_pricing_rule_fields_with_deposit_tax_discount",
+        transcript=_EXPLICIT_PRICING_RULE_TRANSCRIPT,
+        provider_events=(
+            {
+                "type": "tool_use",
+                "input": {
+                    "transcript": _EXPLICIT_PRICING_RULE_TRANSCRIPT,
+                    "line_items": [
+                        {
+                            "description": "Patio sealing",
+                            "details": None,
+                            "price": 260,
+                        },
+                        {
+                            "description": "Drainage line cleanout",
+                            "details": None,
+                            "price": 180,
+                        },
+                    ],
+                    "pricing_hints": {
+                        "explicit_total": 459.95,
+                        "deposit_amount": 150,
+                        "tax_rate": 6.5,
+                        "discount_type": "percent",
+                        "discount_value": 10,
+                    },
+                    "confidence_notes": [
+                        "Total includes tax and discount adjustments; line-item sum may differ."
+                    ],
+                },
+            },
+        ),
+        expected_models=("primary-model",),
+        expected_invocation_tier="primary",
+        expect_total_matches_priced_sum=False,
+        expect_extraction_tier="primary",
+        expect_line_item_count_min=2,
+        expect_line_item_count_max=2,
+        expect_pricing_hints={
+            "explicit_total": 459.95,
+            "deposit_amount": 150,
+            "tax_rate": 6.5,
+            "discount_type": "percent",
+            "discount_value": 10,
+        },
+        expect_repair_attempted=False,
+        expect_repair_outcome="not_attempted",
+        human_notes="Pricing hints should retain explicit total/deposit/tax/discount fields.",
+    ),
+    ExtractionEvalCase(
+        name="typed_vs_transcript_conflict_with_unresolved_segments",
+        transcript=_TYPED_TRANSCRIPT_CONFLICT_TRANSCRIPT,
+        provider_events=(
+            {
+                "type": "tool_use",
+                "input": {
+                    "transcript": _TYPED_TRANSCRIPT_CONFLICT_TRANSCRIPT,
+                    "line_items": [
+                        {
+                            "description": "Patio sealing",
+                            "details": None,
+                            "price": 260,
+                        },
+                        {
+                            "description": "Drainage line cleanout",
+                            "details": None,
+                            "price": 180,
+                        },
+                    ],
+                    "pricing_hints": {"explicit_total": 440},
+                    "customer_notes_suggestion": {
+                        "text": "Customer may want to waive drainage cleanout if budget is tight.",
+                        "confidence": "low",
+                        "source": "typed_conflict",
+                    },
+                    "unresolved_segments": [
+                        {
+                            "raw_text": "Typed note says skip drainage if budget is tight.",
+                            "confidence": "low",
+                            "source": "typed_conflict",
+                        },
+                        {
+                            "raw_text": "Transcript still includes drainage line cleanout.",
+                            "confidence": "medium",
+                            "source": "transcript_conflict",
+                        },
+                    ],
+                    "confidence_notes": ["Typed and transcript inputs conflict on drainage scope."],
+                },
+            },
+        ),
+        expected_models=("primary-model",),
+        expected_invocation_tier="primary",
+        expect_total_matches_priced_sum=True,
+        expect_extraction_tier="primary",
+        expect_line_item_count_min=2,
+        expect_line_item_count_max=2,
+        expect_confidence_note_substrings=("conflict on drainage scope",),
+        expect_pricing_hints={"explicit_total": 440},
+        expect_unresolved_segment_sources=("typed_conflict", "transcript_conflict"),
+        expect_customer_notes_source="typed_conflict",
+        expect_repair_attempted=False,
+        expect_repair_outcome="not_attempted",
+        human_notes="Typed-vs-transcript conflict should survive as unresolved sidecar details.",
     ),
     ExtractionEvalCase(
         name="repair_succeeds_after_one_invalid_payload",

--- a/backend/app/features/quotes/tests/test_extraction_eval.py
+++ b/backend/app/features/quotes/tests/test_extraction_eval.py
@@ -6,6 +6,7 @@ manually with ``make extraction-eval`` before prompt/model changes.
 
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass
 from typing import Any
 
@@ -13,7 +14,7 @@ import anthropic
 import httpx
 import pytest
 
-from app.features.quotes.schemas import ExtractionResult
+from app.features.quotes.schemas import ExtractionResult, PreparedCaptureInput
 from app.features.quotes.tests.fixtures.extraction_eval_cases import (
     EXTRACTION_EVAL_CASES,
     ExtractionEvalCase,
@@ -71,6 +72,66 @@ def _build_outcomes(case: ExtractionEvalCase) -> list[object]:
     return outcomes
 
 
+def _build_capture_input(case: ExtractionEvalCase) -> PreparedCaptureInput | str:
+    if case.source_type == "text" and case.raw_typed_notes is None and case.raw_transcript is None:
+        return case.transcript
+    if case.source_type == "voice":
+        return PreparedCaptureInput(
+            transcript=case.transcript,
+            source_type="voice",
+            raw_typed_notes=None,
+            raw_transcript=case.raw_transcript or case.transcript,
+        )
+    if case.source_type == "voice+text":
+        return PreparedCaptureInput(
+            transcript=case.transcript,
+            source_type="voice+text",
+            raw_typed_notes=case.raw_typed_notes or case.transcript,
+            raw_transcript=case.raw_transcript or case.transcript,
+        )
+    return PreparedCaptureInput(
+        transcript=case.transcript,
+        source_type="text",
+        raw_typed_notes=case.raw_typed_notes or case.transcript,
+        raw_transcript=None,
+    )
+
+
+def _assert_request_capture_provenance(
+    case: ExtractionEvalCase,
+    *,
+    calls: list[dict[str, object]],
+) -> None:
+    assert calls
+    messages = calls[0]["messages"]
+    assert isinstance(messages, list)
+    assert messages
+    first_message = messages[0]
+    assert isinstance(first_message, dict)
+    content = first_message["content"]
+    assert isinstance(content, str)
+    request_payload = json.loads(content)
+    prepared_capture_input = request_payload["prepared_capture_input"]
+
+    assert prepared_capture_input["source_type"] == case.source_type
+    assert prepared_capture_input["transcript"] == case.transcript
+
+    expected_raw_typed_notes = case.raw_typed_notes
+    expected_raw_transcript = case.raw_transcript
+    if case.source_type == "text":
+        expected_raw_typed_notes = expected_raw_typed_notes or case.transcript
+        expected_raw_transcript = None
+    elif case.source_type == "voice":
+        expected_raw_typed_notes = None
+        expected_raw_transcript = expected_raw_transcript or case.transcript
+    else:
+        expected_raw_typed_notes = expected_raw_typed_notes or case.transcript
+        expected_raw_transcript = expected_raw_transcript or case.transcript
+
+    assert prepared_capture_input["raw_typed_notes"] == expected_raw_typed_notes
+    assert prepared_capture_input["raw_transcript"] == expected_raw_transcript
+
+
 def _assert_extraction_invariants(
     result: ExtractionResult,
     *,
@@ -122,6 +183,20 @@ def _assert_extraction_quality(
         normalized_substring = substring.casefold()
         assert any(normalized_substring in note.casefold() for note in result.confidence_notes)
 
+    if case.expect_pricing_hints:
+        pricing_hints_payload = result.pricing_hints.model_dump(mode="json")
+        for key, value in case.expect_pricing_hints.items():
+            assert pricing_hints_payload[key] == value
+
+    if case.expect_unresolved_segment_sources:
+        assert [segment.source for segment in result.unresolved_segments] == list(
+            case.expect_unresolved_segment_sources
+        )
+
+    if case.expect_customer_notes_source is not None:
+        assert result.customer_notes_suggestion is not None
+        assert result.customer_notes_suggestion.source == case.expect_customer_notes_source
+
     if case.expect_all_line_items_flagged is not None:
         assert result.line_items
         assert all(item.flagged is case.expect_all_line_items_flagged for item in result.line_items)
@@ -152,7 +227,7 @@ async def test_extraction_eval_baseline_invariants_hold_for_primary_fixture() ->
         client=client,
     )
 
-    result = await integration.extract(case.transcript)
+    result = await integration.extract(_build_capture_input(case))
 
     _assert_extraction_invariants(
         result,
@@ -160,6 +235,7 @@ async def test_extraction_eval_baseline_invariants_hold_for_primary_fixture() ->
         expect_total_matches_priced_sum=case.expect_total_matches_priced_sum,
     )
     assert [call["model"] for call in client.messages.calls] == list(case.expected_models)
+    _assert_request_capture_provenance(case, calls=client.messages.calls)
 
     metadata = integration.pop_last_call_metadata()
     assert metadata is not None
@@ -178,7 +254,7 @@ async def test_extraction_eval_invariants(case: ExtractionEvalCase) -> None:
         client=client,
     )
 
-    result = await integration.extract(case.transcript)
+    result = await integration.extract(_build_capture_input(case))
 
     _assert_extraction_invariants(
         result,
@@ -186,6 +262,7 @@ async def test_extraction_eval_invariants(case: ExtractionEvalCase) -> None:
         expect_total_matches_priced_sum=case.expect_total_matches_priced_sum,
     )
     assert [call["model"] for call in client.messages.calls] == list(case.expected_models)
+    _assert_request_capture_provenance(case, calls=client.messages.calls)
 
     metadata = integration.pop_last_call_metadata()
     assert metadata is not None

--- a/frontend/src/features/quotes/tests/ReviewScreen.test.tsx
+++ b/frontend/src/features/quotes/tests/ReviewScreen.test.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -495,6 +495,9 @@ describe("DocumentEditScreen", () => {
     expect(section2.compareDocumentPosition(section3)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
     expect(section3.compareDocumentPosition(section4)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
     expect(screen.getByText("Original capture transcript text.")).toBeInTheDocument();
+    const transcriptSection = section4.closest("section");
+    expect(transcriptSection).not.toBeNull();
+    expect(within(transcriptSection as HTMLElement).queryByRole("textbox")).not.toBeInTheDocument();
   });
 
   it("persists dismiss actions for hidden items through sidecar metadata patch", async () => {


### PR DESCRIPTION
## Summary
- expand backend extraction eval fixtures with PR5 golden/matrix cases for typed-only, voice-only, mixed voice+text, append-style transcript, explicit pricing hints, and typed-vs-transcript conflicts
- harden `test_extraction_eval.py` to run provenance-aware capture inputs and assert request provenance plus conflict/pricing expectations
- add a frontend review test assertion that Capture Details transcript remains display-only (no editable textbox)

## Verification
- `cd backend && .venv/bin/pytest -v -m extraction_eval -o cache_dir=.pytest_cache`
- `make backend-verify`
- `make frontend-verify`

Closes #399