### PR TITLE
Task #407: split backend verify targets and backend CI jobs

### DIFF
--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -8,8 +8,48 @@ on:
   workflow_call:
 
 jobs:
+  backend-static:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+      - id: setup-python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.13'
+          cache: 'pip'
+          cache-dependency-path: backend/requirements.txt
+      - name: Cache mypy results
+        uses: actions/cache@v5
+        with:
+          path: backend/.mypy_cache
+          key: mypy-${{ runner.os }}-${{ hashFiles('backend/**/*.py', 'pyproject.toml') }}
+          restore-keys: |
+            mypy-${{ runner.os }}-
+      - name: Cache Ruff results
+        uses: actions/cache@v5
+        with:
+          path: backend/.ruff_cache
+          key: ruff-${{ runner.os }}-py${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('backend/**/*.py', 'pyproject.toml') }}
+          restore-keys: |
+            ruff-${{ runner.os }}-py${{ steps.setup-python.outputs.python-version }}-
+            ruff-${{ runner.os }}-
+      - name: Install dependencies
+        run: |
+          python -m venv backend/.venv
+          backend/.venv/bin/pip install --upgrade pip
+          backend/.venv/bin/pip install -r backend/requirements.txt
+          backend/.venv/bin/pip install pip-audit==2.10.0
+      - name: Validate dependency audit exceptions
+        run: python3 scripts/validate_dependency_audit_exceptions.py
+      - name: Backend dependency audit
+        run: backend/.venv/bin/pip-audit -r backend/requirements.txt
+      - name: Template guard
+        run: make template-verify
+      - name: Backend static verify
+        run: make backend-static-verify
+
   backend-test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       SECRET_KEY: "test-secret-key-that-is-at-least-32-bytes"
       TEST_REDIS_URL: "redis://localhost:6379/15"
@@ -43,28 +83,18 @@ jobs:
           python-version: '3.13'
           cache: 'pip'
           cache-dependency-path: backend/requirements.txt
-      - name: Install ffmpeg
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y ffmpeg
-      - name: Cache mypy results
-        uses: actions/cache@v5
+      - name: Setup ffmpeg
+        uses: FedericoCarboni/setup-ffmpeg@37062fbf7149fc5578d6c57e08aed62458b375d6 # v3.1
         with:
-          path: backend/.mypy_cache
-          key: mypy-${{ runner.os }}-${{ hashFiles('backend/**/*.py', 'pyproject.toml') }}
-          restore-keys: |
-            mypy-${{ runner.os }}-
+          ffmpeg-version: release
+      - name: FFmpeg diagnostics
+        run: |
+          ffmpeg -version
+          ffprobe -version
       - name: Install dependencies
         run: |
           python -m venv backend/.venv
           backend/.venv/bin/pip install --upgrade pip
           backend/.venv/bin/pip install -r backend/requirements.txt
-          backend/.venv/bin/pip install pip-audit==2.10.0
-      - name: Validate dependency audit exceptions
-        run: python3 scripts/validate_dependency_audit_exceptions.py
-      - name: Backend dependency audit
-        run: backend/.venv/bin/pip-audit -r backend/requirements.txt
-      - name: Template guard
-        run: make template-verify
-      - name: Backend verify
-        run: make backend-verify
+      - name: Backend test verify
+        run: make backend-test-verify

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help verify backend-verify frontend-verify db-verify template-verify extraction-live extraction-eval extraction-quality
+.PHONY: help verify backend-verify backend-static-verify backend-test-verify frontend-verify db-verify template-verify extraction-live extraction-eval extraction-quality
 
 help: ## Show available targets
 	@grep -E '^[a-zA-Z_-]+:.*##' $(MAKEFILE_LIST) | awk -F ':.*## ' '{printf "  %-20s %s\n", $$1, $$2}'
@@ -9,6 +9,10 @@ verify: ## Run all backend and frontend verification checks
 	@$(MAKE) frontend-verify SKIP_FILE_SIZE_CHECK=1
 
 backend-verify: ## Run backend lint, type checks, security scan, and tests
+	@$(MAKE) backend-static-verify SKIP_FILE_SIZE_CHECK=$(SKIP_FILE_SIZE_CHECK)
+	@$(MAKE) backend-test-verify
+
+backend-static-verify: ## Run backend boundaries, lint, type checks, and security scan
 	@bash scripts/check_backend_boundaries.sh
 	@if [ "$(SKIP_FILE_SIZE_CHECK)" != "1" ]; then bash scripts/check_file_sizes.sh --scope backend; fi
 	@test -x backend/.venv/bin/ruff || (echo "Missing backend/.venv. Run: cd backend && python3 -m venv .venv && .venv/bin/pip install -r requirements.txt" && exit 1)
@@ -16,7 +20,11 @@ backend-verify: ## Run backend lint, type checks, security scan, and tests
 		.venv/bin/ruff check . --cache-dir .ruff_cache && \
 		.venv/bin/ruff format --check . && \
 		.venv/bin/mypy . --cache-dir .mypy_cache && \
-		.venv/bin/bandit -r app/ -x app/core/tests,app/features/auth/tests,app/features/customers/tests,app/features/invoices/tests,app/features/profile/tests,app/features/quotes/tests,app/shared/tests && \
+		.venv/bin/bandit -r app/ -x app/core/tests,app/features/auth/tests,app/features/customers/tests,app/features/invoices/tests,app/features/profile/tests,app/features/quotes/tests,app/shared/tests
+
+backend-test-verify: ## Run backend pytest suite (excluding live/eval markers)
+	@test -x backend/.venv/bin/pytest || (echo "Missing backend/.venv. Run: cd backend && python3 -m venv .venv && .venv/bin/pip install -r requirements.txt" && exit 1)
+	@cd backend && \
 		.venv/bin/pytest -v -m "not live and not extraction_eval and not extraction_quality" -o cache_dir=.pytest_cache
 
 frontend-verify: ## Run frontend type checks, lint, tests, and build


### PR DESCRIPTION
## Summary
- split backend verification targets in `Makefile` into `backend-static-verify` and `backend-test-verify`
- keep `backend-verify` as the aggregator contract for local/full backend verification
- split `.github/workflows/backend-test.yml` into `backend-static` and `backend-test`
- pin backend CI runner to `ubuntu-24.04`
- replace apt-based ffmpeg install with `FedericoCarboni/setup-ffmpeg` pinned to full SHA (`37062fbf7149fc5578d6c57e08aed62458b375d6`, `# v3.1`) and add `ffmpeg -version`/`ffprobe -version` diagnostics
- keep dependency audit + template guard + static checks in `backend-static`, and pytest-only path in `backend-test`

## Verification
- `make backend-static-verify`
- `make backend-test-verify`
- `make backend-verify`

## Notes
- `ffmpeg-version: release` is used intentionally: the action code path is SHA-pinned, while the downloaded ffmpeg binary remains latest release resolved by the action.
- branch protection follow-up: if required checks were previously configured around the old single-job shape, ensure both `backend-static` and `backend-test` status checks are required.
- reusable workflow behavior remains unchanged: callers of this workflow via `workflow_call` still succeed only when all workflow jobs succeed.

Refs: #406
Supersedes: #408

Closes #407