### PR TITLE
Task #418: persist line-item price status and unify actionable sidecar

### DIFF
--- a/backend/alembic/versions/20260416_0024_add_line_item_price_status.py
+++ b/backend/alembic/versions/20260416_0024_add_line_item_price_status.py
@@ -1,0 +1,33 @@
+"""Add line-item price status for extraction 2.5 semantics.
+
+Revision ID: 20260416_0024
+Revises: 20260415_0023
+Create Date: 2026-04-16
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "20260416_0024"
+down_revision: str | None = "20260415_0023"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column("line_items", sa.Column("price_status", sa.Text(), nullable=True))
+    op.create_check_constraint(
+        "ck_line_items_price_status",
+        "line_items",
+        "price_status in ('priced', 'included', 'unknown') or price_status is null",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("ck_line_items_price_status", "line_items", type_="check")
+    op.drop_column("line_items", "price_status")

--- a/backend/app/features/invoices/repository.py
+++ b/backend/app/features/invoices/repository.py
@@ -23,6 +23,10 @@ from app.features.customers.models import Customer
 from app.features.event_logs.models import EventLog
 from app.features.jobs.models import JobRecord, JobStatus
 from app.features.quotes.models import Document, LineItem, QuoteStatus
+from app.features.quotes.price_status import (
+    LineItemPriceStatus,
+    resolve_line_item_price_status,
+)
 from app.features.quotes.repository import QuoteRenderContext, QuoteRenderLineItem
 from app.features.quotes.schemas import LineItemDraft
 from app.shared.pricing import (
@@ -718,6 +722,7 @@ class InvoiceRepository:
                     description=item.description,
                     details=item.details,
                     price=_to_decimal(item.price),
+                    price_status=item.price_status,
                     sort_order=index,
                 )
             )
@@ -787,6 +792,7 @@ def _build_render_context(
                 description=line_item.description,
                 details=line_item.details,
                 price=line_item.price,
+                price_status=_resolve_line_item_price_status_for_render(line_item),
             )
             for line_item in document.line_items
         ],
@@ -812,3 +818,15 @@ def _format_document_date(value: date | None, timezone: str | None) -> str | Non
         return None
     del timezone
     return value.strftime("%b %d, %Y")
+
+
+def _resolve_line_item_price_status_for_render(line_item: LineItem) -> LineItemPriceStatus:
+    try:
+        return resolve_line_item_price_status(
+            price=line_item.price,
+            price_status=line_item.price_status,
+            description=line_item.description,
+            details=line_item.details,
+        )
+    except ValueError:
+        return "priced" if line_item.price is not None else "unknown"

--- a/backend/app/features/invoices/repository.py
+++ b/backend/app/features/invoices/repository.py
@@ -25,7 +25,7 @@ from app.features.jobs.models import JobRecord, JobStatus
 from app.features.quotes.models import Document, LineItem, QuoteStatus
 from app.features.quotes.price_status import (
     LineItemPriceStatus,
-    resolve_line_item_price_status,
+    resolve_line_item_price_status_with_fallback,
 )
 from app.features.quotes.repository import QuoteRenderContext, QuoteRenderLineItem
 from app.features.quotes.schemas import LineItemDraft
@@ -821,12 +821,9 @@ def _format_document_date(value: date | None, timezone: str | None) -> str | Non
 
 
 def _resolve_line_item_price_status_for_render(line_item: LineItem) -> LineItemPriceStatus:
-    try:
-        return resolve_line_item_price_status(
-            price=line_item.price,
-            price_status=line_item.price_status,
-            description=line_item.description,
-            details=line_item.details,
-        )
-    except ValueError:
-        return "priced" if line_item.price is not None else "unknown"
+    return resolve_line_item_price_status_with_fallback(
+        price=line_item.price,
+        price_status=line_item.price_status,
+        description=line_item.description,
+        details=line_item.details,
+    )

--- a/backend/app/features/quotes/creation/service.py
+++ b/backend/app/features/quotes/creation/service.py
@@ -161,6 +161,7 @@ class QuoteCreationService:
                         description=item.description,
                         details=item.details,
                         price=item.price,
+                        price_status=item.price_status,
                         flagged=item.flagged,
                         flag_reason=item.flag_reason,
                     )

--- a/backend/app/features/quotes/extraction_append/service.py
+++ b/backend/app/features/quotes/extraction_append/service.py
@@ -12,7 +12,7 @@ from app.features.quotes.extraction_outcomes import classify_extraction_result
 from app.features.quotes.models import Document, LineItem, QuoteStatus
 from app.features.quotes.price_status import (
     LineItemPriceStatus,
-    resolve_line_item_price_status,
+    resolve_line_item_price_status_with_fallback,
 )
 from app.features.quotes.review_metadata import (
     build_append_suggestion,
@@ -49,15 +49,12 @@ _APPEND_TRANSCRIPT_BULLET_PREFIXES = ("- ", "* ")
 
 
 def _resolve_line_item_price_status_for_append(line_item: LineItem) -> LineItemPriceStatus:
-    try:
-        return resolve_line_item_price_status(
-            price=line_item.price,
-            price_status=line_item.price_status,
-            description=line_item.description,
-            details=line_item.details,
-        )
-    except ValueError:
-        return "priced" if line_item.price is not None else "unknown"
+    return resolve_line_item_price_status_with_fallback(
+        price=line_item.price,
+        price_status=line_item.price_status,
+        description=line_item.description,
+        details=line_item.details,
+    )
 
 
 class QuoteExtractionAppendRepositoryProtocol(Protocol):
@@ -161,7 +158,12 @@ class QuoteExtractionAppendService:
                 description=item.description,
                 details=item.details,
                 price=item.price,
-                price_status=item.price_status,
+                price_status=resolve_line_item_price_status_with_fallback(
+                    price=item.price,
+                    price_status=item.price_status,
+                    description=item.description,
+                    details=item.details,
+                ),
                 flagged=item.flagged,
                 flag_reason=item.flag_reason,
             )

--- a/backend/app/features/quotes/extraction_append/service.py
+++ b/backend/app/features/quotes/extraction_append/service.py
@@ -9,7 +9,11 @@ from uuid import UUID
 
 from app.features.quotes.errors import QuoteServiceError
 from app.features.quotes.extraction_outcomes import classify_extraction_result
-from app.features.quotes.models import Document, QuoteStatus
+from app.features.quotes.models import Document, LineItem, QuoteStatus
+from app.features.quotes.price_status import (
+    LineItemPriceStatus,
+    resolve_line_item_price_status,
+)
 from app.features.quotes.review_metadata import (
     build_append_suggestion,
     build_extraction_review_metadata,
@@ -42,6 +46,18 @@ _APPENDABLE_QUOTE_STATUSES = frozenset(
 _APPEND_UNAVAILABLE_DETAIL = "This quote can no longer be edited."
 _APPEND_TRANSCRIPT_SEPARATOR_PATTERN = re.compile(r"(?:^|\n\n)Added later(?: \(\d+\))?:\n")
 _APPEND_TRANSCRIPT_BULLET_PREFIXES = ("- ", "* ")
+
+
+def _resolve_line_item_price_status_for_append(line_item: LineItem) -> LineItemPriceStatus:
+    try:
+        return resolve_line_item_price_status(
+            price=line_item.price,
+            price_status=line_item.price_status,
+            description=line_item.description,
+            details=line_item.details,
+        )
+    except ValueError:
+        return "priced" if line_item.price is not None else "unknown"
 
 
 class QuoteExtractionAppendRepositoryProtocol(Protocol):
@@ -145,6 +161,7 @@ class QuoteExtractionAppendService:
                 description=item.description,
                 details=item.details,
                 price=item.price,
+                price_status=item.price_status,
                 flagged=item.flagged,
                 flag_reason=item.flag_reason,
             )
@@ -156,6 +173,7 @@ class QuoteExtractionAppendService:
                     description=line_item.description,
                     details=line_item.details,
                     price=document_field_float_or_none(line_item.price),
+                    price_status=_resolve_line_item_price_status_for_append(line_item),
                     flagged=line_item.flagged,
                     flag_reason=line_item.flag_reason,
                 )

--- a/backend/app/features/quotes/models.py
+++ b/backend/app/features/quotes/models.py
@@ -172,6 +172,7 @@ class LineItem(Base):
     description: Mapped[str] = mapped_column(sa.Text, nullable=False)
     details: Mapped[str | None] = mapped_column(sa.Text, nullable=True)
     price: Mapped[Decimal | None] = mapped_column(sa.Numeric(10, 2), nullable=True)
+    price_status: Mapped[str | None] = mapped_column(sa.Text, nullable=True)
     flagged: Mapped[bool] = mapped_column(
         sa.Boolean,
         nullable=False,

--- a/backend/app/features/quotes/price_status.py
+++ b/backend/app/features/quotes/price_status.py
@@ -1,0 +1,56 @@
+"""Helpers for normalizing line-item price status semantics."""
+
+from __future__ import annotations
+
+import re
+from decimal import Decimal
+from typing import Literal
+
+LineItemPriceStatus = Literal["priced", "included", "unknown"]
+_LINE_ITEM_PRICE_STATUS_VALUES = frozenset({"priced", "included", "unknown"})
+_INCLUDED_NO_CHARGE_PATTERN = re.compile(
+    r"\b(included|no[\s-]?charge|n/?c|complimentary|at no cost)\b",
+    flags=re.IGNORECASE,
+)
+
+
+def has_included_no_charge_language(*parts: str | None) -> bool:
+    """Return True when text includes explicit included/no-charge language."""
+    for part in parts:
+        if part is None:
+            continue
+        if _INCLUDED_NO_CHARGE_PATTERN.search(part):
+            return True
+    return False
+
+
+def resolve_line_item_price_status(
+    *,
+    price: float | Decimal | None,
+    price_status: str | None,
+    description: str | None,
+    details: str | None,
+) -> LineItemPriceStatus:
+    """Resolve one line-item status with compatibility handling for legacy rows."""
+    normalized_status: LineItemPriceStatus | None = None
+    if isinstance(price_status, str):
+        normalized = price_status.strip().casefold()
+        if normalized:
+            if normalized not in _LINE_ITEM_PRICE_STATUS_VALUES:
+                raise ValueError("price_status must be one of priced, included, or unknown")
+            normalized_status = normalized  # type: ignore[assignment]
+
+    has_price = price is not None
+
+    if normalized_status == "priced" and not has_price:
+        raise ValueError("price_status=priced requires a numeric price")
+    if normalized_status in {"included", "unknown"} and has_price:
+        raise ValueError("price_status included/unknown requires a null price")
+
+    if normalized_status is not None:
+        return normalized_status
+    if has_price:
+        return "priced"
+    if has_included_no_charge_language(description, details):
+        return "included"
+    return "unknown"

--- a/backend/app/features/quotes/price_status.py
+++ b/backend/app/features/quotes/price_status.py
@@ -54,3 +54,27 @@ def resolve_line_item_price_status(
     if has_included_no_charge_language(description, details):
         return "included"
     return "unknown"
+
+
+def resolve_line_item_price_status_with_fallback(
+    *,
+    price: float | Decimal | None,
+    price_status: str | None,
+    description: str | None,
+    details: str | None,
+) -> LineItemPriceStatus:
+    """Resolve price status and gracefully recover from malformed status payloads."""
+    try:
+        return resolve_line_item_price_status(
+            price=price,
+            price_status=price_status,
+            description=description,
+            details=details,
+        )
+    except ValueError:
+        return resolve_line_item_price_status(
+            price=price,
+            price_status=None,
+            description=description,
+            details=details,
+        )

--- a/backend/app/features/quotes/repository.py
+++ b/backend/app/features/quotes/repository.py
@@ -20,7 +20,7 @@ from app.features.jobs.models import JobRecord, JobStatus
 from app.features.quotes.models import Document, LineItem, QuoteStatus
 from app.features.quotes.price_status import (
     LineItemPriceStatus,
-    resolve_line_item_price_status,
+    resolve_line_item_price_status_with_fallback,
 )
 from app.features.quotes.schemas import LineItemDraft
 from app.shared.pricing import (
@@ -987,15 +987,12 @@ def _format_quote_date(value: datetime, timezone: str | None) -> str:
 
 
 def _resolve_line_item_price_status_for_render(line_item: LineItem) -> LineItemPriceStatus:
-    try:
-        return resolve_line_item_price_status(
-            price=line_item.price,
-            price_status=line_item.price_status,
-            description=line_item.description,
-            details=line_item.details,
-        )
-    except ValueError:
-        return "priced" if line_item.price is not None else "unknown"
+    return resolve_line_item_price_status_with_fallback(
+        price=line_item.price,
+        price_status=line_item.price_status,
+        description=line_item.description,
+        details=line_item.details,
+    )
 
 
 def _can_reassign_customer(*, status: str, has_linked_invoice: bool) -> bool:

--- a/backend/app/features/quotes/repository.py
+++ b/backend/app/features/quotes/repository.py
@@ -18,6 +18,10 @@ from app.features.customers.models import Customer
 from app.features.event_logs.models import EventLog
 from app.features.jobs.models import JobRecord, JobStatus
 from app.features.quotes.models import Document, LineItem, QuoteStatus
+from app.features.quotes.price_status import (
+    LineItemPriceStatus,
+    resolve_line_item_price_status,
+)
 from app.features.quotes.schemas import LineItemDraft
 from app.shared.pricing import (
     DiscountType,
@@ -61,6 +65,7 @@ class QuoteRenderLineItem:
     description: str
     details: str | None
     price: Decimal | None
+    price_status: LineItemPriceStatus
 
 
 @dataclass(slots=True)
@@ -768,6 +773,7 @@ class QuoteRepository:
                     description=item.description,
                     details=item.details,
                     price=_to_decimal(item.price),
+                    price_status=item.price_status,
                     flagged=item.flagged,
                     flag_reason=item.flag_reason,
                     sort_order=next_sort_order + index,
@@ -890,6 +896,7 @@ class QuoteRepository:
                     description=item.description,
                     details=item.details,
                     price=_to_decimal(item.price),
+                    price_status=item.price_status,
                     flagged=item.flagged,
                     flag_reason=item.flag_reason,
                     sort_order=index,
@@ -958,6 +965,7 @@ def _build_render_context(
                 description=line_item.description,
                 details=line_item.details,
                 price=line_item.price,
+                price_status=_resolve_line_item_price_status_for_render(line_item),
             )
             for line_item in document.line_items
         ],
@@ -976,6 +984,18 @@ def _format_quote_date(value: datetime, timezone: str | None) -> str:
             resolved_tz = UTC
 
     return value.astimezone(resolved_tz).strftime("%b %d, %Y")
+
+
+def _resolve_line_item_price_status_for_render(line_item: LineItem) -> LineItemPriceStatus:
+    try:
+        return resolve_line_item_price_status(
+            price=line_item.price,
+            price_status=line_item.price_status,
+            description=line_item.description,
+            details=line_item.details,
+        )
+    except ValueError:
+        return "priced" if line_item.price is not None else "unknown"
 
 
 def _can_reassign_customer(*, status: str, has_linked_invoice: bool) -> bool:

--- a/backend/app/features/quotes/review_metadata.py
+++ b/backend/app/features/quotes/review_metadata.py
@@ -5,14 +5,15 @@ from __future__ import annotations
 from collections.abc import Mapping, Sequence
 from hashlib import sha256
 from typing import Literal, cast
+from uuid import uuid4
 
 from app.features.quotes.schemas import (
     ExtractionResult,
+    ExtractionReviewActionableItem,
     ExtractionReviewAppendSuggestion,
     ExtractionReviewHiddenDetails,
     ExtractionReviewMetadataV1,
     ExtractionReviewState,
-    ExtractionReviewUnresolvedSegment,
     HiddenItemState,
     NotesSeededFieldMetadata,
     PlacementConfidence,
@@ -84,28 +85,14 @@ def build_extraction_review_metadata(
         ),
     )
 
-    unresolved_segments = _dedupe_unresolved_segments(extraction_result)
-    merged_append_suggestions, incoming_append_ids = _merge_append_suggestions(
-        previous_suggestions=previous.hidden_details.append_suggestions,
-        incoming_suggestions=append_suggestions or [],
+    next_actionable_items = _build_actionable_items(
+        extraction_result=extraction_result,
+        previous_items=previous.hidden_details.items,
+        previous_state=previous.hidden_detail_state,
+        append_suggestions=append_suggestions or [],
     )
-    hidden_details = ExtractionReviewHiddenDetails(
-        unresolved_segments=unresolved_segments,
-        append_suggestions=merged_append_suggestions,
-        confidence_notes=(
-            list(extraction_result.confidence_notes)
-            if extraction_result.confidence_notes
-            else list(previous.hidden_details.confidence_notes)
-        ),
-    )
-    current_hidden_item_ids = {
-        *[item.id for item in unresolved_segments],
-        *[item.id for item in merged_append_suggestions],
-    }
-    resurfaced_hidden_item_ids = {
-        *[item.id for item in unresolved_segments],
-        *incoming_append_ids,
-    }
+    hidden_details = ExtractionReviewHiddenDetails(items=next_actionable_items)
+    current_hidden_item_ids = {item.id for item in next_actionable_items}
 
     return ExtractionReviewMetadataV1(
         pipeline_version=extraction_result.pipeline_version,
@@ -125,7 +112,6 @@ def build_extraction_review_metadata(
         hidden_detail_state=_build_hidden_detail_state(
             previous_state=previous.hidden_detail_state,
             current_item_ids=current_hidden_item_ids,
-            resurfaced_item_ids=resurfaced_hidden_item_ids,
         ),
         extraction_degraded_reason_code=extraction_result.extraction_degraded_reason_code,
     )
@@ -171,11 +157,18 @@ def clear_append_suggestions_for_manual_edits(
     if not notes_changed and not pricing_changed:
         return metadata
 
-    filtered_append_suggestions = [
+    filtered_items = [
         item
-        for item in metadata.hidden_details.append_suggestions
+        for item in metadata.hidden_details.items
         if not (
-            (notes_changed and item.kind == "note") or (pricing_changed and item.kind == "pricing")
+            item.kind == "append_suggestion"
+            and (
+                (notes_changed and item.field == "notes")
+                or (
+                    pricing_changed
+                    and item.field in {"explicit_total", "deposit_amount", "tax_rate", "discount"}
+                )
+            )
         )
     ]
     updated_review_state = metadata.review_state.model_copy(
@@ -186,9 +179,7 @@ def clear_append_suggestions_for_manual_edits(
             ),
         }
     )
-    updated_hidden_details = metadata.hidden_details.model_copy(
-        update={"append_suggestions": filtered_append_suggestions}
-    )
+    updated_hidden_details = ExtractionReviewHiddenDetails(items=filtered_items)
     return metadata.model_copy(
         update={
             "review_state": updated_review_state,
@@ -275,16 +266,10 @@ def _build_hidden_detail_state(
     *,
     previous_state: Mapping[str, HiddenItemState],
     current_item_ids: set[str],
-    resurfaced_item_ids: set[str],
 ) -> dict[str, HiddenItemState]:
-    merged: dict[str, HiddenItemState] = {
-        item_id: state.model_copy(deep=True) for item_id, state in previous_state.items()
-    }
+    merged: dict[str, HiddenItemState] = {}
     for item_id in current_item_ids:
-        previous = merged.get(item_id, HiddenItemState())
-        if item_id in resurfaced_item_ids:
-            merged[item_id] = HiddenItemState()
-            continue
+        previous = previous_state.get(item_id, HiddenItemState())
         merged[item_id] = HiddenItemState(
             reviewed=previous.reviewed,
             dismissed=previous.dismissed,
@@ -292,38 +277,110 @@ def _build_hidden_detail_state(
     return merged
 
 
-def _dedupe_unresolved_segments(
+def _build_actionable_items(
+    *,
     extraction_result: ExtractionResult,
-) -> list[ExtractionReviewUnresolvedSegment]:
-    deduped: dict[str, ExtractionReviewUnresolvedSegment] = {}
+    previous_items: Sequence[ExtractionReviewActionableItem],
+    previous_state: Mapping[str, HiddenItemState],
+    append_suggestions: Sequence[ExtractionReviewAppendSuggestion],
+) -> list[ExtractionReviewActionableItem]:
+    previous_by_signature: dict[str, ExtractionReviewActionableItem] = {
+        _actionable_signature(item): item for item in previous_items
+    }
+    deduped: dict[str, ExtractionReviewActionableItem] = {}
+
     for segment in extraction_result.unresolved_segments:
-        hidden_id = build_hidden_item_id(
-            "unresolved",
-            segment.source,
-            segment.confidence,
-            segment.raw_text,
-        )
-        if hidden_id in deduped:
-            continue
-        deduped[hidden_id] = ExtractionReviewUnresolvedSegment(
-            id=hidden_id,
-            raw_text=segment.raw_text,
+        candidate = ExtractionReviewActionableItem(
+            id="pending",
+            kind="unresolved_segment",
+            field=None,
+            reason=segment.source,
             confidence=segment.confidence,
-            source=segment.source,
+            text=segment.raw_text,
         )
+        signature = _actionable_signature(candidate)
+        previous = previous_by_signature.get(signature)
+        previous_item_state = previous_state.get(previous.id) if previous is not None else None
+        deduped[signature] = candidate.model_copy(
+            update={
+                "id": (
+                    previous.id
+                    if previous is not None
+                    and (previous_item_state is None or not previous_item_state.dismissed)
+                    else _build_new_occurrence_id()
+                )
+            }
+        )
+
+    for suggestion in append_suggestions:
+        field: PricingFieldName | Literal["notes"]
+        if suggestion.pricing_field is None:
+            field = "notes"
+        else:
+            field = suggestion.pricing_field
+        candidate = ExtractionReviewActionableItem(
+            id="pending",
+            kind="append_suggestion",
+            field=field,
+            reason=suggestion.source,
+            confidence=suggestion.confidence,
+            text=suggestion.raw_text,
+        )
+        signature = _actionable_signature(candidate)
+        previous = previous_by_signature.get(signature)
+        previous_item_state = previous_state.get(previous.id) if previous is not None else None
+        deduped[signature] = candidate.model_copy(
+            update={
+                "id": (
+                    previous.id
+                    if previous is not None
+                    and (previous_item_state is None or not previous_item_state.dismissed)
+                    else _build_new_occurrence_id()
+                )
+            }
+        )
+
+    confidence_notes = (
+        list(extraction_result.confidence_notes)
+        if extraction_result.confidence_notes
+        else [item.text for item in previous_items if item.kind == "confidence_note"]
+    )
+    for note in confidence_notes:
+        candidate = ExtractionReviewActionableItem(
+            id="pending",
+            kind="confidence_note",
+            field=None,
+            reason="confidence_note",
+            confidence=None,
+            text=note,
+        )
+        signature = _actionable_signature(candidate)
+        previous = previous_by_signature.get(signature)
+        previous_item_state = previous_state.get(previous.id) if previous is not None else None
+        deduped[signature] = candidate.model_copy(
+            update={
+                "id": (
+                    previous.id
+                    if previous is not None
+                    and (previous_item_state is None or not previous_item_state.dismissed)
+                    else _build_new_occurrence_id()
+                )
+            }
+        )
+
     return list(deduped.values())
 
 
-def _merge_append_suggestions(
-    *,
-    previous_suggestions: Sequence[ExtractionReviewAppendSuggestion],
-    incoming_suggestions: Sequence[ExtractionReviewAppendSuggestion],
-) -> tuple[list[ExtractionReviewAppendSuggestion], set[str]]:
-    merged: dict[str, ExtractionReviewAppendSuggestion] = {
-        item.id: item for item in previous_suggestions
-    }
-    incoming_ids: set[str] = set()
-    for item in incoming_suggestions:
-        merged[item.id] = item
-        incoming_ids.add(item.id)
-    return list(merged.values()), incoming_ids
+def _actionable_signature(item: ExtractionReviewActionableItem) -> str:
+    return "|".join(
+        (
+            item.kind,
+            item.field or "",
+            item.reason or "",
+            item.text.strip().casefold(),
+        )
+    )
+
+
+def _build_new_occurrence_id() -> str:
+    return f"occ:{uuid4().hex[:16]}"

--- a/backend/app/features/quotes/schemas.py
+++ b/backend/app/features/quotes/schemas.py
@@ -8,6 +8,10 @@ from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
+from app.features.quotes.price_status import (
+    LineItemPriceStatus,
+    resolve_line_item_price_status,
+)
 from app.shared.input_limits import (
     AUDIO_TRANSCRIPT_MAX_CHARS,
     CONFIDENCE_NOTE_MAX_CHARS,
@@ -31,14 +35,75 @@ def _normalize_optional_title(value: object) -> object:
     return trimmed or None
 
 
+def _normalize_line_item_price_status_payload(value: object) -> object:
+    if not isinstance(value, dict):
+        return value
+    payload = dict(value)
+    payload["price_status"] = resolve_line_item_price_status(
+        price=payload.get("price"),
+        price_status=(
+            payload.get("price_status") if isinstance(payload.get("price_status"), str) else None
+        ),
+        description=(
+            payload.get("description") if isinstance(payload.get("description"), str) else None
+        ),
+        details=payload.get("details") if isinstance(payload.get("details"), str) else None,
+    )
+    return payload
+
+
+def _normalize_line_item_price_status_for_response(value: object) -> object:
+    payload: dict[str, Any] | None = None
+    if isinstance(value, dict):
+        payload = dict(value)
+    else:
+        fields = (
+            "id",
+            "description",
+            "details",
+            "price",
+            "price_status",
+            "flagged",
+            "flag_reason",
+            "sort_order",
+        )
+        extracted = {field: getattr(value, field) for field in fields if hasattr(value, field)}
+        if extracted:
+            payload = extracted
+    if payload is None:
+        return value
+
+    try:
+        payload["price_status"] = resolve_line_item_price_status(
+            price=payload.get("price"),
+            price_status=(
+                payload.get("price_status")
+                if isinstance(payload.get("price_status"), str)
+                else None
+            ),
+            description=(
+                payload.get("description") if isinstance(payload.get("description"), str) else None
+            ),
+            details=payload.get("details") if isinstance(payload.get("details"), str) else None,
+        )
+    except ValueError:
+        payload["price_status"] = "priced" if payload.get("price") is not None else "unknown"
+    return payload
+
+
 class LineItemDraft(BaseModel):
     """Editable line item payload used for quote creation and updates."""
 
     description: str = Field(min_length=1, max_length=LINE_ITEM_DESCRIPTION_MAX_CHARS)
     details: str | None = Field(default=None, max_length=LINE_ITEM_DETAILS_MAX_CHARS)
     price: float | None = None
+    price_status: LineItemPriceStatus | None = None
     flagged: bool = False
     flag_reason: str | None = None
+
+    _normalize_price_status = model_validator(mode="before")(
+        _normalize_line_item_price_status_payload
+    )
 
 
 class LineItemExtracted(LineItemDraft):
@@ -321,15 +386,168 @@ class ExtractionReviewUnresolvedSegment(BaseModel):
     source: UnresolvedSegmentSource
 
 
+ActionableItemKind = Literal["append_suggestion", "unresolved_segment", "confidence_note"]
+ActionableItemField = Literal["notes", "explicit_total", "deposit_amount", "tax_rate", "discount"]
+
+
+def _coerce_pricing_field(field: str | None) -> PricingFieldName | None:
+    if field == "explicit_total":
+        return "explicit_total"
+    if field == "deposit_amount":
+        return "deposit_amount"
+    if field == "tax_rate":
+        return "tax_rate"
+    if field == "discount":
+        return "discount"
+    return None
+
+
+def _coerce_unresolved_segment_source(reason: str | None) -> UnresolvedSegmentSource:
+    if reason == "leftover_classification":
+        return "leftover_classification"
+    if reason == "typed_conflict":
+        return "typed_conflict"
+    if reason == "transcript_conflict":
+        return "transcript_conflict"
+    return "leftover_classification"
+
+
+class ExtractionReviewActionableItem(BaseModel):
+    """Unified actionable hidden item persisted in extraction sidecar metadata."""
+
+    id: str = Field(min_length=1)
+    kind: ActionableItemKind
+    field: ActionableItemField | None = None
+    reason: str | None = Field(default=None, max_length=64)
+    confidence: Literal["medium", "low"] | None = None
+    text: str = Field(min_length=1, max_length=EXTRACTION_TRANSCRIPT_MAX_CHARS)
+
+
 class ExtractionReviewHiddenDetails(BaseModel):
     """Hidden extraction details shown in Capture Details surfaces."""
 
+    items: list[ExtractionReviewActionableItem] = Field(default_factory=list)
     unresolved_segments: list[ExtractionReviewUnresolvedSegment] = Field(default_factory=list)
     append_suggestions: list[ExtractionReviewAppendSuggestion] = Field(default_factory=list)
     confidence_notes: list[Annotated[str, Field(max_length=CONFIDENCE_NOTE_MAX_CHARS)]] = Field(
         default_factory=list,
         max_length=CONFIDENCE_NOTES_MAX_ITEMS,
     )
+
+    @model_validator(mode="before")
+    @classmethod
+    def normalize_legacy_shapes(cls, value: object) -> object:
+        if not isinstance(value, dict):
+            return value
+        payload = dict(value)
+        if isinstance(payload.get("items"), list):
+            return payload
+
+        items: list[dict[str, Any]] = []
+        for suggestion_candidate in payload.get("append_suggestions", []):
+            suggestion: dict[str, Any] | None
+            if isinstance(suggestion_candidate, dict):
+                suggestion = suggestion_candidate
+            else:
+                model_dump = getattr(suggestion_candidate, "model_dump", None)
+                suggestion = model_dump(mode="json") if callable(model_dump) else None
+            if not isinstance(suggestion, dict):
+                continue
+            raw_text = suggestion.get("raw_text")
+            if not isinstance(raw_text, str) or not raw_text.strip():
+                continue
+            suggestion_pricing_field = suggestion.get("pricing_field")
+            field = _coerce_pricing_field(
+                suggestion_pricing_field if isinstance(suggestion_pricing_field, str) else None
+            )
+            items.append(
+                {
+                    "id": str(suggestion.get("id", "")),
+                    "kind": "append_suggestion",
+                    "field": "notes" if field is None else field,
+                    "reason": suggestion.get("source"),
+                    "confidence": suggestion.get("confidence"),
+                    "text": raw_text,
+                }
+            )
+
+        for segment_candidate in payload.get("unresolved_segments", []):
+            segment: dict[str, Any] | None
+            if isinstance(segment_candidate, dict):
+                segment = segment_candidate
+            else:
+                model_dump = getattr(segment_candidate, "model_dump", None)
+                segment = model_dump(mode="json") if callable(model_dump) else None
+            if not isinstance(segment, dict):
+                continue
+            raw_text = segment.get("raw_text")
+            if not isinstance(raw_text, str) or not raw_text.strip():
+                continue
+            items.append(
+                {
+                    "id": str(segment.get("id", "")),
+                    "kind": "unresolved_segment",
+                    "field": None,
+                    "reason": segment.get("source"),
+                    "confidence": segment.get("confidence"),
+                    "text": raw_text,
+                }
+            )
+
+        for index, note in enumerate(payload.get("confidence_notes", [])):
+            if not isinstance(note, str) or not note.strip():
+                continue
+            note_id = f"legacy-confidence-{index}"
+            items.append(
+                {
+                    "id": note_id,
+                    "kind": "confidence_note",
+                    "field": None,
+                    "reason": "legacy_confidence_note",
+                    "confidence": None,
+                    "text": note,
+                }
+            )
+
+        payload["items"] = items
+        return payload
+
+    @model_validator(mode="after")
+    def sync_legacy_views(self) -> ExtractionReviewHiddenDetails:
+        unresolved_segments: list[ExtractionReviewUnresolvedSegment] = []
+        append_suggestions: list[ExtractionReviewAppendSuggestion] = []
+        confidence_notes: list[str] = []
+        for item in self.items:
+            if item.kind == "unresolved_segment":
+                unresolved_source = _coerce_unresolved_segment_source(item.reason)
+                unresolved_segments.append(
+                    ExtractionReviewUnresolvedSegment(
+                        id=item.id,
+                        raw_text=item.text,
+                        confidence=item.confidence or "medium",
+                        source=unresolved_source,
+                    )
+                )
+                continue
+            if item.kind == "append_suggestion":
+                pricing_field = _coerce_pricing_field(item.field)
+                append_suggestions.append(
+                    ExtractionReviewAppendSuggestion(
+                        id=item.id,
+                        kind=("note" if pricing_field is None else "pricing"),
+                        raw_text=item.text,
+                        confidence=item.confidence or "medium",
+                        source="append_capture",
+                        pricing_field=pricing_field,
+                    )
+                )
+                continue
+            confidence_notes.append(item.text)
+
+        self.unresolved_segments = unresolved_segments
+        self.append_suggestions = append_suggestions
+        self.confidence_notes = confidence_notes
+        return self
 
 
 class HiddenItemState(BaseModel):
@@ -350,6 +568,23 @@ class ExtractionReviewMetadataV1(BaseModel):
     )
     hidden_detail_state: dict[str, HiddenItemState] = Field(default_factory=dict)
     extraction_degraded_reason_code: str | None = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def normalize_legacy_metadata_shape(cls, value: object) -> object:
+        if not isinstance(value, dict):
+            return value
+        payload = dict(value)
+        hidden_details = payload.get("hidden_details")
+        hidden_payload = dict(hidden_details) if isinstance(hidden_details, dict) else {}
+        for key in ("append_suggestions", "unresolved_segments", "confidence_notes", "items"):
+            if key in payload and key not in hidden_payload:
+                hidden_payload[key] = payload[key]
+        if hidden_payload:
+            payload["hidden_details"] = hidden_payload
+        if "hidden_item_state" in payload and "hidden_detail_state" not in payload:
+            payload["hidden_detail_state"] = payload["hidden_item_state"]
+        return payload
 
     @classmethod
     def model_validate_with_defaults(
@@ -500,9 +735,14 @@ class LineItemResponse(BaseModel):
     description: str
     details: str | None
     price: float | None
+    price_status: LineItemPriceStatus
     flagged: bool = False
     flag_reason: str | None = None
     sort_order: int
+
+    _normalize_price_status = model_validator(mode="before")(
+        _normalize_line_item_price_status_for_response
+    )
 
 
 class PublicLineItemResponse(BaseModel):
@@ -513,6 +753,11 @@ class PublicLineItemResponse(BaseModel):
     description: str
     details: str | None
     price: float | None
+    price_status: LineItemPriceStatus
+
+    _normalize_price_status = model_validator(mode="before")(
+        _normalize_line_item_price_status_for_response
+    )
 
 
 class QuoteListItemResponse(BaseModel):

--- a/backend/app/features/quotes/schemas.py
+++ b/backend/app/features/quotes/schemas.py
@@ -11,6 +11,7 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator, model_valida
 from app.features.quotes.price_status import (
     LineItemPriceStatus,
     resolve_line_item_price_status,
+    resolve_line_item_price_status_with_fallback,
 )
 from app.shared.input_limits import (
     AUDIO_TRANSCRIPT_MAX_CHARS,
@@ -73,21 +74,16 @@ def _normalize_line_item_price_status_for_response(value: object) -> object:
     if payload is None:
         return value
 
-    try:
-        payload["price_status"] = resolve_line_item_price_status(
-            price=payload.get("price"),
-            price_status=(
-                payload.get("price_status")
-                if isinstance(payload.get("price_status"), str)
-                else None
-            ),
-            description=(
-                payload.get("description") if isinstance(payload.get("description"), str) else None
-            ),
-            details=payload.get("details") if isinstance(payload.get("details"), str) else None,
-        )
-    except ValueError:
-        payload["price_status"] = "priced" if payload.get("price") is not None else "unknown"
+    payload["price_status"] = resolve_line_item_price_status_with_fallback(
+        price=payload.get("price"),
+        price_status=(
+            payload.get("price_status") if isinstance(payload.get("price_status"), str) else None
+        ),
+        description=(
+            payload.get("description") if isinstance(payload.get("description"), str) else None
+        ),
+        details=payload.get("details") if isinstance(payload.get("details"), str) else None,
+    )
     return payload
 
 

--- a/backend/app/features/quotes/tests/test_pdf_template.py
+++ b/backend/app/features/quotes/tests/test_pdf_template.py
@@ -89,6 +89,7 @@ def _make_context(
                 description="Leaf cleanup",
                 details=line_item_details,
                 price=line_item_price,
+                price_status="priced" if line_item_price is not None else "unknown",
             )
         ],
         created_at=created_at,
@@ -155,11 +156,11 @@ def test_render_shows_em_dash_for_null_line_item_and_total_prices(
     rendered_html = captured_html[0]
     assert "$0.00" not in rendered_html
     assert "$None" not in rendered_html
-    assert rendered_html.count("&mdash;") == 2
+    assert rendered_html.count("&mdash;") == 1
     assert re.search(
         (
             r"<td>\s*<span class=\"line-item-description\">Leaf cleanup</span>\s*</td>\s*"
-            r"<td class=\"price-col\">\s*&mdash;\s*</td>"
+            r"<td class=\"price-col\">\s*TBD\s*</td>"
         ),
         rendered_html,
         re.DOTALL,
@@ -919,7 +920,7 @@ def test_render_handles_sparse_quote_without_blank_placeholders(
     assert 'class="line-item-details"' not in rendered_html
     assert "CUSTOMER SIGNATURE" in rendered_html
     assert "ACCEPTED BY" not in rendered_html.upper()
-    assert rendered_html.count("&mdash;") == 2
+    assert rendered_html.count("&mdash;") == 1
 
 
 def test_render_handles_denser_quote_layout_without_placeholder_regressions(
@@ -948,6 +949,7 @@ def test_render_handles_denser_quote_layout_without_placeholder_regressions(
                     description=f"Line item {index}",
                     details="Detailed scope line",
                     price=Decimal("130.00"),
+                    price_status="priced",
                 )
                 for index in range(1, 7)
             ],

--- a/backend/app/features/quotes/tests/test_price_status.py
+++ b/backend/app/features/quotes/tests/test_price_status.py
@@ -1,0 +1,32 @@
+"""Unit tests for line-item price-status normalization helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.features.quotes.price_status import (
+    resolve_line_item_price_status,
+    resolve_line_item_price_status_with_fallback,
+)
+
+
+def test_resolve_line_item_price_status_rejects_included_with_numeric_price() -> None:
+    with pytest.raises(ValueError, match="price_status included/unknown requires a null price"):
+        resolve_line_item_price_status(
+            price=90.0,
+            price_status="included",
+            description="Final walkthrough",
+            details="No-charge item",
+        )
+
+
+def test_resolve_line_item_price_status_with_fallback_coerces_invalid_combo() -> None:
+    assert (
+        resolve_line_item_price_status_with_fallback(
+            price=90.0,
+            price_status="included",
+            description="Final walkthrough",
+            details="No-charge item",
+        )
+        == "priced"
+    )

