### PR TITLE
Task #421: simplify Capture Details and add occurrence-fingerprint warning

### DIFF
--- a/frontend/src/features/quotes/components/CaptureDetailsSheet.tsx
+++ b/frontend/src/features/quotes/components/CaptureDetailsSheet.tsx
@@ -1,6 +1,7 @@
 import * as Dialog from "@radix-ui/react-dialog";
 
 import type { ExtractionReviewHiddenDetails, HiddenItemState } from "@/features/quotes/types/quote.types";
+import { resolveCaptureDetailsActionableItems } from "@/features/quotes/utils/captureDetails";
 
 interface CaptureDetailsSheetProps {
   open: boolean;
@@ -8,17 +9,8 @@ interface CaptureDetailsSheetProps {
   transcript: string;
   hiddenDetails?: ExtractionReviewHiddenDetails;
   hiddenDetailState?: Record<string, HiddenItemState>;
-  onReviewHiddenItem?: (itemId: string) => Promise<void> | void;
   onDismissHiddenItem?: (itemId: string) => Promise<void> | void;
   isMutating?: boolean;
-}
-
-interface ResolvedHiddenItem {
-  id: string;
-  kind: "append_suggestion" | "unresolved_segment" | "confidence_note";
-  field: "notes" | "explicit_total" | "deposit_amount" | "tax_rate" | "discount" | null;
-  reason: string | null;
-  text: string;
 }
 
 function formatPricingField(
@@ -40,50 +32,21 @@ function formatPricingField(
   return "discount";
 }
 
-function renderEmptySection(message: string): React.ReactElement {
-  return (
-    <p className="rounded-lg border border-outline-variant/30 bg-surface-container-high p-3 text-sm text-on-surface-variant">
-      {message}
-    </p>
-  );
-}
-
-function resolveHiddenItems(hiddenDetails?: ExtractionReviewHiddenDetails): ResolvedHiddenItem[] {
-  if (!hiddenDetails) {
-    return [];
+function buildActionableLabel(item: {
+  kind: "append_suggestion" | "unresolved_segment" | "confidence_note";
+  field: "notes" | "explicit_total" | "deposit_amount" | "tax_rate" | "discount" | null;
+  reason: string | null;
+}): string {
+  if (item.kind === "append_suggestion") {
+    const pricingField = formatPricingField(item.field === "notes" ? null : item.field);
+    return item.field === "notes"
+      ? "Notes suggestion"
+      : `Pricing suggestion${pricingField ? ` (${pricingField})` : ""}`;
   }
-  if (Array.isArray(hiddenDetails.items) && hiddenDetails.items.length > 0) {
-    return hiddenDetails.items.map((item) => ({
-      id: item.id,
-      kind: item.kind,
-      field: item.field ?? null,
-      reason: item.reason ?? null,
-      text: item.text,
-    }));
+  if (item.kind === "unresolved_segment") {
+    return (item.reason ?? "leftover_classification").replaceAll("_", " ");
   }
-
-  const fromSuggestions: ResolvedHiddenItem[] = hiddenDetails.append_suggestions.map((suggestion) => ({
-    id: suggestion.id,
-    kind: "append_suggestion",
-    field: suggestion.pricing_field ?? "notes",
-    reason: suggestion.source,
-    text: suggestion.raw_text,
-  }));
-  const fromUnresolved: ResolvedHiddenItem[] = hiddenDetails.unresolved_segments.map((segment) => ({
-    id: segment.id,
-    kind: "unresolved_segment",
-    field: null,
-    reason: segment.source,
-    text: segment.raw_text,
-  }));
-  const fromConfidence: ResolvedHiddenItem[] = hiddenDetails.confidence_notes.map((note, index) => ({
-    id: `legacy-confidence-${index}`,
-    kind: "confidence_note",
-    field: null,
-    reason: "legacy_confidence_note",
-    text: note,
-  }));
-  return [...fromSuggestions, ...fromUnresolved, ...fromConfidence];
+  return "Capture note";
 }
 
 export function CaptureDetailsSheet({
@@ -92,20 +55,11 @@ export function CaptureDetailsSheet({
   transcript,
   hiddenDetails,
   hiddenDetailState,
-  onReviewHiddenItem,
   onDismissHiddenItem,
   isMutating = false,
 }: CaptureDetailsSheetProps): React.ReactElement {
-  const hiddenItems = resolveHiddenItems(hiddenDetails);
-  const visibleAppendSuggestions = hiddenItems.filter(
-    (item) => item.kind === "append_suggestion" && !hiddenDetailState?.[item.id]?.dismissed,
-  );
-  const visibleUnresolvedSegments = hiddenItems.filter(
-    (item) => item.kind === "unresolved_segment" && !hiddenDetailState?.[item.id]?.dismissed,
-  );
-  const visibleConfidenceNotes = hiddenItems.filter(
-    (item) => item.kind === "confidence_note" && !hiddenDetailState?.[item.id]?.dismissed,
-  );
+  const actionableItems = resolveCaptureDetailsActionableItems(hiddenDetails)
+    .filter((item) => !hiddenDetailState?.[item.id]?.dismissed);
 
   return (
     <Dialog.Root open={open} onOpenChange={(nextOpen) => { if (!nextOpen) onClose(); }}>
@@ -126,119 +80,32 @@ export function CaptureDetailsSheet({
             <div className="mt-4 max-h-[70vh] space-y-5 overflow-y-auto pr-1">
               <section className="space-y-2">
                 <h3 className="text-[0.6875rem] font-bold uppercase tracking-widest text-outline">
-                  New Suggestions From Latest Capture
+                  Actionable Capture Details
                 </h3>
-                {visibleAppendSuggestions.length === 0 ? renderEmptySection("No new suggestions from the latest capture.") : (
+                {actionableItems.length > 0 ? (
                   <ul className="space-y-2">
-                    {visibleAppendSuggestions.map((suggestion) => {
-                      const pricingField = formatPricingField(
-                        suggestion.field === "notes" ? null : suggestion.field,
-                      );
-                      const itemState = hiddenDetailState?.[suggestion.id];
-                      return (
-                        <li
-                          key={suggestion.id}
-                          className="rounded-lg border border-outline-variant/30 bg-surface-container-high p-3 text-sm text-on-surface"
-                        >
-                          <p className="font-semibold">
-                            {suggestion.field === "notes" ? "Notes suggestion" : "Pricing suggestion"}
-                            {pricingField ? ` (${pricingField})` : ""}
-                          </p>
-                          <p className="mt-1 whitespace-pre-wrap text-on-surface-variant">{suggestion.text}</p>
-                          <div className="mt-3 flex items-center gap-2">
-                            {itemState?.reviewed ? (
-                              <span className="rounded-full bg-success/10 px-2 py-0.5 text-[0.6875rem] font-semibold uppercase tracking-wide text-success">
-                                Reviewed
-                              </span>
-                            ) : (
-                              <button
-                                type="button"
-                                className="rounded-md border border-outline-variant/40 px-2 py-1 text-[0.6875rem] font-semibold uppercase tracking-wide text-on-surface-variant transition-colors hover:bg-surface-container-lowest disabled:cursor-not-allowed disabled:opacity-60"
-                                disabled={isMutating || !onReviewHiddenItem}
-                                onClick={() => { void onReviewHiddenItem?.(suggestion.id); }}
-                              >
-                                Mark reviewed
-                              </button>
-                            )}
-                            <button
-                              type="button"
-                              className="rounded-md border border-outline-variant/40 px-2 py-1 text-[0.6875rem] font-semibold uppercase tracking-wide text-on-surface-variant transition-colors hover:bg-surface-container-lowest disabled:cursor-not-allowed disabled:opacity-60"
-                              disabled={isMutating || !onDismissHiddenItem}
-                              onClick={() => { void onDismissHiddenItem?.(suggestion.id); }}
-                            >
-                              Dismiss
-                            </button>
-                          </div>
-                        </li>
-                      );
-                    })}
-                  </ul>
-                )}
-              </section>
-
-              <section className="space-y-2">
-                <h3 className="text-[0.6875rem] font-bold uppercase tracking-widest text-outline">
-                  Unresolved Capture Details
-                </h3>
-                {visibleUnresolvedSegments.length === 0 ? renderEmptySection("No unresolved capture details.") : (
-                  <ul className="space-y-2">
-                    {visibleUnresolvedSegments.map((segment) => {
-                      const itemState = hiddenDetailState?.[segment.id];
-                      return (
-                        <li
-                          key={segment.id}
-                          className="rounded-lg border border-outline-variant/30 bg-surface-container-high p-3 text-sm text-on-surface"
-                        >
-                          <p className="font-semibold">
-                            {(segment.reason ?? "leftover_classification").replaceAll("_", " ")}
-                          </p>
-                          <p className="mt-1 whitespace-pre-wrap text-on-surface-variant">{segment.text}</p>
-                          <div className="mt-3 flex items-center gap-2">
-                            {itemState?.reviewed ? (
-                              <span className="rounded-full bg-success/10 px-2 py-0.5 text-[0.6875rem] font-semibold uppercase tracking-wide text-success">
-                                Reviewed
-                              </span>
-                            ) : (
-                              <button
-                                type="button"
-                                className="rounded-md border border-outline-variant/40 px-2 py-1 text-[0.6875rem] font-semibold uppercase tracking-wide text-on-surface-variant transition-colors hover:bg-surface-container-lowest disabled:cursor-not-allowed disabled:opacity-60"
-                                disabled={isMutating || !onReviewHiddenItem}
-                                onClick={() => { void onReviewHiddenItem?.(segment.id); }}
-                              >
-                                Mark reviewed
-                              </button>
-                            )}
-                            <button
-                              type="button"
-                              className="rounded-md border border-outline-variant/40 px-2 py-1 text-[0.6875rem] font-semibold uppercase tracking-wide text-on-surface-variant transition-colors hover:bg-surface-container-lowest disabled:cursor-not-allowed disabled:opacity-60"
-                              disabled={isMutating || !onDismissHiddenItem}
-                              onClick={() => { void onDismissHiddenItem?.(segment.id); }}
-                            >
-                              Dismiss
-                            </button>
-                          </div>
-                        </li>
-                      );
-                    })}
-                  </ul>
-                )}
-              </section>
-
-              <section className="space-y-2">
-                <h3 className="text-[0.6875rem] font-bold uppercase tracking-widest text-outline">
-                  AI Review Notes
-                </h3>
-                {visibleConfidenceNotes.length === 0 ? renderEmptySection("No AI review notes.") : (
-                  <ul className="space-y-2">
-                    {visibleConfidenceNotes.map((note) => (
+                    {actionableItems.map((item) => (
                       <li
-                        key={note.id}
-                        className="rounded-lg border border-outline-variant/30 bg-surface-container-high p-3 text-sm text-on-surface whitespace-pre-wrap"
+                        key={item.id}
+                        className="rounded-lg border border-outline-variant/30 bg-surface-container-high p-3 text-sm text-on-surface"
                       >
-                        {note.text}
+                        <p className="font-semibold">{buildActionableLabel(item)}</p>
+                        <p className="mt-1 whitespace-pre-wrap text-on-surface-variant">{item.text}</p>
+                        <div className="mt-3">
+                          <button
+                            type="button"
+                            className="rounded-md border border-outline-variant/40 px-2 py-1 text-[0.6875rem] font-semibold uppercase tracking-wide text-on-surface-variant transition-colors hover:bg-surface-container-lowest disabled:cursor-not-allowed disabled:opacity-60"
+                            disabled={isMutating || !onDismissHiddenItem}
+                            onClick={() => { void onDismissHiddenItem?.(item.id); }}
+                          >
+                            Dismiss
+                          </button>
+                        </div>
                       </li>
                     ))}
                   </ul>
+                ) : (
+                  <p className="text-sm text-on-surface-variant">No actionable capture details.</p>
                 )}
               </section>
 

--- a/frontend/src/features/quotes/components/DocumentEditOverlays.tsx
+++ b/frontend/src/features/quotes/components/DocumentEditOverlays.tsx
@@ -20,7 +20,7 @@ interface DocumentEditOverlaysProps {
   showLeaveWarning: boolean;
   onLeaveConfirm: () => void;
   onLeaveCancel: () => void;
-  showContinueWarning: boolean;
+  continueWarningReason: "review" | "capture-details" | null;
   onContinueConfirm: () => void;
   onContinueCancel: () => void;
 }
@@ -40,10 +40,21 @@ export function DocumentEditOverlays({
   showLeaveWarning,
   onLeaveConfirm,
   onLeaveCancel,
-  showContinueWarning,
+  continueWarningReason,
   onContinueConfirm,
   onContinueCancel,
 }: DocumentEditOverlaysProps): React.ReactElement {
+  const showContinueWarning = continueWarningReason !== null;
+  const continueWarningCopy = continueWarningReason === "capture-details"
+    ? {
+        title: "Review Capture Details before continuing?",
+        body: "New capture details are available. Open Capture Details now, or continue anyway.",
+      }
+    : {
+        title: "Review pending extraction markers?",
+        body: "Notes and pricing still have pending review markers. Review now, or continue anyway.",
+      };
+
   return (
     <>
       {isAssignmentSheetOpen ? (
@@ -82,8 +93,8 @@ export function DocumentEditOverlays({
 
       {showContinueWarning ? (
         <ConfirmModal
-          title="Review pending extraction markers?"
-          body="Notes and pricing still have pending review markers. Review now, or continue anyway."
+          title={continueWarningCopy.title}
+          body={continueWarningCopy.body}
           confirmLabel="Continue anyway"
           cancelLabel="Review now"
           onConfirm={onContinueConfirm}

--- a/frontend/src/features/quotes/components/DocumentEditScreenView.tsx
+++ b/frontend/src/features/quotes/components/DocumentEditScreenView.tsx
@@ -34,7 +34,7 @@ interface DocumentEditScreenViewProps {
   lineItemSheetInitialItem: LineItemDraftWithFlags;
   toastMessage: string | null;
   showLeaveWarning: boolean;
-  showContinueWarning: boolean;
+  continueWarningReason: "review" | "capture-details" | null;
   isSavingDraft: boolean;
   isContinuing: boolean;
   onRequestNavigation: (target: { to: string; replace?: boolean }) => void;
@@ -51,8 +51,8 @@ interface DocumentEditScreenViewProps {
   onDiscountValueChange: (nextDiscountValue: number | null) => void;
   onDepositAmountChange: (nextDepositAmount: number | null) => void;
   onNotesChange: (nextNotes: string) => void;
-  onReviewHiddenItem: (itemId: string) => Promise<void>;
   onDismissHiddenItem: (itemId: string) => Promise<void>;
+  onCaptureDetailsOpen: () => void;
   onSaveDraft: () => void;
   onPrimaryAction: () => void;
   onCloseAssignment: () => void;
@@ -93,7 +93,7 @@ export function DocumentEditScreenView({
   lineItemSheetInitialItem,
   toastMessage,
   showLeaveWarning,
-  showContinueWarning,
+  continueWarningReason,
   isSavingDraft,
   isContinuing,
   onRequestNavigation,
@@ -110,8 +110,8 @@ export function DocumentEditScreenView({
   onDiscountValueChange,
   onDepositAmountChange,
   onNotesChange,
-  onReviewHiddenItem,
   onDismissHiddenItem,
+  onCaptureDetailsOpen,
   onSaveDraft,
   onPrimaryAction,
   onCloseAssignment,
@@ -171,8 +171,8 @@ export function DocumentEditScreenView({
         onDiscountValueChange={onDiscountValueChange}
         onDepositAmountChange={onDepositAmountChange}
         onNotesChange={onNotesChange}
-        onReviewHiddenItem={onReviewHiddenItem}
         onDismissHiddenItem={onDismissHiddenItem}
+        onCaptureDetailsOpen={onCaptureDetailsOpen}
       />
 
       <ReviewActionFooter
@@ -200,7 +200,7 @@ export function DocumentEditScreenView({
         showLeaveWarning={showLeaveWarning}
         onLeaveConfirm={onLeaveConfirm}
         onLeaveCancel={onLeaveCancel}
-        showContinueWarning={showContinueWarning}
+        continueWarningReason={continueWarningReason}
         onContinueConfirm={onContinueConfirm}
         onContinueCancel={onContinueCancel}
       />

--- a/frontend/src/features/quotes/components/ReviewFormContent.tsx
+++ b/frontend/src/features/quotes/components/ReviewFormContent.tsx
@@ -6,6 +6,7 @@ import { ReviewDocumentTypeSelector, type ReviewDocumentType } from "@/features/
 import { ReviewLineItemsSection } from "@/features/quotes/components/ReviewLineItemsSection";
 import { TotalAmountSection } from "@/features/quotes/components/TotalAmountSection";
 import type { ExtractionReviewHiddenDetails, ExtractionTier, HiddenItemState } from "@/features/quotes/types/quote.types";
+import { hasUndismissedCaptureDetailsItems, resolveCaptureDetailsActionableItems } from "@/features/quotes/utils/captureDetails";
 import { FeedbackMessage } from "@/shared/components/FeedbackMessage";
 import {
   DOCUMENT_NOTES_MAX_CHARS,
@@ -28,22 +29,6 @@ function ReviewPendingMarker({ title, message }: ReviewPendingMarkerProps): Reac
       </div>
     </section>
   );
-}
-
-function resolveHiddenActionableItems(hiddenDetails?: ExtractionReviewHiddenDetails): Array<{ id: string }> {
-  if (!hiddenDetails) {
-    return [];
-  }
-  if (Array.isArray(hiddenDetails.items) && hiddenDetails.items.length > 0) {
-    return hiddenDetails.items;
-  }
-
-  const legacyItems = [
-    ...hiddenDetails.append_suggestions.map((item) => ({ id: item.id })),
-    ...hiddenDetails.unresolved_segments.map((item) => ({ id: item.id })),
-    ...hiddenDetails.confidence_notes.map((_, index) => ({ id: `legacy-confidence-${index}` })),
-  ];
-  return legacyItems;
 }
 
 interface ReviewFormContentProps {
@@ -98,8 +83,8 @@ interface ReviewFormContentProps {
   onDiscountValueChange: (nextDiscountValue: number | null) => void;
   onDepositAmountChange: (nextDepositAmount: number | null) => void;
   onNotesChange: (nextNotes: string) => void;
-  onReviewHiddenItem: (itemId: string) => Promise<void>;
   onDismissHiddenItem: (itemId: string) => Promise<void>;
+  onCaptureDetailsOpen: () => void;
 }
 
 export function ReviewFormContent({
@@ -136,16 +121,18 @@ export function ReviewFormContent({
   onDiscountValueChange,
   onDepositAmountChange,
   onNotesChange,
-  onReviewHiddenItem,
   onDismissHiddenItem,
+  onCaptureDetailsOpen,
 }: ReviewFormContentProps): React.ReactElement {
   const [isCaptureDetailsOpen, setIsCaptureDetailsOpen] = useState(false);
   const showDueDateField = documentType === "invoice";
   const showQuoteOnlySections = documentType === "quote";
   const showSevereDegradedMarker = extractionTier === "degraded"
     && draft.lineItems.length === 0;
-  const hasHiddenActionableItems = resolveHiddenActionableItems(hiddenDetails)
-    .some((item) => !hiddenDetailState?.[item.id]?.dismissed);
+  const hasHiddenActionableItems = hasUndismissedCaptureDetailsItems(
+    resolveCaptureDetailsActionableItems(hiddenDetails),
+    hiddenDetailState,
+  );
 
   return (
     <form
@@ -234,12 +221,15 @@ export function ReviewFormContent({
           <button
             type="button"
             className="inline-flex w-full cursor-pointer items-center justify-between rounded-lg border border-outline-variant/30 bg-surface-container-high px-4 py-3 text-left transition-colors hover:bg-surface-container-lowest"
-            onClick={() => setIsCaptureDetailsOpen(true)}
+            onClick={() => {
+              onCaptureDetailsOpen();
+              setIsCaptureDetailsOpen(true);
+            }}
           >
             <div>
               <p className="text-[0.6875rem] font-bold uppercase tracking-widest text-outline">Capture Details</p>
               <p className="text-sm text-on-surface-variant">
-                Suggestions, unresolved details, AI review notes, and transcript.
+                Actionable items and transcript.
               </p>
             </div>
             <div className="inline-flex items-center gap-1.5">
@@ -322,7 +312,6 @@ export function ReviewFormContent({
           transcript={draft.transcript ?? ""}
           hiddenDetails={hiddenDetails}
           hiddenDetailState={hiddenDetailState}
-          onReviewHiddenItem={onReviewHiddenItem}
           onDismissHiddenItem={onDismissHiddenItem}
           isMutating={isMutatingHiddenItems}
         />

--- a/frontend/src/features/quotes/components/ReviewScreen.tsx
+++ b/frontend/src/features/quotes/components/ReviewScreen.tsx
@@ -4,6 +4,7 @@ import { useBeforeUnload, useLocation, useNavigate, useParams } from "react-rout
 import { profileService } from "@/features/profile/services/profileService";
 import { DocumentEditScreenView } from "@/features/quotes/components/DocumentEditScreenView";
 import { buildDefaultInvoiceDueDate, buildDocumentSnapshotKey, buildSaveValidationMessage, isInvoiceDocument, persistDocumentDraft } from "@/features/quotes/components/documentEditUtils";
+import { useCaptureDetailsWarning } from "@/features/quotes/hooks/useCaptureDetailsWarning";
 import { useHiddenDetailLifecycle } from "@/features/quotes/hooks/useHiddenDetailLifecycle";
 import { applyLineItemSheetDelete, applyLineItemSheetSave, resolveLineItemSheetInitialItem, type ReviewLineItemSheetState } from "@/features/quotes/components/reviewLineItemSheetState";
 import { buildLineItemSubmitState, EMPTY_LINE_ITEM } from "@/features/quotes/components/reviewScreenUtils";
@@ -33,7 +34,7 @@ export function DocumentEditScreen(): React.ReactElement {
   const [submitAction, setSubmitAction] = useState<"save" | "continue" | null>(null);
   const [isAssignmentSheetOpen, setIsAssignmentSheetOpen] = useState(false);
   const [showLeaveWarning, setShowLeaveWarning] = useState(false);
-  const [showContinueWarning, setShowContinueWarning] = useState(false);
+  const [continueWarningReason, setContinueWarningReason] = useState<"review" | "capture-details" | null>(null);
   const [pendingNavigationTarget, setPendingNavigationTarget] = useState<{
     to: string;
     replace?: boolean;
@@ -82,13 +83,22 @@ export function DocumentEditScreen(): React.ReactElement {
   const documentId = id ?? "";
   const {
     isMutatingHiddenItems,
-    reviewHiddenItem,
     dismissHiddenItem,
   } = useHiddenDetailLifecycle({
     canMutate: Boolean(document && !isInvoiceDocument(document)),
     documentId,
     refreshDocument: async () => refreshDocument(),
     setSaveError,
+  });
+  const extractionReviewMetadata = document && !isInvoiceDocument(document)
+    ? document.extraction_review_metadata
+    : undefined;
+  const hiddenDetailState = extractionReviewMetadata?.hidden_detail_state;
+  const { shouldWarnOnContinue, markCaptureDetailsOpened } = useCaptureDetailsWarning({
+    documentId,
+    isQuoteDocument: draft?.docType === "quote",
+    hiddenDetails: extractionReviewMetadata?.hidden_details,
+    hiddenDetailState,
   });
   useEffect(() => {
     if (!id) {
@@ -138,7 +148,6 @@ export function DocumentEditScreen(): React.ReactElement {
   const hasUnsavedChanges = currentSnapshotKey !== null
     && savedSnapshotKey !== null
     && currentSnapshotKey !== savedSnapshotKey;
-
   useBeforeUnload((event) => {
     if (!hasUnsavedChanges) {
       return;
@@ -163,7 +172,6 @@ export function DocumentEditScreen(): React.ReactElement {
       navigate(nextTarget.to, { replace: nextTarget.replace });
     }
   }
-
   function handleLeaveCancel(): void {
     setShowLeaveWarning(false);
     setPendingNavigationTarget(null);
@@ -175,7 +183,6 @@ export function DocumentEditScreen(): React.ReactElement {
       </main>
     );
   }
-
   const activeDocumentType = draft?.docType ?? (document && isInvoiceDocument(document) ? "invoice" : "quote");
   const shouldUseQuoteListBackTarget = locationState.origin === "preview" && requiresCustomerAssignment;
   const invoiceBackTarget = `/invoices/${documentId}`;
@@ -212,10 +219,6 @@ export function DocumentEditScreen(): React.ReactElement {
     lineItemsForSubmit,
     lineItemSum,
   } = buildLineItemSubmitState(activeDraft.lineItems);
-  const extractionReviewMetadata = !isInvoiceDocument(activeDocument)
-    ? activeDocument.extraction_review_metadata
-    : undefined;
-  const hiddenDetailState = extractionReviewMetadata?.hidden_detail_state;
   const notesReviewPending = activeDraft.docType === "quote"
     && Boolean(extractionReviewMetadata?.review_state.notes_pending);
   const pricingReviewPending = activeDraft.docType === "quote"
@@ -351,7 +354,7 @@ export function DocumentEditScreen(): React.ReactElement {
       lineItemSheetInitialItem={lineItemSheetInitialItem}
       toastMessage={toastMessage}
       showLeaveWarning={showLeaveWarning}
-      showContinueWarning={showContinueWarning}
+      continueWarningReason={continueWarningReason}
       isSavingDraft={submitAction === "save"}
       isContinuing={submitAction === "continue"}
       onRequestNavigation={requestNavigation}
@@ -399,12 +402,16 @@ export function DocumentEditScreen(): React.ReactElement {
       onDiscountValueChange={(nextDiscountValue) => { setToastMessage(null); setDraft((currentDraft) => ({ ...currentDraft, discountValue: nextDiscountValue })); }}
       onDepositAmountChange={(nextDepositAmount) => { setToastMessage(null); setDraft((currentDraft) => ({ ...currentDraft, depositAmount: nextDepositAmount })); }}
       onNotesChange={(nextNotes) => { setToastMessage(null); setDraft((currentDraft) => ({ ...currentDraft, notes: nextNotes })); }}
-      onReviewHiddenItem={reviewHiddenItem}
       onDismissHiddenItem={dismissHiddenItem}
+      onCaptureDetailsOpen={markCaptureDetailsOpened}
       onSaveDraft={() => { void saveDraft("save"); }}
       onPrimaryAction={() => {
         if (activeDraft.docType === "quote" && (notesReviewPending || pricingReviewPending)) {
-          setShowContinueWarning(true);
+          setContinueWarningReason("review");
+          return;
+        }
+        if (shouldWarnOnContinue) {
+          setContinueWarningReason("capture-details");
           return;
         }
         void saveDraft("continue");
@@ -433,10 +440,10 @@ export function DocumentEditScreen(): React.ReactElement {
       onLeaveConfirm={handleLeaveConfirm}
       onLeaveCancel={handleLeaveCancel}
       onContinueConfirm={() => {
-        setShowContinueWarning(false);
+        setContinueWarningReason(null);
         void saveDraft("continue");
       }}
-      onContinueCancel={() => setShowContinueWarning(false)}
+      onContinueCancel={() => setContinueWarningReason(null)}
     />
   );
 }

--- a/frontend/src/features/quotes/hooks/useCaptureDetailsWarning.ts
+++ b/frontend/src/features/quotes/hooks/useCaptureDetailsWarning.ts
@@ -1,0 +1,75 @@
+import { useCallback, useMemo, useState } from "react";
+
+import type { ExtractionReviewHiddenDetails, HiddenItemState } from "@/features/quotes/types/quote.types";
+import {
+  buildCaptureDetailsFingerprint,
+  hasUndismissedCaptureDetailsItems,
+  resolveCaptureDetailsActionableItems,
+} from "@/features/quotes/utils/captureDetails";
+
+function buildCaptureDetailsFingerprintStorageKey(documentId: string): string {
+  return `stima_capture_details_fingerprint:${documentId}`;
+}
+
+interface UseCaptureDetailsWarningParams {
+  documentId: string;
+  isQuoteDocument: boolean;
+  hiddenDetails?: ExtractionReviewHiddenDetails;
+  hiddenDetailState?: Record<string, HiddenItemState>;
+}
+
+interface UseCaptureDetailsWarningResult {
+  shouldWarnOnContinue: boolean;
+  markCaptureDetailsOpened: () => void;
+}
+
+export function useCaptureDetailsWarning({
+  documentId,
+  isQuoteDocument,
+  hiddenDetails,
+  hiddenDetailState,
+}: UseCaptureDetailsWarningParams): UseCaptureDetailsWarningResult {
+  const [openedFingerprintOverrides, setOpenedFingerprintOverrides] = useState<Record<string, string>>({});
+  const captureDetailsItems = useMemo(
+    () => resolveCaptureDetailsActionableItems(hiddenDetails),
+    [hiddenDetails],
+  );
+  const captureDetailsFingerprint = useMemo(
+    () => buildCaptureDetailsFingerprint(captureDetailsItems),
+    [captureDetailsItems],
+  );
+  const hasUndismissedCaptureDetails = useMemo(
+    () => hasUndismissedCaptureDetailsItems(captureDetailsItems, hiddenDetailState),
+    [captureDetailsItems, hiddenDetailState],
+  );
+  const lastOpenedCaptureDetailsFingerprint = useMemo(() => {
+    if (!documentId) {
+      return "";
+    }
+    if (Object.prototype.hasOwnProperty.call(openedFingerprintOverrides, documentId)) {
+      return openedFingerprintOverrides[documentId] ?? "";
+    }
+    return window.localStorage.getItem(buildCaptureDetailsFingerprintStorageKey(documentId)) ?? "";
+  }, [documentId, openedFingerprintOverrides]);
+
+  const markCaptureDetailsOpened = useCallback(() => {
+    if (!documentId) {
+      return;
+    }
+    setOpenedFingerprintOverrides((current) => ({
+      ...current,
+      [documentId]: captureDetailsFingerprint,
+    }));
+    window.localStorage.setItem(
+      buildCaptureDetailsFingerprintStorageKey(documentId),
+      captureDetailsFingerprint,
+    );
+  }, [captureDetailsFingerprint, documentId]);
+
+  return {
+    shouldWarnOnContinue: isQuoteDocument
+      && hasUndismissedCaptureDetails
+      && captureDetailsFingerprint !== lastOpenedCaptureDetailsFingerprint,
+    markCaptureDetailsOpened,
+  };
+}

--- a/frontend/src/features/quotes/hooks/useHiddenDetailLifecycle.ts
+++ b/frontend/src/features/quotes/hooks/useHiddenDetailLifecycle.ts
@@ -12,7 +12,6 @@ interface UseHiddenDetailLifecycleParams {
 
 interface HiddenDetailLifecycleActions {
   isMutatingHiddenItems: boolean;
-  reviewHiddenItem: (itemId: string) => Promise<void>;
   dismissHiddenItem: (itemId: string) => Promise<void>;
 }
 
@@ -45,13 +44,6 @@ export function useHiddenDetailLifecycle({
     [canMutate, documentId, refreshDocument, setSaveError],
   );
 
-  const reviewHiddenItem = useCallback(
-    async (itemId: string): Promise<void> => {
-      await mutateExtractionReviewMetadata({ review_hidden_item: itemId });
-    },
-    [mutateExtractionReviewMetadata],
-  );
-
   const dismissHiddenItem = useCallback(
     async (itemId: string): Promise<void> => {
       await mutateExtractionReviewMetadata({ dismiss_hidden_item: itemId });
@@ -61,7 +53,6 @@ export function useHiddenDetailLifecycle({
 
   return {
     isMutatingHiddenItems,
-    reviewHiddenItem,
     dismissHiddenItem,
   };
 }

--- a/frontend/src/features/quotes/tests/ReviewScreen.test.tsx
+++ b/frontend/src/features/quotes/tests/ReviewScreen.test.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -182,9 +182,13 @@ function makeInvoice(overrides: Partial<InvoiceDetail> = {}): InvoiceDetail {
 function renderScreen(options?: {
   document?: QuoteDetail | InvoiceDetail;
   locationState?: unknown;
-}): { clearDraftMock: ReturnType<typeof vi.fn> } {
+}): {
+  clearDraftMock: ReturnType<typeof vi.fn>;
+  setDocument: (nextDocument: QuoteDetail | InvoiceDetail) => void;
+} {
   const document = options?.document ?? makeQuote();
   const clearDraftMock = vi.fn();
+  let setDocumentStateRef: ((nextDocument: QuoteDetail | InvoiceDetail) => void) | null = null;
 
   useLocationMock.mockReturnValue({ state: options?.locationState ?? null });
 
@@ -193,6 +197,9 @@ function renderScreen(options?: {
     const [draftState, setDraftState] = useState(
       "customer" in document ? mapInvoiceToEditDraft(document) : mapQuoteToEditDraft(document),
     );
+    setDocumentStateRef = (nextDocument) => {
+      setDocumentState(nextDocument);
+    };
 
     return {
       document: documentState,
@@ -223,7 +230,17 @@ function renderScreen(options?: {
     </MemoryRouter>,
   );
 
-  return { clearDraftMock };
+  return {
+    clearDraftMock,
+    setDocument: (nextDocument) => {
+      if (!setDocumentStateRef) {
+        return;
+      }
+      act(() => {
+        setDocumentStateRef?.(nextDocument);
+      });
+    },
+  };
 }
 
 beforeEach(() => {
@@ -395,7 +412,7 @@ describe("DocumentEditScreen", () => {
     });
   });
 
-  it("does not gate Continue when only hidden Capture Details items exist", async () => {
+  it("shows a soft Continue warning when new undismissed Capture Details items exist", async () => {
     renderScreen({
       document: makeQuote({
         extraction_review_metadata: {
@@ -422,12 +439,8 @@ describe("DocumentEditScreen", () => {
 
     fireEvent.click(await screen.findByRole("button", { name: /continue to preview/i }));
 
-    expect(screen.queryByRole("dialog", { name: /review pending extraction markers/i })).not.toBeInTheDocument();
-    await waitFor(() => {
-      expect(mockedQuoteService.updateQuote).toHaveBeenCalledWith("doc-1", expect.objectContaining({
-        doc_type: "quote",
-      }));
-    });
+    expect(screen.getByRole("dialog", { name: /review capture details before continuing/i })).toBeInTheDocument();
+    expect(mockedQuoteService.updateQuote).not.toHaveBeenCalled();
   });
 
   it("does not show the capture-details alert icon for transcript-only details", async () => {
@@ -471,7 +484,7 @@ describe("DocumentEditScreen", () => {
     expect(await screen.findByLabelText("Capture details need review")).toBeInTheDocument();
   });
 
-  it("renders Capture Details sections in the required order", async () => {
+  it("renders one unified actionable feed plus transcript with dismiss-only actions", async () => {
     renderScreen({
       document: makeQuote({
         extraction_review_metadata: {
@@ -504,22 +517,22 @@ describe("DocumentEditScreen", () => {
 
     fireEvent.click(await screen.findByRole("button", { name: /capture details/i }));
 
-    const section1 = await screen.findByText("New Suggestions From Latest Capture");
-    const section2 = screen.getByText("Unresolved Capture Details");
-    const section3 = screen.getByText("AI Review Notes");
-    const section4 = screen.getByText("Transcript");
-
-    expect(section1.compareDocumentPosition(section2)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
-    expect(section2.compareDocumentPosition(section3)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
-    expect(section3.compareDocumentPosition(section4)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+    const actionableHeading = await screen.findByText("Actionable Capture Details");
+    const transcriptHeading = screen.getByText("Transcript");
+    expect(actionableHeading.compareDocumentPosition(transcriptHeading)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+    expect(screen.queryByText("New Suggestions From Latest Capture")).not.toBeInTheDocument();
+    expect(screen.queryByText("Unresolved Capture Details")).not.toBeInTheDocument();
+    expect(screen.queryByText("AI Review Notes")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /mark reviewed/i })).not.toBeInTheDocument();
+    expect(screen.getAllByRole("button", { name: /^dismiss$/i }).length).toBeGreaterThan(0);
     expect(screen.getByText("Original capture transcript text.")).toBeInTheDocument();
-    const transcriptSection = section4.closest("section");
+    const transcriptSection = transcriptHeading.closest("section");
     expect(transcriptSection).not.toBeNull();
     expect(within(transcriptSection as HTMLElement).queryByRole("textbox")).not.toBeInTheDocument();
   });
 
-  it("persists dismiss actions for hidden items through sidecar metadata patch", async () => {
-    renderScreen({
+  it("updates capture-details fingerprint on open, ignores dismiss-only changes, and re-warns on new occurrences", async () => {
+    const { setDocument } = renderScreen({
       document: makeQuote({
         extraction_review_metadata: {
           ...makeQuote().extraction_review_metadata!,
@@ -541,6 +554,23 @@ describe("DocumentEditScreen", () => {
       }),
     });
 
+    fireEvent.click(await screen.findByRole("button", { name: /continue to preview/i }));
+    expect(screen.getByRole("dialog", { name: /review capture details before continuing/i })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /review now/i }));
+    expect(mockedQuoteService.updateQuote).not.toHaveBeenCalled();
+
+    fireEvent.click(await screen.findByRole("button", { name: /capture details/i }));
+    expect(window.localStorage.getItem("stima_capture_details_fingerprint:doc-1")).toBe("append-1");
+    fireEvent.click(screen.getByRole("button", { name: /^close$/i }));
+
+    fireEvent.click(screen.getByRole("button", { name: /continue to preview/i }));
+    await waitFor(() => {
+      expect(mockedQuoteService.updateQuote).toHaveBeenCalledWith("doc-1", expect.objectContaining({
+        doc_type: "quote",
+      }));
+    });
+    mockedQuoteService.updateQuote.mockClear();
+
     fireEvent.click(await screen.findByRole("button", { name: /capture details/i }));
     fireEvent.click(screen.getByRole("button", { name: /dismiss/i }));
 
@@ -549,6 +579,39 @@ describe("DocumentEditScreen", () => {
         dismiss_hidden_item: "append-1",
       });
     });
+
+    fireEvent.click(screen.getByRole("button", { name: /^close$/i }));
+    fireEvent.click(screen.getByRole("button", { name: /continue to preview/i }));
+    await waitFor(() => {
+      expect(mockedQuoteService.updateQuote).toHaveBeenCalledWith("doc-1", expect.objectContaining({
+        doc_type: "quote",
+      }));
+    });
+    expect(screen.queryByRole("dialog", { name: /review capture details before continuing/i })).not.toBeInTheDocument();
+    mockedQuoteService.updateQuote.mockClear();
+
+    setDocument(makeQuote({
+      extraction_review_metadata: {
+        ...makeQuote().extraction_review_metadata!,
+        hidden_details: {
+          append_suggestions: [
+            {
+              id: "append-2",
+              kind: "note",
+              raw_text: "Add gate latch note",
+              confidence: "low",
+              source: "append_capture",
+            },
+          ],
+          unresolved_segments: [],
+          confidence_notes: [],
+        },
+        hidden_detail_state: {},
+      },
+    }));
+
+    fireEvent.click(screen.getByRole("button", { name: /continue to preview/i }));
+    expect(screen.getByRole("dialog", { name: /review capture details before continuing/i })).toBeInTheDocument();
   });
 
   it("locks type selector after sharing", async () => {

--- a/frontend/src/features/quotes/utils/captureDetails.ts
+++ b/frontend/src/features/quotes/utils/captureDetails.ts
@@ -1,0 +1,67 @@
+import type { ExtractionReviewHiddenDetails, HiddenItemState } from "@/features/quotes/types/quote.types";
+
+export interface CaptureDetailsActionableItem {
+  id: string;
+  kind: "append_suggestion" | "unresolved_segment" | "confidence_note";
+  field: "notes" | "explicit_total" | "deposit_amount" | "tax_rate" | "discount" | null;
+  reason: string | null;
+  text: string;
+}
+
+export function resolveCaptureDetailsActionableItems(
+  hiddenDetails?: ExtractionReviewHiddenDetails,
+): CaptureDetailsActionableItem[] {
+  if (!hiddenDetails) {
+    return [];
+  }
+
+  if (Array.isArray(hiddenDetails.items) && hiddenDetails.items.length > 0) {
+    return hiddenDetails.items.map((item) => ({
+      id: item.id,
+      kind: item.kind,
+      field: item.field ?? null,
+      reason: item.reason ?? null,
+      text: item.text,
+    }));
+  }
+
+  const appendSuggestions = hiddenDetails.append_suggestions ?? [];
+  const unresolvedSegments = hiddenDetails.unresolved_segments ?? [];
+  const confidenceNotes = hiddenDetails.confidence_notes ?? [];
+
+  return [
+    ...appendSuggestions.map((suggestion) => ({
+      id: suggestion.id,
+      kind: "append_suggestion" as const,
+      field: (suggestion.pricing_field ?? "notes") as CaptureDetailsActionableItem["field"],
+      reason: suggestion.source,
+      text: suggestion.raw_text,
+    })),
+    ...unresolvedSegments.map((segment) => ({
+      id: segment.id,
+      kind: "unresolved_segment" as const,
+      field: null,
+      reason: segment.source,
+      text: segment.raw_text,
+    })),
+    ...confidenceNotes.map((note, index) => ({
+      id: `legacy-confidence-${index}`,
+      kind: "confidence_note" as const,
+      field: null,
+      reason: "legacy_confidence_note",
+      text: note,
+    })),
+  ];
+}
+
+export function hasUndismissedCaptureDetailsItems(
+  items: CaptureDetailsActionableItem[],
+  hiddenDetailState?: Record<string, HiddenItemState>,
+): boolean {
+  return items.some((item) => !hiddenDetailState?.[item.id]?.dismissed);
+}
+
+export function buildCaptureDetailsFingerprint(items: CaptureDetailsActionableItem[]): string {
+  const ids = Array.from(new Set(items.map((item) => item.id))).sort();
+  return ids.join("|");
+}


### PR DESCRIPTION
## Summary
- simplify Capture Details to a unified actionable feed plus transcript
- remove reviewed-state controls from the frontend and keep dismiss-only item interaction
- add per-quote local actionable-occurrence fingerprint tracking so Continue shows a soft warning only when new undismissed items appear since last open
- keep capture-details alert icon keyed to undismissed actionable items and update review flow tests for the new behavior

## Verification
- `cd frontend && npx vitest run src/features/quotes/tests/ReviewScreen.test.tsx src/features/quotes/tests/CaptureScreen.test.tsx src/features/quotes/tests/quoteService.integration.test.ts src/features/quotes/tests/usePersistedReview.test.tsx`
- `cd backend && .venv/bin/pytest app/features/quotes/tests/test_quote_append_extraction.py -m "not live and not extraction_eval and not extraction_quality" -o cache_dir=.pytest_cache`
- `cd frontend && npx tsc --noEmit`
- `cd frontend && npx eslint src/features/quotes`
- `make backend-static-verify`
- `make verify`

Closes #421