### PR TITLE
Task #420: Pricing simplification and subtotal authority

### DIFF
--- a/backend/app/features/quotes/creation/service.py
+++ b/backend/app/features/quotes/creation/service.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
+from dataclasses import dataclass
 from typing import Literal, Protocol
 from uuid import UUID
 
@@ -17,10 +18,13 @@ from app.features.quotes.schemas import (
     LineItemDraft,
     PricingFieldName,
     QuoteCreateRequest,
+    UnresolvedSegment,
 )
 from app.shared.event_logger import log_event
 from app.shared.pricing import (
     PricingValidationError,
+    amounts_materially_differ,
+    derive_document_subtotal_from_line_items,
     document_field_float_or_none,
     validate_document_pricing_input,
 )
@@ -133,9 +137,40 @@ class QuoteCreationService:
         )
         extraction_metadata = classify_extraction_result(extraction_result)
         seeded_notes = _seeded_notes_from_result(extraction_result)
-        seeded_pricing_fields = _seeded_pricing_fields(extraction_result)
+        extracted_line_items = [
+            LineItemDraft(
+                description=item.description,
+                details=item.details,
+                price=item.price,
+                price_status=item.price_status,
+                flagged=item.flagged,
+                flag_reason=item.flag_reason,
+            )
+            for item in extraction_result.line_items
+        ]
+        pricing_application = _resolve_initial_pricing_application(
+            extraction_result=extraction_result,
+            line_items=extracted_line_items,
+        )
+        validated_pricing = _validate_document_pricing_for_quote(
+            total_amount=pricing_application.total_amount,
+            line_items=extracted_line_items,
+            discount_type=pricing_application.discount_type,
+            discount_value=pricing_application.discount_value,
+            tax_rate=pricing_application.tax_rate,
+            deposit_amount=pricing_application.deposit_amount,
+        )
+        seeded_pricing_fields = _seeded_pricing_fields(
+            extraction_result=extraction_result,
+            validated_pricing=validated_pricing,
+            seeded_explicit_total=pricing_application.seeded_explicit_total,
+        )
+        metadata_extraction_result = _apply_initial_pricing_hidden_item(
+            extraction_result=extraction_result,
+            hidden_explicit_total_text=pricing_application.hidden_explicit_total_text,
+        )
         extraction_review_metadata = build_extraction_review_metadata(
-            extraction_result,
+            metadata_extraction_result,
             seeded_notes=seeded_notes is not None,
             seeded_notes_confidence=(
                 extraction_result.customer_notes_suggestion.confidence
@@ -156,22 +191,12 @@ class QuoteCreationService:
                 customer_id=customer_id,
                 title=None,
                 transcript=extraction_result.transcript,
-                line_items=[
-                    LineItemDraft(
-                        description=item.description,
-                        details=item.details,
-                        price=item.price,
-                        price_status=item.price_status,
-                        flagged=item.flagged,
-                        flag_reason=item.flag_reason,
-                    )
-                    for item in extraction_result.line_items
-                ],
-                total_amount=extraction_result.pricing_hints.explicit_total,
-                tax_rate=extraction_result.pricing_hints.tax_rate,
-                discount_type=extraction_result.pricing_hints.discount_type,
-                discount_value=extraction_result.pricing_hints.discount_value,
-                deposit_amount=extraction_result.pricing_hints.deposit_amount,
+                line_items=extracted_line_items,
+                total_amount=document_field_float_or_none(validated_pricing.total_amount),
+                tax_rate=document_field_float_or_none(validated_pricing.tax_rate),
+                discount_type=validated_pricing.discount_type,
+                discount_value=document_field_float_or_none(validated_pricing.discount_value),
+                deposit_amount=document_field_float_or_none(validated_pricing.deposit_amount),
                 notes=seeded_notes,
                 source_type=source_type,
                 extraction_tier=extraction_metadata.tier,
@@ -328,15 +353,138 @@ def _seeded_notes_from_result(extraction_result: ExtractionResult) -> str | None
     return normalized or None
 
 
-def _seeded_pricing_fields(extraction_result: ExtractionResult) -> set[PricingFieldName]:
+@dataclass(frozen=True, slots=True)
+class _InitialPricingApplication:
+    total_amount: float | None
+    tax_rate: float | None
+    discount_type: str | None
+    discount_value: float | None
+    deposit_amount: float | None
+    seeded_explicit_total: bool
+    hidden_explicit_total_text: str | None
+
+
+def _resolve_initial_pricing_application(
+    *,
+    extraction_result: ExtractionResult,
+    line_items: list[LineItemDraft],
+) -> _InitialPricingApplication:
     pricing_hints = extraction_result.pricing_hints
+    line_items_define_subtotal, derived_line_item_subtotal = (
+        derive_document_subtotal_from_line_items(line_items)
+    )
+    has_reliable_priced_line_sum = (
+        line_items_define_subtotal and derived_line_item_subtotal is not None
+    )
+    has_valid_discount_candidate = (
+        pricing_hints.discount_type is not None and pricing_hints.discount_value is not None
+    )
+    has_tax_or_discount_candidate = (
+        pricing_hints.tax_rate is not None or has_valid_discount_candidate
+    )
+
+    seeded_explicit_total = False
+    hidden_explicit_total_text: str | None = None
+    total_amount: float | None
+
+    if has_reliable_priced_line_sum:
+        total_amount = derived_line_item_subtotal
+        if pricing_hints.explicit_total is not None and amounts_materially_differ(
+            pricing_hints.explicit_total, derived_line_item_subtotal
+        ):
+            hidden_explicit_total_text = (
+                f"Total {pricing_hints.explicit_total:g} conflicts with visible line-item subtotal "
+                f"{derived_line_item_subtotal:g}."
+            )
+    elif pricing_hints.explicit_total is not None and not has_tax_or_discount_candidate:
+        total_amount = pricing_hints.explicit_total
+        seeded_explicit_total = True
+    else:
+        total_amount = None
+        if pricing_hints.explicit_total is not None and has_tax_or_discount_candidate:
+            hidden_explicit_total_text = (
+                f"Total {pricing_hints.explicit_total:g} needs review because tax or discount was "
+                "also captured."
+            )
+
+    # Optional pricing fields require a subtotal authority source.
+    if total_amount is None:
+        return _InitialPricingApplication(
+            total_amount=None,
+            tax_rate=None,
+            discount_type=None,
+            discount_value=None,
+            deposit_amount=None,
+            seeded_explicit_total=seeded_explicit_total,
+            hidden_explicit_total_text=hidden_explicit_total_text,
+        )
+
+    return _InitialPricingApplication(
+        total_amount=total_amount,
+        tax_rate=pricing_hints.tax_rate,
+        discount_type=pricing_hints.discount_type if has_valid_discount_candidate else None,
+        discount_value=pricing_hints.discount_value if has_valid_discount_candidate else None,
+        deposit_amount=pricing_hints.deposit_amount,
+        seeded_explicit_total=seeded_explicit_total,
+        hidden_explicit_total_text=hidden_explicit_total_text,
+    )
+
+
+def _apply_initial_pricing_hidden_item(
+    *,
+    extraction_result: ExtractionResult,
+    hidden_explicit_total_text: str | None,
+) -> ExtractionResult:
+    if hidden_explicit_total_text is None:
+        return extraction_result
+    return extraction_result.model_copy(
+        update={
+            "unresolved_segments": [
+                *extraction_result.unresolved_segments,
+                UnresolvedSegment(
+                    raw_text=hidden_explicit_total_text,
+                    confidence="medium",
+                    source="transcript_conflict",
+                ),
+            ]
+        }
+    )
+
+
+def _seeded_pricing_fields(
+    *,
+    extraction_result: ExtractionResult,
+    validated_pricing: object,
+    seeded_explicit_total: bool,
+) -> set[PricingFieldName]:
+    pricing_hints = extraction_result.pricing_hints
+    normalized_total_amount = document_field_float_or_none(
+        getattr(validated_pricing, "total_amount", None)
+    )
+    normalized_tax_rate = document_field_float_or_none(getattr(validated_pricing, "tax_rate", None))
+    normalized_discount_type = getattr(validated_pricing, "discount_type", None)
+    normalized_discount_value = document_field_float_or_none(
+        getattr(validated_pricing, "discount_value", None)
+    )
+    normalized_deposit_amount = document_field_float_or_none(
+        getattr(validated_pricing, "deposit_amount", None)
+    )
     seeded: set[PricingFieldName] = set()
-    if pricing_hints.explicit_total is not None:
+    if (
+        seeded_explicit_total
+        and pricing_hints.explicit_total is not None
+        and normalized_total_amount is not None
+    ):
         seeded.add("explicit_total")
-    if pricing_hints.deposit_amount is not None:
+    if pricing_hints.deposit_amount is not None and normalized_deposit_amount is not None:
         seeded.add("deposit_amount")
-    if pricing_hints.tax_rate is not None:
+    if pricing_hints.tax_rate is not None and normalized_tax_rate is not None:
         seeded.add("tax_rate")
-    if pricing_hints.discount_type is not None and pricing_hints.discount_value is not None:
+    if (
+        pricing_hints.discount_type is not None
+        and pricing_hints.discount_value is not None
+        and normalized_discount_type is not None
+        and normalized_discount_value is not None
+    ):
         seeded.add("discount")
     return seeded

--- a/backend/app/features/quotes/extraction_append/service.py
+++ b/backend/app/features/quotes/extraction_append/service.py
@@ -29,6 +29,7 @@ from app.features.quotes.schemas import (
 )
 from app.shared.pricing import (
     PricingValidationError,
+    amounts_materially_differ,
     derive_document_subtotal_from_line_items,
     document_field_float_or_none,
     resolve_document_subtotal_for_edit,
@@ -220,6 +221,9 @@ class QuoteExtractionAppendService:
         line_items_define_subtotal, derived_line_item_subtotal = (
             derive_document_subtotal_from_line_items(merged_line_items)
         )
+        has_reliable_priced_line_sum = (
+            line_items_define_subtotal and derived_line_item_subtotal is not None
+        )
         current_subtotal = resolve_document_subtotal_for_edit(
             total_amount=quote.total_amount,
             discount_type=next_discount_type,
@@ -233,8 +237,33 @@ class QuoteExtractionAppendService:
             extraction_result=normalized_extraction_result,
             line_items_define_subtotal=line_items_define_subtotal,
             derived_line_item_subtotal=derived_line_item_subtotal,
+            seeded_tax_rate=seeded_tax_rate,
+            seeded_discount=seeded_discount,
             current_subtotal=current_subtotal,
         )
+        explicit_total_append_suggestion = _resolve_explicit_total_append_suggestion(
+            quote=quote,
+            extraction_result=normalized_extraction_result,
+            has_reliable_priced_line_sum=has_reliable_priced_line_sum,
+            derived_line_item_subtotal=derived_line_item_subtotal,
+            seeded_tax_rate=seeded_tax_rate,
+            seeded_discount=seeded_discount,
+        )
+        if explicit_total_append_suggestion is not None:
+            append_suggestions.append(explicit_total_append_suggestion)
+        if next_total_input is None:
+            # Optional pricing cannot be newly seeded without a subtotal authority source.
+            next_discount_type = quote.discount_type
+            next_discount_value = document_field_float_or_none(quote.discount_value)
+            update_discount_type = False
+            update_discount_value = False
+            seeded_discount = False
+            next_tax_rate = document_field_float_or_none(quote.tax_rate)
+            update_tax_rate = False
+            seeded_tax_rate = False
+            next_deposit_amount = document_field_float_or_none(quote.deposit_amount)
+            update_deposit_amount = False
+            seeded_deposit_amount = False
         validated_pricing = _validate_document_pricing_for_append(
             total_amount=next_total_input,
             line_items=merged_line_items,
@@ -266,7 +295,9 @@ class QuoteExtractionAppendService:
         if (
             normalized_extraction_result.pricing_hints.explicit_total is not None
             and quote.total_amount is None
-            and not line_items_define_subtotal
+            and not has_reliable_priced_line_sum
+            and not seeded_tax_rate
+            and not seeded_discount
             and validated_total_amount is not None
         ):
             seeded_pricing_fields.add("explicit_total")
@@ -707,13 +738,58 @@ def _resolve_total_amount_for_append(
     extraction_result: ExtractionResult,
     line_items_define_subtotal: bool,
     derived_line_item_subtotal: float | None,
+    seeded_tax_rate: bool,
+    seeded_discount: bool,
     current_subtotal: float | None,
 ) -> float | None:
-    if line_items_define_subtotal:
+    has_reliable_priced_line_sum = (
+        line_items_define_subtotal and derived_line_item_subtotal is not None
+    )
+    if has_reliable_priced_line_sum:
         return derived_line_item_subtotal
-    if quote.total_amount is None and extraction_result.pricing_hints.explicit_total is not None:
+    if (
+        quote.total_amount is None
+        and extraction_result.pricing_hints.explicit_total is not None
+        and not seeded_tax_rate
+        and not seeded_discount
+    ):
         return extraction_result.pricing_hints.explicit_total
     return current_subtotal
+
+
+def _resolve_explicit_total_append_suggestion(
+    *,
+    quote: Document,
+    extraction_result: ExtractionResult,
+    has_reliable_priced_line_sum: bool,
+    derived_line_item_subtotal: float | None,
+    seeded_tax_rate: bool,
+    seeded_discount: bool,
+) -> ExtractionReviewAppendSuggestion | None:
+    explicit_total = extraction_result.pricing_hints.explicit_total
+    if explicit_total is None:
+        return None
+
+    if (
+        has_reliable_priced_line_sum
+        and derived_line_item_subtotal is not None
+        and amounts_materially_differ(explicit_total, derived_line_item_subtotal)
+    ):
+        return _build_pricing_append_suggestion(
+            pricing_field="explicit_total",
+            value=explicit_total,
+        )
+
+    if (
+        not has_reliable_priced_line_sum
+        and quote.total_amount is None
+        and (seeded_tax_rate or seeded_discount)
+    ):
+        return _build_pricing_append_suggestion(
+            pricing_field="explicit_total",
+            value=explicit_total,
+        )
+    return None
 
 
 def _is_populated_text(value: str | None) -> bool:
@@ -762,7 +838,7 @@ def _normalize_material_text(value: str | None) -> str:
 def _is_materially_same_number(candidate: float, existing: float | None) -> bool:
     if existing is None:
         return False
-    return _normalize_material_number(candidate) == _normalize_material_number(existing)
+    return not amounts_materially_differ(candidate, existing)
 
 
 def _normalize_material_number(value: float | None) -> float | None:

--- a/backend/app/features/quotes/repository.py
+++ b/backend/app/features/quotes/repository.py
@@ -27,7 +27,7 @@ from app.shared.pricing import (
     DiscountType,
     PricingInput,
     calculate_breakdown_from_persisted,
-    calculate_line_item_sum,
+    derive_document_subtotal_from_line_items,
 )
 
 _PUBLIC_QUOTE_STATUSES = (
@@ -938,9 +938,7 @@ def _build_render_context(
             tax_rate=document.tax_rate,
             deposit_amount=document.deposit_amount,
         ),
-        line_item_sum=calculate_line_item_sum(
-            [line_item.price for line_item in document.line_items]
-        ),
+        line_item_sum=_to_decimal(derive_document_subtotal_from_line_items(document.line_items)[1]),
     )
     return QuoteRenderContext(
         quote_id=document.id,

--- a/backend/app/features/quotes/tests/test_creation_service.py
+++ b/backend/app/features/quotes/tests/test_creation_service.py
@@ -36,6 +36,7 @@ class _CreationRepository:
         self.create_calls = 0
         self.rollback_calls = 0
         self.commit_calls = 0
+        self.last_create_kwargs: dict[str, object] | None = None
 
     async def customer_exists_for_user(self, *, user_id: UUID, customer_id: UUID) -> bool:
         del user_id
@@ -44,6 +45,7 @@ class _CreationRepository:
 
     async def create(self, **kwargs):  # noqa: ANN003, ANN201
         self.create_calls += 1
+        self.last_create_kwargs = kwargs
         if self._sequence_collision_on_first_create and self.create_calls == 1:
             raise IntegrityError(
                 statement="INSERT INTO documents (...) VALUES (...)",
@@ -123,3 +125,52 @@ async def test_create_extracted_draft_commit_false_skips_commit() -> None:
     assert quote.id is not None  # nosec B101 - pytest assertion
     assert repository.create_calls == 1  # nosec B101 - pytest assertion
     assert repository.commit_calls == 0  # nosec B101 - pytest assertion
+
+
+async def test_create_extracted_draft_prefers_line_item_subtotal_over_conflicting_total() -> None:
+    repository = _CreationRepository()
+    service = QuoteCreationService(
+        repository=cast(QuoteCreationRepositoryProtocol, repository),
+    )
+    extraction_result = ExtractionResult(
+        transcript="Mulch 120 and cleanup included, total 140",
+        line_items=[
+            LineItemExtractedV2(
+                raw_text="Mulch 120",
+                description="Mulch",
+                details="5 yards",
+                price=120,
+                price_status="priced",
+                confidence="medium",
+            ),
+            LineItemExtractedV2(
+                raw_text="Cleanup included",
+                description="Cleanup",
+                details="Included / no charge",
+                price=None,
+                price_status="included",
+                confidence="medium",
+            ),
+        ],
+        pricing_hints=PricingHints(explicit_total=140),
+        confidence_notes=[],
+    )
+
+    quote = await service.create_extracted_draft(
+        user_id=uuid4(),
+        customer_id=None,
+        extraction_result=extraction_result,
+        source_type="text",
+        commit=False,
+    )
+
+    assert quote.id is not None  # nosec B101 - pytest assertion
+    assert repository.last_create_kwargs is not None  # nosec B101 - pytest assertion
+    assert repository.last_create_kwargs["total_amount"] == 120.0  # nosec B101 - pytest assertion
+    review_metadata = repository.last_create_kwargs["extraction_review_metadata"]
+    assert isinstance(review_metadata, dict)  # nosec B101 - pytest assertion
+    hidden_items = review_metadata["hidden_details"]["items"]  # type: ignore[index]
+    assert any(
+        item["kind"] == "unresolved_segment" and "total 140" in item["text"].lower()
+        for item in hidden_items
+    )  # nosec B101 - pytest assertion

--- a/backend/app/features/quotes/tests/test_quote_append_extraction.py
+++ b/backend/app/features/quotes/tests/test_quote_append_extraction.py
@@ -372,6 +372,85 @@ async def test_append_extraction_withholds_populated_notes_and_deposit_but_seeds
     ]
 
 
+async def test_append_extraction_withholds_ambiguous_explicit_total_when_tax_candidate_present(
+    client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def _extract_ambiguous_total(
+        self,
+        notes: str,
+        *,
+        mode: ExtractionMode = "initial",
+    ) -> ExtractionResult:  # noqa: ANN001
+        del self, notes, mode
+        return ExtractionResult(
+            transcript="append ambiguous explicit total",
+            line_items=[],
+            pricing_hints=PricingHints(
+                explicit_total=200,
+                tax_rate=0.0825,
+            ),
+            confidence_notes=[],
+        )
+
+    monkeypatch.setattr(
+        _MockExtractionIntegration,
+        "extract",
+        _extract_ambiguous_total,
+    )
+
+    csrf_token = await _register_and_login(client, _credentials())
+    customer_id = await _create_customer(client, csrf_token)
+    create_response = await client.post(
+        "/api/quotes",
+        json={
+            "customer_id": customer_id,
+            "transcript": "Unknown pricing scope",
+            "line_items": [
+                {
+                    "description": "Cleanup",
+                    "details": "Need to confirm price onsite",
+                    "price": None,
+                    "price_status": "unknown",
+                }
+            ],
+            "total_amount": None,
+            "notes": None,
+            "source_type": "text",
+        },
+        headers={"X-CSRF-Token": csrf_token},
+    )
+    assert create_response.status_code == 201
+    quote_id = create_response.json()["id"]
+    app.state.arq_pool = None
+
+    append_response = await client.post(
+        f"/api/quotes/{quote_id}/append-extraction",
+        files=[("notes", (None, "append ambiguous explicit total"))],
+        headers={"X-CSRF-Token": csrf_token},
+    )
+    assert append_response.status_code == 200
+
+    detail_response = await client.get(f"/api/quotes/{quote_id}")
+    assert detail_response.status_code == 200
+    payload = detail_response.json()
+    assert payload["total_amount"] is None
+    assert payload["tax_rate"] is None
+    append_suggestions = payload["extraction_review_metadata"]["hidden_details"][
+        "append_suggestions"
+    ]
+    assert append_suggestions == [
+        {
+            "id": append_suggestions[0]["id"],
+            "kind": "pricing",
+            "raw_text": "Total 200",
+            "confidence": "medium",
+            "source": "append_capture",
+            "pricing_field": "explicit_total",
+        }
+    ]
+
+
 async def test_append_extraction_resurfaces_previously_dismissed_matching_suggestion(
     client: AsyncClient,
     db_session: AsyncSession,

--- a/backend/app/features/quotes/tests/test_quote_crud.py
+++ b/backend/app/features/quotes/tests/test_quote_crud.py
@@ -283,6 +283,80 @@ async def test_quote_detail_normalizes_pre_v25_rows_with_null_price_status(
     ]
 
 
+async def test_create_quote_uses_priced_and_included_rows_as_subtotal_authority(
+    client: AsyncClient,
+) -> None:
+    csrf_token = await _register_and_login(client, _credentials())
+    customer_id = await _create_customer(client, csrf_token)
+
+    response = await client.post(
+        "/api/quotes",
+        json={
+            "customer_id": customer_id,
+            "transcript": "Mulch and cleanup included",
+            "line_items": [
+                {
+                    "description": "Mulch",
+                    "details": "5 yards",
+                    "price": 120,
+                    "price_status": "priced",
+                },
+                {
+                    "description": "Cleanup",
+                    "details": "Included / no charge",
+                    "price": None,
+                    "price_status": "included",
+                },
+            ],
+            "total_amount": None,
+            "notes": None,
+            "source_type": "text",
+        },
+        headers={"X-CSRF-Token": csrf_token},
+    )
+
+    assert response.status_code == 201
+    payload = response.json()
+    assert payload["total_amount"] == 120
+
+
+async def test_create_quote_with_unknown_price_rows_leaves_total_empty_without_explicit_total(
+    client: AsyncClient,
+) -> None:
+    csrf_token = await _register_and_login(client, _credentials())
+    customer_id = await _create_customer(client, csrf_token)
+
+    response = await client.post(
+        "/api/quotes",
+        json={
+            "customer_id": customer_id,
+            "transcript": "Mulch and edging TBD",
+            "line_items": [
+                {
+                    "description": "Mulch",
+                    "details": "5 yards",
+                    "price": 120,
+                    "price_status": "priced",
+                },
+                {
+                    "description": "Edging",
+                    "details": "Need to confirm price onsite",
+                    "price": None,
+                    "price_status": "unknown",
+                },
+            ],
+            "total_amount": None,
+            "notes": None,
+            "source_type": "text",
+        },
+        headers={"X-CSRF-Token": csrf_token},
+    )
+
+    assert response.status_code == 201
+    payload = response.json()
+    assert payload["total_amount"] is None
+
+
 async def test_get_quote_returns_404_for_nonexistent_id(client: AsyncClient) -> None:
     await _register_and_login(client, _credentials())
 

--- a/backend/app/shared/pricing.py
+++ b/backend/app/shared/pricing.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from collections.abc import Sequence
 from dataclasses import dataclass
 from decimal import ROUND_HALF_UP, Decimal
@@ -13,6 +14,10 @@ _ZERO = Decimal("0")
 _ONE = Decimal("1")
 _HUNDRED = Decimal("100")
 _MONEY_QUANTIZER = Decimal("0.01")
+_INCLUDED_NO_CHARGE_PATTERN = re.compile(
+    r"\b(included|no[\s-]?charge|n/?c|complimentary|at no cost)\b",
+    flags=re.IGNORECASE,
+)
 
 
 class PricingValidationError(Exception):
@@ -292,18 +297,8 @@ def derive_document_subtotal_from_line_items(
     line_items: Sequence[object] | None,
 ) -> tuple[bool, float | None]:
     """Return whether priced line items fully define a subtotal and that float value."""
-    substantive_items = [
-        line_item for line_item in (line_items or ()) if document_line_item_has_content(line_item)
-    ]
-    if not substantive_items:
-        return True, None
-    if any(getattr(line_item, "price", None) is None for line_item in substantive_items):
-        return False, None
-
-    line_item_sum = calculate_line_item_sum(
-        [to_decimal(getattr(line_item, "price", None)) for line_item in substantive_items]
-    )
-    return True, document_field_float_or_none(line_item_sum)
+    defines_subtotal, line_item_subtotal = _derive_line_item_subtotal_decimal(line_items)
+    return defines_subtotal, document_field_float_or_none(line_item_subtotal)
 
 
 def resolve_document_subtotal_for_edit(
@@ -316,9 +311,7 @@ def resolve_document_subtotal_for_edit(
     line_items: Sequence[object] | None,
 ) -> float | None:
     """Reverse-calculate subtotal from persisted totals for PATCH merge logic."""
-    line_item_sum = calculate_line_item_sum(
-        [to_decimal(getattr(line_item, "price", None)) for line_item in (line_items or ())]
-    )
+    _, line_item_sum = _derive_line_item_subtotal_decimal(line_items)
     breakdown = calculate_breakdown_from_persisted(
         PricingInput(
             total_amount=document_field_decimal_or_none(total_amount),
@@ -342,9 +335,7 @@ def validate_document_pricing_input(
     deposit_amount: float | None,
 ) -> PricingInput:
     """Validate API pricing fields; raises PricingValidationError on contract violations."""
-    line_item_sum = calculate_line_item_sum(
-        [to_decimal(getattr(line_item, "price", None)) for line_item in (line_items or ())]
-    )
+    _, line_item_sum = _derive_line_item_subtotal_decimal(line_items)
     pricing, _ = validate_and_calculate_from_input(
         subtotal_input=to_decimal(total_amount),
         line_item_sum=line_item_sum,
@@ -378,6 +369,72 @@ def _resolve_subtotal_from_persisted(
         percent_multiplier = _ONE - (percent_discount / _HUNDRED)
         return _quantize_money(total_amount / (tax_multiplier * percent_multiplier))
     return _quantize_money(total_amount / tax_multiplier)
+
+
+def amounts_materially_differ(
+    candidate: float | Decimal | None,
+    baseline: float | Decimal | None,
+) -> bool:
+    """Return true when two monetary values differ by more than one cent."""
+    if candidate is None or baseline is None:
+        return False
+    return abs(_to_money_decimal(candidate) - _to_money_decimal(baseline)) > _MONEY_QUANTIZER
+
+
+def _derive_line_item_subtotal_decimal(
+    line_items: Sequence[object] | None,
+) -> tuple[bool, Decimal | None]:
+    substantive_items = [
+        line_item for line_item in (line_items or ()) if document_line_item_has_content(line_item)
+    ]
+    if not substantive_items:
+        return True, None
+
+    priced_values: list[Decimal] = []
+    for line_item in substantive_items:
+        status = _resolve_line_item_price_status_for_pricing(line_item)
+        if status == "unknown":
+            return False, None
+        if status == "priced":
+            price = to_decimal(getattr(line_item, "price", None))
+            if price is None:
+                return False, None
+            priced_values.append(price)
+
+    if not priced_values:
+        return True, None
+    return True, _quantize_money(sum(priced_values, start=_ZERO))
+
+
+def _resolve_line_item_price_status_for_pricing(
+    line_item: object,
+) -> Literal["priced", "included", "unknown"]:
+    price = getattr(line_item, "price", None)
+    has_price = price is not None
+    raw_status = getattr(line_item, "price_status", None)
+    if isinstance(raw_status, str):
+        normalized = raw_status.strip().casefold()
+        if normalized == "priced":
+            return "priced" if has_price else "unknown"
+        if normalized == "included":
+            return "included" if not has_price else "priced"
+        if normalized == "unknown":
+            return "unknown" if not has_price else "priced"
+
+    if has_price:
+        return "priced"
+    description = getattr(line_item, "description", None)
+    details = getattr(line_item, "details", None)
+    if _has_included_no_charge_language(description, details):
+        return "included"
+    return "unknown"
+
+
+def _has_included_no_charge_language(*parts: object) -> bool:
+    for part in parts:
+        if isinstance(part, str) and _INCLUDED_NO_CHARGE_PATTERN.search(part):
+            return True
+    return False
 
 
 def _validate_discount_fields(
@@ -438,3 +495,8 @@ def _normalize_optional_amount(value: Decimal | None) -> Decimal | None:
 
 def _quantize_money(value: Decimal) -> Decimal:
     return value.quantize(_MONEY_QUANTIZER, rounding=ROUND_HALF_UP)
+
+
+def _to_money_decimal(value: float | Decimal) -> Decimal:
+    decimal_value = value if isinstance(value, Decimal) else Decimal(str(value))
+    return _quantize_money(decimal_value)

--- a/backend/app/shared/tests/test_pricing.py
+++ b/backend/app/shared/tests/test_pricing.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 from decimal import Decimal
+from types import SimpleNamespace
 
 import pytest
 from app.shared.pricing import (
     PricingInput,
     PricingValidationError,
     calculate_breakdown_from_persisted,
+    derive_document_subtotal_from_line_items,
     validate_and_calculate_from_input,
 )
 
@@ -57,3 +59,103 @@ def test_calculate_breakdown_from_persisted_recovers_percent_discount_subtotal()
     assert breakdown.tax_amount == Decimal("16.00")
     assert breakdown.total_amount == Decimal("176.00")
     assert breakdown.balance_due == Decimal("126.00")
+
+
+def test_derive_document_subtotal_from_line_items_priced_and_included_rows() -> None:
+    defines_subtotal, subtotal = derive_document_subtotal_from_line_items(
+        [
+            _line_item("Mulch", price=120.0, price_status="priced"),
+            _line_item(
+                "Cleanup",
+                details="Included / no charge",
+                price=None,
+                price_status="included",
+            ),
+        ]
+    )
+
+    assert defines_subtotal is True
+    assert subtotal == 120.0
+
+
+def test_derive_document_subtotal_from_line_items_priced_and_unknown_rows() -> None:
+    defines_subtotal, subtotal = derive_document_subtotal_from_line_items(
+        [
+            _line_item("Mulch", price=120.0, price_status="priced"),
+            _line_item(
+                "Edging",
+                details="Need price confirmation",
+                price=None,
+                price_status="unknown",
+            ),
+        ]
+    )
+
+    assert defines_subtotal is False
+    assert subtotal is None
+
+
+def test_derive_document_subtotal_from_line_items_all_included_rows() -> None:
+    defines_subtotal, subtotal = derive_document_subtotal_from_line_items(
+        [
+            _line_item(
+                "Cleanup",
+                details="Included / no charge",
+                price=None,
+                price_status="included",
+            ),
+            _line_item(
+                "Debris hauling",
+                details="Complimentary",
+                price=None,
+                price_status="included",
+            ),
+        ]
+    )
+
+    assert defines_subtotal is True
+    assert subtotal is None
+
+
+def test_derive_document_subtotal_from_line_items_all_unknown_rows() -> None:
+    defines_subtotal, subtotal = derive_document_subtotal_from_line_items(
+        [
+            _line_item(
+                "Cleanup",
+                details="Need to confirm scope",
+                price=None,
+                price_status="unknown",
+            ),
+            _line_item(
+                "Edging",
+                details="Estimate pending",
+                price=None,
+                price_status="unknown",
+            ),
+        ]
+    )
+
+    assert defines_subtotal is False
+    assert subtotal is None
+
+
+def test_derive_document_subtotal_from_line_items_empty_rows() -> None:
+    defines_subtotal, subtotal = derive_document_subtotal_from_line_items([])
+
+    assert defines_subtotal is True
+    assert subtotal is None
+
+
+def _line_item(
+    description: str,
+    *,
+    details: str | None = None,
+    price: float | None,
+    price_status: str | None,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        description=description,
+        details=details,
+        price=price,
+        price_status=price_status,
+    )

--- a/frontend/src/features/quotes/tests/TotalAmountSection.test.tsx
+++ b/frontend/src/features/quotes/tests/TotalAmountSection.test.tsx
@@ -1,0 +1,32 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { TotalAmountSection } from "@/features/quotes/components/TotalAmountSection";
+
+describe("TotalAmountSection", () => {
+  it("renders line-item sum and forwards subtotal edits", () => {
+    const onTotalChange = vi.fn();
+
+    render(
+      <TotalAmountSection
+        lineItemSum={120}
+        total={120}
+        taxRate={null}
+        discountType={null}
+        discountValue={null}
+        depositAmount={null}
+        onTotalChange={onTotalChange}
+        onTaxRateChange={vi.fn()}
+        onDiscountTypeChange={vi.fn()}
+        onDiscountValueChange={vi.fn()}
+        onDepositAmountChange={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Line Item Sum")).toBeInTheDocument();
+    expect(screen.getByText("$120.00")).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText(/total amount/i), { target: { value: "150" } });
+    expect(onTotalChange).toHaveBeenCalledWith(150);
+  });
+});

--- a/frontend/src/features/quotes/tests/lineItemDraftTotals.test.ts
+++ b/frontend/src/features/quotes/tests/lineItemDraftTotals.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+
+import { syncDraftTotalWithLineItems } from "@/features/quotes/utils/lineItemDraftTotals";
+import type { LineItemDraftWithFlags } from "@/features/quotes/types/quote.types";
+
+function makeLineItem(overrides: Partial<LineItemDraftWithFlags>): LineItemDraftWithFlags {
+  return {
+    description: "Work item",
+    details: null,
+    price: null,
+    ...overrides,
+  };
+}
+
+describe("lineItemDraftTotals", () => {
+  it("re-syncs subtotal from priced rows when remaining null rows are included", () => {
+    const currentLineItems: LineItemDraftWithFlags[] = [
+      makeLineItem({ description: "Mulch", price: 120, priceStatus: "priced" }),
+      makeLineItem({ description: "Cleanup", details: "Included / no charge", price: null, priceStatus: "included" }),
+    ];
+    const nextLineItems: LineItemDraftWithFlags[] = [
+      makeLineItem({ description: "Mulch", price: 150, priceStatus: "priced" }),
+      makeLineItem({ description: "Cleanup", details: "Included / no charge", price: null, priceStatus: "included" }),
+    ];
+
+    const nextTotal = syncDraftTotalWithLineItems(
+      { lineItems: currentLineItems, total: 120 },
+      nextLineItems,
+    );
+
+    expect(nextTotal).toBe(150);
+  });
+
+  it("does not re-sync subtotal when unknown pricing rows are present", () => {
+    const currentLineItems: LineItemDraftWithFlags[] = [
+      makeLineItem({ description: "Mulch", price: 120, priceStatus: "priced" }),
+      makeLineItem({ description: "Edging", details: "Need to confirm price", price: null, priceStatus: "unknown" }),
+    ];
+    const nextLineItems: LineItemDraftWithFlags[] = [
+      makeLineItem({ description: "Mulch", price: 160, priceStatus: "priced" }),
+      makeLineItem({ description: "Edging", details: "Need to confirm price", price: null, priceStatus: "unknown" }),
+    ];
+
+    const nextTotal = syncDraftTotalWithLineItems(
+      { lineItems: currentLineItems, total: 120 },
+      nextLineItems,
+    );
+
+    expect(nextTotal).toBe(120);
+  });
+
+  it("clears subtotal when all substantive rows are included", () => {
+    const currentLineItems: LineItemDraftWithFlags[] = [
+      makeLineItem({ description: "Mulch", price: 120, priceStatus: "priced" }),
+    ];
+    const nextLineItems: LineItemDraftWithFlags[] = [
+      makeLineItem({ description: "Cleanup", details: "Included / no charge", price: null, priceStatus: "included" }),
+    ];
+
+    const nextTotal = syncDraftTotalWithLineItems(
+      { lineItems: currentLineItems, total: 120 },
+      nextLineItems,
+    );
+
+    expect(nextTotal).toBeNull();
+  });
+});

--- a/frontend/src/features/quotes/utils/lineItemDraftTotals.ts
+++ b/frontend/src/features/quotes/utils/lineItemDraftTotals.ts
@@ -1,4 +1,5 @@
 import type { LineItemDraftWithFlags } from "@/features/quotes/types/quote.types";
+import { resolvePriceStatus } from "@/features/quotes/utils/priceStatus";
 import { resolveLineItemSum } from "@/shared/lib/pricing";
 
 interface DraftLineItemTotalsState {
@@ -10,31 +11,46 @@ export function syncDraftTotalWithLineItems(
   currentState: DraftLineItemTotalsState,
   nextLineItems: LineItemDraftWithFlags[],
 ): number | null {
-  const currentDerivedSubtotal = resolveFullyPricedLineItemSum(currentState.lineItems);
-  if (currentDerivedSubtotal !== currentState.total) {
+  const currentDerivedSubtotal = resolveLineItemAuthoritativeSubtotal(currentState.lineItems);
+  if (currentState.total !== null && !currentDerivedSubtotal.definesSubtotal) {
+    return currentState.total;
+  }
+  if (!isSameMoneyValue(currentDerivedSubtotal.subtotal, currentState.total)) {
     return currentState.total;
   }
 
-  const nextDerivedSubtotal = resolveFullyPricedLineItemSum(nextLineItems);
-  if (nextDerivedSubtotal === null) {
-    return hasSubstantiveLineItems(nextLineItems) ? currentState.total : null;
+  const nextDerivedSubtotal = resolveLineItemAuthoritativeSubtotal(nextLineItems);
+  if (!nextDerivedSubtotal.definesSubtotal) {
+    return currentState.total;
   }
-  return nextDerivedSubtotal;
+  return nextDerivedSubtotal.subtotal;
 }
 
-function resolveFullyPricedLineItemSum(lineItems: LineItemDraftWithFlags[]): number | null {
+function resolveLineItemAuthoritativeSubtotal(lineItems: LineItemDraftWithFlags[]): {
+  definesSubtotal: boolean;
+  subtotal: number | null;
+} {
   const substantiveLineItems = lineItems.filter(hasLineItemContent);
   if (substantiveLineItems.length === 0) {
-    return null;
+    return { definesSubtotal: true, subtotal: null };
   }
-  if (substantiveLineItems.some((lineItem) => lineItem.price === null)) {
-    return null;
-  }
-  return resolveLineItemSum(substantiveLineItems.map((lineItem) => lineItem.price));
-}
 
-function hasSubstantiveLineItems(lineItems: LineItemDraftWithFlags[]): boolean {
-  return lineItems.some(hasLineItemContent);
+  const pricedValues: number[] = [];
+  for (const lineItem of substantiveLineItems) {
+    const priceStatus = resolvePriceStatus({
+      price: lineItem.price,
+      priceStatus: lineItem.priceStatus,
+      description: lineItem.description,
+      details: lineItem.details,
+    });
+    if (priceStatus === "unknown") {
+      return { definesSubtotal: false, subtotal: null };
+    }
+    if (priceStatus === "priced" && lineItem.price !== null) {
+      pricedValues.push(lineItem.price);
+    }
+  }
+  return { definesSubtotal: true, subtotal: resolveLineItemSum(pricedValues) };
 }
 
 function hasLineItemContent(lineItem: LineItemDraftWithFlags): boolean {
@@ -43,4 +59,11 @@ function hasLineItemContent(lineItem: LineItemDraftWithFlags): boolean {
     || (lineItem.details?.trim().length ?? 0) > 0
     || lineItem.price !== null
   );
+}
+
+function isSameMoneyValue(left: number | null, right: number | null): boolean {
+  if (left === null || right === null) {
+    return left === right;
+  }
+  return Math.round(left * 100) === Math.round(right * 100);
 }


### PR DESCRIPTION
## Summary
- enforce shared subtotal authority from visible priced line items only when all null-price rows are `included`
- keep `unknown` null-price rows from silently counting as included/free scope, and leave subtotal empty when pricing authority is incomplete
- apply the same authority/ambiguity rules in initial extraction draft creation and append extraction (including hidden actionable handling for conflicting/ambiguous `explicit_total`)
- re-sync frontend subtotal on line-item edits using `priceStatus` semantics with cent-stable comparisons
- add targeted backend/frontend tests for priced+included, priced+unknown, all-included, all-unknown, explicit-total conflict, and append ambiguity behavior

## Verification
- `cd backend && .venv/bin/pytest app/shared/tests/test_pricing.py app/features/quotes/tests/test_creation_service.py app/features/quotes/tests/test_quote_crud.py app/features/quotes/tests/test_quote_append_extraction.py -m "not live and not extraction_eval and not extraction_quality" -o cache_dir=.pytest_cache`
- `cd frontend && npx vitest run src/features/quotes/tests/TotalAmountSection.test.tsx src/features/quotes/tests/reviewScreenState.test.ts src/features/quotes/tests/LineItemEditSheet.test.tsx src/features/quotes/tests/lineItemDraftTotals.test.ts`
- `make backend-static-verify`
- `cd frontend && npx tsc --noEmit && npx eslint src/features/quotes src/shared/lib/pricing.ts`
- `make verify`

Closes #420