### PR TITLE
Task #409: align backend patch verification guidance with static checks

### DIFF
--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -26,12 +26,13 @@ For bug fixes, backend business logic, contract-sensitive behavior, and stateful
 
 ## Verification Tiers (Backend)
 
-- Tier 1 (implementation loop): smallest backend checks proving changed behavior.
+- Tier 1 (implementation loop): smallest backend checks proving changed behavior, plus `make backend-static-verify` before push/PR update for backend code changes.
   - Example: `cd backend && .venv/bin/pytest app/features/<feature>/tests/test_<scope>.py`
   - Example: `cd backend && ruff check app/features/<feature>`
-- Tier 2 (post-review patch): rerun only checks covering patched findings unless scope expands.
+- Tier 2 (post-review patch): rerun only checks covering patched findings unless scope expands, and run `make backend-static-verify` before pushing backend patch commits.
 - Tier 3 (PR/final gate): `make backend-verify` (or `make verify` when cross-surface).
 - Tier 4 (operator-only heavy): live/provider-backed checks run by human operator when explicitly required.
+- Docs-only or non-backend-only changes do not require backend static verification.
 
 ## Agent Runtime Constraints
 
@@ -46,6 +47,7 @@ Integration tests require **PostgreSQL** reachable at `TEST_DATABASE_URL` (see `
 ### Other constraints
 
 - Do not run bare `pytest` from agent sessions; use `cd backend && .venv/bin/pytest ...` for targeted tests.
+- For backend code changes, pair targeted behavior checks with `make backend-static-verify` before push/PR update.
 - Backend pytest uses host-local services in this repo; if backend tests are required, prefer escalated runs over repeated sandbox retries.
 - If sandboxed pytest hangs during startup/collection, suspect sandbox-to-local-service access first.
 - Do not run `make db-verify` or live extraction checks from agent sessions.

--- a/docs/template/EXECUTION_BRIEF.md
+++ b/docs/template/EXECUTION_BRIEF.md
@@ -51,6 +51,8 @@ Capture commands by tier so reruns stay proportional:
 - Tier 3 (PR/final gate): `<canonical broad verify command for touched surface>`
 - Tier 4 (operator-only heavy, when needed): `<manual/live check>`
 
+For backend code changes, include `make backend-static-verify` before push/PR update alongside the targeted behavior check. Docs-only or non-backend-only changes do not require backend static verification.
+
 ## Open Product Decisions / Blockers
 
 - `<Decision the implementation should not silently lock in>`

--- a/docs/template/KICKOFF.md
+++ b/docs/template/KICKOFF.md
@@ -16,6 +16,7 @@ Use these prompts to start work on already-scoped tasks without reloading unnece
 - Use the short reviewer kickoff by default.
 - After `ACTIONABLE`, patch listed findings only unless scope expands.
 - Verification follows tiers from `docs/workflow/VERIFY.md`.
+- For backend code changes, run the targeted behavior check plus `make backend-static-verify` before push/PR update.
 
 ## When To Load Which Asset
 
@@ -42,7 +43,7 @@ Then execute the full Task flow end-to-end:
    - default: create/switch to `task-<id>-<slug>`
    - `execution=parallel`: run `scripts/worktree-init.sh <task-id> [slug]`, use returned `WORKTREE_READY` path only, and verify `backend/.venv` / `frontend/node_modules` symlinks before verification.
 3. Implement minimally and preserve contracts unless issue scope says otherwise.
-4. Run relevant verification by tier.
+4. Run relevant verification by tier (for backend code changes, include targeted behavior checks plus `make backend-static-verify` before push/PR update).
 5. Open PR with `Closes #<task-id>`.
 6. Return the short reviewer kickoff from section 3a.
 7. After review verdict:
@@ -53,6 +54,8 @@ Then execute the full Task flow end-to-end:
 ### Backend integration pytest in agent/sandbox environments
 
 Before running Tier 1 `cd backend && .venv/bin/pytest ...` or Tier 3 `make backend-verify` from an **agent**: integration tests need **PostgreSQL** at `TEST_DATABASE_URL` (see `backend/conftest.py`). **Sandboxed** agent shells often cannot reach `localhost:5432` → **all tests error (`E`) during setup**, not real assertion failures. **Run outside sandbox** (network to localhost) or have the **human** run the command and paste output — do not burn retries in a blocked environment. Canonical detail: `docs/workflow/VERIFY.md` and `backend/AGENTS.md`.
+
+For backend code changes, run `make backend-static-verify` before push/PR update in addition to any targeted behavior checks; docs-only or non-backend-only changes do not need backend static verification.
 
 Behavior Matrix (required for stateful/cross-layer tasks):
 - states/statuses and allowed actions
@@ -79,7 +82,7 @@ Inputs:
 Deliver:
 1. Patch listed findings only.
 2. Keep Task issue authoritative.
-3. Rerun targeted verification unless scope expanded.
+3. Rerun targeted verification unless scope expanded; for backend code patches also run `make backend-static-verify` before push/PR update.
 4. Return concise patch summary + targeted verification + follow-up (if any).
 ```
 

--- a/docs/workflow/VERIFY.md
+++ b/docs/workflow/VERIFY.md
@@ -8,10 +8,11 @@ Run the relevant checks before claiming completion.
 
 ### Verification Tiers
 
-- Tier 1 (implementation loop): run the smallest checks that prove changed behavior.
-- Tier 2 (post-review patch): rerun only checks needed for patched findings unless scope expands.
+- Tier 1 (implementation loop): run the smallest checks that prove changed behavior. For backend code changes, run the targeted backend behavior check plus `make backend-static-verify` before push/PR update.
+- Tier 2 (post-review patch): rerun only checks needed for patched findings unless scope expands. For backend code patches, keep the targeted rerun and also run `make backend-static-verify` before pushing follow-up commits.
 - Tier 3 (PR/final gate): run canonical broad verify targets for affected surfaces (`make backend-verify`, `make frontend-verify`, `make verify` as applicable).
 - Tier 4 (operator-only heavy): live/provider/manual or unusually expensive checks only when explicitly required.
+- Docs-only or non-backend-only changes do not require backend static verification.
 
 ### Agent execution: backend tests vs sandboxes
 
@@ -21,7 +22,7 @@ This applies to **network-isolated agent runs** (Cursor sandbox, VS Code / Copil
 
 **Do:**
 
-- Use `cd backend && .venv/bin/pytest ...` for targeted runs or `make backend-verify` for Tier 3 — never bare `pytest` (wrong interpreter / deps).
+- Use `cd backend && .venv/bin/pytest ...` for targeted backend behavior runs, pair backend code changes with `make backend-static-verify` before push, and reserve `make backend-verify` for Tier 3 broad gates — never bare `pytest` (wrong interpreter / deps).
 - When running from an **agent**, assume sandbox **until proven otherwise**. If you see all-`E` or hang at startup/collection, **stop** and either escalate to a **non-sandboxed** run with **localhost network**, or ask the **human** to run the exact command and paste the traceback.
 - Confirm failures with `-x --tb=short` once before declaring product bugs.
 
@@ -82,4 +83,3 @@ cd backend && alembic upgrade head
 - Frontend: type-check + tests + lint + production build.
 - No-contract refactors: include parity lock results in final verification summary.
 - Template maintenance: unresolved-token guard passes (`./scripts/check-unresolved-template-tokens.sh`).
-


### PR DESCRIPTION
## Summary
- Confirmed `main` already includes Task #407 runtime split prerequisites for this task:
  - `.github/workflows/backend-test.yml` has `backend-static` + `backend-test` jobs.
  - `backend-static` restores/saves `backend/.ruff_cache`.
  - `backend-test` does not restore `.ruff_cache`/`.mypy_cache`.
- Updated agent-facing workflow docs/prompts so backend implementation and `ACTIONABLE` patch flows require:
  - targeted behavior verification for the touched change, and
  - `make backend-static-verify` before push/PR update.
- Kept tiered verification semantics intact (`Tier 2` targeted reruns; `Tier 3` broad gates) and explicitly scoped docs-only/non-backend-only changes out of the backend static requirement.
- Reproduced Bandit warning noise with the task command; did not include broad nosec comment rewrites in this PR to keep the patch minimal/surgical.

## Files
- `backend/AGENTS.md`
- `docs/template/EXECUTION_BRIEF.md`
- `docs/template/KICKOFF.md`
- `docs/workflow/VERIFY.md`

## Verification
- `cd backend && .venv/bin/bandit -r app/ -x app/core/tests,app/features/auth/tests,app/features/customers/tests,app/features/invoices/tests,app/features/profile/tests,app/features/quotes/tests,app/shared/tests`
- `make backend-static-verify`
- `make backend-verify`

## Tracking
- Closes #409
- Parent Spec: #406
- #407 confirmed landed via current `main` repo shape (split backend workflow jobs/targets already present).