### PR TITLE
Task #417: Extraction 2.5 contract trimming and provider DTO adapters

### DIFF
--- a/backend/app/features/jobs/schemas.py
+++ b/backend/app/features/jobs/schemas.py
@@ -8,7 +8,10 @@ from uuid import UUID
 from pydantic import BaseModel, ConfigDict
 
 from app.features.jobs.models import JobRecord, JobStatus, JobType
-from app.features.quotes.schemas import ExtractionResult
+from app.features.quotes.schemas import (
+    ExtractionResult,
+    project_extraction_result_for_public_response,
+)
 
 
 class JobRecordResponse(BaseModel):
@@ -40,5 +43,7 @@ def job_record_to_response(record: JobRecord) -> JobRecordResponse:
         "quote_id": record.document_id if record.status == JobStatus.SUCCESS else None
     }
     if record.status == JobStatus.SUCCESS and record.result_json is not None:
-        updates["extraction_result"] = ExtractionResult.model_validate_json(record.result_json)
+        updates["extraction_result"] = project_extraction_result_for_public_response(
+            ExtractionResult.model_validate_json(record.result_json)
+        )
     return response.model_copy(update=updates)

--- a/backend/app/features/quotes/api.py
+++ b/backend/app/features/quotes/api.py
@@ -59,6 +59,7 @@ from app.features.quotes.schemas import (
     QuoteListItemResponse,
     QuoteResponse,
     QuoteUpdateRequest,
+    project_extraction_result_for_public_response,
 )
 from app.features.quotes.service import QuoteService, QuoteServiceError
 from app.integrations.audio import infer_audio_format