--- a/backend/app/features/quotes/tests/test_quote_append_extraction.py
+++ b/backend/app/features/quotes/tests/test_quote_append_extraction.py
@@ -56,6 +56,48 @@ _override_extraction_service_dependency = quotes_test_module._override_extractio
 _reset_rate_limiter = quotes_test_module._reset_rate_limiter
 
 
+async def test_extraction_review_metadata_parses_legacy_grouped_hidden_details() -> None:
+    metadata = ExtractionReviewMetadataV1.model_validate(
+        {
+            "pipeline_version": "v2",
+            "hidden_details": {
+                "append_suggestions": [
+                    {
+                        "id": "append-note-1",
+                        "kind": "note",
+                        "raw_text": "Add gate note",
+                        "confidence": "medium",
+                        "source": "append_capture",
+                        "pricing_field": None,
+                    }
+                ],
+                "unresolved_segments": [
+                    {
+                        "id": "unresolved-1",
+                        "raw_text": "Clarify edging scope",
+                        "confidence": "low",
+                        "source": "leftover_classification",
+                    }
+                ],
+                "confidence_notes": ["Legacy confidence note"],
+            },
+            "hidden_detail_state": {
+                "append-note-1": {"reviewed": False, "dismissed": True},
+            },
+        }
+    )
+
+    assert [item["kind"] for item in metadata.hidden_details.model_dump(mode="json")["items"]] == [
+        "append_suggestion",
+        "unresolved_segment",
+        "confidence_note",
+    ]
+    assert metadata.hidden_details.items[0].field == "notes"
+    assert metadata.hidden_details.items[0].text == "Add gate note"
+    assert metadata.hidden_details.items[1].reason == "leftover_classification"
+    assert metadata.hidden_details.items[2].text == "Legacy confidence note"
+
+
 async def test_append_extraction_sync_retryable_failure_uses_degraded_append_semantics(
     client: AsyncClient,
     monkeypatch: pytest.MonkeyPatch,
@@ -319,8 +361,15 @@ async def test_append_extraction_resurfaces_previously_dismissed_matching_sugges
 
     detail_response = await client.get(f"/api/quotes/{quote_id}")
     assert detail_response.status_code == 200
-    hidden_state = detail_response.json()["extraction_review_metadata"]["hidden_detail_state"]
-    assert hidden_state[suggestion_id] == {"reviewed": False, "dismissed": False}
+    metadata_payload = detail_response.json()["extraction_review_metadata"]
+    hidden_state = metadata_payload["hidden_detail_state"]
+    next_item = next(
+        item
+        for item in metadata_payload["hidden_details"]["items"]
+        if item["kind"] == "append_suggestion" and item["text"] == suggestion_text
+    )
+    assert next_item["id"] != suggestion_id
+    assert hidden_state[next_item["id"]] == {"reviewed": False, "dismissed": False}
 
 
 async def test_append_extraction_preserves_existing_confidence_notes_when_new_notes_empty(

--- a/backend/app/features/quotes/tests/test_quote_crud.py
+++ b/backend/app/features/quotes/tests/test_quote_crud.py
@@ -7,7 +7,7 @@ from uuid import UUID, uuid4
 
 import pytest
 from httpx import AsyncClient
-from sqlalchemy import func, select
+from sqlalchemy import func, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.features.quotes.models import Document, LineItem, QuoteStatus
@@ -193,6 +193,96 @@ async def test_quote_crud_happy_path_with_ordering_and_line_item_replacement(
     assert patched["notes"] == "Updated note"
 
 
+async def test_quote_detail_price_status_round_trip(
+    client: AsyncClient,
+) -> None:
+    csrf_token = await _register_and_login(client, _credentials())
+    customer_id = await _create_customer(client, csrf_token)
+
+    create_response = await client.post(
+        "/api/quotes",
+        json={
+            "customer_id": customer_id,
+            "transcript": "Initial quote",
+            "line_items": [
+                {"description": "Brown mulch", "details": None, "price": 120},
+                {
+                    "description": "Cleanup labor",
+                    "details": "Included / no charge",
+                    "price": None,
+                    "price_status": "included",
+                },
+                {
+                    "description": "Optional edging",
+                    "details": "Need to confirm price onsite",
+                    "price": None,
+                    "price_status": "unknown",
+                },
+            ],
+            "total_amount": 120,
+            "notes": None,
+            "source_type": "text",
+        },
+        headers={"X-CSRF-Token": csrf_token},
+    )
+    assert create_response.status_code == 201
+    payload = create_response.json()
+    assert [item["price_status"] for item in payload["line_items"]] == [
+        "priced",
+        "included",
+        "unknown",
+    ]
+
+    detail_response = await client.get(f"/api/quotes/{payload['id']}")
+    assert detail_response.status_code == 200
+    detail_payload = detail_response.json()
+    assert [item["price_status"] for item in detail_payload["line_items"]] == [
+        "priced",
+        "included",
+        "unknown",
+    ]
+
+
+async def test_quote_detail_normalizes_pre_v25_rows_with_null_price_status(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    csrf_token = await _register_and_login(client, _credentials())
+    customer_id = await _create_customer(client, csrf_token)
+    create_response = await client.post(
+        "/api/quotes",
+        json={
+            "customer_id": customer_id,
+            "transcript": "Legacy normalization test",
+            "line_items": [
+                {"description": "Brown mulch", "details": None, "price": 120},
+                {"description": "Cleanup labor", "details": "Included / no charge", "price": None},
+                {"description": "Optional edging", "details": "Need estimate", "price": None},
+            ],
+            "total_amount": 120,
+            "notes": None,
+            "source_type": "text",
+        },
+        headers={"X-CSRF-Token": csrf_token},
+    )
+    assert create_response.status_code == 201
+    quote_id = UUID(create_response.json()["id"])
+
+    await db_session.execute(
+        update(LineItem).where(LineItem.document_id == quote_id).values(price_status=None)
+    )
+    await db_session.commit()
+
+    detail_response = await client.get(f"/api/quotes/{quote_id}")
+    assert detail_response.status_code == 200
+    detail_payload = detail_response.json()
+    assert [item["price_status"] for item in detail_payload["line_items"]] == [
+        "priced",
+        "included",
+        "unknown",
+    ]
+
+
 async def test_get_quote_returns_404_for_nonexistent_id(client: AsyncClient) -> None:
     await _register_and_login(client, _credentials())
 
@@ -281,6 +371,7 @@ async def test_create_manual_draft_without_customer_persists_empty_draft_and_log
         "pricing_pending": False,
     }
     assert detail_payload["extraction_review_metadata"]["hidden_details"] == {
+        "items": [],
         "unresolved_segments": [],
         "append_suggestions": [],
         "confidence_notes": [],
@@ -502,6 +593,7 @@ async def test_update_quote_replaces_line_items_when_provided(
             "description": "Premium mulch refresh",
             "details": "6 yards",
             "price": 180.0,
+            "price_status": "priced",
             "flagged": False,
             "flag_reason": None,
             "sort_order": 0,

--- a/backend/app/features/quotes/tests/test_quote_to_invoice.py
+++ b/backend/app/features/quotes/tests/test_quote_to_invoice.py
@@ -436,6 +436,7 @@ async def test_convert_quote_to_invoice_rejects_duplicates_and_patch_preserves_s
             "details": "Touch-up and cleanup",
             "id": patched_invoice["line_items"][0]["id"],
             "price": 90.0,
+            "price_status": "priced",
             "flagged": False,
             "flag_reason": None,
             "sort_order": 0,

--- a/backend/app/templates/quote.html
+++ b/backend/app/templates/quote.html
@@ -484,8 +484,10 @@
             <td class="price-col">
               {% if line_item.price is not none %}
               ${{ "{:,.2f}".format(line_item.price) }}
+              {% elif line_item.price_status == "included" %}
+              Included
               {% else %}
-              &mdash;
+              TBD
               {% endif %}
             </td>
           </tr>

--- a/frontend/src/features/public/components/PublicQuotePage.tsx
+++ b/frontend/src/features/public/components/PublicQuotePage.tsx
@@ -6,6 +6,7 @@ import {
   publicService,
 } from "@/features/public/services/publicService";
 import type { PublicDocument } from "@/features/public/types/public.types";
+import { resolvePriceStatus } from "@/features/quotes/utils/priceStatus";
 import { PricingRow } from "@/shared/components/PricingRow";
 import { formatCurrency } from "@/shared/lib/formatters";
 import { calculatePricingFromPersisted, resolveLineItemSum } from "@/shared/lib/pricing";
@@ -277,28 +278,38 @@ export function PublicQuotePage(): React.ReactElement {
                 </span>
               </div>
               <ul className="mt-4 space-y-3">
-                {documentData.line_items.map((item, index) => (
-                  <li
-                    key={`${index}-${item.description}-${item.details ?? "none"}`}
-                    className="rounded-2xl border border-surface-container-high bg-surface-container-lowest p-4"
-                  >
-                    <div className="flex items-start justify-between gap-4">
-                      <div className="min-w-0">
-                        <p className="font-semibold break-words [overflow-wrap:anywhere]">
-                          {item.description}
-                        </p>
-                        {item.details ? (
-                          <p className="mt-1 text-sm text-on-surface-variant break-words [overflow-wrap:anywhere]">
-                            {item.details}
+                {documentData.line_items.map((item, index) => {
+                  const resolvedPriceStatus = resolvePriceStatus({
+                    price: item.price,
+                    priceStatus: item.price_status,
+                    description: item.description,
+                    details: item.details,
+                  });
+                  return (
+                    <li
+                      key={`${index}-${item.description}-${item.details ?? "none"}`}
+                      className="rounded-2xl border border-surface-container-high bg-surface-container-lowest p-4"
+                    >
+                      <div className="flex items-start justify-between gap-4">
+                        <div className="min-w-0">
+                          <p className="font-semibold break-words [overflow-wrap:anywhere]">
+                            {item.description}
                           </p>
-                        ) : null}
+                          {item.details ? (
+                            <p className="mt-1 text-sm text-on-surface-variant break-words [overflow-wrap:anywhere]">
+                              {item.details}
+                            </p>
+                          ) : null}
+                        </div>
+                        <p className={`shrink-0 text-sm font-semibold ${resolvedPriceStatus === "included" ? "text-success" : ""}`}>
+                          {resolvedPriceStatus === "priced" && item.price !== null
+                            ? formatCurrency(item.price)
+                            : (resolvedPriceStatus === "included" ? "Included" : "TBD")}
+                        </p>
                       </div>
-                      <p className="shrink-0 text-sm font-semibold">
-                        {item.price !== null ? formatCurrency(item.price) : "TBD"}
-                      </p>
-                    </div>
-                  </li>
-                ))}
+                    </li>
+                  );
+                })}
               </ul>
             </section>
 

--- a/frontend/src/features/public/types/public.types.ts
+++ b/frontend/src/features/public/types/public.types.ts
@@ -1,4 +1,5 @@
 import type { DiscountType } from "@/shared/lib/pricing";
+import type { PriceStatus } from "@/features/quotes/types/quote.types";
 
 export type PublicQuoteStatus = "shared" | "viewed" | "approved" | "declined";
 export type PublicInvoiceStatus = "sent";
@@ -7,6 +8,7 @@ export interface PublicDocumentLineItem {
   description: string;
   details: string | null;
   price: number | null;
+  price_status?: PriceStatus;
 }
 
 interface PublicDocumentBase {

--- a/frontend/src/features/quotes/components/CaptureDetailsSheet.tsx
+++ b/frontend/src/features/quotes/components/CaptureDetailsSheet.tsx
@@ -13,6 +13,14 @@ interface CaptureDetailsSheetProps {
   isMutating?: boolean;
 }
 
+interface ResolvedHiddenItem {
+  id: string;
+  kind: "append_suggestion" | "unresolved_segment" | "confidence_note";
+  field: "notes" | "explicit_total" | "deposit_amount" | "tax_rate" | "discount" | null;
+  reason: string | null;
+  text: string;
+}
+
 function formatPricingField(
   pricingField: "explicit_total" | "deposit_amount" | "tax_rate" | "discount" | null | undefined,
 ): string | null {
@@ -40,6 +48,44 @@ function renderEmptySection(message: string): React.ReactElement {
   );
 }
 
+function resolveHiddenItems(hiddenDetails?: ExtractionReviewHiddenDetails): ResolvedHiddenItem[] {
+  if (!hiddenDetails) {
+    return [];
+  }
+  if (Array.isArray(hiddenDetails.items) && hiddenDetails.items.length > 0) {
+    return hiddenDetails.items.map((item) => ({
+      id: item.id,
+      kind: item.kind,
+      field: item.field ?? null,
+      reason: item.reason ?? null,
+      text: item.text,
+    }));
+  }
+
+  const fromSuggestions: ResolvedHiddenItem[] = hiddenDetails.append_suggestions.map((suggestion) => ({
+    id: suggestion.id,
+    kind: "append_suggestion",
+    field: suggestion.pricing_field ?? "notes",
+    reason: suggestion.source,
+    text: suggestion.raw_text,
+  }));
+  const fromUnresolved: ResolvedHiddenItem[] = hiddenDetails.unresolved_segments.map((segment) => ({
+    id: segment.id,
+    kind: "unresolved_segment",
+    field: null,
+    reason: segment.source,
+    text: segment.raw_text,
+  }));
+  const fromConfidence: ResolvedHiddenItem[] = hiddenDetails.confidence_notes.map((note, index) => ({
+    id: `legacy-confidence-${index}`,
+    kind: "confidence_note",
+    field: null,
+    reason: "legacy_confidence_note",
+    text: note,
+  }));
+  return [...fromSuggestions, ...fromUnresolved, ...fromConfidence];
+}
+
 export function CaptureDetailsSheet({
   open,
   onClose,
@@ -50,14 +96,15 @@ export function CaptureDetailsSheet({
   onDismissHiddenItem,
   isMutating = false,
 }: CaptureDetailsSheetProps): React.ReactElement {
-  const appendSuggestions = hiddenDetails?.append_suggestions ?? [];
-  const unresolvedSegments = hiddenDetails?.unresolved_segments ?? [];
-  const confidenceNotes = hiddenDetails?.confidence_notes ?? [];
-  const visibleAppendSuggestions = appendSuggestions.filter(
-    (suggestion) => !hiddenDetailState?.[suggestion.id]?.dismissed,
+  const hiddenItems = resolveHiddenItems(hiddenDetails);
+  const visibleAppendSuggestions = hiddenItems.filter(
+    (item) => item.kind === "append_suggestion" && !hiddenDetailState?.[item.id]?.dismissed,
   );
-  const visibleUnresolvedSegments = unresolvedSegments.filter(
-    (segment) => !hiddenDetailState?.[segment.id]?.dismissed,
+  const visibleUnresolvedSegments = hiddenItems.filter(
+    (item) => item.kind === "unresolved_segment" && !hiddenDetailState?.[item.id]?.dismissed,
+  );
+  const visibleConfidenceNotes = hiddenItems.filter(
+    (item) => item.kind === "confidence_note" && !hiddenDetailState?.[item.id]?.dismissed,
   );
 
   return (
@@ -84,7 +131,9 @@ export function CaptureDetailsSheet({
                 {visibleAppendSuggestions.length === 0 ? renderEmptySection("No new suggestions from the latest capture.") : (
                   <ul className="space-y-2">
                     {visibleAppendSuggestions.map((suggestion) => {
-                      const pricingField = formatPricingField(suggestion.pricing_field);
+                      const pricingField = formatPricingField(
+                        suggestion.field === "notes" ? null : suggestion.field,
+                      );
                       const itemState = hiddenDetailState?.[suggestion.id];
                       return (
                         <li
@@ -92,10 +141,10 @@ export function CaptureDetailsSheet({
                           className="rounded-lg border border-outline-variant/30 bg-surface-container-high p-3 text-sm text-on-surface"
                         >
                           <p className="font-semibold">
-                            {suggestion.kind === "pricing" ? "Pricing suggestion" : "Notes suggestion"}
+                            {suggestion.field === "notes" ? "Notes suggestion" : "Pricing suggestion"}
                             {pricingField ? ` (${pricingField})` : ""}
                           </p>
-                          <p className="mt-1 whitespace-pre-wrap text-on-surface-variant">{suggestion.raw_text}</p>
+                          <p className="mt-1 whitespace-pre-wrap text-on-surface-variant">{suggestion.text}</p>
                           <div className="mt-3 flex items-center gap-2">
                             {itemState?.reviewed ? (
                               <span className="rounded-full bg-success/10 px-2 py-0.5 text-[0.6875rem] font-semibold uppercase tracking-wide text-success">
@@ -141,9 +190,9 @@ export function CaptureDetailsSheet({
                           className="rounded-lg border border-outline-variant/30 bg-surface-container-high p-3 text-sm text-on-surface"
                         >
                           <p className="font-semibold">
-                            {segment.source.replaceAll("_", " ")}
+                            {(segment.reason ?? "leftover_classification").replaceAll("_", " ")}
                           </p>
-                          <p className="mt-1 whitespace-pre-wrap text-on-surface-variant">{segment.raw_text}</p>
+                          <p className="mt-1 whitespace-pre-wrap text-on-surface-variant">{segment.text}</p>
                           <div className="mt-3 flex items-center gap-2">
                             {itemState?.reviewed ? (
                               <span className="rounded-full bg-success/10 px-2 py-0.5 text-[0.6875rem] font-semibold uppercase tracking-wide text-success">
@@ -179,14 +228,14 @@ export function CaptureDetailsSheet({
                 <h3 className="text-[0.6875rem] font-bold uppercase tracking-widest text-outline">
                   AI Review Notes
                 </h3>
-                {confidenceNotes.length === 0 ? renderEmptySection("No AI review notes.") : (
+                {visibleConfidenceNotes.length === 0 ? renderEmptySection("No AI review notes.") : (
                   <ul className="space-y-2">
-                    {confidenceNotes.map((note, index) => (
+                    {visibleConfidenceNotes.map((note) => (
                       <li
-                        key={`${note}-${index}`}
+                        key={note.id}
                         className="rounded-lg border border-outline-variant/30 bg-surface-container-high p-3 text-sm text-on-surface whitespace-pre-wrap"
                       >
-                        {note}
+                        {note.text}
                       </li>
                     ))}
                   </ul>

--- a/frontend/src/features/quotes/components/CaptureScreen.tsx
+++ b/frontend/src/features/quotes/components/CaptureScreen.tsx
@@ -121,6 +121,7 @@ export function CaptureScreen(): React.ReactElement {
         description: lineItem.description,
         details: lineItem.details,
         price: lineItem.price,
+        priceStatus: lineItem.price_status,
         flagged: lineItem.flagged,
         flagReason: lineItem.flag_reason,
       })),

--- a/frontend/src/features/quotes/components/LineItemCard.tsx
+++ b/frontend/src/features/quotes/components/LineItemCard.tsx
@@ -1,7 +1,11 @@
+import type { PriceStatus } from "@/features/quotes/types/quote.types";
+import { getPriceStatusLabel, resolvePriceStatus } from "@/features/quotes/utils/priceStatus";
+
 interface LineItemCardProps {
   description: string;
   details: string | null;
   price: number | null;
+  priceStatus?: PriceStatus | null;
   flagged?: boolean;
   disabled?: boolean;
   ariaLabel?: string;
@@ -12,11 +16,14 @@ export function LineItemCard({
   description,
   details,
   price,
+  priceStatus,
   flagged = false,
   disabled = false,
   ariaLabel,
   onClick,
 }: LineItemCardProps): React.ReactElement {
+  const resolvedStatus = resolvePriceStatus({ price, priceStatus, description, details });
+  const priceLabel = getPriceStatusLabel({ price, priceStatus: resolvedStatus, description, details });
   return (
     <button
       type="button"
@@ -39,7 +46,15 @@ export function LineItemCard({
         {details ? <p className="mt-0.5 text-sm text-on-surface-variant">{details}</p> : null}
       </div>
       <div className="flex shrink-0 items-center gap-2">
-        {price != null ? <p className="font-bold text-on-surface">${price.toFixed(2)}</p> : null}
+        <p
+          className={`font-bold ${
+            resolvedStatus === "included"
+              ? "text-success"
+              : "text-on-surface"
+          }`}
+        >
+          {priceLabel}
+        </p>
         <span className="material-symbols-outlined text-outline">chevron_right</span>
       </div>
     </button>

--- a/frontend/src/features/quotes/components/LineItemEditSheet.tsx
+++ b/frontend/src/features/quotes/components/LineItemEditSheet.tsx
@@ -2,6 +2,7 @@ import { useRef, useState } from "react";
 import * as Dialog from "@radix-ui/react-dialog";
 
 import type { LineItemDraftWithFlags } from "@/features/quotes/types/quote.types";
+import { resolvePriceStatus } from "@/features/quotes/utils/priceStatus";
 import { FeedbackMessage } from "@/shared/components/FeedbackMessage";
 import {
   LINE_ITEM_DESCRIPTION_MAX_CHARS,
@@ -50,6 +51,14 @@ export function LineItemEditSheet({
   const [priceInput, setPriceInput] = useState(
     initialLineItem.price == null ? "" : initialLineItem.price.toString(),
   );
+  const [isIncluded, setIsIncluded] = useState(
+    resolvePriceStatus({
+      price: initialLineItem.price,
+      priceStatus: initialLineItem.priceStatus,
+      description: initialLineItem.description,
+      details: initialLineItem.details,
+    }) === "included",
+  );
   const [formError, setFormError] = useState<string | null>(null);
   const title = mode === "edit" ? "Edit Line Item" : "Add Line Item";
 
@@ -67,11 +76,15 @@ export function LineItemEditSheet({
     }
 
     setFormError(null);
+    const resolvedPriceStatus = parsedPrice.value !== null
+      ? "priced"
+      : (isIncluded ? "included" : "unknown");
     onSave({
       ...initialLineItem,
       description: trimmedDescription,
       details: details.trim().length > 0 ? details.trim() : null,
-      price: parsedPrice.value,
+      price: resolvedPriceStatus === "priced" ? parsedPrice.value : null,
+      priceStatus: resolvedPriceStatus,
     });
   }
 
@@ -145,9 +158,30 @@ export function LineItemEditSheet({
                   inputMode="decimal"
                   placeholder="$ 0.00"
                   value={priceInput}
-                  onChange={(event) => setPriceInput(event.target.value)}
+                  disabled={isIncluded}
+                  onChange={(event) => {
+                    setPriceInput(event.target.value);
+                    if (event.target.value.trim().length > 0) {
+                      setIsIncluded(false);
+                    }
+                  }}
                   className="w-full rounded-lg bg-surface-container-high px-4 py-3 font-body text-sm text-on-surface placeholder:text-outline transition-all focus:bg-surface-container-lowest focus:outline-none focus:ring-2 focus:ring-primary/30"
                 />
+                <label className="mt-2 inline-flex items-center gap-2 text-sm text-on-surface-variant">
+                  <input
+                    id="line-item-sheet-included"
+                    type="checkbox"
+                    checked={isIncluded}
+                    onChange={(event) => {
+                      const nextIncluded = event.target.checked;
+                      setIsIncluded(nextIncluded);
+                      if (nextIncluded) {
+                        setPriceInput("");
+                      }
+                    }}
+                  />
+                  Included / no-charge item
+                </label>
               </section>
             </div>
 

--- a/frontend/src/features/quotes/components/QuoteLineItemsSection.tsx
+++ b/frontend/src/features/quotes/components/QuoteLineItemsSection.tsx
@@ -1,6 +1,7 @@
 import { formatCurrency } from "@/shared/lib/formatters";
 
 import type { LineItem } from "@/features/quotes/types/quote.types";
+import { resolvePriceStatus } from "@/features/quotes/utils/priceStatus";
 
 interface QuoteLineItemsSectionProps {
   lineItems: LineItem[];
@@ -20,26 +21,36 @@ export function QuoteLineItemsSection({
         </span>
       </div>
       <ul className="space-y-2">
-        {lineItems.map((item) => (
-          <li
-            key={item.id}
-            className="ghost-shadow flex items-start justify-between rounded-lg bg-surface-container-lowest p-3"
-          >
-            <div className="min-w-0 flex-1">
-              <p className="font-medium text-on-surface break-words [overflow-wrap:anywhere]">
-                {item.description}
-              </p>
-              {item.details ? (
-                <p className="mt-1 text-sm text-on-surface-variant break-words [overflow-wrap:anywhere]">
-                  {item.details}
+        {lineItems.map((item) => {
+          const resolvedPriceStatus = resolvePriceStatus({
+            price: item.price,
+            priceStatus: item.price_status,
+            description: item.description,
+            details: item.details,
+          });
+          return (
+            <li
+              key={item.id}
+              className="ghost-shadow flex items-start justify-between rounded-lg bg-surface-container-lowest p-3"
+            >
+              <div className="min-w-0 flex-1">
+                <p className="font-medium text-on-surface break-words [overflow-wrap:anywhere]">
+                  {item.description}
                 </p>
-              ) : null}
-            </div>
-            <p className="ml-4 shrink-0 font-bold text-on-surface">
-              {item.price !== null ? formatCurrency(item.price) : "TBD"}
-            </p>
-          </li>
-        ))}
+                {item.details ? (
+                  <p className="mt-1 text-sm text-on-surface-variant break-words [overflow-wrap:anywhere]">
+                    {item.details}
+                  </p>
+                ) : null}
+              </div>
+              <p className={`ml-4 shrink-0 font-bold ${resolvedPriceStatus === "included" ? "text-success" : "text-on-surface"}`}>
+                {resolvedPriceStatus === "priced" && item.price !== null
+                  ? formatCurrency(item.price)
+                  : (resolvedPriceStatus === "included" ? "Included" : "TBD")}
+              </p>
+            </li>
+          );
+        })}
       </ul>
     </section>
   );

--- a/frontend/src/features/quotes/components/ReviewFormContent.tsx
+++ b/frontend/src/features/quotes/components/ReviewFormContent.tsx
@@ -30,12 +30,35 @@ function ReviewPendingMarker({ title, message }: ReviewPendingMarkerProps): Reac
   );
 }
 
+function resolveHiddenActionableItems(hiddenDetails?: ExtractionReviewHiddenDetails): Array<{ id: string }> {
+  if (!hiddenDetails) {
+    return [];
+  }
+  if (Array.isArray(hiddenDetails.items) && hiddenDetails.items.length > 0) {
+    return hiddenDetails.items;
+  }
+
+  const legacyItems = [
+    ...hiddenDetails.append_suggestions.map((item) => ({ id: item.id })),
+    ...hiddenDetails.unresolved_segments.map((item) => ({ id: item.id })),
+    ...hiddenDetails.confidence_notes.map((_, index) => ({ id: `legacy-confidence-${index}` })),
+  ];
+  return legacyItems;
+}
+
 interface ReviewFormContentProps {
   customerName: string | null;
   draft: {
     title: string;
     transcript?: string;
-    lineItems: Array<{ description: string; details: string | null; price: number | null; flagged?: boolean; flagReason?: string | null }>;
+    lineItems: Array<{
+      description: string;
+      details: string | null;
+      price: number | null;
+      priceStatus?: "priced" | "included" | "unknown";
+      flagged?: boolean;
+      flagReason?: string | null;
+    }>;
     total: number | null;
     taxRate: number | null;
     discountType: "fixed" | "percent" | null;
@@ -121,18 +144,8 @@ export function ReviewFormContent({
   const showQuoteOnlySections = documentType === "quote";
   const showSevereDegradedMarker = extractionTier === "degraded"
     && draft.lineItems.length === 0;
-  const hasVisibleAppendSuggestions = Boolean(
-    hiddenDetails?.append_suggestions.some((suggestion) => !hiddenDetailState?.[suggestion.id]?.dismissed),
-  );
-  const hasVisibleUnresolvedSegments = Boolean(
-    hiddenDetails?.unresolved_segments.some((segment) => !hiddenDetailState?.[segment.id]?.dismissed),
-  );
-  const hasHiddenActionableItems = Boolean(
-    hiddenDetails
-      && (hasVisibleAppendSuggestions
-        || hasVisibleUnresolvedSegments
-        || hiddenDetails.confidence_notes.length > 0),
-  );
+  const hasHiddenActionableItems = resolveHiddenActionableItems(hiddenDetails)
+    .some((item) => !hiddenDetailState?.[item.id]?.dismissed);
 
   return (
     <form

--- a/frontend/src/features/quotes/components/ReviewLineItemsSection.tsx
+++ b/frontend/src/features/quotes/components/ReviewLineItemsSection.tsx
@@ -41,6 +41,7 @@ export function ReviewLineItemsSection({
                 description={displayDescription}
                 details={lineItem.details}
                 price={lineItem.price}
+                priceStatus={lineItem.priceStatus}
                 flagged={lineItem.flagged}
                 disabled={isInteractionLocked}
                 onClick={() => onEditLineItem(index)}

--- a/frontend/src/features/quotes/components/reviewScreenUtils.ts
+++ b/frontend/src/features/quotes/components/reviewScreenUtils.ts
@@ -5,6 +5,7 @@ import type {
   LineItemDraftWithFlags,
 } from "@/features/quotes/types/quote.types";
 import { normalizeOptionalTitle } from "@/features/quotes/utils/normalizeOptionalTitle";
+import { resolvePriceStatus } from "@/features/quotes/utils/priceStatus";
 
 export const EMPTY_LINE_ITEM: LineItemDraftWithFlags = {
   description: "",
@@ -14,10 +15,17 @@ export const EMPTY_LINE_ITEM: LineItemDraftWithFlags = {
 
 export function normalizeLineItem(item: LineItemDraftWithFlags): LineItemDraftWithFlags {
   const normalizedDetails = item.details?.trim() ?? "";
+  const details = normalizedDetails.length > 0 ? normalizedDetails : null;
   return {
     description: item.description.trim(),
-    details: normalizedDetails.length > 0 ? normalizedDetails : null,
+    details,
     price: item.price,
+    priceStatus: resolvePriceStatus({
+      price: item.price,
+      priceStatus: item.priceStatus,
+      description: item.description,
+      details,
+    }),
     flagged: item.flagged,
     flagReason: item.flagReason,
   };
@@ -44,6 +52,7 @@ export function buildLineItemSubmitState(lineItems: LineItemDraftWithFlags[]): {
       description: lineItem.description,
       details: lineItem.details,
       price: lineItem.price,
+      price_status: lineItem.priceStatus,
       flagged: lineItem.flagged,
       flag_reason: lineItem.flagReason ?? null,
     }));
@@ -66,6 +75,7 @@ export function mapExtractedLineItems(extraction: ExtractionResult): LineItemDra
     description: lineItem.description,
     details: lineItem.details,
     price: lineItem.price,
+    priceStatus: lineItem.price_status,
     flagged: lineItem.flagged,
     flagReason: lineItem.flag_reason,
   }));

--- a/frontend/src/features/quotes/hooks/persistedDocumentDraft.ts
+++ b/frontend/src/features/quotes/hooks/persistedDocumentDraft.ts
@@ -218,7 +218,7 @@ export function mapInvoiceToEditDraft(invoice: InvoiceDetail): DocumentEditDraft
       description: item.description,
       details: item.details,
       price: item.price,
-      priceStatus: item.price !== null ? "priced" : "unknown",
+      priceStatus: item.price_status ?? (item.price !== null ? "priced" : "unknown"),
     })),
     total: breakdown.subtotal ?? invoice.total_amount,
     taxRate: invoice.tax_rate,

--- a/frontend/src/features/quotes/hooks/persistedDocumentDraft.ts
+++ b/frontend/src/features/quotes/hooks/persistedDocumentDraft.ts
@@ -40,6 +40,7 @@ function isValidLineItemDraft(value: unknown): value is LineItemDraftWithFlags {
     description,
     details,
     price,
+    priceStatus,
     flagged,
     flagReason,
   } = value;
@@ -48,6 +49,7 @@ function isValidLineItemDraft(value: unknown): value is LineItemDraftWithFlags {
     typeof description === "string"
     && (details === null || details === undefined || typeof details === "string")
     && (price === null || price === undefined || typeof price === "number")
+    && (priceStatus === undefined || priceStatus === "priced" || priceStatus === "included" || priceStatus === "unknown")
     && (flagged === undefined || typeof flagged === "boolean")
     && (flagReason === undefined || flagReason === null || typeof flagReason === "string")
   );
@@ -180,6 +182,7 @@ export function mapQuoteToEditDraft(quote: QuoteDetail): DocumentEditDraft {
       description: item.description,
       details: item.details,
       price: item.price,
+      priceStatus: item.price_status,
       flagged: item.flagged,
       flagReason: item.flag_reason,
     })),
@@ -215,6 +218,7 @@ export function mapInvoiceToEditDraft(invoice: InvoiceDetail): DocumentEditDraft
       description: item.description,
       details: item.details,
       price: item.price,
+      priceStatus: item.price !== null ? "priced" : "unknown",
     })),
     total: breakdown.subtotal ?? invoice.total_amount,
     taxRate: invoice.tax_rate,

--- a/frontend/src/features/quotes/tests/LineItemCard.test.tsx
+++ b/frontend/src/features/quotes/tests/LineItemCard.test.tsx
@@ -34,6 +34,20 @@ describe("LineItemCard", () => {
     expect(screen.getByText("REVIEW")).toBeInTheDocument();
   });
 
+  it("renders included rows with Included label", () => {
+    render(
+      <LineItemCard
+        description="Cleanup labor"
+        details="No separate charge"
+        price={null}
+        priceStatus="included"
+        onClick={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Included")).toBeInTheDocument();
+  });
+
   it("fires onClick when card is clicked", () => {
     const onClickMock = vi.fn();
     render(

--- a/frontend/src/features/quotes/tests/LineItemEditSheet.test.tsx
+++ b/frontend/src/features/quotes/tests/LineItemEditSheet.test.tsx
@@ -10,6 +10,7 @@ function makeLineItem(overrides: Partial<LineItemDraftWithFlags> = {}): LineItem
     description: "Brown mulch",
     details: "5 yards",
     price: 120,
+    priceStatus: "priced",
     flagged: true,
     flagReason: "Needs review",
     ...overrides,
@@ -97,6 +98,33 @@ describe("LineItemEditSheet", () => {
       description: "Premium mulch",
       details: "6 yards",
       price: null,
+      priceStatus: "unknown",
+      flagged: true,
+      flagReason: "Needs review",
+    });
+  });
+
+  it("saves included/no-charge rows with included price status", () => {
+    const onSave = vi.fn();
+
+    render(
+      <LineItemEditSheet
+        open
+        mode="edit"
+        initialLineItem={makeLineItem()}
+        onClose={vi.fn()}
+        onSave={onSave}
+      />,
+    );
+
+    fireEvent.click(screen.getByLabelText(/included \/ no-charge item/i));
+    fireEvent.click(screen.getByRole("button", { name: /^save$/i }));
+
+    expect(onSave).toHaveBeenCalledWith({
+      description: "Brown mulch",
+      details: "5 yards",
+      price: null,
+      priceStatus: "included",
       flagged: true,
       flagReason: "Needs review",
     });

--- a/frontend/src/features/quotes/tests/ReviewScreen.test.tsx
+++ b/frontend/src/features/quotes/tests/ReviewScreen.test.tsx
@@ -281,6 +281,24 @@ afterEach(() => {
 });
 
 describe("DocumentEditScreen", () => {
+  it("preserves included invoice line-item status when hydrating edit draft", () => {
+    const invoice = makeInvoice({
+      line_items: [
+        {
+          id: "line-included",
+          description: "Permit fee",
+          details: "Included in project scope",
+          price: null,
+          price_status: "included",
+          sort_order: 0,
+        },
+      ],
+    });
+
+    const draft = mapInvoiceToEditDraft(invoice);
+    expect(draft.lineItems[0]?.priceStatus).toBe("included");
+  });
+
   it("disables invoice type when no customer is selected", async () => {
     renderScreen({
       document: makeQuote({

--- a/frontend/src/features/quotes/tests/reviewScreenState.test.ts
+++ b/frontend/src/features/quotes/tests/reviewScreenState.test.ts
@@ -21,8 +21,8 @@ describe("reviewScreenState", () => {
     });
 
     expect(snapshot.lineItems).toEqual([
-      { description: "", details: "Has details", price: null },
-      { description: "", details: null, price: 25 },
+      { description: "", details: "Has details", price: null, price_status: "unknown" },
+      { description: "", details: null, price: 25, price_status: "priced" },
     ]);
   });
 });

--- a/frontend/src/features/quotes/types/quote.types.ts
+++ b/frontend/src/features/quotes/types/quote.types.ts
@@ -1,10 +1,13 @@
 import type { InvoiceStatus } from "@/features/invoices/types/invoice-status";
 import type { DiscountType } from "@/shared/lib/pricing";
 
+export type PriceStatus = "priced" | "included" | "unknown";
+
 export interface LineItemDraft {
   description: string;
   details: string | null;
   price: number | null;
+  price_status?: PriceStatus;
   flagged?: boolean;
   flag_reason?: string | null;
 }
@@ -19,6 +22,7 @@ export interface LineItemExtracted extends LineItemDraft {
 export interface LineItemDraftWithFlags extends LineItemDraft {
   flagged?: boolean;
   flagReason?: string | null;
+  priceStatus?: PriceStatus;
 }
 
 export type PlacementConfidence = "high" | "medium" | "low";
@@ -49,7 +53,7 @@ export interface UnresolvedSegment {
 
 export interface ExtractionResult {
   transcript: string;
-  pipeline_version: "v2";
+  pipeline_version: "v2" | "v2.5";
   line_items: LineItemExtracted[];
   pricing_hints: PricingHints;
   customer_notes_suggestion: ExtractionSuggestion | null;
@@ -98,6 +102,7 @@ export interface LineItem {
   description: string;
   details: string | null;
   price: number | null;
+  price_status?: PriceStatus;
   flagged?: boolean;
   flag_reason?: string | null;
   sort_order: number;
@@ -183,6 +188,13 @@ export interface PricingSeededFieldMetadata {
 }
 
 export interface ExtractionReviewHiddenDetails {
+  items?: Array<{
+    id: string;
+    kind: "append_suggestion" | "unresolved_segment" | "confidence_note";
+    field?: "notes" | "explicit_total" | "deposit_amount" | "tax_rate" | "discount" | null;
+    reason?: string | null;
+    text: string;
+  }>;
   unresolved_segments: Array<{
     id: string;
     raw_text: string;
@@ -206,7 +218,7 @@ export interface HiddenItemState {
 }
 
 export interface ExtractionReviewMetadata {
-  pipeline_version: "v2";
+  pipeline_version: "v2" | "v2.5";
   review_state: ExtractionReviewState;
   seeded_fields: {
     notes: NotesSeededFieldMetadata;

--- a/frontend/src/features/quotes/utils/priceStatus.ts
+++ b/frontend/src/features/quotes/utils/priceStatus.ts
@@ -1,0 +1,45 @@
+import type { PriceStatus } from "@/features/quotes/types/quote.types";
+
+const INCLUDED_NO_CHARGE_PATTERN = /\b(included|no[\s-]?charge|n\/?c|complimentary|at no cost)\b/i;
+
+export function hasIncludedNoChargeLanguage(...parts: Array<string | null | undefined>): boolean {
+  return parts.some((part) => typeof part === "string" && INCLUDED_NO_CHARGE_PATTERN.test(part));
+}
+
+export function resolvePriceStatus(options: {
+  price: number | null;
+  priceStatus?: PriceStatus | null;
+  description?: string | null;
+  details?: string | null;
+}): PriceStatus {
+  const normalizedStatus = options.priceStatus?.trim().toLowerCase();
+  if (normalizedStatus === "priced") {
+    return options.price !== null ? "priced" : "unknown";
+  }
+  if (normalizedStatus === "included" || normalizedStatus === "unknown") {
+    return options.price !== null ? "priced" : normalizedStatus;
+  }
+  if (options.price !== null) {
+    return "priced";
+  }
+  if (hasIncludedNoChargeLanguage(options.description, options.details)) {
+    return "included";
+  }
+  return "unknown";
+}
+
+export function getPriceStatusLabel(options: {
+  price: number | null;
+  priceStatus?: PriceStatus | null;
+  description?: string | null;
+  details?: string | null;
+}): string {
+  const resolvedStatus = resolvePriceStatus(options);
+  if (resolvedStatus === "priced" && options.price !== null) {
+    return `$${options.price.toFixed(2)}`;
+  }
+  if (resolvedStatus === "included") {
+    return "Included";
+  }
+  return "TBD";
+}

--- a/frontend/src/features/quotes/utils/reviewScreenState.ts
+++ b/frontend/src/features/quotes/utils/reviewScreenState.ts
@@ -29,7 +29,12 @@ export function buildDraftSnapshot(
     docType?: "quote" | "invoice";
     title: string;
     transcript?: string;
-    lineItems: { description: string; details: string | null; price: number | null }[];
+    lineItems: {
+      description: string;
+      details: string | null;
+      price: number | null;
+      priceStatus?: "priced" | "included" | "unknown";
+    }[];
     total: number | null;
     taxRate: number | null;
     discountType: "fixed" | "percent" | null;
@@ -50,6 +55,7 @@ export function buildDraftSnapshot(
       description: lineItem.description,
       details: lineItem.details,
       price: lineItem.price,
+      price_status: lineItem.priceStatus,
     }));
 
   return {


### PR DESCRIPTION
## Summary
- add persisted `price_status` semantics (`priced`/`included`/`unknown`) across quote+invoice line-item models, schemas, repository mapping, and render contexts
- normalize legacy rows/metadata and introduce unified actionable sidecar `hidden_details.items` with compatibility bridges for prior grouped shapes
- update frontend draft/review/public flows so line-item editing and display distinguish priced vs included vs unknown, including updated tests and migration coverage

## Verification
- `cd backend && .venv/bin/pytest app/features/quotes/tests/test_quote_crud.py app/features/quotes/tests/test_quote_append_extraction.py app/features/quotes/tests/test_pdf_template.py -m "not live and not extraction_eval and not extraction_quality" -o cache_dir=.pytest_cache`
- `cd backend && .venv/bin/pytest app/features/quotes/tests/test_quote_to_invoice.py -m "not live and not extraction_eval and not extraction_quality" -o cache_dir=.pytest_cache`
- `make backend-static-verify`
- `make frontend-verify`
- `make verify`

Closes #418