### PR TITLE
Task #416: thread extraction mode through sync and async flows

### DIFF
--- a/backend/app/features/quotes/api.py
+++ b/backend/app/features/quotes/api.py
@@ -265,6 +265,7 @@ async def extract_combined(
                 extraction = await extraction_service.extract_combined(
                     clip_inputs,
                     notes,
+                    mode="initial",
                     user_id=user.id,
                     allow_degraded_persist_on_retryable_failure=True,
                 )
@@ -329,6 +330,7 @@ async def extract_combined(
             _job_id=str(job.id),
             correlation_id=current_correlation_id(),
             prepared_capture_input=prepared_capture_input.model_dump(mode="json"),
+            extraction_mode="initial",
             source_type=source_type,
             capture_detail=capture_detail,
             customer_id=str(customer_id) if customer_id is not None else None,
@@ -385,6 +387,7 @@ async def append_extraction(
                 extraction = await extraction_service.extract_combined(
                     clip_inputs,
                     notes,
+                    mode="append",
                     user_id=user.id,
                     allow_degraded_persist_on_retryable_failure=True,
                 )
@@ -440,6 +443,7 @@ async def append_extraction(
             _job_id=str(job.id),
             correlation_id=current_correlation_id(),
             prepared_capture_input=prepared_capture_input.model_dump(mode="json"),
+            extraction_mode="append",
             source_type=source_type,
             capture_detail=capture_detail,
             append_to_quote=True,

--- a/backend/app/features/quotes/extraction_service.py
+++ b/backend/app/features/quotes/extraction_service.py
@@ -15,7 +15,7 @@ from app.features.quotes.extraction_outcomes import (
     log_draft_generation_failed_event,
     should_persist_degraded_retryable_error,
 )
-from app.features.quotes.schemas import ExtractionResult, PreparedCaptureInput
+from app.features.quotes.schemas import ExtractionMode, ExtractionResult, PreparedCaptureInput
 from app.features.quotes.service import QuoteServiceError
 from app.integrations.audio import AudioClip, AudioError
 from app.integrations.extraction import ExtractionError
@@ -30,7 +30,12 @@ from app.shared.input_limits import (
 class ExtractionIntegrationProtocol(Protocol):
     """Structural protocol for extraction integration dependency."""
 
-    async def extract(self, capture_input: PreparedCaptureInput) -> ExtractionResult: ...
+    async def extract(
+        self,
+        capture_input: PreparedCaptureInput,
+        *,
+        mode: ExtractionMode = "initial",
+    ) -> ExtractionResult: ...
 
 
 class AudioIntegrationProtocol(Protocol):
@@ -74,7 +79,7 @@ class ExtractionService:
             transcript=notes,
             source_type="text",
         )
-        return await self._extract_prepared_input(prepared_input)
+        return await self._extract_prepared_input(prepared_input, mode="initial")
 
     async def prepare_capture_input(
         self,
@@ -145,6 +150,7 @@ class ExtractionService:
         clips: Sequence[CaptureAudioClip] | None,
         notes: str | None,
         *,
+        mode: ExtractionMode = "initial",
         user_id: UUID | None = None,
         allow_degraded_persist_on_retryable_failure: bool = False,
     ) -> ExtractionResult:
@@ -156,7 +162,7 @@ class ExtractionService:
                 user_id=user_id,
             )
             try:
-                extraction = await self._extract_prepared_input(prepared_input)
+                extraction = await self._extract_prepared_input(prepared_input, mode=mode)
             except QuoteServiceError as exc:
                 should_persist_degraded = (
                     allow_degraded_persist_on_retryable_failure
@@ -180,9 +186,11 @@ class ExtractionService:
     async def _extract_prepared_input(
         self,
         prepared_input: PreparedCaptureInput,
+        *,
+        mode: ExtractionMode = "initial",
     ) -> ExtractionResult:
         try:
-            return await self._extraction.extract(prepared_input)
+            return await self._extraction.extract(prepared_input, mode=mode)
         except ExtractionError as exc:
             sentry_sdk.capture_exception(exc)
             raise QuoteServiceError(

--- a/backend/app/features/quotes/schemas.py
+++ b/backend/app/features/quotes/schemas.py
@@ -117,6 +117,7 @@ class CaptureSegment(BaseModel):
 
 
 PlacementConfidence = Literal["high", "medium", "low"]
+ExtractionMode = Literal["initial", "append"]
 UnresolvedSegmentSource = Literal[
     "leftover_classification",
     "typed_conflict",

--- a/backend/app/features/quotes/tests/support/helpers.py
+++ b/backend/app/features/quotes/tests/support/helpers.py
@@ -236,6 +236,7 @@ async def _run_extraction_job(
     capture_detail: str,
     customer_id: str | None = None,
     append_to_quote: bool = False,
+    extraction_mode: str | None = None,
     transcript: str = "mulch the front beds",
     prepared_capture_input: PreparedCaptureInput | dict[str, object] | None = None,
     job_try: int = 1,
@@ -255,6 +256,7 @@ async def _run_extraction_job(
         retry_jitter_seconds=DEFAULT_RETRY_JITTER_SECONDS,
     )
     resolved_extraction_integration = extraction_integration or _MockExtractionIntegration()
+    resolved_extraction_mode = extraction_mode or ("append" if append_to_quote else "initial")
     await extraction_job(
         {
             "job_try": job_try,
@@ -265,6 +267,7 @@ async def _run_extraction_job(
         correlation_id=correlation_id,
         transcript=transcript,
         prepared_capture_input=prepared_capture_input,
+        extraction_mode=resolved_extraction_mode,
         source_type=source_type,
         capture_detail=capture_detail,
         customer_id=customer_id,

--- a/backend/app/features/quotes/tests/support/mocks.py
+++ b/backend/app/features/quotes/tests/support/mocks.py
@@ -6,6 +6,7 @@ from typing import TypedDict
 
 from app.features.quotes.repository import QuoteRenderContext
 from app.features.quotes.schemas import (
+    ExtractionMode,
     ExtractionResult,
     LineItemExtractedV2,
     PreparedCaptureInput,
@@ -20,7 +21,13 @@ from app.shared.idempotency import IdempotencyBeginResult
 
 
 class _MockExtractionIntegration:
-    async def extract(self, notes: PreparedCaptureInput | str) -> ExtractionResult:
+    async def extract(
+        self,
+        notes: PreparedCaptureInput | str,
+        *,
+        mode: ExtractionMode = "initial",
+    ) -> ExtractionResult:
+        del mode
         normalized_notes = _capture_transcript(notes)
         if "malformed" in normalized_notes.lower():
             raise ExtractionError("mock malformed extraction payload")
@@ -187,6 +194,11 @@ class _RetryableProviderError(Exception):
 
 
 class _RetryableFailureExtractionIntegration:
-    async def extract(self, notes: PreparedCaptureInput | str) -> ExtractionResult:
-        del notes
+    async def extract(
+        self,
+        notes: PreparedCaptureInput | str,
+        *,
+        mode: ExtractionMode = "initial",
+    ) -> ExtractionResult:
+        del notes, mode
         raise ExtractionError("Claude request failed: retryable") from _RetryableProviderError(429)

--- a/backend/app/features/quotes/tests/test_extraction_eval.py
+++ b/backend/app/features/quotes/tests/test_extraction_eval.py
@@ -227,7 +227,7 @@ async def test_extraction_eval_baseline_invariants_hold_for_primary_fixture() ->
         client=client,
     )
 
-    result = await integration.extract(_build_capture_input(case))
+    result = await integration.extract(_build_capture_input(case), mode="initial")
 
     _assert_extraction_invariants(
         result,
@@ -254,7 +254,7 @@ async def test_extraction_eval_invariants(case: ExtractionEvalCase) -> None:
         client=client,
     )
 
-    result = await integration.extract(_build_capture_input(case))
+    result = await integration.extract(_build_capture_input(case), mode="initial")
 
     _assert_extraction_invariants(
         result,
@@ -279,4 +279,4 @@ async def test_empty_transcript_raises_extraction_error() -> None:
     )
 
     with pytest.raises(ExtractionError, match="notes cannot be empty"):
-        await integration.extract("")
+        await integration.extract("", mode="initial")

--- a/backend/app/features/quotes/tests/test_extraction_live.py
+++ b/backend/app/features/quotes/tests/test_extraction_live.py
@@ -50,7 +50,7 @@ def _print_report_card(name: str, result: ExtractionResult) -> None:
 
 @pytest.mark.live
 async def test_live_clean_with_total() -> None:
-    result = await _build_integration().extract(TRANSCRIPTS["clean_with_total"])
+    result = await _build_integration().extract(TRANSCRIPTS["clean_with_total"], mode="initial")
     _print_report_card("clean_with_total", result)
 
     assert result.total == pytest.approx(435)
@@ -62,7 +62,7 @@ async def test_live_clean_with_total() -> None:
 
 @pytest.mark.live
 async def test_live_clean_no_prices() -> None:
-    result = await _build_integration().extract(TRANSCRIPTS["clean_no_prices"])
+    result = await _build_integration().extract(TRANSCRIPTS["clean_no_prices"], mode="initial")
     _print_report_card("clean_no_prices", result)
 
     assert result.total is None
@@ -72,7 +72,7 @@ async def test_live_clean_no_prices() -> None:
 
 @pytest.mark.live
 async def test_live_total_only() -> None:
-    result = await _build_integration().extract(TRANSCRIPTS["total_only"])
+    result = await _build_integration().extract(TRANSCRIPTS["total_only"], mode="initial")
     _print_report_card("total_only", result)
 
     assert result.total == pytest.approx(2100)
@@ -82,7 +82,7 @@ async def test_live_total_only() -> None:
 
 @pytest.mark.live
 async def test_live_partial_ambiguous() -> None:
-    result = await _build_integration().extract(TRANSCRIPTS["partial_ambiguous"])
+    result = await _build_integration().extract(TRANSCRIPTS["partial_ambiguous"], mode="initial")
     _print_report_card("partial_ambiguous", result)
 
     assert result.line_items
@@ -94,7 +94,10 @@ async def test_live_partial_ambiguous() -> None:
 
 @pytest.mark.live
 async def test_live_noisy_with_hesitation() -> None:
-    result = await _build_integration().extract(TRANSCRIPTS["noisy_with_hesitation"])
+    result = await _build_integration().extract(
+        TRANSCRIPTS["noisy_with_hesitation"],
+        mode="initial",
+    )
     _print_report_card("noisy_with_hesitation", result)
 
     assert result.total is None
@@ -105,7 +108,7 @@ async def test_live_noisy_with_hesitation() -> None:
 
 @pytest.mark.live
 async def test_live_no_pricing_at_all() -> None:
-    result = await _build_integration().extract(TRANSCRIPTS["no_pricing_at_all"])
+    result = await _build_integration().extract(TRANSCRIPTS["no_pricing_at_all"], mode="initial")
     _print_report_card("no_pricing_at_all", result)
 
     assert result.total is None
@@ -130,7 +133,7 @@ async def test_live_fallback_tier_probe_uses_fallback_model_after_primary_exhaus
     )
 
     transcript = TRANSCRIPTS["fallback_tier_probe"]
-    result = await integration.extract(transcript)
+    result = await integration.extract(transcript, mode="initial")
     metadata = integration.pop_last_call_metadata()
 
     _print_report_card("fallback_tier_probe", result)

--- a/backend/app/features/quotes/tests/test_extraction_quality.py
+++ b/backend/app/features/quotes/tests/test_extraction_quality.py
@@ -72,7 +72,7 @@ async def test_extraction_quality_suite() -> None:
     scores = []
 
     for case in selected_cases:
-        result = await integration.extract(case.transcript)
+        result = await integration.extract(case.transcript, mode="initial")
         metadata = integration.pop_last_call_metadata()
 
         line_item_count = len(result.line_items)

--- a/backend/app/features/quotes/tests/test_extraction_service.py
+++ b/backend/app/features/quotes/tests/test_extraction_service.py
@@ -8,7 +8,7 @@ import pytest
 import sentry_sdk
 
 from app.features.quotes.extraction_service import CaptureAudioClip, ExtractionService
-from app.features.quotes.schemas import ExtractionResult, PreparedCaptureInput
+from app.features.quotes.schemas import ExtractionMode, ExtractionResult, PreparedCaptureInput
 from app.features.quotes.service import QuoteServiceError
 from app.integrations.audio import AudioClip, AudioError
 from app.integrations.extraction import ExtractionError
@@ -23,8 +23,13 @@ pytestmark = pytest.mark.asyncio
 
 
 class _FailingExtractionIntegration:
-    async def extract(self, capture_input: PreparedCaptureInput) -> ExtractionResult:
-        del capture_input
+    async def extract(
+        self,
+        capture_input: PreparedCaptureInput,
+        *,
+        mode: ExtractionMode = "initial",
+    ) -> ExtractionResult:
+        del capture_input, mode
         raise ExtractionError("mock extraction failure")
 
 
@@ -48,10 +53,15 @@ class _SuccessfulAudioIntegration:
 
 class _SuccessfulExtractionIntegration:
     def __init__(self) -> None:
-        self.calls: list[PreparedCaptureInput] = []
+        self.calls: list[tuple[PreparedCaptureInput, ExtractionMode]] = []
 
-    async def extract(self, capture_input: PreparedCaptureInput) -> ExtractionResult:
-        self.calls.append(capture_input)
+    async def extract(
+        self,
+        capture_input: PreparedCaptureInput,
+        *,
+        mode: ExtractionMode = "initial",
+    ) -> ExtractionResult:
+        self.calls.append((capture_input, mode))
         return ExtractionResult(
             transcript=capture_input.transcript,
             line_items=[],
@@ -132,11 +142,12 @@ async def test_extract_combined_allows_audio_and_notes_up_to_extraction_limit() 
 
     expected_transcript = f"{transcript}\n\n{notes}"
     assert len(extraction.calls) == 1
-    prepared_capture_input = extraction.calls[0]
+    prepared_capture_input, extraction_mode = extraction.calls[0]
     assert prepared_capture_input.source_type == "voice+text"
     assert prepared_capture_input.raw_typed_notes == notes
     assert prepared_capture_input.raw_transcript == transcript
     assert prepared_capture_input.transcript == expected_transcript
+    assert extraction_mode == "initial"
     assert result.transcript == expected_transcript
     assert len(result.transcript) == EXTRACTION_TRANSCRIPT_MAX_CHARS
 

--- a/backend/app/features/quotes/tests/test_quote_append_extraction.py
+++ b/backend/app/features/quotes/tests/test_quote_append_extraction.py
@@ -15,6 +15,7 @@ from app.features.jobs.repository import JobRepository
 from app.features.quotes.models import Document
 from app.features.quotes.review_metadata import build_hidden_item_id
 from app.features.quotes.schemas import (
+    ExtractionMode,
     ExtractionResult,
     ExtractionReviewAppendSuggestion,
     ExtractionReviewHiddenDetails,
@@ -59,8 +60,13 @@ async def test_append_extraction_sync_retryable_failure_uses_degraded_append_sem
     client: AsyncClient,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    async def _retryable_extract(self, notes: str) -> ExtractionResult:  # noqa: ANN001
-        del self, notes
+    async def _retryable_extract(
+        self,
+        notes: str,
+        *,
+        mode: ExtractionMode = "initial",
+    ) -> ExtractionResult:  # noqa: ANN001
+        del self, notes, mode
         raise ExtractionError("Claude request failed: retryable") from _RetryableProviderError(429)
 
     monkeypatch.setattr(_MockExtractionIntegration, "extract", _retryable_extract)
@@ -145,12 +151,50 @@ async def test_append_extraction_sync_appends_line_items_and_merges_transcript_e
     assert "Added later (2):" not in payload["transcript"]
 
 
+async def test_append_extraction_sync_passes_append_mode_to_extraction_integration(
+    client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    recorded_modes: list[ExtractionMode] = []
+    original_extract = _MockExtractionIntegration.extract
+
+    async def _capture_mode(
+        self,
+        notes: str,
+        *,
+        mode: ExtractionMode = "initial",
+    ) -> ExtractionResult:
+        recorded_modes.append(mode)
+        return await original_extract(self, notes, mode=mode)
+
+    monkeypatch.setattr(_MockExtractionIntegration, "extract", _capture_mode)
+    csrf_token = await _register_and_login(client, _credentials())
+    customer_id = await _create_customer(client, csrf_token)
+    quote = await _create_quote(client, csrf_token, customer_id)
+    quote_id = quote["id"]
+    app.state.arq_pool = None
+
+    response = await client.post(
+        f"/api/quotes/{quote_id}/append-extraction",
+        files=[("notes", (None, "append extraction mode check"))],
+        headers={"X-CSRF-Token": csrf_token},
+    )
+
+    assert response.status_code == 200
+    assert recorded_modes == ["append"]
+
+
 async def test_append_extraction_keeps_populated_notes_and_total_and_records_append_suggestions(
     client: AsyncClient,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    async def _extract_blocked_append_fields(self, notes: str) -> ExtractionResult:  # noqa: ANN001
-        del self, notes
+    async def _extract_blocked_append_fields(
+        self,
+        notes: str,
+        *,
+        mode: ExtractionMode = "initial",
+    ) -> ExtractionResult:  # noqa: ANN001
+        del self, notes, mode
         return ExtractionResult(
             transcript="append blocked fields",
             line_items=[],
@@ -218,8 +262,13 @@ async def test_append_extraction_resurfaces_previously_dismissed_matching_sugges
     suggestion_text = "Add driveway gate code"
     suggestion_id = build_hidden_item_id("append", "note", "none", suggestion_text)
 
-    async def _extract_blocked_note(self, notes: str) -> ExtractionResult:  # noqa: ANN001
-        del self, notes
+    async def _extract_blocked_note(
+        self,
+        notes: str,
+        *,
+        mode: ExtractionMode = "initial",
+    ) -> ExtractionResult:  # noqa: ANN001
+        del self, notes, mode
         return ExtractionResult(
             transcript="append blocked note",
             line_items=[],
@@ -279,8 +328,13 @@ async def test_append_extraction_preserves_existing_confidence_notes_when_new_no
     db_session: AsyncSession,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    async def _extract_without_confidence_notes(self, notes: str) -> ExtractionResult:  # noqa: ANN001
-        del self, notes
+    async def _extract_without_confidence_notes(
+        self,
+        notes: str,
+        *,
+        mode: ExtractionMode = "initial",
+    ) -> ExtractionResult:  # noqa: ANN001
+        del self, notes, mode
         return ExtractionResult(
             transcript="append without confidence notes",
             line_items=[
@@ -580,6 +634,7 @@ async def test_append_extraction_enqueues_async_job_for_owned_quote(
                     "raw_typed_notes": "append this",
                     "raw_transcript": None,
                 },
+                "extraction_mode": "append",
                 "source_type": "text",
                 "capture_detail": "notes",
                 "append_to_quote": True,

--- a/backend/app/features/quotes/tests/test_quote_extraction.py
+++ b/backend/app/features/quotes/tests/test_quote_extraction.py
@@ -16,7 +16,12 @@ from app.features.jobs.models import JobRecord, JobStatus, JobType
 from app.features.jobs.repository import JobRepository
 from app.features.quotes.extraction_service import ExtractionService
 from app.features.quotes.models import Document, QuoteStatus
-from app.features.quotes.schemas import ExtractionResult, PreparedCaptureInput, PricingHints
+from app.features.quotes.schemas import (
+    ExtractionMode,
+    ExtractionResult,
+    PreparedCaptureInput,
+    PricingHints,
+)
 from app.features.quotes.service import QuoteService, QuoteServiceError
 from app.features.quotes.tests import test_quotes as quotes_test_module
 from app.features.quotes.tests.support.helpers import (
@@ -170,6 +175,36 @@ async def test_extract_combined_notes_only_success(client: AsyncClient) -> None:
     assert payload["confidence_notes"] == []
 
 
+async def test_extract_combined_sync_passes_initial_mode_to_extraction_integration(
+    client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    recorded_modes: list[ExtractionMode] = []
+    original_extract = _MockExtractionIntegration.extract
+
+    async def _capture_mode(
+        self,
+        notes: PreparedCaptureInput | str,
+        *,
+        mode: ExtractionMode = "initial",
+    ) -> ExtractionResult:
+        recorded_modes.append(mode)
+        return await original_extract(self, notes, mode=mode)
+
+    monkeypatch.setattr(_MockExtractionIntegration, "extract", _capture_mode)
+    csrf_token = await _register_and_login(client, _credentials())
+    app.state.arq_pool = None
+
+    response = await client.post(
+        "/api/quotes/extract",
+        files=[("notes", (None, "initial extraction mode check"))],
+        headers={"X-CSRF-Token": csrf_token},
+    )
+
+    assert response.status_code == 200
+    assert recorded_modes == ["initial"]
+
+
 async def test_extract_combined_falls_back_to_sync_when_no_arq_pool_is_available(
     client: AsyncClient,
     db_session: AsyncSession,
@@ -212,8 +247,13 @@ async def test_extract_combined_sync_retryable_failure_persists_degraded_draft(
     def _capture(message: str) -> None:
         emitted_events.append(json.loads(message))
 
-    async def _retryable_extract(self, notes: str) -> ExtractionResult:  # noqa: ANN001
-        del self, notes
+    async def _retryable_extract(
+        self,
+        notes: str,
+        *,
+        mode: ExtractionMode = "initial",
+    ) -> ExtractionResult:  # noqa: ANN001
+        del self, notes, mode
         raise ExtractionError("Claude request failed: retryable") from _RetryableProviderError(429)
 
     monkeypatch.setattr(event_logger._EVENT_LOGGER, "info", _capture)  # noqa: SLF001
@@ -285,6 +325,7 @@ async def test_extract_combined_enqueues_async_job_when_arq_pool_is_available(
                     "raw_typed_notes": "mulch the front beds",
                     "raw_transcript": None,
                 },
+                "extraction_mode": "initial",
                 "source_type": "text",
                 "capture_detail": "notes",
                 "customer_id": None,
@@ -748,7 +789,13 @@ async def test_convert_notes_rejects_when_concurrency_limit_is_exhausted(
             self.started = asyncio.Event()
             self.release = asyncio.Event()
 
-        async def extract(self, notes: PreparedCaptureInput) -> ExtractionResult:
+        async def extract(
+            self,
+            notes: PreparedCaptureInput,
+            *,
+            mode: ExtractionMode = "initial",
+        ) -> ExtractionResult:
+            del mode
             self.started.set()
             await self.release.wait()
             return ExtractionResult(

--- a/backend/app/integrations/extraction.py
+++ b/backend/app/integrations/extraction.py
@@ -18,6 +18,7 @@ from pydantic import ValidationError
 from app.features.quotes.schemas import (
     CaptureSegment,
     CaptureSegmentHints,
+    ExtractionMode,
     ExtractionResult,
     ExtractionResultV2,
     LineItemExtractedV2,
@@ -253,7 +254,12 @@ class ExtractionIntegration:
         )
         self._client = client
 
-    async def extract(self, capture_input: PreparedCaptureInput | str) -> ExtractionResult:
+    async def extract(
+        self,
+        capture_input: PreparedCaptureInput | str,
+        *,
+        mode: ExtractionMode = "initial",
+    ) -> ExtractionResult:
         """Call Claude structured output and validate the V2 contract."""
         prepared_input = _coerce_prepared_capture_input(capture_input)
         _set_last_call_metadata(
@@ -293,6 +299,7 @@ class ExtractionIntegration:
                     stage=tier.tier,
                     outcome="failed",
                     level=logging.WARNING,
+                    extraction_mode=mode,
                     extraction_model_id=tier.model_id,
                     extraction_prompt_variant=tier.prompt_variant,
                     error_class=type(exc).__name__,
@@ -307,6 +314,7 @@ class ExtractionIntegration:
             stage="result",
             outcome="failed",
             level=logging.ERROR,
+            extraction_mode=mode,
             reason="all_tiers_failed",
             error_class=type(last_error).__name__,
             error_message=str(last_error),

--- a/backend/app/worker/job_registry.py
+++ b/backend/app/worker/job_registry.py
@@ -27,7 +27,7 @@ from app.features.quotes.extraction_outcomes import (
     should_persist_degraded_retryable_error,
 )
 from app.features.quotes.repository import QuoteEmailContext, QuoteRepository
-from app.features.quotes.schemas import ExtractionResult, PreparedCaptureInput
+from app.features.quotes.schemas import ExtractionMode, ExtractionResult, PreparedCaptureInput
 from app.features.quotes.service import QuoteService, QuoteServiceError
 from app.integrations.email import EmailService
 from app.integrations.extraction import (
@@ -84,6 +84,7 @@ async def extraction_job(
     correlation_id: str | None = None,
     transcript: str | None = None,
     prepared_capture_input: dict[str, Any] | PreparedCaptureInput | None = None,
+    extraction_mode: str | None = None,
     source_type: str = "text",
     capture_detail: str | None = None,
     customer_id: str | None = None,
@@ -100,6 +101,10 @@ async def extraction_job(
         source_type=source_type,
         capture_detail=capture_detail,
     )
+    resolved_extraction_mode = _resolve_worker_extraction_mode(
+        extraction_mode=extraction_mode,
+        append_to_quote=append_to_quote,
+    )
     try:
         await process_job(
             ctx,
@@ -110,6 +115,7 @@ async def extraction_job(
             handler=lambda: _extract_quote_data(
                 ctx,
                 resolved_capture_input,
+                extraction_mode=resolved_extraction_mode,
                 job_id=parsed_job_id,
             ),
             on_success=lambda runtime, result: _store_extraction_result(
@@ -239,6 +245,7 @@ async def _extract_quote_data(
     ctx: dict[str, Any],
     prepared_capture_input: PreparedCaptureInput,
     *,
+    extraction_mode: ExtractionMode,
     job_id: UUID,
 ) -> ExtractionResult:
     extraction_integration = ctx.get("extraction_integration")
@@ -256,7 +263,10 @@ async def _extract_quote_data(
     )
 
     try:
-        result = await extraction_integration.extract(prepared_capture_input)
+        result = await extraction_integration.extract(
+            prepared_capture_input,
+            mode=extraction_mode,
+        )
     except ExtractionError as exc:
         metadata = _pop_extraction_call_metadata(extraction_integration)
         resolved_last_model_id = _resolve_last_model_id(
@@ -494,6 +504,12 @@ def _validate_extraction_source_type(source_type: str) -> Literal["text", "voice
     return cast(Literal["text", "voice"], source_type)
 
 
+def _validate_extraction_mode(extraction_mode: str) -> ExtractionMode:
+    if extraction_mode not in {"initial", "append"}:
+        raise NonRetryableJobError("Extraction job missing valid extraction_mode")
+    return cast(ExtractionMode, extraction_mode)
+
+
 def _parse_optional_uuid(value: str | None) -> UUID | None:
     if value is None:
         return None
@@ -507,6 +523,17 @@ def _resolve_worker_capture_detail(*, source_type: str, capture_detail: str | No
     if source_type == "voice":
         return "audio"
     return "notes"
+
+
+def _resolve_worker_extraction_mode(
+    *,
+    extraction_mode: str | None,
+    append_to_quote: bool,
+) -> ExtractionMode:
+    normalized_mode = (extraction_mode or "").strip().lower()
+    if not normalized_mode:
+        return "append" if append_to_quote else "initial"
+    return _validate_extraction_mode(normalized_mode)
 
 
 def _resolve_prepared_capture_input(

--- a/backend/app/worker/tests/test_job_registry.py
+++ b/backend/app/worker/tests/test_job_registry.py
@@ -11,7 +11,12 @@ from app.features.auth.models import User
 from app.features.jobs.models import JobRecord, JobStatus, JobType
 from app.features.jobs.repository import JobRepository
 from app.features.quotes.models import Document
-from app.features.quotes.schemas import ExtractionResult, PreparedCaptureInput, PricingHints
+from app.features.quotes.schemas import (
+    ExtractionMode,
+    ExtractionResult,
+    PreparedCaptureInput,
+    PricingHints,
+)
 from app.features.quotes.service import QuoteServiceError
 from app.integrations.extraction import ExtractionCallMetadata, ExtractionError
 from app.shared import event_logger, observability
@@ -89,6 +94,57 @@ async def test_extraction_job_accepts_legacy_enqueued_payload_without_source_met
     assert legacy_input.source_type == "text"  # nosec B101 - pytest assertion
     assert legacy_input.raw_typed_notes == "legacy queued transcript"  # nosec B101 - pytest assertion
     assert legacy_input.raw_transcript is None  # nosec B101 - pytest assertion
+
+
+async def test_extraction_job_passes_append_mode_to_integration_for_append_jobs(
+    db_session: AsyncSession,
+) -> None:
+    user = await _seed_user(db_session)
+    repository = JobRepository(db_session)
+    create_record = await repository.create(user_id=user.id, job_type=JobType.EXTRACTION)
+    await db_session.commit()
+
+    await extraction_job(
+        _worker_context(
+            db_session,
+            extraction_integration=_SuccessfulExtractionIntegration(),
+        ),
+        str(create_record.id),
+        transcript="initial quote transcript",
+        source_type="text",
+        capture_detail="notes",
+        extraction_mode="initial",
+    )
+
+    created_job = await _load_job_record(db_session, create_record.id)
+    assert created_job is not None  # nosec B101 - pytest assertion
+    assert created_job.document_id is not None  # nosec B101 - pytest assertion
+
+    append_record = await repository.create(
+        user_id=user.id,
+        job_type=JobType.EXTRACTION,
+        document_id=created_job.document_id,
+    )
+    await db_session.commit()
+
+    capture_integration = _CaptureInputExtractionIntegration()
+    await extraction_job(
+        _worker_context(
+            db_session,
+            extraction_integration=capture_integration,
+        ),
+        str(append_record.id),
+        transcript="append note for quote",
+        source_type="text",
+        capture_detail="notes",
+        append_to_quote=True,
+        extraction_mode="append",
+    )
+
+    refreshed_append_job = await _load_job_record(db_session, append_record.id)
+    assert refreshed_append_job is not None  # nosec B101 - pytest assertion
+    assert refreshed_append_job.status == JobStatus.SUCCESS  # nosec B101 - pytest assertion
+    assert capture_integration.received_modes == ["append"]  # nosec B101 - pytest assertion
 
 
 async def test_extraction_job_marks_terminal_when_draft_persistence_fails(
@@ -328,7 +384,13 @@ async def test_extraction_job_uses_enqueued_correlation_id_and_logs_failure_meta
 
 
 class _SuccessfulExtractionIntegration:
-    async def extract(self, notes: PreparedCaptureInput | str) -> ExtractionResult:
+    async def extract(
+        self,
+        notes: PreparedCaptureInput | str,
+        *,
+        mode: ExtractionMode = "initial",
+    ) -> ExtractionResult:
+        del mode
         transcript = _capture_transcript(notes)
         return ExtractionResult(
             transcript=transcript,
@@ -341,9 +403,16 @@ class _SuccessfulExtractionIntegration:
 class _CaptureInputExtractionIntegration:
     def __init__(self) -> None:
         self.received_inputs: list[PreparedCaptureInput] = []
+        self.received_modes: list[ExtractionMode] = []
 
-    async def extract(self, notes: PreparedCaptureInput | str) -> ExtractionResult:
+    async def extract(
+        self,
+        notes: PreparedCaptureInput | str,
+        *,
+        mode: ExtractionMode = "initial",
+    ) -> ExtractionResult:
         transcript = _capture_transcript(notes)
+        self.received_modes.append(mode)
         if isinstance(notes, PreparedCaptureInput):
             self.received_inputs.append(notes)
         return ExtractionResult(
@@ -361,15 +430,26 @@ class _RetryableProviderError(Exception):
 
 
 class _RetryableFailureExtractionIntegration:
-    async def extract(self, notes: PreparedCaptureInput | str) -> ExtractionResult:
-        del notes
+    async def extract(
+        self,
+        notes: PreparedCaptureInput | str,
+        *,
+        mode: ExtractionMode = "initial",
+    ) -> ExtractionResult:
+        del notes, mode
         raise ExtractionError("Claude request failed: retryable") from _RetryableProviderError(429)
 
 
 class _ValidationRepairFailedExtractionIntegration:
     model_id = "claude-haiku-4-5-20251001"
 
-    async def extract(self, notes: PreparedCaptureInput | str) -> ExtractionResult:
+    async def extract(
+        self,
+        notes: PreparedCaptureInput | str,
+        *,
+        mode: ExtractionMode = "initial",
+    ) -> ExtractionResult:
+        del mode
         transcript = _capture_transcript(notes)
         return ExtractionResult(
             transcript=transcript,
@@ -391,8 +471,13 @@ class _ValidationRepairFailedExtractionIntegration:
 
 
 class _NonRetryableFailureExtractionIntegration:
-    async def extract(self, notes: PreparedCaptureInput | str) -> ExtractionResult:
-        del notes
+    async def extract(
+        self,
+        notes: PreparedCaptureInput | str,
+        *,
+        mode: ExtractionMode = "initial",
+    ) -> ExtractionResult:
+        del notes, mode
         raise ExtractionError("Claude request failed: malformed payload")
 
 
@@ -405,8 +490,13 @@ class _NonRetryableProviderError(Exception):
 class _MetadataFailureExtractionIntegration:
     model_id = "claude-haiku-4-5-20251001"
 
-    async def extract(self, notes: PreparedCaptureInput | str) -> ExtractionResult:
-        del notes
+    async def extract(
+        self,
+        notes: PreparedCaptureInput | str,
+        *,
+        mode: ExtractionMode = "initial",
+    ) -> ExtractionResult:
+        del notes, mode
         raise ExtractionError(
             "Claude request failed: malformed payload"
         ) from _NonRetryableProviderError(status_code=400)


### PR DESCRIPTION
## Summary
- add explicit `ExtractionMode = "initial" | "append"` to extraction contracts
- thread mode through quote extraction service, API sync paths, async enqueue payloads, and worker extraction handling
- keep provider behavior unchanged while enabling explicit mode plumbing
- update test doubles/manual eval callers and add mode-focused assertions for sync initial, sync append, and worker append handling

## Verification
- `cd backend && .venv/bin/pytest app/features/quotes/tests/test_quote_extraction.py app/features/quotes/tests/test_quote_append_extraction.py app/worker/tests/test_job_registry.py -m "not live and not extraction_eval and not extraction_quality" -o cache_dir=.pytest_cache`
- `make backend-static-verify`
- `make backend-verify`

Closes #416