@@ -166,7 +167,8 @@ async def convert_notes(
     del request
     async with extraction_capacity_guard(user.id):
         try:
-            return await extraction_service.convert_notes(payload.notes)
+            extraction = await extraction_service.convert_notes(payload.notes)
+            return project_extraction_result_for_public_response(extraction)
         except QuoteServiceError as exc:
             raise HTTPException(status_code=exc.status_code, detail=exc.detail) from exc
 
@@ -299,9 +301,10 @@ async def extract_combined(
             capture_detail=capture_detail,
             extraction_result=extraction,
         )
+        projected_extraction = project_extraction_result_for_public_response(extraction)
         return PersistedExtractionResponse(
             quote_id=quote.id,
-            **extraction.model_dump(),
+            **projected_extraction.model_dump(),
         )
 
     try:
@@ -411,9 +414,10 @@ async def append_extraction(
             customer_id=updated_quote.customer_id,
             detail=capture_detail,
         )
+        projected_extraction = project_extraction_result_for_public_response(merged_extraction)
         return PersistedExtractionResponse(
             quote_id=updated_quote.id,
-            **merged_extraction.model_dump(),
+            **projected_extraction.model_dump(),
         )
 
     try:

--- a/backend/app/features/quotes/extraction_outcomes.py
+++ b/backend/app/features/quotes/extraction_outcomes.py
@@ -55,7 +55,7 @@ def build_degraded_extraction_result(
     """Build a degraded sentinel result that still preserves user transcript work."""
     return ExtractionResult(
         transcript=transcript,
-        pipeline_version="v2",
+        pipeline_version="v2.5",
         line_items=[],
         pricing_hints=PricingHints(),
         customer_notes_suggestion=None,

--- a/backend/app/features/quotes/schemas.py
+++ b/backend/app/features/quotes/schemas.py
@@ -135,6 +135,32 @@ class PricingHints(BaseModel):
     discount_value: float | None = None
 
 
+class PricingCandidates(PricingHints):
+    """Initial 2.5 provider pricing candidates before backend application."""
+
+
+UnresolvedItemReason = Literal["ambiguous_scope", "possible_conflict", "unplaced_content"]
+
+
+class UnresolvedItem(BaseModel):
+    """Initial 2.5 provider unresolved content candidate."""
+
+    text: str = Field(min_length=1, max_length=EXTRACTION_TRANSCRIPT_MAX_CHARS)
+    reason: UnresolvedItemReason
+
+
+class InitialExtractionCandidate(BaseModel):
+    """Initial 2.5 provider candidate payload prior to backend stamping/adapters."""
+
+    line_items: list[LineItemExtracted] = Field(
+        default_factory=list,
+        max_length=DOCUMENT_LINE_ITEMS_MAX_ITEMS,
+    )
+    notes_candidate: str | None = Field(default=None, max_length=LINE_ITEM_DETAILS_MAX_CHARS)
+    pricing_candidates: PricingCandidates = Field(default_factory=PricingCandidates)
+    unresolved_items: list[UnresolvedItem] = Field(default_factory=list)
+
+
 class ExtractionSuggestion(BaseModel):
     """Suggestion payload for notes-like content placement."""
 
@@ -162,7 +188,7 @@ class ExtractionResultV2(BaseModel):
     """Internal V2 extraction contract used by integration/guards."""
 
     transcript: str = Field(min_length=1, max_length=EXTRACTION_TRANSCRIPT_MAX_CHARS)
-    pipeline_version: Literal["v2"] = "v2"
+    pipeline_version: Literal["v2", "v2.5"] = "v2"
     line_items: list[LineItemExtractedV2] = Field(
         default_factory=list,
         max_length=DOCUMENT_LINE_ITEMS_MAX_ITEMS,
@@ -316,7 +342,7 @@ class HiddenItemState(BaseModel):
 class ExtractionReviewMetadataV1(BaseModel):
     """Sidecar metadata persisted for V2 extraction review behavior."""
 
-    pipeline_version: Literal["v2"] = "v2"
+    pipeline_version: Literal["v2", "v2.5"] = "v2"
     review_state: ExtractionReviewState = Field(default_factory=ExtractionReviewState)
     seeded_fields: SeededFieldsMetadata = Field(default_factory=SeededFieldsMetadata)
     hidden_details: ExtractionReviewHiddenDetails = Field(
@@ -456,6 +482,13 @@ class ExtractionReviewMetadataUpdateRequest(BaseModel):
         if not has_action:
             raise ValueError("At least one extraction review metadata mutation is required")
         return self
+
+
+def project_extraction_result_for_public_response(result: ExtractionResult) -> ExtractionResult:
+    """Project internal extraction payloads to the transitional public legacy contract."""
+    if result.pipeline_version == "v2":
+        return result
+    return result.model_copy(update={"pipeline_version": "v2"})
 
 
 class LineItemResponse(BaseModel):

--- a/backend/app/features/quotes/tests/test_extraction.py
+++ b/backend/app/features/quotes/tests/test_extraction.py
@@ -165,7 +165,7 @@ async def test_extract_handles_ambiguous_partial_input_without_raising() -> None
 
     assert result.line_items
     assert result.line_items[0].description == "Power wash deck"
-    assert "ambiguous" in result.confidence_notes[0].lower()
+    assert result.confidence_notes == []
 
 
 async def test_extract_returns_degraded_result_when_repair_is_still_invalid() -> None:
@@ -565,6 +565,37 @@ async def test_extract_defaults_flag_fields_when_omitted() -> None:
     assert result.line_items[0].flag_reason is None
 
 
+async def test_extract_stamps_backend_owned_transcript_and_pipeline_version() -> None:
+    transcript = TRANSCRIPTS["clean_with_total"]
+    client = _FakeClient(
+        lambda _: _FakeResponse(
+            content=[
+                {
+                    "type": "tool_use",
+                    "input": {
+                        "line_items": [
+                            {
+                                "description": "Spread mulch",
+                                "details": "5 yards",
+                                "price": 350,
+                            }
+                        ],
+                        "notes_candidate": None,
+                        "pricing_candidates": {"explicit_total": 350},
+                        "unresolved_items": [],
+                    },
+                }
+            ]
+        )
+    )
+    integration = ExtractionIntegration(api_key="test", model="test-model", client=client)
+
+    result = await integration.extract(transcript)
+
+    assert result.transcript == transcript
+    assert result.pipeline_version == "v2.5"
+
+
 async def test_extract_degrades_when_substantial_transcript_has_no_line_items() -> None:
     transcript = (
         "Customer asked for gutter cleaning, downspout flush, roof debris sweep, driveway edge "
@@ -595,7 +626,7 @@ async def test_extract_degrades_when_substantial_transcript_has_no_line_items() 
         result.extraction_degraded_reason_code
         == SEMANTIC_DEGRADED_REASON_EMPTY_LINE_ITEMS_SUBSTANTIAL_TRANSCRIPT
     )
-    assert any("No line items were extracted" in note for note in result.confidence_notes)
+    assert result.confidence_notes == []
 
 
 async def test_extract_adds_warning_when_total_has_no_priced_line_items() -> None:
@@ -627,9 +658,10 @@ async def test_extract_adds_warning_when_total_has_no_priced_line_items() -> Non
 
     assert result.extraction_tier == "primary"
     assert result.extraction_degraded_reason_code is None
+    assert result.confidence_notes == []
     assert any(
-        "Explicit total was extracted without any priced line items" in note
-        for note in result.confidence_notes
+        "explicit total was extracted without priced line items" in segment.raw_text.lower()
+        for segment in result.unresolved_segments
     )
 
 
@@ -668,7 +700,7 @@ async def test_extract_flags_duplicate_line_items_with_warning_note() -> None:
     assert result.extraction_tier == "primary"
     assert all(item.flagged is True for item in result.line_items)
     assert all(item.flag_reason for item in result.line_items)
-    assert any("Duplicate extracted line items" in note for note in result.confidence_notes)
+    assert result.confidence_notes == []
 
 
 async def test_tool_schema_line_items_include_optional_flag_fields() -> None:
@@ -677,8 +709,16 @@ async def test_tool_schema_line_items_include_optional_flag_fields() -> None:
     assert line_item_schema["properties"]["flag_reason"] == {"type": ["string", "null"]}
     assert "flagged" not in line_item_schema["required"]
     assert "flag_reason" not in line_item_schema["required"]
-    assert "raw_text" in line_item_schema["required"]
-    assert "confidence" in line_item_schema["required"]
+    assert "raw_text" not in line_item_schema["properties"]
+    assert "confidence" not in line_item_schema["properties"]
+
+    required_fields = set(EXTRACTION_TOOL_SCHEMA["required"])
+    assert "notes_candidate" in required_fields
+    assert "pricing_candidates" in required_fields
+    assert "unresolved_items" in required_fields
+    assert "transcript" not in required_fields
+    assert "pipeline_version" not in required_fields
+    assert "confidence_notes" not in required_fields
 
 
 async def test_hidden_item_id_is_deterministic_and_distinguishes_content() -> None:
@@ -848,7 +888,7 @@ async def test_guard_flags_line_items_with_price_in_description() -> None:
     assert result.line_items[0].flagged is True
     assert "price token" in (result.line_items[0].flag_reason or "").lower()
     assert result.line_items[1].flagged is False
-    assert any("price token" in note.lower() for note in result.confidence_notes)
+    assert result.confidence_notes == []
 
 
 async def test_guard_flags_line_items_with_duplicate_details() -> None:
@@ -886,7 +926,7 @@ async def test_guard_flags_line_items_with_duplicate_details() -> None:
     assert result.line_items[0].flagged is True
     assert "duplicate" in (result.line_items[0].flag_reason or "").lower()
     assert result.line_items[1].flagged is False
-    assert any("duplicate" in note.lower() for note in result.confidence_notes)
+    assert result.confidence_notes == []
 
 
 async def test_extract_preserves_mixed_provenance_in_model_request_payload() -> None:

--- a/backend/app/integrations/extraction.py
+++ b/backend/app/integrations/extraction.py
@@ -20,15 +20,18 @@ from app.features.quotes.schemas import (
     CaptureSegmentHints,
     ExtractionMode,
     ExtractionResult,
-    ExtractionResultV2,
+    ExtractionSuggestion,
+    InitialExtractionCandidate,
     LineItemExtractedV2,
     PreparedCaptureInput,
+    PricingCandidates,
     PricingHints,
+    UnresolvedItem,
+    UnresolvedSegment,
+    UnresolvedSegmentSource,
 )
 from app.shared.extraction_logger import log_extraction_trace
 from app.shared.input_limits import (
-    CONFIDENCE_NOTE_MAX_CHARS,
-    CONFIDENCE_NOTES_MAX_ITEMS,
     DOCUMENT_LINE_ITEMS_MAX_ITEMS,
     EXTRACTION_TRANSCRIPT_MAX_CHARS,
     LINE_ITEM_DESCRIPTION_MAX_CHARS,
@@ -41,18 +44,12 @@ EXTRACTION_TOOL_NAME = "extract_quote"
 EXTRACTION_TOOL_SCHEMA: dict[str, Any] = {
     "type": "object",
     "properties": {
-        "transcript": {"type": "string", "maxLength": EXTRACTION_TRANSCRIPT_MAX_CHARS},
-        "pipeline_version": {"type": "string", "enum": ["v2"]},
         "line_items": {
             "type": "array",
             "maxItems": DOCUMENT_LINE_ITEMS_MAX_ITEMS,
             "items": {
                 "type": "object",
                 "properties": {
-                    "raw_text": {
-                        "type": "string",
-                        "maxLength": EXTRACTION_TRANSCRIPT_MAX_CHARS,
-                    },
                     "description": {
                         "type": "string",
                         "maxLength": LINE_ITEM_DESCRIPTION_MAX_CHARS,
@@ -64,13 +61,16 @@ EXTRACTION_TOOL_SCHEMA: dict[str, Any] = {
                     "price": {"type": ["number", "null"]},
                     "flagged": {"type": "boolean"},
                     "flag_reason": {"type": ["string", "null"]},
-                    "confidence": {"type": "string", "enum": ["high", "medium", "low"]},
                 },
-                "required": ["raw_text", "description", "confidence"],
+                "required": ["description"],
                 "additionalProperties": False,
             },
         },
-        "pricing_hints": {
+        "notes_candidate": {
+            "type": ["string", "null"],
+            "maxLength": LINE_ITEM_DETAILS_MAX_CHARS,
+        },
+        "pricing_candidates": {
             "type": "object",
             "properties": {
                 "explicit_total": {"type": ["number", "null"]},
@@ -81,78 +81,46 @@ EXTRACTION_TOOL_SCHEMA: dict[str, Any] = {
             },
             "additionalProperties": False,
         },
-        "customer_notes_suggestion": {
-            "type": ["object", "null"],
-            "properties": {
-                "text": {
-                    "type": "string",
-                    "maxLength": LINE_ITEM_DETAILS_MAX_CHARS,
-                },
-                "confidence": {"type": "string", "enum": ["high", "medium", "low"]},
-                "source": {
-                    "type": "string",
-                    "enum": [
-                        "leftover_classification",
-                        "typed_conflict",
-                        "transcript_conflict",
-                    ],
-                },
-            },
-            "required": ["text", "confidence", "source"],
-            "additionalProperties": False,
-        },
-        "unresolved_segments": {
+        "unresolved_items": {
             "type": "array",
             "items": {
                 "type": "object",
                 "properties": {
-                    "raw_text": {
+                    "text": {
                         "type": "string",
                         "maxLength": EXTRACTION_TRANSCRIPT_MAX_CHARS,
                     },
-                    "confidence": {"type": "string", "enum": ["medium", "low"]},
-                    "source": {
+                    "reason": {
                         "type": "string",
                         "enum": [
-                            "leftover_classification",
-                            "typed_conflict",
-                            "transcript_conflict",
+                            "ambiguous_scope",
+                            "possible_conflict",
+                            "unplaced_content",
                         ],
                     },
                 },
-                "required": ["raw_text", "confidence", "source"],
+                "required": ["text", "reason"],
                 "additionalProperties": False,
-            },
-        },
-        "confidence_notes": {
-            "type": "array",
-            "maxItems": CONFIDENCE_NOTES_MAX_ITEMS,
-            "items": {
-                "type": "string",
-                "maxLength": CONFIDENCE_NOTE_MAX_CHARS,
             },
         },
     },
     "required": [
-        "transcript",
-        "pipeline_version",
         "line_items",
-        "pricing_hints",
-        "customer_notes_suggestion",
-        "unresolved_segments",
-        "confidence_notes",
+        "notes_candidate",
+        "pricing_candidates",
+        "unresolved_items",
     ],
     "additionalProperties": False,
 }
 
 EXTRACTION_SYSTEM_PROMPT = (
-    "Extract quote line items, pricing hints, and unresolved capture details from structured "
+    "Extract quote line items, pricing candidates, and unresolved capture details from structured "
     "capture input. "
-    "Do not invent pricing. Use null for missing values and keep confidence_notes sparse "
-    "and operator-relevant. "
+    "Do not invent pricing. Use null for missing values. "
     "Set line-item flagged=true only for strong review signals: likely audio mishears, "
     "clearly implausible single-item prices, or critically ambiguous quantity/unit phrasing. "
     "When flagged=true, include a short flag_reason. Keep flagged false otherwise. "
+    "Use notes_candidate only when a short customer-facing note should be seeded. "
     "Return only structured tool output."
 )
 
@@ -173,16 +141,20 @@ SEMANTIC_DEGRADED_REASON_EMPTY_LINE_ITEMS_SUBSTANTIAL_TRANSCRIPT = (
 )
 _SEMANTIC_EMPTY_LINE_ITEMS_MIN_TRANSCRIPT_CHARS = 120
 _SEMANTIC_EMPTY_LINE_ITEMS_MIN_WORDS = 18
-_SEMANTIC_NOTE_EMPTY_LINE_ITEMS_SUBSTANTIAL_TRANSCRIPT = (
-    "No line items were extracted from a substantial transcript; manual review is required."
-)
-_SEMANTIC_NOTE_TOTAL_WITHOUT_PRICED_ITEMS = (
-    "Explicit total was extracted without any priced line items; review pricing details."
-)
-_SEMANTIC_NOTE_DUPLICATE_LINE_ITEMS = (
-    "Duplicate extracted line items were detected and flagged for review."
+_SEMANTIC_UNRESOLVED_TOTAL_WITHOUT_PRICED_ITEMS = (
+    "Explicit total was extracted without priced line items; verify pricing details."
 )
 _SEMANTIC_FLAG_REASON_DUPLICATE_LINE_ITEM = "Possible duplicate line item from extraction output"
+_UNRESOLVED_REASON_TO_SOURCE: dict[str, str] = {
+    "ambiguous_scope": "leftover_classification",
+    "possible_conflict": "transcript_conflict",
+    "unplaced_content": "leftover_classification",
+}
+_LEGACY_UNRESOLVED_SOURCE_TO_REASON: dict[str, str] = {
+    "leftover_classification": "unplaced_content",
+    "typed_conflict": "possible_conflict",
+    "transcript_conflict": "possible_conflict",
+}
 _WHITESPACE_PATTERN = re.compile(r"\s+")
 _BLANK_LINE_SPLIT_PATTERN = re.compile(r"\n\s*\n+")
 _BULLET_PREFIX_PATTERN = re.compile(r"^\s*(?:[-*•]|\d+[.)])\s+")
@@ -393,14 +365,7 @@ class ExtractionIntegration:
         )
 
         payload = _extract_tool_payload(response)
-        payload.setdefault("transcript", prepared_input.transcript)
-        payload.setdefault("pipeline_version", "v2")
-        payload.setdefault("line_items", [])
-        payload.setdefault("pricing_hints", {})
-        payload.setdefault("customer_notes_suggestion", None)
-        payload.setdefault("unresolved_segments", [])
-        payload.setdefault("confidence_notes", [])
-        payload["line_items"] = _normalize_line_item_payloads(payload.get("line_items"))
+        candidate_payload = _coerce_initial_candidate_payload(payload)
         log_extraction_trace(
             _TRACE_EVENT_NAME,
             stage=tier.tier,
@@ -409,20 +374,25 @@ class ExtractionIntegration:
             extraction_prompt_variant=tier.prompt_variant,
             token_input_tokens=_token_usage_value(response_token_usage, "input_tokens"),
             token_output_tokens=_token_usage_value(response_token_usage, "output_tokens"),
-            line_item_count=_list_count(payload.get("line_items")),
-            confidence_note_count=_list_count(payload.get("confidence_notes")),
+            line_item_count=_list_count(candidate_payload.get("line_items")),
+            unresolved_item_count=_list_count(candidate_payload.get("unresolved_items")),
+            notes_candidate_present=bool(candidate_payload.get("notes_candidate")),
             total_present=(
-                _pricing_hints_payload(payload.get("pricing_hints")).get("explicit_total")
+                _pricing_candidates_payload(candidate_payload.get("pricing_candidates")).get(
+                    "explicit_total"
+                )
                 is not None
             ),
             raw_transcript=prepared_input.transcript,
-            raw_tool_payload=payload,
+            raw_tool_payload=candidate_payload,
         )
 
         try:
-            validated_result_v2 = ExtractionResultV2.model_validate(payload)
-            guarded_result_v2 = _apply_semantic_guard_rules(validated_result_v2)
-            result = ExtractionResult.model_validate(guarded_result_v2.model_dump(mode="json"))
+            validated_candidate = InitialExtractionCandidate.model_validate(candidate_payload)
+            result = _build_extraction_result_from_candidate(
+                candidate=validated_candidate,
+                transcript=prepared_input.transcript,
+            )
             _log_result_trace(
                 result=result,
                 invocation_tier=tier.tier,
@@ -445,14 +415,14 @@ class ExtractionIntegration:
                 extraction_prompt_variant=repair_prompt_variant,
                 validation_error_count=len(validation_errors),
                 raw_transcript=prepared_input.transcript,
-                raw_tool_payload=payload,
+                raw_tool_payload=candidate_payload,
             )
             try:
                 repair_response = await self._request_with_retry(
                     typed_client,
                     _build_repair_request(
                         notes=request_content,
-                        invalid_payload=payload,
+                        invalid_payload=candidate_payload,
                         validation_errors=validation_errors,
                     ),
                     model_id=tier.model_id,
@@ -485,18 +455,11 @@ class ExtractionIntegration:
             repair_usage = _extract_token_usage(repair_response)
             repair_model_id = getattr(repair_response, "model", None) or tier.model_id
             repair_payload = _extract_tool_payload(repair_response)
-            repair_payload.setdefault("transcript", prepared_input.transcript)
-            repair_payload.setdefault("pipeline_version", "v2")
-            repair_payload.setdefault("line_items", [])
-            repair_payload.setdefault("pricing_hints", {})
-            repair_payload.setdefault("customer_notes_suggestion", None)
-            repair_payload.setdefault("unresolved_segments", [])
-            repair_payload.setdefault("confidence_notes", [])
-            repair_payload["line_items"] = _normalize_line_item_payloads(
-                repair_payload.get("line_items")
-            )
+            repair_candidate_payload = _coerce_initial_candidate_payload(repair_payload)
             try:
-                repaired_result_v2 = ExtractionResultV2.model_validate(repair_payload)
+                repaired_candidate = InitialExtractionCandidate.model_validate(
+                    repair_candidate_payload
+                )
             except ValidationError:
                 _set_last_call_metadata(
                     model_id=repair_model_id,
@@ -520,7 +483,7 @@ class ExtractionIntegration:
                     token_input_tokens=_token_usage_value(repair_usage, "input_tokens"),
                     token_output_tokens=_token_usage_value(repair_usage, "output_tokens"),
                     raw_transcript=prepared_input.transcript,
-                    raw_tool_payload=repair_payload,
+                    raw_tool_payload=repair_candidate_payload,
                 )
                 degraded_result = _build_validation_repair_failed_result(
                     transcript=prepared_input.transcript
@@ -551,19 +514,22 @@ class ExtractionIntegration:
                 validation_error_count=len(validation_errors),
                 token_input_tokens=_token_usage_value(repair_usage, "input_tokens"),
                 token_output_tokens=_token_usage_value(repair_usage, "output_tokens"),
-                line_item_count=_list_count(repair_payload.get("line_items")),
-                confidence_note_count=_list_count(repair_payload.get("confidence_notes")),
+                line_item_count=_list_count(repair_candidate_payload.get("line_items")),
+                unresolved_item_count=_list_count(repair_candidate_payload.get("unresolved_items")),
+                notes_candidate_present=bool(repair_candidate_payload.get("notes_candidate")),
                 total_present=(
-                    _pricing_hints_payload(repair_payload.get("pricing_hints")).get(
-                        "explicit_total"
-                    )
+                    _pricing_candidates_payload(
+                        repair_candidate_payload.get("pricing_candidates")
+                    ).get("explicit_total")
                     is not None
                 ),
                 raw_transcript=prepared_input.transcript,
-                raw_tool_payload=repair_payload,
+                raw_tool_payload=repair_candidate_payload,
             )
-            guarded_result_v2 = _apply_semantic_guard_rules(repaired_result_v2)
-            result = ExtractionResult.model_validate(guarded_result_v2.model_dump(mode="json"))
+            result = _build_extraction_result_from_candidate(
+                candidate=repaired_candidate,
+                transcript=prepared_input.transcript,
+            )
             _log_result_trace(
                 result=result,
                 invocation_tier=tier.tier,
@@ -600,8 +566,8 @@ class ExtractionIntegration:
                         {
                             "name": EXTRACTION_TOOL_NAME,
                             "description": (
-                                "Extract quote line items, pricing hints, unresolved segments, "
-                                "optional customer-notes suggestion, and sparse confidence notes."
+                                "Extract quote line items, pricing candidates, optional notes "
+                                "candidate, and unresolved items."
                             ),
                             "input_schema": EXTRACTION_TOOL_SCHEMA,
                         }
@@ -700,9 +666,15 @@ def _build_extraction_request(prepared_input: PreparedCaptureInput) -> str:
                 "Use short customer-facing labels; move remainder to details."
             ),
             "pricing_rule": (
-                "Do not invent pricing. Use pricing_hints for explicit pricing directives only."
+                "Do not invent pricing. "
+                "Use pricing_candidates for explicit pricing directives only."
             ),
-            "confidence_notes_rule": "Only include sparse, operator-relevant review notes.",
+            "notes_candidate_rule": (
+                "Use notes_candidate only for concise customer-facing notes; otherwise null."
+            ),
+            "unresolved_items_rule": (
+                "Use unresolved_items for ambiguous or conflicting content that needs review."
+            ),
         },
     }
     return json.dumps(request_payload, ensure_ascii=True, separators=(",", ":"))
@@ -774,7 +746,118 @@ def _parse_price_value(candidate: str) -> float | None:
         return None
 
 
-def _normalize_line_item_payloads(value: object) -> object:
+def _coerce_initial_candidate_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    normalized_payload = dict(payload)
+    normalized_payload.setdefault("line_items", [])
+    normalized_payload["line_items"] = _normalize_initial_line_item_payloads(
+        normalized_payload.get("line_items")
+    )
+
+    pricing_candidates = normalized_payload.get("pricing_candidates")
+    if not isinstance(pricing_candidates, dict):
+        legacy_hints = normalized_payload.get("pricing_hints")
+        if isinstance(legacy_hints, dict):
+            pricing_candidates = dict(legacy_hints)
+        else:
+            pricing_candidates = {}
+        if (
+            "explicit_total" not in pricing_candidates
+            and normalized_payload.get("total") is not None
+        ):
+            pricing_candidates["explicit_total"] = normalized_payload.get("total")
+    normalized_payload["pricing_candidates"] = pricing_candidates
+
+    notes_candidate = normalized_payload.get("notes_candidate")
+    if not isinstance(notes_candidate, str):
+        notes_candidate = None
+        legacy_notes = normalized_payload.get("customer_notes_suggestion")
+        if isinstance(legacy_notes, dict):
+            legacy_text = legacy_notes.get("text")
+            if isinstance(legacy_text, str):
+                notes_candidate = legacy_text
+    normalized_payload["notes_candidate"] = notes_candidate
+
+    unresolved_items = normalized_payload.get("unresolved_items")
+    if not isinstance(unresolved_items, list):
+        unresolved_items = []
+        legacy_unresolved = normalized_payload.get("unresolved_segments")
+        if isinstance(legacy_unresolved, list):
+            for item in legacy_unresolved:
+                if not isinstance(item, dict):
+                    continue
+                text = item.get("raw_text")
+                if not isinstance(text, str) or not text.strip():
+                    continue
+                source = item.get("source")
+                reason = (
+                    _LEGACY_UNRESOLVED_SOURCE_TO_REASON.get(source)
+                    if isinstance(source, str)
+                    else None
+                )
+                unresolved_items.append(
+                    {
+                        "text": text,
+                        "reason": reason or "unplaced_content",
+                    }
+                )
+    normalized_payload["unresolved_items"] = unresolved_items
+    return normalized_payload
+
+
+def _build_extraction_result_from_candidate(
+    *,
+    candidate: InitialExtractionCandidate,
+    transcript: str,
+) -> ExtractionResult:
+    notes_candidate = (candidate.notes_candidate or "").strip()
+    unresolved_segments = [
+        _to_unresolved_segment(unresolved_item) for unresolved_item in candidate.unresolved_items
+    ]
+    result = ExtractionResult(
+        transcript=transcript,
+        pipeline_version="v2.5",
+        line_items=[
+            LineItemExtractedV2(
+                raw_text=(line_item.details or line_item.description).strip()
+                or line_item.description,
+                confidence="medium",
+                description=line_item.description,
+                details=line_item.details,
+                price=line_item.price,
+                flagged=line_item.flagged,
+                flag_reason=line_item.flag_reason,
+            )
+            for line_item in candidate.line_items
+        ],
+        pricing_hints=PricingHints.model_validate(
+            candidate.pricing_candidates.model_dump(mode="json")
+        ),
+        customer_notes_suggestion=(
+            ExtractionSuggestion(
+                text=notes_candidate,
+                confidence="medium",
+                source="leftover_classification",
+            )
+            if notes_candidate
+            else None
+        ),
+        unresolved_segments=unresolved_segments,
+        confidence_notes=[],
+    )
+    return _apply_semantic_guard_rules(result)
+
+
+def _to_unresolved_segment(item: UnresolvedItem) -> UnresolvedSegment:
+    source = _UNRESOLVED_REASON_TO_SOURCE.get(item.reason, "leftover_classification")
+    confidence: Literal["medium", "low"] = "medium" if item.reason == "possible_conflict" else "low"
+    return UnresolvedSegment(
+        raw_text=item.text.strip(),
+        confidence=confidence,
+        source=cast(UnresolvedSegmentSource, source),
+    )
+
+
+def _normalize_initial_line_item_payloads(value: object) -> object:
     if not isinstance(value, list):
         return value
 
@@ -783,24 +866,16 @@ def _normalize_line_item_payloads(value: object) -> object:
         if not isinstance(item, dict):
             continue
         normalized_item = dict(item)
-        description = normalized_item.get("description")
-        normalized_item.setdefault(
-            "raw_text",
-            (
-                description
-                if isinstance(description, str) and description.strip()
-                else "Unspecified item"
-            ),
-        )
-        normalized_item.setdefault("confidence", "medium")
+        normalized_item.setdefault("flagged", False)
+        normalized_item.setdefault("flag_reason", None)
         normalized_items.append(normalized_item)
     return normalized_items
 
 
-def _pricing_hints_payload(value: object) -> dict[str, Any]:
+def _pricing_candidates_payload(value: object) -> dict[str, Any]:
     if isinstance(value, dict):
         return value
-    return PricingHints().model_dump(mode="json")
+    return PricingCandidates().model_dump(mode="json")
 
 
 def _is_retryable_provider_error(exc: Exception) -> bool:
@@ -922,6 +997,8 @@ def _log_result_trace(
         extraction_tier=result.extraction_tier,
         extraction_degraded_reason_code=result.extraction_degraded_reason_code,
         line_item_count=len(result.line_items),
+        flagged_line_item_count=sum(1 for item in result.line_items if item.flagged),
+        unresolved_segment_count=len(result.unresolved_segments),
         confidence_note_count=len(result.confidence_notes),
         total_present=result.pricing_hints.explicit_total is not None,
         raw_transcript=result.transcript,
@@ -964,7 +1041,7 @@ def _compact_validation_errors(error: ValidationError) -> list[str]:
 def _build_validation_repair_failed_result(*, transcript: str) -> ExtractionResult:
     return ExtractionResult(
         transcript=transcript,
-        pipeline_version="v2",
+        pipeline_version="v2.5",
         line_items=[],
         pricing_hints=PricingHints(),
         customer_notes_suggestion=None,
@@ -975,39 +1052,40 @@ def _build_validation_repair_failed_result(*, transcript: str) -> ExtractionResu
     )
 
 
-def _apply_semantic_guard_rules(result: ExtractionResultV2) -> ExtractionResultV2:
+def _apply_semantic_guard_rules(result: ExtractionResult) -> ExtractionResult:
     """Apply incident-informed semantic checks after schema validation succeeds.
 
     Rule outcomes are intentionally constrained:
-    - Empty line items + substantial transcript -> degraded (allowlisted structural failure).
-    - Explicit total without priced line items -> warning note only (tier remains primary).
-    - Duplicate extracted line items -> line-level flags + warning note only.
+    - Empty line items + substantial transcript -> degraded reason code.
+    - Explicit total without priced line items -> unresolved actionable item.
+    - Duplicate/price token/duplicate-details -> visible line-item flags only.
     """
 
-    confidence_notes = list(result.confidence_notes)
     line_items = list(result.line_items)
+    unresolved_segments = list(result.unresolved_segments)
     extraction_tier = result.extraction_tier
     degraded_reason_code = result.extraction_degraded_reason_code
 
     if _should_degrade_for_empty_line_items_with_substantial_transcript(result):
         extraction_tier = "degraded"
         degraded_reason_code = SEMANTIC_DEGRADED_REASON_EMPTY_LINE_ITEMS_SUBSTANTIAL_TRANSCRIPT
-        _append_semantic_note(
-            confidence_notes,
-            _SEMANTIC_NOTE_EMPTY_LINE_ITEMS_SUBSTANTIAL_TRANSCRIPT,
-        )
 
     if _should_warn_for_total_without_priced_items(result):
-        _append_semantic_note(confidence_notes, _SEMANTIC_NOTE_TOTAL_WITHOUT_PRICED_ITEMS)
+        unresolved_segments = _append_semantic_unresolved_segment(
+            unresolved_segments,
+            text=_SEMANTIC_UNRESOLVED_TOTAL_WITHOUT_PRICED_ITEMS,
+            source="leftover_classification",
+        )
 
-    line_items = _flag_line_items_with_price_in_description(line_items, confidence_notes)
-    line_items = _flag_line_items_with_duplicate_details(line_items, confidence_notes)
-    line_items = _apply_duplicate_line_item_flags(line_items, confidence_notes)
+    line_items = _flag_line_items_with_price_in_description(line_items)
+    line_items = _flag_line_items_with_duplicate_details(line_items)
+    line_items = _apply_duplicate_line_item_flags(line_items)
 
     return result.model_copy(
         update={
             "line_items": line_items,
-            "confidence_notes": confidence_notes,
+            "unresolved_segments": unresolved_segments,
+            "confidence_notes": [],
             "extraction_tier": extraction_tier,
             "extraction_degraded_reason_code": degraded_reason_code,
         }
@@ -1015,7 +1093,7 @@ def _apply_semantic_guard_rules(result: ExtractionResultV2) -> ExtractionResultV
 
 
 def _should_degrade_for_empty_line_items_with_substantial_transcript(
-    result: ExtractionResultV2,
+    result: ExtractionResult,
 ) -> bool:
     if result.extraction_tier == "degraded" or result.line_items:
         return False
@@ -1025,7 +1103,7 @@ def _should_degrade_for_empty_line_items_with_substantial_transcript(
     return len(normalized_transcript.split()) >= _SEMANTIC_EMPTY_LINE_ITEMS_MIN_WORDS
 
 
-def _should_warn_for_total_without_priced_items(result: ExtractionResultV2) -> bool:
+def _should_warn_for_total_without_priced_items(result: ExtractionResult) -> bool:
     return (
         result.pricing_hints.explicit_total is not None
         and bool(result.line_items)
@@ -1035,7 +1113,6 @@ def _should_warn_for_total_without_priced_items(result: ExtractionResultV2) -> b
 
 def _apply_duplicate_line_item_flags(
     line_items: list[LineItemExtractedV2],
-    confidence_notes: list[str],
 ) -> list[LineItemExtractedV2]:
     duplicate_groups: dict[tuple[str, float | None], list[int]] = {}
     for index, item in enumerate(line_items):
@@ -1051,7 +1128,6 @@ def _apply_duplicate_line_item_flags(
     if not duplicate_indexes:
         return line_items
 
-    _append_semantic_note(confidence_notes, _SEMANTIC_NOTE_DUPLICATE_LINE_ITEMS)
     updated_items = list(line_items)
     for index in duplicate_indexes:
         existing = updated_items[index]
@@ -1066,7 +1142,6 @@ def _apply_duplicate_line_item_flags(
 
 def _flag_line_items_with_price_in_description(
     line_items: list[LineItemExtractedV2],
-    confidence_notes: list[str],
 ) -> list[LineItemExtractedV2]:
     flagged_indexes = [
         index for index, item in enumerate(line_items) if _contains_price_token(item.description)
@@ -1074,10 +1149,6 @@ def _flag_line_items_with_price_in_description(
     if not flagged_indexes:
         return line_items
 
-    _append_semantic_note(
-        confidence_notes,
-        "Line-item descriptions should not include price tokens; review flagged items.",
-    )
     updated_items = list(line_items)
     for index in flagged_indexes:
         current = updated_items[index]
@@ -1092,7 +1163,6 @@ def _flag_line_items_with_price_in_description(
 
 def _flag_line_items_with_duplicate_details(
     line_items: list[LineItemExtractedV2],
-    confidence_notes: list[str],
 ) -> list[LineItemExtractedV2]:
     flagged_indexes = [
         index
@@ -1104,10 +1174,6 @@ def _flag_line_items_with_duplicate_details(
     if not flagged_indexes:
         return line_items
 
-    _append_semantic_note(
-        confidence_notes,
-        "Some line-item details duplicate the description; review flagged items.",
-    )
     updated_items = list(line_items)
     for index in flagged_indexes:
         current = updated_items[index]
@@ -1125,12 +1191,27 @@ def _normalize_line_item_description(value: str) -> str:
     return collapsed_whitespace.casefold()
 
 
-def _append_semantic_note(confidence_notes: list[str], note: str) -> None:
-    if note in confidence_notes:
-        return
-    if len(confidence_notes) >= CONFIDENCE_NOTES_MAX_ITEMS:
-        return
-    confidence_notes.append(note)
+def _append_semantic_unresolved_segment(
+    unresolved_segments: list[UnresolvedSegment],
+    *,
+    text: str,
+    source: UnresolvedSegmentSource,
+) -> list[UnresolvedSegment]:
+    normalized_text = text.strip()
+    if any(
+        segment.raw_text.strip().casefold() == normalized_text.casefold()
+        and segment.source == source
+        for segment in unresolved_segments
+    ):
+        return unresolved_segments
+    return [
+        *unresolved_segments,
+        UnresolvedSegment(
+            raw_text=normalized_text,
+            confidence="medium",
+            source=source,
+        ),
+    ]
 
 
 def _contains_price_token(text: str) -> bool:


### PR DESCRIPTION
## Summary
- trim the initial extraction provider schema to 2.5 candidate fields (`line_items`, `notes_candidate`, `pricing_candidates`, `unresolved_items`)
- add backend adapters that stamp transcript/tier/degraded metadata and internal `pipeline_version="v2.5"`
- keep transitional consumer compatibility by projecting API/job extraction responses to legacy `pipeline_version="v2"`
- shift semantic guard product output away from generic `confidence_notes` into visible flags/unresolved items
- update extraction integration tests for schema removal + adapter stamping behavior

## Verification
- `cd backend && .venv/bin/pytest app/features/quotes/tests/test_extraction.py app/features/quotes/tests/test_extraction_service.py -m "not live and not extraction_eval and not extraction_quality" -o cache_dir=.pytest_cache`
- `make backend-static-verify`
- `make backend-verify`

Closes #417
