### PR TITLE
Task #422: Refresh extraction tests and eval fixtures for 2.5 mode split

### DIFF
--- a/backend/app/features/quotes/tests/fixtures/extraction_eval_cases.py
+++ b/backend/app/features/quotes/tests/fixtures/extraction_eval_cases.py
@@ -5,12 +5,9 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Literal
 
+from app.features.quotes.schemas import ExtractionMode
 from app.features.quotes.tests.fixtures.transcripts import TRANSCRIPTS
 
-_SEMANTIC_EMPTY_LINE_ITEMS_BELOW_TRANSCRIPT = (
-    "Clean gutters flush drains sweep roof patch fascia trim shrubs edge beds "
-    "check lights and confirm work schedule."
-)
 _SEMANTIC_EMPTY_LINE_ITEMS_ABOVE_TRANSCRIPT = (
     "Clean gutters flush drains sweep roof patch fascia trim shrubs edge beds "
     "check lights and confirm full work schedule tomorrow morning."
@@ -39,6 +36,16 @@ _APPEND_CAPTURE_TRANSCRIPT = (
     "Added later:\n"
     "- include driveway edging for 95"
 )
+_APPEND_CORRECTIVE_TRANSCRIPT = (
+    "Added later: actually remove driveway edging from the previous draft and keep only lights."
+)
+_APPEND_INCLUDED_SCOPE_TRANSCRIPT = "Added later: debris disposal is included at no extra charge."
+_APPEND_CONCURRENT_TRANSCRIPT = (
+    "Added later batch two: add hedge trim for 120 while another append is processing."
+)
+_APPEND_ASYNC_USER_EDIT_RACE_TRANSCRIPT = (
+    "Added later: gate code 1942 and tax is 7 percent for this follow-up scope."
+)
 _EXPLICIT_PRICING_RULE_TRANSCRIPT = (
     "Patio and drainage scope: seal patio for 260 and clear drainage line for 180. "
     "Pricing notes: deposit 150, tax 6.5 percent, discount 10 percent, total 459.95."
@@ -60,6 +67,7 @@ class ExtractionEvalCase:
     """Declarative extraction eval fixture used by manual property checks."""
 
     name: str
+    extraction_mode: ExtractionMode
     transcript: str
     provider_events: tuple[dict[str, Any], ...]
     expected_models: tuple[str, ...]
@@ -72,7 +80,7 @@ class ExtractionEvalCase:
     expect_degraded_reason_code: str | None = None
     expect_line_item_count_min: int | None = None
     expect_line_item_count_max: int | None = None
-    expect_confidence_note_substrings: tuple[str, ...] = ()
+    expect_line_item_price_statuses: tuple[Literal["priced", "included", "unknown"], ...] = ()
     expect_pricing_hints: dict[str, float | str | None] | None = None
     expect_unresolved_segment_sources: tuple[_UNRESOLVED_SEGMENT_SOURCE, ...] = ()
     expect_customer_notes_source: _UNRESOLVED_SEGMENT_SOURCE | None = None
@@ -94,13 +102,13 @@ class ExtractionEvalCase:
 
 EXTRACTION_EVAL_CASES: tuple[ExtractionEvalCase, ...] = (
     ExtractionEvalCase(
-        name="baseline_primary_contract_invariants",
+        name="baseline_initial_happy_path",
+        extraction_mode="initial",
         transcript=TRANSCRIPTS["clean_with_total"],
         provider_events=(
             {
                 "type": "tool_use",
                 "input": {
-                    "transcript": TRANSCRIPTS["clean_with_total"],
                     "line_items": [
                         {
                             "description": "Rear garage floodlights",
@@ -113,8 +121,9 @@ EXTRACTION_EVAL_CASES: tuple[ExtractionEvalCase, ...] = (
                             "price": 75,
                         },
                     ],
-                    "total": 435,
-                    "confidence_notes": [],
+                    "notes_candidate": None,
+                    "pricing_candidates": {"explicit_total": 435},
+                    "unresolved_items": [],
                 },
             },
         ),
@@ -126,10 +135,13 @@ EXTRACTION_EVAL_CASES: tuple[ExtractionEvalCase, ...] = (
         expect_line_item_count_max=2,
         expect_repair_attempted=False,
         expect_repair_outcome="not_attempted",
-        human_notes="Baseline primary extraction invariants remain stable.",
+        human_notes=(
+            "Baseline initial extraction keeps visible math aligned with visible line items."
+        ),
     ),
     ExtractionEvalCase(
         name="fallback_tier_after_primary_rate_limit",
+        extraction_mode="initial",
         transcript=TRANSCRIPTS["fallback_tier_probe"],
         provider_events=(
             {
@@ -138,7 +150,6 @@ EXTRACTION_EVAL_CASES: tuple[ExtractionEvalCase, ...] = (
             {
                 "type": "tool_use",
                 "input": {
-                    "transcript": TRANSCRIPTS["fallback_tier_probe"],
                     "line_items": [
                         {
                             "description": "Replace porch lights",
@@ -151,10 +162,9 @@ EXTRACTION_EVAL_CASES: tuple[ExtractionEvalCase, ...] = (
                             "price": 45,
                         },
                     ],
-                    "total": 165,
-                    "confidence_notes": [
-                        "Primary model unavailable; fallback tier produced extraction output."
-                    ],
+                    "notes_candidate": None,
+                    "pricing_candidates": {"explicit_total": 165},
+                    "unresolved_items": [],
                 },
             },
         ),
@@ -164,19 +174,18 @@ EXTRACTION_EVAL_CASES: tuple[ExtractionEvalCase, ...] = (
         expect_extraction_tier="primary",
         expect_line_item_count_min=2,
         expect_line_item_count_max=2,
-        expect_confidence_note_substrings=("fallback tier produced extraction output",),
         expect_repair_attempted=False,
         expect_repair_outcome="not_attempted",
-        human_notes="Fallback invocation should remain quote-facing primary when usable.",
+        human_notes="Fallback invocation remains primary-tier output when payload validates.",
     ),
     ExtractionEvalCase(
-        name="typed_landscaping_capture_with_explicit_total",
+        name="typed_only_capture_with_explicit_total",
+        extraction_mode="initial",
         transcript=_TYPED_LANDSCAPING_TRANSCRIPT,
         provider_events=(
             {
                 "type": "tool_use",
                 "input": {
-                    "transcript": _TYPED_LANDSCAPING_TRANSCRIPT,
                     "line_items": [
                         {
                             "description": "Brown mulch",
@@ -194,10 +203,9 @@ EXTRACTION_EVAL_CASES: tuple[ExtractionEvalCase, ...] = (
                             "price": 60,
                         },
                     ],
-                    "pricing_hints": {
-                        "explicit_total": 365,
-                    },
-                    "confidence_notes": [],
+                    "notes_candidate": None,
+                    "pricing_candidates": {"explicit_total": 365},
+                    "unresolved_items": [],
                 },
             },
         ),
@@ -210,16 +218,16 @@ EXTRACTION_EVAL_CASES: tuple[ExtractionEvalCase, ...] = (
         expect_pricing_hints={"explicit_total": 365},
         expect_repair_attempted=False,
         expect_repair_outcome="not_attempted",
-        human_notes="Typed-only landscaping capture should preserve explicit quantity math.",
+        human_notes="Typed-only capture remains a deterministic initial-mode baseline.",
     ),
     ExtractionEvalCase(
-        name="voice_only_landscaping_capture_spoken_equivalent",
+        name="voice_only_capture_equivalent",
+        extraction_mode="initial",
         transcript=_VOICE_EQUIVALENT_TRANSCRIPT,
         provider_events=(
             {
                 "type": "tool_use",
                 "input": {
-                    "transcript": _VOICE_EQUIVALENT_TRANSCRIPT,
                     "line_items": [
                         {
                             "description": "Brown mulch",
@@ -237,8 +245,9 @@ EXTRACTION_EVAL_CASES: tuple[ExtractionEvalCase, ...] = (
                             "price": 60,
                         },
                     ],
-                    "pricing_hints": {"explicit_total": 365},
-                    "confidence_notes": [],
+                    "notes_candidate": None,
+                    "pricing_candidates": {"explicit_total": 365},
+                    "unresolved_items": [],
                 },
             },
         ),
@@ -253,16 +262,16 @@ EXTRACTION_EVAL_CASES: tuple[ExtractionEvalCase, ...] = (
         expect_pricing_hints={"explicit_total": 365},
         expect_repair_attempted=False,
         expect_repair_outcome="not_attempted",
-        human_notes="Voice-only equivalent should retain the same pricing structure.",
+        human_notes="Voice-only capture mirrors typed math and contract shape.",
     ),
     ExtractionEvalCase(
-        name="mixed_voice_text_capture_with_typed_vs_transcript_conflict",
+        name="mixed_voice_text_conflict_initial",
+        extraction_mode="initial",
         transcript=_MIXED_VOICE_TEXT_TRANSCRIPT,
         provider_events=(
             {
                 "type": "tool_use",
                 "input": {
-                    "transcript": _MIXED_VOICE_TEXT_TRANSCRIPT,
                     "line_items": [
                         {
                             "description": "Brown mulch",
@@ -280,30 +289,17 @@ EXTRACTION_EVAL_CASES: tuple[ExtractionEvalCase, ...] = (
                             "price": 60,
                         },
                     ],
-                    "pricing_hints": {"explicit_total": 365},
-                    "customer_notes_suggestion": {
-                        "text": (
-                            "Typed follow-up conflicts with transcript scope; "
-                            "confirm edging details."
-                        ),
-                        "confidence": "low",
-                        "source": "typed_conflict",
-                    },
-                    "unresolved_segments": [
+                    "notes_candidate": "Typed follow-up conflicts with transcript scope.",
+                    "pricing_candidates": {"explicit_total": 365},
+                    "unresolved_items": [
                         {
-                            "raw_text": "Typed follow-up says skip edging on one side.",
-                            "confidence": "low",
-                            "source": "typed_conflict",
+                            "text": "Typed follow-up says skip edging on one side.",
+                            "reason": "possible_conflict",
                         },
                         {
-                            "raw_text": "Transcript includes edging for full front beds.",
-                            "confidence": "medium",
-                            "source": "transcript_conflict",
+                            "text": "Transcript includes edging for full front beds.",
+                            "reason": "possible_conflict",
                         },
-                    ],
-                    "confidence_notes": [
-                        "Typed and transcript conflict on edging scope; "
-                        "operator confirmation required."
                     ],
                 },
             },
@@ -317,40 +313,33 @@ EXTRACTION_EVAL_CASES: tuple[ExtractionEvalCase, ...] = (
         expect_extraction_tier="primary",
         expect_line_item_count_min=3,
         expect_line_item_count_max=3,
-        expect_confidence_note_substrings=("conflict on edging scope",),
         expect_pricing_hints={"explicit_total": 365},
-        expect_unresolved_segment_sources=("typed_conflict", "transcript_conflict"),
-        expect_customer_notes_source="typed_conflict",
+        expect_unresolved_segment_sources=("transcript_conflict", "transcript_conflict"),
+        expect_customer_notes_source="leftover_classification",
         expect_repair_attempted=False,
         expect_repair_outcome="not_attempted",
         human_notes=(
-            "Mixed capture should retain provenance and preserve typed/transcript conflicts."
+            "Mixed capture keeps source provenance and conflict details without confidence notes."
         ),
     ),
     ExtractionEvalCase(
-        name="append_capture_follow_up_transcript_sample",
+        name="append_additive_visible_scope",
+        extraction_mode="append",
         transcript=_APPEND_CAPTURE_TRANSCRIPT,
         provider_events=(
             {
                 "type": "tool_use",
                 "input": {
-                    "transcript": _APPEND_CAPTURE_TRANSCRIPT,
-                    "line_items": [
-                        {
-                            "description": "Floodlights",
-                            "details": "2 units",
-                            "price": 360,
-                        },
+                    "new_line_items": [
                         {
                             "description": "Driveway edging",
                             "details": None,
                             "price": 95,
-                        },
+                        }
                     ],
-                    "pricing_hints": {"explicit_total": 455},
-                    "confidence_notes": [
-                        "Append capture added a new line item after the initial transcript."
-                    ],
+                    "notes_candidate": None,
+                    "pricing_candidates": {"explicit_total": 95},
+                    "unresolved_items": [],
                 },
             },
         ),
@@ -358,22 +347,87 @@ EXTRACTION_EVAL_CASES: tuple[ExtractionEvalCase, ...] = (
         expected_invocation_tier="primary",
         expect_total_matches_priced_sum=True,
         expect_extraction_tier="primary",
-        expect_line_item_count_min=2,
-        expect_line_item_count_max=2,
-        expect_confidence_note_substrings=("append capture added",),
-        expect_pricing_hints={"explicit_total": 455},
+        expect_line_item_count_min=1,
+        expect_line_item_count_max=1,
+        expect_pricing_hints={"explicit_total": 95},
         expect_repair_attempted=False,
         expect_repair_outcome="not_attempted",
-        human_notes="Append-style transcript section should remain deterministic in eval fixtures.",
+        human_notes="Append mode returns additive scope only using append schema.",
     ),
     ExtractionEvalCase(
-        name="explicit_pricing_rule_fields_with_deposit_tax_discount",
+        name="append_corrective_language_routes_to_unresolved",
+        extraction_mode="append",
+        transcript=_APPEND_CORRECTIVE_TRANSCRIPT,
+        provider_events=(
+            {
+                "type": "tool_use",
+                "input": {
+                    "new_line_items": [],
+                    "notes_candidate": None,
+                    "pricing_candidates": {},
+                    "unresolved_items": [
+                        {
+                            "text": "Remove driveway edging from prior draft",
+                            "reason": "correction",
+                        }
+                    ],
+                },
+            },
+        ),
+        expected_models=("primary-model",),
+        expected_invocation_tier="primary",
+        expect_total_matches_priced_sum=False,
+        expect_extraction_tier="primary",
+        expect_line_item_count_min=0,
+        expect_line_item_count_max=0,
+        expect_unresolved_segment_sources=("transcript_conflict",),
+        expect_repair_attempted=False,
+        expect_repair_outcome="not_attempted",
+        human_notes=(
+            "Corrective append content must route to unresolved items, not visible rewrites."
+        ),
+    ),
+    ExtractionEvalCase(
+        name="append_included_scope_price_status",
+        extraction_mode="append",
+        transcript=_APPEND_INCLUDED_SCOPE_TRANSCRIPT,
+        provider_events=(
+            {
+                "type": "tool_use",
+                "input": {
+                    "new_line_items": [
+                        {
+                            "description": "Debris disposal",
+                            "details": "Included with cleanup",
+                            "price": None,
+                            "price_status": "included",
+                        }
+                    ],
+                    "notes_candidate": None,
+                    "pricing_candidates": {},
+                    "unresolved_items": [],
+                },
+            },
+        ),
+        expected_models=("primary-model",),
+        expected_invocation_tier="primary",
+        expect_total_matches_priced_sum=False,
+        expect_extraction_tier="primary",
+        expect_line_item_count_min=1,
+        expect_line_item_count_max=1,
+        expect_line_item_price_statuses=("included",),
+        expect_repair_attempted=False,
+        expect_repair_outcome="not_attempted",
+        human_notes="Included append scope should preserve included/price-null semantics.",
+    ),
+    ExtractionEvalCase(
+        name="initial_pricing_fields_with_deposit_tax_discount",
+        extraction_mode="initial",
         transcript=_EXPLICIT_PRICING_RULE_TRANSCRIPT,
         provider_events=(
             {
                 "type": "tool_use",
                 "input": {
-                    "transcript": _EXPLICIT_PRICING_RULE_TRANSCRIPT,
                     "line_items": [
                         {
                             "description": "Patio sealing",
@@ -386,16 +440,15 @@ EXTRACTION_EVAL_CASES: tuple[ExtractionEvalCase, ...] = (
                             "price": 180,
                         },
                     ],
-                    "pricing_hints": {
+                    "notes_candidate": None,
+                    "pricing_candidates": {
                         "explicit_total": 459.95,
                         "deposit_amount": 150,
                         "tax_rate": 6.5,
                         "discount_type": "percent",
                         "discount_value": 10,
                     },
-                    "confidence_notes": [
-                        "Total includes tax and discount adjustments; line-item sum may differ."
-                    ],
+                    "unresolved_items": [],
                 },
             },
         ),
@@ -414,16 +467,65 @@ EXTRACTION_EVAL_CASES: tuple[ExtractionEvalCase, ...] = (
         },
         expect_repair_attempted=False,
         expect_repair_outcome="not_attempted",
-        human_notes="Pricing hints should retain explicit total/deposit/tax/discount fields.",
+        human_notes=(
+            "Initial mode preserves explicit pricing candidates for downstream fill-empty logic."
+        ),
+    ),
+    ExtractionEvalCase(
+        name="initial_conflicting_total_with_unknown_price_status",
+        extraction_mode="initial",
+        transcript=(
+            "Paint fence and replace gate latch. Pricing is unclear per line item but customer "
+            "says "
+            "total should be 225."
+        ),
+        provider_events=(
+            {
+                "type": "tool_use",
+                "input": {
+                    "line_items": [
+                        {
+                            "description": "Paint fence",
+                            "details": None,
+                            "price": None,
+                            "price_status": "unknown",
+                        },
+                        {
+                            "description": "Replace gate latch",
+                            "details": None,
+                            "price": None,
+                            "price_status": "unknown",
+                        },
+                    ],
+                    "notes_candidate": None,
+                    "pricing_candidates": {"explicit_total": 225},
+                    "unresolved_items": [],
+                },
+            },
+        ),
+        expected_models=("primary-model",),
+        expected_invocation_tier="primary",
+        expect_total_matches_priced_sum=False,
+        expect_extraction_tier="primary",
+        expect_line_item_count_min=2,
+        expect_line_item_count_max=2,
+        expect_line_item_price_statuses=("unknown", "unknown"),
+        expect_pricing_hints={"explicit_total": 225},
+        expect_unresolved_segment_sources=("leftover_classification",),
+        expect_repair_attempted=False,
+        expect_repair_outcome="not_attempted",
+        human_notes=(
+            "Conflicting totals with unknown item pricing should create unresolved review guidance."
+        ),
     ),
     ExtractionEvalCase(
         name="typed_vs_transcript_conflict_with_unresolved_segments",
+        extraction_mode="initial",
         transcript=_TYPED_TRANSCRIPT_CONFLICT_TRANSCRIPT,
         provider_events=(
             {
                 "type": "tool_use",
                 "input": {
-                    "transcript": _TYPED_TRANSCRIPT_CONFLICT_TRANSCRIPT,
                     "line_items": [
                         {
                             "description": "Patio sealing",
@@ -436,25 +538,20 @@ EXTRACTION_EVAL_CASES: tuple[ExtractionEvalCase, ...] = (
                             "price": 180,
                         },
                     ],
-                    "pricing_hints": {"explicit_total": 440},
-                    "customer_notes_suggestion": {
-                        "text": "Customer may want to waive drainage cleanout if budget is tight.",
-                        "confidence": "low",
-                        "source": "typed_conflict",
-                    },
-                    "unresolved_segments": [
+                    "notes_candidate": (
+                        "Customer may want to waive drainage cleanout if budget is tight."
+                    ),
+                    "pricing_candidates": {"explicit_total": 440},
+                    "unresolved_items": [
                         {
-                            "raw_text": "Typed note says skip drainage if budget is tight.",
-                            "confidence": "low",
-                            "source": "typed_conflict",
+                            "text": "Typed note says skip drainage if budget is tight.",
+                            "reason": "possible_conflict",
                         },
                         {
-                            "raw_text": "Transcript still includes drainage line cleanout.",
-                            "confidence": "medium",
-                            "source": "transcript_conflict",
+                            "text": "Transcript still includes drainage line cleanout.",
+                            "reason": "possible_conflict",
                         },
                     ],
-                    "confidence_notes": ["Typed and transcript inputs conflict on drainage scope."],
                 },
             },
         ),
@@ -464,31 +561,30 @@ EXTRACTION_EVAL_CASES: tuple[ExtractionEvalCase, ...] = (
         expect_extraction_tier="primary",
         expect_line_item_count_min=2,
         expect_line_item_count_max=2,
-        expect_confidence_note_substrings=("conflict on drainage scope",),
         expect_pricing_hints={"explicit_total": 440},
-        expect_unresolved_segment_sources=("typed_conflict", "transcript_conflict"),
-        expect_customer_notes_source="typed_conflict",
+        expect_unresolved_segment_sources=("transcript_conflict", "transcript_conflict"),
+        expect_customer_notes_source="leftover_classification",
         expect_repair_attempted=False,
         expect_repair_outcome="not_attempted",
-        human_notes="Typed-vs-transcript conflict should survive as unresolved sidecar details.",
+        human_notes="Conflict details remain actionable via unresolved segments in 2.5.",
     ),
     ExtractionEvalCase(
         name="repair_succeeds_after_one_invalid_payload",
+        extraction_mode="initial",
         transcript=TRANSCRIPTS["clean_with_total"],
         provider_events=(
             {
                 "type": "tool_use",
                 "input": {
-                    "transcript": TRANSCRIPTS["clean_with_total"],
                     "line_items": "invalid-shape",
-                    "total": 435,
-                    "confidence_notes": [],
+                    "notes_candidate": None,
+                    "pricing_candidates": {"explicit_total": 435},
+                    "unresolved_items": [],
                 },
             },
             {
                 "type": "tool_use",
                 "input": {
-                    "transcript": TRANSCRIPTS["clean_with_total"],
                     "line_items": [
                         {
                             "description": "Trim shrubs",
@@ -496,8 +592,9 @@ EXTRACTION_EVAL_CASES: tuple[ExtractionEvalCase, ...] = (
                             "price": 125,
                         }
                     ],
-                    "total": 125,
-                    "confidence_notes": [],
+                    "notes_candidate": None,
+                    "pricing_candidates": {"explicit_total": 125},
+                    "unresolved_items": [],
                 },
             },
         ),
@@ -514,24 +611,25 @@ EXTRACTION_EVAL_CASES: tuple[ExtractionEvalCase, ...] = (
     ),
     ExtractionEvalCase(
         name="repair_still_invalid_degrades_with_reason_code",
+        extraction_mode="initial",
         transcript=TRANSCRIPTS["clean_with_total"],
         provider_events=(
             {
                 "type": "tool_use",
                 "input": {
-                    "transcript": TRANSCRIPTS["clean_with_total"],
                     "line_items": "invalid-shape",
-                    "total": 435,
-                    "confidence_notes": [],
+                    "notes_candidate": None,
+                    "pricing_candidates": {"explicit_total": 435},
+                    "unresolved_items": [],
                 },
             },
             {
                 "type": "tool_use",
                 "input": {
-                    "transcript": TRANSCRIPTS["clean_with_total"],
                     "line_items": "still-invalid",
-                    "total": 435,
-                    "confidence_notes": [],
+                    "notes_candidate": None,
+                    "pricing_candidates": {"explicit_total": 435},
+                    "unresolved_items": [],
                 },
             },
         ),
@@ -548,40 +646,17 @@ EXTRACTION_EVAL_CASES: tuple[ExtractionEvalCase, ...] = (
         human_notes="Invalid repair payload should degrade with validation repair failure.",
     ),
     ExtractionEvalCase(
-        name="semantic_empty_items_below_threshold_stays_primary",
-        transcript=_SEMANTIC_EMPTY_LINE_ITEMS_BELOW_TRANSCRIPT,
-        provider_events=(
-            {
-                "type": "tool_use",
-                "input": {
-                    "transcript": _SEMANTIC_EMPTY_LINE_ITEMS_BELOW_TRANSCRIPT,
-                    "line_items": [],
-                    "total": None,
-                    "confidence_notes": [],
-                },
-            },
-        ),
-        expected_models=("primary-model",),
-        expected_invocation_tier="primary",
-        expect_total_matches_priced_sum=False,
-        expect_extraction_tier="primary",
-        expect_line_item_count_min=0,
-        expect_line_item_count_max=0,
-        expect_repair_attempted=False,
-        expect_repair_outcome="not_attempted",
-        human_notes="Boundary probe just below transcript-char threshold.",
-    ),
-    ExtractionEvalCase(
-        name="semantic_empty_items_at_or_above_threshold_degrades",
+        name="degraded_extraction_for_substantial_empty_payload",
+        extraction_mode="initial",
         transcript=_SEMANTIC_EMPTY_LINE_ITEMS_ABOVE_TRANSCRIPT,
         provider_events=(
             {
                 "type": "tool_use",
                 "input": {
-                    "transcript": _SEMANTIC_EMPTY_LINE_ITEMS_ABOVE_TRANSCRIPT,
                     "line_items": [],
-                    "total": None,
-                    "confidence_notes": [],
+                    "notes_candidate": None,
+                    "pricing_candidates": {},
+                    "unresolved_items": [],
                 },
             },
         ),
@@ -592,66 +667,21 @@ EXTRACTION_EVAL_CASES: tuple[ExtractionEvalCase, ...] = (
         expect_degraded_reason_code="semantic_empty_line_items_substantial_transcript",
         expect_line_item_count_min=0,
         expect_line_item_count_max=0,
-        expect_confidence_note_substrings=(
-            "No line items were extracted from a substantial transcript",
-        ),
         expect_repair_attempted=False,
         expect_repair_outcome="not_attempted",
-        human_notes="Boundary probe at/above semantic transcript + word thresholds.",
+        human_notes=(
+            "Substantial transcripts with empty extraction degrade without "
+            "confidence-note fallback."
+        ),
     ),
     ExtractionEvalCase(
-        name="total_mismatch_transcript",
-        transcript=(
-            "Paint fence for 150 and replace gate latch for 100. Customer says total should be 225."
-        ),
+        name="duplicate_line_items_are_flagged",
+        extraction_mode="initial",
+        transcript="Clean gutters for 150, also clean the gutters on the back for 150.",
         provider_events=(
             {
                 "type": "tool_use",
                 "input": {
-                    "transcript": (
-                        "Paint fence for 150 and replace gate latch for 100. "
-                        "Customer says total should be 225."
-                    ),
-                    "line_items": [
-                        {
-                            "description": "Paint fence",
-                            "details": None,
-                            "price": 150,
-                        },
-                        {
-                            "description": "Replace gate latch",
-                            "details": None,
-                            "price": 100,
-                        },
-                    ],
-                    "total": 225,
-                    "confidence_notes": [
-                        "Stated total does not match line item sum; review total before sending."
-                    ],
-                },
-            },
-        ),
-        expected_models=("primary-model",),
-        expected_invocation_tier="primary",
-        expect_total_matches_priced_sum=True,
-        expect_extraction_tier="primary",
-        expect_line_item_count_min=2,
-        expect_line_item_count_max=2,
-        expect_confidence_note_substrings=("does not match line item sum",),
-        expect_repair_attempted=False,
-        expect_repair_outcome="not_attempted",
-        human_notes="Total mismatch should recalculate or provide explicit mismatch guidance.",
-    ),
-    ExtractionEvalCase(
-        name="duplicate_line_items_in_transcript",
-        transcript=("Clean gutters for 150, also clean the gutters on the back for 150."),
-        provider_events=(
-            {
-                "type": "tool_use",
-                "input": {
-                    "transcript": (
-                        "Clean gutters for 150, also clean the gutters on the back for 150."
-                    ),
                     "line_items": [
                         {
                             "description": "Clean gutters",
@@ -664,8 +694,9 @@ EXTRACTION_EVAL_CASES: tuple[ExtractionEvalCase, ...] = (
                             "price": 150,
                         },
                     ],
-                    "total": 300,
-                    "confidence_notes": [],
+                    "notes_candidate": None,
+                    "pricing_candidates": {"explicit_total": 300},
+                    "unresolved_items": [],
                 },
             },
         ),
@@ -679,36 +710,71 @@ EXTRACTION_EVAL_CASES: tuple[ExtractionEvalCase, ...] = (
         expect_flag_reason_substrings=("duplicate",),
         expect_repair_attempted=False,
         expect_repair_outcome="not_attempted",
-        human_notes="Duplicate post-validation semantic flagging should mark both entries.",
+        human_notes="Duplicate semantic guard should remain visible through line-item flags.",
     ),
     ExtractionEvalCase(
-        name="very_short_transcript",
-        transcript="Mow lawn 50",
+        name="append_concurrent_followups_candidate_shape",
+        extraction_mode="append",
+        transcript=_APPEND_CONCURRENT_TRANSCRIPT,
         provider_events=(
             {
                 "type": "tool_use",
                 "input": {
-                    "transcript": "Mow lawn 50",
-                    "line_items": [
+                    "new_line_items": [
                         {
-                            "description": "Mow lawn",
+                            "description": "Hedge trim follow-up",
                             "details": None,
-                            "price": 50,
+                            "price": 120,
                         }
                     ],
-                    "total": 50,
-                    "confidence_notes": [],
+                    "notes_candidate": None,
+                    "pricing_candidates": {"deposit_amount": 60},
+                    "unresolved_items": [],
                 },
             },
         ),
         expected_models=("primary-model",),
         expected_invocation_tier="primary",
-        expect_total_matches_priced_sum=True,
+        expect_total_matches_priced_sum=False,
         expect_extraction_tier="primary",
         expect_line_item_count_min=1,
         expect_line_item_count_max=1,
+        expect_pricing_hints={"deposit_amount": 60},
         expect_repair_attempted=False,
         expect_repair_outcome="not_attempted",
-        human_notes="Very short transcripts should not trip empty-items semantic degradation.",
+        human_notes=(
+            "Concurrent append manual plan: run two appends back-to-back and verify additive "
+            "application against latest persisted state."
+        ),
+    ),
+    ExtractionEvalCase(
+        name="append_async_user_edit_race_candidate_shape",
+        extraction_mode="append",
+        transcript=_APPEND_ASYNC_USER_EDIT_RACE_TRANSCRIPT,
+        provider_events=(
+            {
+                "type": "tool_use",
+                "input": {
+                    "new_line_items": [],
+                    "notes_candidate": "Gate code 1942",
+                    "pricing_candidates": {"tax_rate": 7.0},
+                    "unresolved_items": [],
+                },
+            },
+        ),
+        expected_models=("primary-model",),
+        expected_invocation_tier="primary",
+        expect_total_matches_priced_sum=False,
+        expect_extraction_tier="primary",
+        expect_line_item_count_min=0,
+        expect_line_item_count_max=0,
+        expect_pricing_hints={"tax_rate": 7.0},
+        expect_customer_notes_source="leftover_classification",
+        expect_repair_attempted=False,
+        expect_repair_outcome="not_attempted",
+        human_notes=(
+            "Async user-edit race manual plan: if operator fills notes/pricing before async apply, "
+            "candidate should become withheld instead of overwriting visible fields."
+        ),
     ),
 )

--- a/backend/app/features/quotes/tests/fixtures/extraction_quality_cases.py
+++ b/backend/app/features/quotes/tests/fixtures/extraction_quality_cases.py
@@ -64,6 +64,7 @@ _Q15_LANDSCAPE_JARGON = (
 QUALITY_CASES: tuple[ExtractionQualityCase, ...] = (
     ExtractionQualityCase(
         name="Q01_multi_item_exact_prices",
+        extraction_mode="initial",
         transcript=TRANSCRIPTS["clean_with_total"],
         expected_line_items=(
             ExpectedLineItem(description="Rear garage floodlights", price=360),
@@ -76,6 +77,7 @@ QUALITY_CASES: tuple[ExtractionQualityCase, ...] = (
     ),
     ExtractionQualityCase(
         name="Q02_multi_item_no_prices",
+        extraction_mode="initial",
         transcript=TRANSCRIPTS["clean_no_prices"],
         expected_line_items=(
             ExpectedLineItem(description="Trim shrubs", price=None),
@@ -91,6 +93,7 @@ QUALITY_CASES: tuple[ExtractionQualityCase, ...] = (
     ),
     ExtractionQualityCase(
         name="Q03_single_item_job",
+        extraction_mode="initial",
         transcript=_Q03_SINGLE_ITEM_JOB,
         expected_line_items=(ExpectedLineItem(description="Power wash driveway", price=400),),
         expected_total=400,
@@ -100,6 +103,7 @@ QUALITY_CASES: tuple[ExtractionQualityCase, ...] = (
     ),
     ExtractionQualityCase(
         name="Q04_quantities_in_description",
+        extraction_mode="initial",
         transcript=_Q04_QUANTITY_MATH,
         expected_line_items=(
             ExpectedLineItem(description="Brown mulch", details="5 yards", price=225),
@@ -112,6 +116,7 @@ QUALITY_CASES: tuple[ExtractionQualityCase, ...] = (
     ),
     ExtractionQualityCase(
         name="Q05_mixed_services_materials",
+        extraction_mode="initial",
         transcript=_Q05_MIXED_SERVICES_AND_MATERIALS,
         expected_line_items=(
             ExpectedLineItem(description="Driveway section repair", price=800),
@@ -125,6 +130,7 @@ QUALITY_CASES: tuple[ExtractionQualityCase, ...] = (
     ),
     ExtractionQualityCase(
         name="Q06_mid_sentence_correction",
+        extraction_mode="initial",
         transcript=_Q06_MID_SENTENCE_CORRECTION,
         expected_line_items=(
             ExpectedLineItem(description="Power wash deck", price=275),
@@ -138,6 +144,7 @@ QUALITY_CASES: tuple[ExtractionQualityCase, ...] = (
     ),
     ExtractionQualityCase(
         name="Q07_item_described_in_two_parts",
+        extraction_mode="initial",
         transcript=_Q07_ITEM_DESCRIBED_IN_PARTS,
         expected_line_items=(
             ExpectedLineItem(
@@ -152,6 +159,7 @@ QUALITY_CASES: tuple[ExtractionQualityCase, ...] = (
     ),
     ExtractionQualityCase(
         name="Q08_verbose_with_filler_words",
+        extraction_mode="initial",
         transcript=_Q08_VERBOSE_WITH_FILLER,
         expected_line_items=(
             ExpectedLineItem(description="Brown mulch", price=120),
@@ -165,6 +173,7 @@ QUALITY_CASES: tuple[ExtractionQualityCase, ...] = (
     ),
     ExtractionQualityCase(
         name="Q09_total_only_transcript",
+        extraction_mode="initial",
         transcript=TRANSCRIPTS["total_only"],
         expected_line_items=(
             ExpectedLineItem(
@@ -183,6 +192,7 @@ QUALITY_CASES: tuple[ExtractionQualityCase, ...] = (
     ),
     ExtractionQualityCase(
         name="Q10_tax_and_discount_language",
+        extraction_mode="initial",
         transcript=_Q10_TAX_AND_DISCOUNT,
         expected_line_items=(
             ExpectedLineItem(
@@ -193,13 +203,14 @@ QUALITY_CASES: tuple[ExtractionQualityCase, ...] = (
         ),
         expected_total=None,
         expect_total=False,
-        confidence_note_substrings=("discount", "tax"),
+        expected_pricing_fields=("tax_rate", "discount_type", "discount_value"),
         category="tax_discount",
         difficulty="medium",
         human_notes="Discount and tax should appear as confidence notes, not line-item math.",
     ),
     ExtractionQualityCase(
         name="Q11_very_short_transcript",
+        extraction_mode="initial",
         transcript=_Q11_VERY_SHORT,
         expected_line_items=(ExpectedLineItem(description="Mow lawn", price=50),),
         expected_total=50,
@@ -209,6 +220,7 @@ QUALITY_CASES: tuple[ExtractionQualityCase, ...] = (
     ),
     ExtractionQualityCase(
         name="Q12_extended_multi_item_transcript",
+        extraction_mode="initial",
         transcript=_Q12_EXTENDED_MULTI_ITEM,
         expected_line_items=(
             ExpectedLineItem(
@@ -240,6 +252,7 @@ QUALITY_CASES: tuple[ExtractionQualityCase, ...] = (
     ),
     ExtractionQualityCase(
         name="Q13_duplicate_detection",
+        extraction_mode="initial",
         transcript=_Q13_DUPLICATE_DETECTION,
         expected_line_items=(
             ExpectedLineItem(
@@ -263,6 +276,7 @@ QUALITY_CASES: tuple[ExtractionQualityCase, ...] = (
     ),
     ExtractionQualityCase(
         name="Q14_item_split_across_sentences",
+        extraction_mode="initial",
         transcript=_Q14_IMPLICIT_SPLIT,
         expected_line_items=(
             ExpectedLineItem(description="Sod installation", price=1000, price_tolerance_pct=0.15),
@@ -278,6 +292,7 @@ QUALITY_CASES: tuple[ExtractionQualityCase, ...] = (
     ),
     ExtractionQualityCase(
         name="Q15_landscape_jargon_future_followup",
+        extraction_mode="initial",
         transcript=_Q15_LANDSCAPE_JARGON,
         expected_line_items=(
             ExpectedLineItem(description="Dethatch aerate overseed lawn", price=250),

--- a/backend/app/features/quotes/tests/scoring/extraction_scorer.py
+++ b/backend/app/features/quotes/tests/scoring/extraction_scorer.py
@@ -9,7 +9,7 @@ from difflib import SequenceMatcher
 from math import isclose
 from typing import Any, Literal
 
-from app.features.quotes.schemas import ExtractionResult, LineItemExtracted
+from app.features.quotes.schemas import ExtractionMode, ExtractionResult, LineItemExtracted
 from app.integrations.extraction import ExtractionCallMetadata
 
 _DESCRIPTION_MATCH_THRESHOLD = 0.4
@@ -34,6 +34,7 @@ class ExtractionQualityCase:
     """Ground truth case for extraction quality measurement."""
 
     name: str
+    extraction_mode: ExtractionMode
     transcript: str
     expected_line_items: tuple[ExpectedLineItem, ...]
     expected_total: float | None = None
@@ -42,7 +43,29 @@ class ExtractionQualityCase:
     expected_line_item_count_max: int | None = None
     expect_prices: bool = True
     expect_total: bool = True
-    confidence_note_substrings: tuple[str, ...] = ()
+    expected_pricing_fields: tuple[
+        Literal[
+            "explicit_total",
+            "deposit_amount",
+            "tax_rate",
+            "discount_type",
+            "discount_value",
+        ],
+        ...,
+    ] = ()
+    expected_unresolved_sources: tuple[
+        Literal["leftover_classification", "typed_conflict", "transcript_conflict"], ...
+    ] = ()
+    expected_append_outcome: (
+        Literal[
+            "adds_visible_scope",
+            "withholds_correction",
+            "included_scope",
+            "fills_pricing_fields",
+            "no_visible_change",
+        ]
+        | None
+    ) = None
     category: str = "general"
     difficulty: Literal["easy", "medium", "hard"] = "medium"
     cost_tier: Literal["standard", "high"] = "standard"
@@ -70,7 +93,10 @@ class CaseScore:
     difficulty: str
     item_scores: tuple[ItemMatchResult, ...]
     total_score: float
-    confidence_note_score: float | None
+    flag_accuracy: float
+    unresolved_score: float
+    pricing_behavior_score: float
+    append_outcome_score: float | None
     precision: float
     recall: float
     extras_count: int
@@ -255,18 +281,94 @@ def _score_total(
     return 0.0
 
 
-def _score_confidence_notes(expected: Sequence[str], actual_notes: Sequence[str]) -> float | None:
-    if not expected:
+def _score_flags(result: ExtractionResult, item_scores: Sequence[ItemMatchResult]) -> float:
+    expected_flag_scores = [
+        float(score.flag_score)
+        for score in item_scores
+        if score.expected.expected_flagged and score.flag_score is not None
+    ]
+    if expected_flag_scores:
+        return _average(expected_flag_scores, default=1.0)
+    return 1.0 if not any(item.flagged for item in result.line_items) else 0.5
+
+
+def _score_unresolved_items(
+    expected_sources: Sequence[str], actual_sources: Sequence[str]
+) -> float:
+    if not expected_sources:
+        return 1.0 if not actual_sources else 0.5
+
+    remaining_actual = list(actual_sources)
+    matched = 0
+    for source in expected_sources:
+        if source in remaining_actual:
+            matched += 1
+            remaining_actual.remove(source)
+
+    recall = matched / len(expected_sources)
+    precision = matched / max(len(actual_sources), 1)
+    return (recall + precision) / 2.0
+
+
+def _score_pricing_behavior(case: ExtractionQualityCase, result: ExtractionResult) -> float:
+    status_scores: list[float] = []
+    for item in result.line_items:
+        if item.price is None:
+            status_scores.append(1.0 if item.price_status in {"included", "unknown"} else 0.0)
+        else:
+            status_scores.append(1.0 if item.price_status == "priced" else 0.0)
+
+    pricing_hints_payload = result.pricing_hints.model_dump(mode="json")
+    expected_pricing_scores: list[float] = []
+    for field in case.expected_pricing_fields:
+        expected_pricing_scores.append(1.0 if pricing_hints_payload.get(field) is not None else 0.0)
+
+    priced_values = [item.price for item in result.line_items if item.price is not None]
+    total_alignment_score = 1.0
+    if priced_values and result.total is not None:
+        total_alignment_score = (
+            1.0 if isclose(sum(priced_values), result.total, abs_tol=0.01) else 0.0
+        )
+
+    dimensions: list[float] = []
+    if status_scores:
+        dimensions.append(_average(status_scores, default=1.0))
+    if expected_pricing_scores:
+        dimensions.append(_average(expected_pricing_scores, default=1.0))
+    dimensions.append(total_alignment_score)
+    return _average(dimensions, default=1.0)
+
+
+def _score_append_outcome(case: ExtractionQualityCase, result: ExtractionResult) -> float | None:
+    if case.extraction_mode != "append":
         return None
 
-    folded_notes = [note.casefold() for note in actual_notes]
-    found_count = 0
-    for fragment in expected:
-        folded_fragment = fragment.casefold()
-        if any(folded_fragment in note for note in folded_notes):
-            found_count += 1
+    expected = case.expected_append_outcome
+    if expected is None:
+        return 1.0
 
-    return found_count / len(expected)
+    has_visible_items = bool(result.line_items)
+    has_transcript_conflict = any(
+        segment.source == "transcript_conflict" for segment in result.unresolved_segments
+    )
+    has_included_scope = any(
+        item.price is None and item.price_status == "included" for item in result.line_items
+    )
+    has_pricing_fields = any(
+        value is not None for value in result.pricing_hints.model_dump(mode="json").values()
+    )
+
+    if expected == "adds_visible_scope":
+        return 1.0 if has_visible_items else 0.0
+    if expected == "withholds_correction":
+        return 1.0 if (not has_visible_items and has_transcript_conflict) else 0.0
+    if expected == "included_scope":
+        return 1.0 if has_included_scope else 0.0
+    if expected == "fills_pricing_fields":
+        return 1.0 if has_pricing_fields else 0.0
+    if expected == "no_visible_change":
+        return 1.0 if not has_visible_items else 0.0
+    return 1.0
 
 
 def _description_recall(item_scores: Sequence[ItemMatchResult]) -> float:
@@ -320,19 +422,30 @@ def score_case(
     details_accuracy = _details_accuracy(item_scores)
     total_score = _score_total(case.expected_total, result.total, case.expected_total_tolerance_pct)
     extras_penalty = min(extras_count / max(len(case.expected_line_items), 1), 1.0)
-
-    overall = _clamp(
-        (0.40 * description_recall)
-        + (0.25 * price_accuracy)
-        + (0.15 * total_score)
-        + (0.10 * details_accuracy)
-        + (0.10 * (1.0 - extras_penalty))
+    flag_accuracy = _score_flags(result, item_scores)
+    unresolved_score = _score_unresolved_items(
+        case.expected_unresolved_sources,
+        [segment.source for segment in result.unresolved_segments],
     )
+    pricing_behavior_score = _score_pricing_behavior(case, result)
+    append_outcome_score = _score_append_outcome(case, result)
 
-    confidence_note_score = _score_confidence_notes(
-        case.confidence_note_substrings,
-        result.confidence_notes,
-    )
+    weighted_dimensions: list[tuple[float, float]] = [
+        (description_recall, 0.30),
+        (price_accuracy, 0.18),
+        (total_score, 0.12),
+        (details_accuracy, 0.08),
+        (1.0 - extras_penalty, 0.10),
+        (flag_accuracy, 0.08),
+        (unresolved_score, 0.07),
+        (pricing_behavior_score, 0.07),
+    ]
+    if append_outcome_score is not None:
+        weighted_dimensions.append((append_outcome_score, 0.08))
+
+    weighted_total = sum(score * weight for score, weight in weighted_dimensions)
+    weight_sum = sum(weight for _, weight in weighted_dimensions)
+    overall = _clamp(weighted_total / weight_sum if weight_sum else 0.0)
 
     return CaseScore(
         name=case.name,
@@ -340,7 +453,10 @@ def score_case(
         difficulty=case.difficulty,
         item_scores=item_scores,
         total_score=total_score,
-        confidence_note_score=confidence_note_score,
+        flag_accuracy=flag_accuracy,
+        unresolved_score=unresolved_score,
+        pricing_behavior_score=pricing_behavior_score,
+        append_outcome_score=append_outcome_score,
         precision=precision,
         recall=recall,
         extras_count=extras_count,
@@ -408,8 +524,14 @@ def format_report(cases: Sequence[ExtractionQualityCase], scores: Sequence[CaseS
             f"{description_recall:.2f}  Price: {price_accuracy:.2f}  "
             f"Details: {details_label}  Total: {score.total_score:.2f}"
         )
-        if score.confidence_note_score is not None:
-            lines.append(f"  Confidence notes: {score.confidence_note_score:.2f}")
+        lines.append(
+            "  Flags: "
+            f"{score.flag_accuracy:.2f}  "
+            f"Unresolved: {score.unresolved_score:.2f}  "
+            f"Pricing behavior: {score.pricing_behavior_score:.2f}"
+        )
+        if score.append_outcome_score is not None:
+            lines.append(f"  Append outcome: {score.append_outcome_score:.2f}")
         lines.append(f"  Overall: {score.overall:.2f}")
 
     summary = aggregate_scores(scores)

--- a/backend/app/features/quotes/tests/test_extraction_eval.py
+++ b/backend/app/features/quotes/tests/test_extraction_eval.py
@@ -20,12 +20,13 @@ from app.features.quotes.tests.fixtures.extraction_eval_cases import (
     ExtractionEvalCase,
 )
 from app.integrations.extraction import (
+    APPEND_EXTRACTION_TOOL_SCHEMA,
+    EXTRACTION_TOOL_SCHEMA,
     ExtractionCallMetadata,
     ExtractionError,
     ExtractionIntegration,
 )
 from app.shared.input_limits import (
-    CONFIDENCE_NOTES_MAX_ITEMS,
     DOCUMENT_LINE_ITEMS_MAX_ITEMS,
 )
 
@@ -111,10 +112,24 @@ def _assert_request_capture_provenance(
     content = first_message["content"]
     assert isinstance(content, str)
     request_payload = json.loads(content)
+    assert request_payload["extraction_mode"] == case.extraction_mode
     prepared_capture_input = request_payload["prepared_capture_input"]
 
     assert prepared_capture_input["source_type"] == case.source_type
     assert prepared_capture_input["transcript"] == case.transcript
+
+    tools = calls[0]["tools"]
+    assert isinstance(tools, list)
+    assert tools
+    first_tool = tools[0]
+    assert isinstance(first_tool, dict)
+    input_schema = first_tool["input_schema"]
+    expected_schema = (
+        APPEND_EXTRACTION_TOOL_SCHEMA
+        if case.extraction_mode == "append"
+        else EXTRACTION_TOOL_SCHEMA
+    )
+    assert input_schema == expected_schema
 
     expected_raw_typed_notes = case.raw_typed_notes
     expected_raw_transcript = case.raw_transcript
@@ -140,7 +155,7 @@ def _assert_extraction_invariants(
 ) -> None:
     assert result.transcript == transcript
     assert len(result.line_items) <= DOCUMENT_LINE_ITEMS_MAX_ITEMS
-    assert len(result.confidence_notes) <= CONFIDENCE_NOTES_MAX_ITEMS
+    assert result.confidence_notes == []
     assert all(item.description.strip() for item in result.line_items)
     if result.extraction_tier == "degraded":
         assert result.extraction_degraded_reason_code is not None
@@ -151,14 +166,7 @@ def _assert_extraction_invariants(
         priced_items = [item.price for item in result.line_items if item.price is not None]
         assert priced_items
         priced_sum = sum(priced_items)
-        if priced_sum != pytest.approx(result.total):
-            assert any(
-                any(
-                    token in note.casefold()
-                    for token in ("mismatch", "does not match", "doesn't match", "line item sum")
-                )
-                for note in result.confidence_notes
-            )
+        assert priced_sum == pytest.approx(result.total)
 
 
 def _assert_extraction_quality(
@@ -179,14 +187,16 @@ def _assert_extraction_quality(
     if case.expect_line_item_count_max is not None:
         assert line_item_count <= case.expect_line_item_count_max
 
-    for substring in case.expect_confidence_note_substrings:
-        normalized_substring = substring.casefold()
-        assert any(normalized_substring in note.casefold() for note in result.confidence_notes)
-
     if case.expect_pricing_hints:
         pricing_hints_payload = result.pricing_hints.model_dump(mode="json")
         for key, value in case.expect_pricing_hints.items():
             assert pricing_hints_payload[key] == value
+
+    if case.expect_line_item_price_statuses:
+        assert (
+            tuple(item.price_status for item in result.line_items)
+            == case.expect_line_item_price_statuses
+        )
 
     if case.expect_unresolved_segment_sources:
         assert [segment.source for segment in result.unresolved_segments] == list(
@@ -227,7 +237,7 @@ async def test_extraction_eval_baseline_invariants_hold_for_primary_fixture() ->
         client=client,
     )
 
-    result = await integration.extract(_build_capture_input(case), mode="initial")
+    result = await integration.extract(_build_capture_input(case), mode=case.extraction_mode)
 
     _assert_extraction_invariants(
         result,
@@ -254,7 +264,7 @@ async def test_extraction_eval_invariants(case: ExtractionEvalCase) -> None:
         client=client,
     )
 
-    result = await integration.extract(_build_capture_input(case), mode="initial")
+    result = await integration.extract(_build_capture_input(case), mode=case.extraction_mode)
 
     _assert_extraction_invariants(
         result,

--- a/backend/app/features/quotes/tests/test_extraction_quality.py
+++ b/backend/app/features/quotes/tests/test_extraction_quality.py
@@ -72,7 +72,7 @@ async def test_extraction_quality_suite() -> None:
     scores = []
 
     for case in selected_cases:
-        result = await integration.extract(case.transcript, mode="initial")
+        result = await integration.extract(case.transcript, mode=case.extraction_mode)
         metadata = integration.pop_last_call_metadata()
 
         line_item_count = len(result.line_items)

--- a/backend/app/features/quotes/tests/test_extraction_scorer.py
+++ b/backend/app/features/quotes/tests/test_extraction_scorer.py
@@ -72,6 +72,7 @@ def test_match_line_items_enforces_one_to_one_consumption() -> None:
 def test_score_case_zero_division_guards_no_must_match_items() -> None:
     case = ExtractionQualityCase(
         name="no_must_match",
+        extraction_mode="initial",
         transcript="optional only",
         expected_line_items=(ExpectedLineItem(description="optional service", must_match=False),),
         expected_total=None,
@@ -86,6 +87,7 @@ def test_score_case_zero_division_guards_no_must_match_items() -> None:
 def test_score_case_zero_division_guards_no_priced_or_details_items() -> None:
     case = ExtractionQualityCase(
         name="no_price_no_details",
+        extraction_mode="initial",
         transcript="trim shrubs",
         expected_line_items=(
             ExpectedLineItem(description="trim shrubs", price=None, details=None),
@@ -99,9 +101,30 @@ def test_score_case_zero_division_guards_no_priced_or_details_items() -> None:
     assert score.total_score == pytest.approx(1.0)
 
 
+def test_score_case_high_quality_no_longer_depends_on_confidence_notes() -> None:
+    case = ExtractionQualityCase(
+        name="no_confidence_notes_needed",
+        extraction_mode="initial",
+        transcript="weekly lawn service 45 with 6.5 percent tax",
+        expected_line_items=(ExpectedLineItem(description="weekly lawn service", price=45),),
+        expected_total=45,
+        expected_pricing_fields=("tax_rate",),
+    )
+
+    result = _result([_item("weekly lawn service", price=45)], total=45).model_copy(
+        update={"pricing_hints": PricingHints(explicit_total=45, tax_rate=6.5)}
+    )
+
+    score = score_case(case, result)
+
+    assert score.pricing_behavior_score == pytest.approx(1.0)
+    assert score.overall > 0.95
+
+
 def test_score_case_clamps_overall_upper_bound(monkeypatch: pytest.MonkeyPatch) -> None:
     case = ExtractionQualityCase(
         name="clamp_upper",
+        extraction_mode="initial",
         transcript="x",
         expected_line_items=(ExpectedLineItem(description="x"),),
     )
@@ -120,6 +143,7 @@ def test_score_case_clamps_overall_upper_bound(monkeypatch: pytest.MonkeyPatch) 
 def test_score_case_clamps_overall_lower_bound(monkeypatch: pytest.MonkeyPatch) -> None:
     case = ExtractionQualityCase(
         name="clamp_lower",
+        extraction_mode="initial",
         transcript="x",
         expected_line_items=(ExpectedLineItem(description="x"),),
     )
@@ -161,7 +185,10 @@ def test_aggregate_scores_groups_by_category_and_difficulty() -> None:
             difficulty="easy",
             item_scores=(),
             total_score=1.0,
-            confidence_note_score=None,
+            flag_accuracy=1.0,
+            unresolved_score=1.0,
+            pricing_behavior_score=1.0,
+            append_outcome_score=None,
             precision=1.0,
             recall=1.0,
             extras_count=0,
@@ -174,7 +201,10 @@ def test_aggregate_scores_groups_by_category_and_difficulty() -> None:
             difficulty="hard",
             item_scores=(),
             total_score=1.0,
-            confidence_note_score=None,
+            flag_accuracy=1.0,
+            unresolved_score=1.0,
+            pricing_behavior_score=1.0,
+            append_outcome_score=None,
             precision=1.0,
             recall=1.0,
             extras_count=0,
@@ -187,7 +217,10 @@ def test_aggregate_scores_groups_by_category_and_difficulty() -> None:
             difficulty="easy",
             item_scores=(),
             total_score=1.0,
-            confidence_note_score=None,
+            flag_accuracy=1.0,
+            unresolved_score=1.0,
+            pricing_behavior_score=1.0,
+            append_outcome_score=None,
             precision=1.0,
             recall=1.0,
             extras_count=0,
@@ -208,6 +241,7 @@ def test_aggregate_scores_groups_by_category_and_difficulty() -> None:
 def test_format_report_includes_case_lines_and_summary() -> None:
     case = ExtractionQualityCase(
         name="report_case",
+        extraction_mode="initial",
         transcript="trim shrubs for 50",
         expected_line_items=(ExpectedLineItem(description="trim shrubs", price=50),),
         expected_total=50,


### PR DESCRIPTION
## Summary
- split extraction eval fixtures into explicit `initial`/`append` cases and refreshed scenario coverage for typed-only, voice-only, mixed input, corrective append, included-scope append, conflicting totals, degraded extraction, concurrent append follow-ups, and async user-edit race candidates
- updated eval harness assertions to validate request `extraction_mode`, verify mode-specific schema selection (`initial` vs `append`), and remove confidence-note expectations from product-facing invariants
- refreshed extraction quality scoring to evaluate visible flags, unresolved items, pricing behavior, and append outcomes instead of generic confidence notes; updated scorer fixtures/tests accordingly

## Verification
- `cd backend && .venv/bin/pytest app/features/quotes/tests/test_extraction_eval.py app/features/quotes/tests/test_extraction_scorer.py app/features/quotes/tests/test_extraction_quality.py -m "not live and not extraction_eval and not extraction_quality" -o cache_dir=.pytest_cache`
- `cd backend && .venv/bin/pytest app/features/quotes/tests/test_extraction_eval.py -m extraction_eval -o cache_dir=.pytest_cache`
- `cd frontend && npx vitest run src/features/quotes/tests`
- `make backend-static-verify`
- `cd frontend && npx tsc --noEmit && npx eslint src/features/quotes`

Closes #422