### PR TITLE
Task #423: remove extraction compatibility shims

### DIFF
--- a/backend/app/features/jobs/schemas.py
+++ b/backend/app/features/jobs/schemas.py
@@ -10,7 +10,6 @@ from pydantic import BaseModel, ConfigDict
 from app.features.jobs.models import JobRecord, JobStatus, JobType
 from app.features.quotes.schemas import (
     ExtractionResult,
-    project_extraction_result_for_public_response,
 )
 
 
@@ -43,7 +42,5 @@ def job_record_to_response(record: JobRecord) -> JobRecordResponse:
         "quote_id": record.document_id if record.status == JobStatus.SUCCESS else None
     }
     if record.status == JobStatus.SUCCESS and record.result_json is not None:
-        updates["extraction_result"] = project_extraction_result_for_public_response(
-            ExtractionResult.model_validate_json(record.result_json)
-        )
+        updates["extraction_result"] = ExtractionResult.model_validate_json(record.result_json)
     return response.model_copy(update=updates)

--- a/backend/app/features/jobs/tests/test_jobs_api.py
+++ b/backend/app/features/jobs/tests/test_jobs_api.py
@@ -45,9 +45,7 @@ async def test_get_job_status_returns_owned_extraction_result(
     await repository.set_extraction_success(
         record.id,
         quote_id=quote.id,
-        result_json=(
-            '{"transcript":"mulch the beds","line_items":[],"total":null,"confidence_notes":[]}'
-        ),
+        result_json=('{"transcript":"mulch the beds","line_items":[],"total":null}'),
     )
     await db_session.commit()
 
@@ -72,7 +70,6 @@ async def test_get_job_status_returns_owned_extraction_result(
         },
         "customer_notes_suggestion": None,
         "unresolved_segments": [],
-        "confidence_notes": [],
         "extraction_tier": "primary",
         "extraction_degraded_reason_code": None,
     }

--- a/backend/app/features/jobs/tests/test_jobs_repository.py
+++ b/backend/app/features/jobs/tests/test_jobs_repository.py
@@ -25,7 +25,7 @@ async def test_job_repository_supports_explicit_status_paths(
     await repository.set_running(success_record.id, expected_job_type=JobType.EXTRACTION)
     await repository.set_success_with_result(
         success_record.id,
-        result_json='{"transcript":"mulch","line_items":[],"total":null,"confidence_notes":[]}',
+        result_json='{"transcript":"mulch","line_items":[],"total":null}',
         expected_job_type=JobType.EXTRACTION,
     )
 

--- a/backend/app/features/quotes/api.py
+++ b/backend/app/features/quotes/api.py
@@ -59,7 +59,6 @@ from app.features.quotes.schemas import (
     QuoteListItemResponse,
     QuoteResponse,
     QuoteUpdateRequest,
-    project_extraction_result_for_public_response,
 )
 from app.features.quotes.service import QuoteService, QuoteServiceError
 from app.integrations.audio import infer_audio_format
@@ -168,7 +167,7 @@ async def convert_notes(
     async with extraction_capacity_guard(user.id):
         try:
             extraction = await extraction_service.convert_notes(payload.notes)
-            return project_extraction_result_for_public_response(extraction)
+            return extraction
         except QuoteServiceError as exc:
             raise HTTPException(status_code=exc.status_code, detail=exc.detail) from exc
 
@@ -301,10 +300,9 @@ async def extract_combined(
             capture_detail=capture_detail,
             extraction_result=extraction,
         )
-        projected_extraction = project_extraction_result_for_public_response(extraction)
         return PersistedExtractionResponse(
             quote_id=quote.id,
-            **projected_extraction.model_dump(),
+            **extraction.model_dump(),
         )
 
     try:
@@ -414,10 +412,9 @@ async def append_extraction(
             customer_id=updated_quote.customer_id,
             detail=capture_detail,
         )
-        projected_extraction = project_extraction_result_for_public_response(merged_extraction)
         return PersistedExtractionResponse(
             quote_id=updated_quote.id,
-            **projected_extraction.model_dump(),
+            **merged_extraction.model_dump(),
         )
 
     try:

--- a/backend/app/features/quotes/extraction_outcomes.py
+++ b/backend/app/features/quotes/extraction_outcomes.py
@@ -60,7 +60,6 @@ def build_degraded_extraction_result(
         pricing_hints=PricingHints(),
         customer_notes_suggestion=None,
         unresolved_segments=[],
-        confidence_notes=[],
         extraction_tier=EXTRACTION_TIER_DEGRADED,
         extraction_degraded_reason_code=reason_code,
     )

--- a/backend/app/features/quotes/mutation/service.py
+++ b/backend/app/features/quotes/mutation/service.py
@@ -326,7 +326,6 @@ class QuoteMutationService:
         next_metadata = apply_hidden_detail_lifecycle_updates(
             metadata,
             dismiss_hidden_item=data.dismiss_hidden_item,
-            review_hidden_item=data.review_hidden_item,
             clear_notes_pending=(
                 data.clear_review_state is not None
                 and data.clear_review_state.notes_pending is True

--- a/backend/app/features/quotes/review_metadata.py
+++ b/backend/app/features/quotes/review_metadata.py
@@ -192,7 +192,6 @@ def apply_hidden_detail_lifecycle_updates(
     metadata: ExtractionReviewMetadataV1,
     *,
     dismiss_hidden_item: str | None = None,
-    review_hidden_item: str | None = None,
     clear_notes_pending: bool = False,
     clear_pricing_pending: bool = False,
 ) -> ExtractionReviewMetadataV1:
@@ -200,7 +199,6 @@ def apply_hidden_detail_lifecycle_updates(
     if not any(
         (
             dismiss_hidden_item is not None,
-            review_hidden_item is not None,
             clear_notes_pending,
             clear_pricing_pending,
         )
@@ -211,18 +209,8 @@ def apply_hidden_detail_lifecycle_updates(
         item_id: value.model_copy(deep=True)
         for item_id, value in metadata.hidden_detail_state.items()
     }
-    if review_hidden_item is not None:
-        previous = next_state.get(review_hidden_item, HiddenItemState())
-        next_state[review_hidden_item] = HiddenItemState(
-            reviewed=True,
-            dismissed=previous.dismissed,
-        )
     if dismiss_hidden_item is not None:
-        previous = next_state.get(dismiss_hidden_item, HiddenItemState())
-        next_state[dismiss_hidden_item] = HiddenItemState(
-            reviewed=previous.reviewed,
-            dismissed=True,
-        )
+        next_state[dismiss_hidden_item] = HiddenItemState(dismissed=True)
 
     updated_review_state = metadata.review_state.model_copy(
         update={
@@ -270,10 +258,7 @@ def _build_hidden_detail_state(
     merged: dict[str, HiddenItemState] = {}
     for item_id in current_item_ids:
         previous = previous_state.get(item_id, HiddenItemState())
-        merged[item_id] = HiddenItemState(
-            reviewed=previous.reviewed,
-            dismissed=previous.dismissed,
-        )
+        merged[item_id] = HiddenItemState(dismissed=previous.dismissed)
     return merged
 
 
@@ -325,34 +310,6 @@ def _build_actionable_items(
             reason=suggestion.source,
             confidence=suggestion.confidence,
             text=suggestion.raw_text,
-        )
-        signature = _actionable_signature(candidate)
-        previous = previous_by_signature.get(signature)
-        previous_item_state = previous_state.get(previous.id) if previous is not None else None
-        deduped[signature] = candidate.model_copy(
-            update={
-                "id": (
-                    previous.id
-                    if previous is not None
-                    and (previous_item_state is None or not previous_item_state.dismissed)
-                    else _build_new_occurrence_id()
-                )
-            }
-        )
-
-    confidence_notes = (
-        list(extraction_result.confidence_notes)
-        if extraction_result.confidence_notes
-        else [item.text for item in previous_items if item.kind == "confidence_note"]
-    )
-    for note in confidence_notes:
-        candidate = ExtractionReviewActionableItem(
-            id="pending",
-            kind="confidence_note",
-            field=None,
-            reason="confidence_note",
-            confidence=None,
-            text=note,
         )
         signature = _actionable_signature(candidate)
         previous = previous_by_signature.get(signature)

--- a/backend/app/features/quotes/schemas.py
+++ b/backend/app/features/quotes/schemas.py
@@ -15,8 +15,6 @@ from app.features.quotes.price_status import (
 )
 from app.shared.input_limits import (
     AUDIO_TRANSCRIPT_MAX_CHARS,
-    CONFIDENCE_NOTE_MAX_CHARS,
-    CONFIDENCE_NOTES_MAX_ITEMS,
     DOCUMENT_LINE_ITEMS_MAX_ITEMS,
     DOCUMENT_NOTES_MAX_CHARS,
     DOCUMENT_TRANSCRIPT_MAX_CHARS,
@@ -282,10 +280,6 @@ class ExtractionResultV2(BaseModel):
     pricing_hints: PricingHints = Field(default_factory=PricingHints)
     customer_notes_suggestion: ExtractionSuggestion | None = None
     unresolved_segments: list[UnresolvedSegment] = Field(default_factory=list)
-    confidence_notes: list[Annotated[str, Field(max_length=CONFIDENCE_NOTE_MAX_CHARS)]] = Field(
-        default_factory=list,
-        max_length=CONFIDENCE_NOTES_MAX_ITEMS,
-    )
     extraction_tier: Literal["primary", "degraded"] = "primary"
     extraction_degraded_reason_code: str | None = None
 
@@ -407,30 +401,8 @@ class ExtractionReviewUnresolvedSegment(BaseModel):
     source: UnresolvedSegmentSource
 
 
-ActionableItemKind = Literal["append_suggestion", "unresolved_segment", "confidence_note"]
+ActionableItemKind = Literal["append_suggestion", "unresolved_segment"]
 ActionableItemField = Literal["notes", "explicit_total", "deposit_amount", "tax_rate", "discount"]
-
-
-def _coerce_pricing_field(field: str | None) -> PricingFieldName | None:
-    if field == "explicit_total":
-        return "explicit_total"
-    if field == "deposit_amount":
-        return "deposit_amount"
-    if field == "tax_rate":
-        return "tax_rate"
-    if field == "discount":
-        return "discount"
-    return None
-
-
-def _coerce_unresolved_segment_source(reason: str | None) -> UnresolvedSegmentSource:
-    if reason == "leftover_classification":
-        return "leftover_classification"
-    if reason == "typed_conflict":
-        return "typed_conflict"
-    if reason == "transcript_conflict":
-        return "transcript_conflict"
-    return "leftover_classification"
 
 
 class ExtractionReviewActionableItem(BaseModel):
@@ -448,133 +420,11 @@ class ExtractionReviewHiddenDetails(BaseModel):
     """Hidden extraction details shown in Capture Details surfaces."""
 
     items: list[ExtractionReviewActionableItem] = Field(default_factory=list)
-    unresolved_segments: list[ExtractionReviewUnresolvedSegment] = Field(default_factory=list)
-    append_suggestions: list[ExtractionReviewAppendSuggestion] = Field(default_factory=list)
-    confidence_notes: list[Annotated[str, Field(max_length=CONFIDENCE_NOTE_MAX_CHARS)]] = Field(
-        default_factory=list,
-        max_length=CONFIDENCE_NOTES_MAX_ITEMS,
-    )
-
-    @model_validator(mode="before")
-    @classmethod
-    def normalize_legacy_shapes(cls, value: object) -> object:
-        if not isinstance(value, dict):
-            return value
-        payload = dict(value)
-        if isinstance(payload.get("items"), list):
-            return payload
-
-        items: list[dict[str, Any]] = []
-        for suggestion_candidate in payload.get("append_suggestions", []):
-            suggestion: dict[str, Any] | None
-            if isinstance(suggestion_candidate, dict):
-                suggestion = suggestion_candidate
-            else:
-                model_dump = getattr(suggestion_candidate, "model_dump", None)
-                suggestion = model_dump(mode="json") if callable(model_dump) else None
-            if not isinstance(suggestion, dict):
-                continue
-            raw_text = suggestion.get("raw_text")
-            if not isinstance(raw_text, str) or not raw_text.strip():
-                continue
-            suggestion_pricing_field = suggestion.get("pricing_field")
-            field = _coerce_pricing_field(
-                suggestion_pricing_field if isinstance(suggestion_pricing_field, str) else None
-            )
-            items.append(
-                {
-                    "id": str(suggestion.get("id", "")),
-                    "kind": "append_suggestion",
-                    "field": "notes" if field is None else field,
-                    "reason": suggestion.get("source"),
-                    "confidence": suggestion.get("confidence"),
-                    "text": raw_text,
-                }
-            )
-
-        for segment_candidate in payload.get("unresolved_segments", []):
-            segment: dict[str, Any] | None
-            if isinstance(segment_candidate, dict):
-                segment = segment_candidate
-            else:
-                model_dump = getattr(segment_candidate, "model_dump", None)
-                segment = model_dump(mode="json") if callable(model_dump) else None
-            if not isinstance(segment, dict):
-                continue
-            raw_text = segment.get("raw_text")
-            if not isinstance(raw_text, str) or not raw_text.strip():
-                continue
-            items.append(
-                {
-                    "id": str(segment.get("id", "")),
-                    "kind": "unresolved_segment",
-                    "field": None,
-                    "reason": segment.get("source"),
-                    "confidence": segment.get("confidence"),
-                    "text": raw_text,
-                }
-            )
-
-        for index, note in enumerate(payload.get("confidence_notes", [])):
-            if not isinstance(note, str) or not note.strip():
-                continue
-            note_id = f"legacy-confidence-{index}"
-            items.append(
-                {
-                    "id": note_id,
-                    "kind": "confidence_note",
-                    "field": None,
-                    "reason": "legacy_confidence_note",
-                    "confidence": None,
-                    "text": note,
-                }
-            )
-
-        payload["items"] = items
-        return payload
-
-    @model_validator(mode="after")
-    def sync_legacy_views(self) -> ExtractionReviewHiddenDetails:
-        unresolved_segments: list[ExtractionReviewUnresolvedSegment] = []
-        append_suggestions: list[ExtractionReviewAppendSuggestion] = []
-        confidence_notes: list[str] = []
-        for item in self.items:
-            if item.kind == "unresolved_segment":
-                unresolved_source = _coerce_unresolved_segment_source(item.reason)
-                unresolved_segments.append(
-                    ExtractionReviewUnresolvedSegment(
-                        id=item.id,
-                        raw_text=item.text,
-                        confidence=item.confidence or "medium",
-                        source=unresolved_source,
-                    )
-                )
-                continue
-            if item.kind == "append_suggestion":
-                pricing_field = _coerce_pricing_field(item.field)
-                append_suggestions.append(
-                    ExtractionReviewAppendSuggestion(
-                        id=item.id,
-                        kind=("note" if pricing_field is None else "pricing"),
-                        raw_text=item.text,
-                        confidence=item.confidence or "medium",
-                        source="append_capture",
-                        pricing_field=pricing_field,
-                    )
-                )
-                continue
-            confidence_notes.append(item.text)
-
-        self.unresolved_segments = unresolved_segments
-        self.append_suggestions = append_suggestions
-        self.confidence_notes = confidence_notes
-        return self
 
 
 class HiddenItemState(BaseModel):
     """Lifecycle state persisted for one hidden extraction item."""
 
-    reviewed: bool = False
     dismissed: bool = False
 
 
@@ -589,23 +439,6 @@ class ExtractionReviewMetadataV1(BaseModel):
     )
     hidden_detail_state: dict[str, HiddenItemState] = Field(default_factory=dict)
     extraction_degraded_reason_code: str | None = None
-
-    @model_validator(mode="before")
-    @classmethod
-    def normalize_legacy_metadata_shape(cls, value: object) -> object:
-        if not isinstance(value, dict):
-            return value
-        payload = dict(value)
-        hidden_details = payload.get("hidden_details")
-        hidden_payload = dict(hidden_details) if isinstance(hidden_details, dict) else {}
-        for key in ("append_suggestions", "unresolved_segments", "confidence_notes", "items"):
-            if key in payload and key not in hidden_payload:
-                hidden_payload[key] = payload[key]
-        if hidden_payload:
-            payload["hidden_details"] = hidden_payload
-        if "hidden_item_state" in payload and "hidden_detail_state" not in payload:
-            payload["hidden_detail_state"] = payload["hidden_item_state"]
-        return payload
 
     @classmethod
     def model_validate_with_defaults(
@@ -723,7 +556,6 @@ class ExtractionReviewMetadataUpdateRequest(BaseModel):
     """Sidecar-only mutation payload for hidden-item lifecycle and review state."""
 
     dismiss_hidden_item: str | None = Field(default=None, min_length=1)
-    review_hidden_item: str | None = Field(default=None, min_length=1)
     clear_review_state: ExtractionReviewStateClearRequest | None = None
 
     @model_validator(mode="after")
@@ -731,20 +563,12 @@ class ExtractionReviewMetadataUpdateRequest(BaseModel):
         has_action = any(
             (
                 self.dismiss_hidden_item is not None,
-                self.review_hidden_item is not None,
                 self.clear_review_state is not None,
             )
         )
         if not has_action:
             raise ValueError("At least one extraction review metadata mutation is required")
         return self
-
-
-def project_extraction_result_for_public_response(result: ExtractionResult) -> ExtractionResult:
-    """Project internal extraction payloads to the transitional public legacy contract."""
-    if result.pipeline_version == "v2":
-        return result
-    return result.model_copy(update={"pipeline_version": "v2"})
 
 
 class LineItemResponse(BaseModel):

--- a/backend/app/features/quotes/tests/support/mocks.py
+++ b/backend/app/features/quotes/tests/support/mocks.py
@@ -49,7 +49,6 @@ class _MockExtractionIntegration:
                     )
                 ],
                 pricing_hints=PricingHints(explicit_total=120),
-                confidence_notes=[],
             )
 
         return ExtractionResult(
@@ -64,7 +63,6 @@ class _MockExtractionIntegration:
                 )
             ],
             pricing_hints=PricingHints(explicit_total=120),
-            confidence_notes=[],
         )
 
 

--- a/backend/app/features/quotes/tests/test_creation_service.py
+++ b/backend/app/features/quotes/tests/test_creation_service.py
@@ -111,7 +111,6 @@ async def test_create_extracted_draft_commit_false_skips_commit() -> None:
             )
         ],
         pricing_hints=PricingHints(explicit_total=120),
-        confidence_notes=[],
     )
 
     quote = await service.create_extracted_draft(
@@ -153,7 +152,6 @@ async def test_create_extracted_draft_prefers_line_item_subtotal_over_conflictin
             ),
         ],
         pricing_hints=PricingHints(explicit_total=140),
-        confidence_notes=[],
     )
 
     quote = await service.create_extracted_draft(

--- a/backend/app/features/quotes/tests/test_extraction.py
+++ b/backend/app/features/quotes/tests/test_extraction.py
@@ -86,7 +86,6 @@ async def test_extract_keeps_null_prices_without_zero_fill() -> None:
                             },
                         ],
                         "total": None,
-                        "confidence_notes": ["No explicit pricing in notes"],
                     },
                 }
             ]
@@ -118,7 +117,6 @@ async def test_extract_preserves_total_only_payload() -> None:
                             }
                         ],
                         "pricing_hints": {"explicit_total": 2100},
-                        "confidence_notes": [],
                     },
                 }
             ]
@@ -154,7 +152,6 @@ async def test_extract_handles_ambiguous_partial_input_without_raising() -> None
                             },
                         ],
                         "total": None,
-                        "confidence_notes": ["Siding price ambiguous in transcript"],
                     },
                 }
             ]
@@ -166,7 +163,6 @@ async def test_extract_handles_ambiguous_partial_input_without_raising() -> None
 
     assert result.line_items
     assert result.line_items[0].description == "Power wash deck"
-    assert result.confidence_notes == []
 
 
 async def test_extract_returns_degraded_result_when_repair_is_still_invalid() -> None:
@@ -181,7 +177,6 @@ async def test_extract_returns_degraded_result_when_repair_is_still_invalid() ->
                             "transcript": transcript,
                             "line_items": "invalid-shape",
                             "total": 435,
-                            "confidence_notes": [],
                         },
                     }
                 ]
@@ -194,7 +189,6 @@ async def test_extract_returns_degraded_result_when_repair_is_still_invalid() ->
                             "transcript": transcript,
                             "line_items": "still-invalid",
                             "total": 435,
-                            "confidence_notes": [],
                         },
                     }
                 ]
@@ -223,7 +217,6 @@ async def test_extract_attempts_one_repair_then_accepts_valid_repaired_payload()
                             "transcript": transcript,
                             "line_items": "invalid-shape",
                             "total": 435,
-                            "confidence_notes": [],
                         },
                     }
                 ]
@@ -242,7 +235,6 @@ async def test_extract_attempts_one_repair_then_accepts_valid_repaired_payload()
                                 }
                             ],
                             "pricing_hints": {"explicit_total": 125},
-                            "confidence_notes": [],
                         },
                     }
                 ]
@@ -284,7 +276,6 @@ async def test_extract_sets_repair_failure_metadata_when_repair_request_errors()
                             "transcript": transcript,
                             "line_items": "invalid-shape",
                             "total": 435,
-                            "confidence_notes": [],
                         },
                     }
                 ]
@@ -327,7 +318,6 @@ async def test_extract_builds_client_with_configured_timeout_and_disabled_sdk_re
                             "input": {
                                 "transcript": transcript,
                                 "line_items": [],
-                                "confidence_notes": [],
                             },
                         }
                     ]
@@ -374,7 +364,6 @@ async def test_extract_retries_rate_limit_then_succeeds(
                         "input": {
                             "transcript": transcript,
                             "line_items": [],
-                            "confidence_notes": [],
                         },
                     }
                 ]
@@ -413,7 +402,6 @@ async def test_extract_does_not_invoke_fallback_before_primary_exhaustion() -> N
                         "input": {
                             "transcript": transcript,
                             "line_items": [],
-                            "confidence_notes": [],
                         },
                     }
                 ]
@@ -451,7 +439,6 @@ async def test_extract_invokes_fallback_after_primary_exhaustion_and_tags_metada
                         "input": {
                             "transcript": transcript,
                             "line_items": [],
-                            "confidence_notes": [],
                         },
                     }
                 ]
@@ -521,7 +508,6 @@ async def test_extract_accepts_flagged_line_items_with_reason() -> None:
                             }
                         ],
                         "total": 9000,
-                        "confidence_notes": [],
                     },
                 }
             ]
@@ -552,7 +538,6 @@ async def test_extract_defaults_flag_fields_when_omitted() -> None:
                             }
                         ],
                         "total": 350,
-                        "confidence_notes": [],
                     },
                 }
             ]
@@ -612,7 +597,6 @@ async def test_extract_degrades_when_substantial_transcript_has_no_line_items() 
                         "transcript": transcript,
                         "line_items": [],
                         "total": None,
-                        "confidence_notes": [],
                     },
                 }
             ]
@@ -627,7 +611,6 @@ async def test_extract_degrades_when_substantial_transcript_has_no_line_items() 
         result.extraction_degraded_reason_code
         == SEMANTIC_DEGRADED_REASON_EMPTY_LINE_ITEMS_SUBSTANTIAL_TRANSCRIPT
     )
-    assert result.confidence_notes == []
 
 
 async def test_extract_adds_warning_when_total_has_no_priced_line_items() -> None:
@@ -647,7 +630,6 @@ async def test_extract_adds_warning_when_total_has_no_priced_line_items() -> Non
                             }
                         ],
                         "pricing_hints": {"explicit_total": 2100},
-                        "confidence_notes": [],
                     },
                 }
             ]
@@ -659,7 +641,6 @@ async def test_extract_adds_warning_when_total_has_no_priced_line_items() -> Non
 
     assert result.extraction_tier == "primary"
     assert result.extraction_degraded_reason_code is None
-    assert result.confidence_notes == []
     assert any(
         "explicit total was extracted without priced line items" in segment.raw_text.lower()
         for segment in result.unresolved_segments
@@ -688,7 +669,6 @@ async def test_extract_flags_duplicate_line_items_with_warning_note() -> None:
                             },
                         ],
                         "total": 240,
-                        "confidence_notes": [],
                     },
                 }
             ]
@@ -701,7 +681,6 @@ async def test_extract_flags_duplicate_line_items_with_warning_note() -> None:
     assert result.extraction_tier == "primary"
     assert all(item.flagged is True for item in result.line_items)
     assert all(item.flag_reason for item in result.line_items)
-    assert result.confidence_notes == []
 
 
 async def test_tool_schema_line_items_include_optional_flag_fields() -> None:
@@ -831,7 +810,6 @@ async def test_extract_exercises_all_transcript_fixtures(fixture_name: str) -> N
                             }
                         ],
                         "total": None,
-                        "confidence_notes": [],
                     },
                 }
             ]
@@ -879,7 +857,6 @@ async def test_extract_emits_trace_events_for_primary_repair_and_result_stages(
                             "transcript": transcript,
                             "line_items": "invalid-shape",
                             "total": 435,
-                            "confidence_notes": [],
                         },
                     }
                 ]
@@ -898,7 +875,6 @@ async def test_extract_emits_trace_events_for_primary_repair_and_result_stages(
                                 }
                             ],
                             "pricing_hints": {"explicit_total": 125},
-                            "confidence_notes": [],
                         },
                     }
                 ]
@@ -941,7 +917,6 @@ async def test_guard_flags_line_items_with_price_in_description() -> None:
                             },
                         ],
                         "total": None,
-                        "confidence_notes": [],
                     },
                 }
             ]
@@ -954,7 +929,6 @@ async def test_guard_flags_line_items_with_price_in_description() -> None:
     assert result.line_items[0].flagged is True
     assert "price token" in (result.line_items[0].flag_reason or "").lower()
     assert result.line_items[1].flagged is False
-    assert result.confidence_notes == []
 
 
 async def test_guard_flags_line_items_with_duplicate_details() -> None:
@@ -979,7 +953,6 @@ async def test_guard_flags_line_items_with_duplicate_details() -> None:
                             },
                         ],
                         "total": None,
-                        "confidence_notes": [],
                     },
                 }
             ]
@@ -992,7 +965,6 @@ async def test_guard_flags_line_items_with_duplicate_details() -> None:
     assert result.line_items[0].flagged is True
     assert "duplicate" in (result.line_items[0].flag_reason or "").lower()
     assert result.line_items[1].flagged is False
-    assert result.confidence_notes == []
 
 
 async def test_extract_preserves_mixed_provenance_in_model_request_payload() -> None:
@@ -1020,7 +992,6 @@ async def test_extract_preserves_mixed_provenance_in_model_request_payload() -> 
                     "input": {
                         "transcript": prepared_capture_input.transcript,
                         "line_items": [],
-                        "confidence_notes": [],
                     },
                 }
             ]

--- a/backend/app/features/quotes/tests/test_extraction_eval.py
+++ b/backend/app/features/quotes/tests/test_extraction_eval.py
@@ -155,7 +155,6 @@ def _assert_extraction_invariants(
 ) -> None:
     assert result.transcript == transcript
     assert len(result.line_items) <= DOCUMENT_LINE_ITEMS_MAX_ITEMS
-    assert result.confidence_notes == []
     assert all(item.description.strip() for item in result.line_items)
     if result.extraction_tier == "degraded":
         assert result.extraction_degraded_reason_code is not None

--- a/backend/app/features/quotes/tests/test_extraction_live.py
+++ b/backend/app/features/quotes/tests/test_extraction_live.py
@@ -45,7 +45,7 @@ def _print_report_card(name: str, result: ExtractionResult) -> None:
     print(f"[{name}]")
     print(f"  items: {items}")
     print(f"  total: {total}")
-    print(f"  confidence: {result.confidence_notes}")
+    print(f"  confidence: {result.unresolved_segments}")
 
 
 @pytest.mark.live
@@ -89,7 +89,7 @@ async def test_live_partial_ambiguous() -> None:
     prices = [item.price for item in result.line_items]
     assert any(price is not None for price in prices)
     assert any(price is None for price in prices)
-    assert result.confidence_notes
+    assert result.unresolved_segments
 
 
 @pytest.mark.live
@@ -114,7 +114,7 @@ async def test_live_no_pricing_at_all() -> None:
     assert result.total is None
     assert result.line_items
     assert all(item.price is None for item in result.line_items)
-    assert result.confidence_notes
+    assert result.unresolved_segments
 
 
 @pytest.mark.live

--- a/backend/app/features/quotes/tests/test_extraction_scorer.py
+++ b/backend/app/features/quotes/tests/test_extraction_scorer.py
@@ -46,13 +46,11 @@ def _result(
     line_items: list[LineItemExtractedV2],
     *,
     total: float | None = None,
-    confidence_notes: list[str] | None = None,
 ) -> ExtractionResult:
     return ExtractionResult(
         transcript="unit test transcript",
         line_items=line_items,
         pricing_hints=PricingHints(explicit_total=total),
-        confidence_notes=confidence_notes or [],
     )
 
 

--- a/backend/app/features/quotes/tests/test_extraction_service.py
+++ b/backend/app/features/quotes/tests/test_extraction_service.py
@@ -65,7 +65,6 @@ class _SuccessfulExtractionIntegration:
         return ExtractionResult(
             transcript=capture_input.transcript,
             line_items=[],
-            confidence_notes=[],
         )
 
 

--- a/backend/app/features/quotes/tests/test_quote_append_extraction.py
+++ b/backend/app/features/quotes/tests/test_quote_append_extraction.py
@@ -18,11 +18,10 @@ from app.features.quotes.review_metadata import build_hidden_item_id
 from app.features.quotes.schemas import (
     ExtractionMode,
     ExtractionResult,
-    ExtractionReviewAppendSuggestion,
+    ExtractionReviewActionableItem,
     ExtractionReviewHiddenDetails,
     ExtractionReviewMetadataV1,
     ExtractionReviewState,
-    ExtractionReviewUnresolvedSegment,
     ExtractionSuggestion,
     HiddenItemState,
     LineItemExtractedV2,
@@ -57,46 +56,33 @@ _override_extraction_service_dependency = quotes_test_module._override_extractio
 _reset_rate_limiter = quotes_test_module._reset_rate_limiter
 
 
-async def test_extraction_review_metadata_parses_legacy_grouped_hidden_details() -> None:
+async def test_extraction_review_metadata_accepts_items_only_hidden_details() -> None:
     metadata = ExtractionReviewMetadataV1.model_validate(
         {
-            "pipeline_version": "v2",
+            "pipeline_version": "v2.5",
             "hidden_details": {
-                "append_suggestions": [
+                "items": [
                     {
                         "id": "append-note-1",
-                        "kind": "note",
-                        "raw_text": "Add gate note",
+                        "kind": "append_suggestion",
+                        "field": "notes",
+                        "reason": "append_capture",
                         "confidence": "medium",
-                        "source": "append_capture",
-                        "pricing_field": None,
+                        "text": "Add gate note",
                     }
                 ],
-                "unresolved_segments": [
-                    {
-                        "id": "unresolved-1",
-                        "raw_text": "Clarify edging scope",
-                        "confidence": "low",
-                        "source": "leftover_classification",
-                    }
-                ],
-                "confidence_notes": ["Legacy confidence note"],
             },
             "hidden_detail_state": {
-                "append-note-1": {"reviewed": False, "dismissed": True},
+                "append-note-1": {"dismissed": True},
             },
         }
     )
 
     assert [item["kind"] for item in metadata.hidden_details.model_dump(mode="json")["items"]] == [
         "append_suggestion",
-        "unresolved_segment",
-        "confidence_note",
     ]
     assert metadata.hidden_details.items[0].field == "notes"
     assert metadata.hidden_details.items[0].text == "Add gate note"
-    assert metadata.hidden_details.items[1].reason == "leftover_classification"
-    assert metadata.hidden_details.items[2].text == "Legacy confidence note"
 
 
 async def test_append_extraction_sync_retryable_failure_uses_degraded_append_semantics(
@@ -249,7 +235,6 @@ async def test_append_extraction_routes_corrective_language_to_unresolved_hidden
                 )
             ],
             pricing_hints=PricingHints(),
-            confidence_notes=[],
         )
 
     monkeypatch.setattr(
@@ -306,7 +291,6 @@ async def test_append_extraction_withholds_populated_notes_and_deposit_but_seeds
                 confidence="medium",
                 source="leftover_classification",
             ),
-            confidence_notes=[],
         )
 
     monkeypatch.setattr(
@@ -341,33 +325,32 @@ async def test_append_extraction_withholds_populated_notes_and_deposit_but_seeds
     assert payload["total_amount"] == 59.54
     assert payload["deposit_amount"] == 40
     assert payload["tax_rate"] == 0.0825
-    append_suggestions = payload["extraction_review_metadata"]["hidden_details"][
-        "append_suggestions"
-    ]
+    items = payload["extraction_review_metadata"]["hidden_details"]["items"]
+    append_suggestions = [item for item in items if item["kind"] == "append_suggestion"]
     assert append_suggestions == [
         {
             "id": append_suggestions[0]["id"],
-            "kind": "note",
-            "raw_text": "Add driveway gate code",
+            "kind": "append_suggestion",
+            "field": "notes",
+            "reason": "append_capture",
             "confidence": "medium",
-            "source": "append_capture",
-            "pricing_field": None,
+            "text": "Add driveway gate code",
         },
         {
             "id": append_suggestions[1]["id"],
-            "kind": "pricing",
-            "raw_text": "Total 999",
+            "kind": "append_suggestion",
+            "field": "explicit_total",
+            "reason": "append_capture",
             "confidence": "medium",
-            "source": "append_capture",
-            "pricing_field": "explicit_total",
+            "text": "Total 999",
         },
         {
             "id": append_suggestions[2]["id"],
-            "kind": "pricing",
-            "raw_text": "Deposit 150",
+            "kind": "append_suggestion",
+            "field": "deposit_amount",
+            "reason": "append_capture",
             "confidence": "medium",
-            "source": "append_capture",
-            "pricing_field": "deposit_amount",
+            "text": "Deposit 150",
         },
     ]
 
@@ -390,7 +373,6 @@ async def test_append_extraction_withholds_ambiguous_explicit_total_when_tax_can
                 explicit_total=200,
                 tax_rate=0.0825,
             ),
-            confidence_notes=[],
         )
 
     monkeypatch.setattr(
@@ -436,17 +418,16 @@ async def test_append_extraction_withholds_ambiguous_explicit_total_when_tax_can
     payload = detail_response.json()
     assert payload["total_amount"] is None
     assert payload["tax_rate"] is None
-    append_suggestions = payload["extraction_review_metadata"]["hidden_details"][
-        "append_suggestions"
-    ]
+    items = payload["extraction_review_metadata"]["hidden_details"]["items"]
+    append_suggestions = [item for item in items if item["kind"] == "append_suggestion"]
     assert append_suggestions == [
         {
             "id": append_suggestions[0]["id"],
-            "kind": "pricing",
-            "raw_text": "Total 200",
+            "kind": "append_suggestion",
+            "field": "explicit_total",
+            "reason": "append_capture",
             "confidence": "medium",
-            "source": "append_capture",
-            "pricing_field": "explicit_total",
+            "text": "Total 200",
         }
     ]
 
@@ -475,7 +456,6 @@ async def test_append_extraction_resurfaces_previously_dismissed_matching_sugges
                 confidence="low",
                 source="leftover_classification",
             ),
-            confidence_notes=[],
         )
 
     monkeypatch.setattr(
@@ -494,16 +474,18 @@ async def test_append_extraction_resurfaces_previously_dismissed_matching_sugges
     assert persisted_quote is not None
     persisted_quote.extraction_review_metadata = ExtractionReviewMetadataV1(
         hidden_details=ExtractionReviewHiddenDetails(
-            append_suggestions=[
-                ExtractionReviewAppendSuggestion(
+            items=[
+                ExtractionReviewActionableItem(
                     id=suggestion_id,
-                    kind="note",
-                    raw_text=suggestion_text,
+                    kind="append_suggestion",
+                    field="notes",
+                    reason="append_capture",
                     confidence="low",
+                    text=suggestion_text,
                 )
             ]
         ),
-        hidden_detail_state={suggestion_id: HiddenItemState(reviewed=True, dismissed=True)},
+        hidden_detail_state={suggestion_id: HiddenItemState(dismissed=True)},
     ).model_dump(mode="json")
     await db_session.commit()
 
@@ -524,70 +506,7 @@ async def test_append_extraction_resurfaces_previously_dismissed_matching_sugges
         if item["kind"] == "append_suggestion" and item["text"] == suggestion_text
     )
     assert next_item["id"] != suggestion_id
-    assert hidden_state[next_item["id"]] == {"reviewed": False, "dismissed": False}
-
-
-async def test_append_extraction_preserves_existing_confidence_notes_when_new_notes_empty(
-    client: AsyncClient,
-    db_session: AsyncSession,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    async def _extract_without_confidence_notes(
-        self,
-        notes: str,
-        *,
-        mode: ExtractionMode = "initial",
-    ) -> ExtractionResult:  # noqa: ANN001
-        del self, notes, mode
-        return ExtractionResult(
-            transcript="append without confidence notes",
-            line_items=[
-                LineItemExtractedV2(
-                    raw_text="Added labor 15",
-                    description="Added labor",
-                    details=None,
-                    price=15,
-                    confidence="medium",
-                )
-            ],
-            pricing_hints=PricingHints(explicit_total=15),
-            confidence_notes=[],
-        )
-
-    monkeypatch.setattr(
-        _MockExtractionIntegration,
-        "extract",
-        _extract_without_confidence_notes,
-    )
-
-    csrf_token = await _register_and_login(client, _credentials())
-    customer_id = await _create_customer(client, csrf_token)
-    quote = await _create_quote(client, csrf_token, customer_id)
-    quote_id = UUID(quote["id"])
-    app.state.arq_pool = None
-
-    persisted_quote = await db_session.get(Document, quote_id)
-    assert persisted_quote is not None
-    persisted_quote.extraction_review_metadata = ExtractionReviewMetadataV1(
-        hidden_details=ExtractionReviewHiddenDetails(
-            confidence_notes=["keep existing confidence note"]
-        ),
-    ).model_dump(mode="json")
-    await db_session.commit()
-
-    append_response = await client.post(
-        f"/api/quotes/{quote_id}/append-extraction",
-        files=[("notes", (None, "append this follow-up"))],
-        headers={"X-CSRF-Token": csrf_token},
-    )
-    assert append_response.status_code == 200
-
-    detail_response = await client.get(f"/api/quotes/{quote_id}")
-    assert detail_response.status_code == 200
-    detail_payload = detail_response.json()
-    assert detail_payload["extraction_review_metadata"]["hidden_details"]["confidence_notes"] == [
-        "keep existing confidence note"
-    ]
+    assert hidden_state[next_item["id"]] == {"dismissed": False}
 
 
 async def test_patch_extraction_review_metadata_updates_sidecar_only(
@@ -603,12 +522,14 @@ async def test_patch_extraction_review_metadata_updates_sidecar_only(
     assert persisted_quote is not None
     persisted_quote.extraction_review_metadata = ExtractionReviewMetadataV1(
         hidden_details=ExtractionReviewHiddenDetails(
-            append_suggestions=[
-                ExtractionReviewAppendSuggestion(
+            items=[
+                ExtractionReviewActionableItem(
                     id="append-note-1",
-                    kind="note",
-                    raw_text="Add mulch color confirmation",
+                    kind="append_suggestion",
+                    field="notes",
+                    reason="append_capture",
                     confidence="medium",
+                    text="Add mulch color confirmation",
                 )
             ]
         ),
@@ -622,7 +543,6 @@ async def test_patch_extraction_review_metadata_updates_sidecar_only(
     )
     assert patch_response.status_code == 200
     assert patch_response.json()["hidden_detail_state"]["append-note-1"] == {
-        "reviewed": False,
         "dismissed": True,
     }
 
@@ -633,53 +553,7 @@ async def test_patch_extraction_review_metadata_updates_sidecar_only(
     assert payload["total_amount"] == 55
     assert payload["line_items"][0]["description"] == "line item"
     assert payload["extraction_review_metadata"]["hidden_detail_state"]["append-note-1"] == {
-        "reviewed": False,
         "dismissed": True,
-    }
-
-
-async def test_patch_extraction_review_metadata_marks_hidden_item_reviewed(
-    client: AsyncClient,
-    db_session: AsyncSession,
-) -> None:
-    csrf_token = await _register_and_login(client, _credentials())
-    customer_id = await _create_customer(client, csrf_token)
-    quote = await _create_quote(client, csrf_token, customer_id)
-    quote_id = UUID(quote["id"])
-
-    persisted_quote = await db_session.get(Document, quote_id)
-    assert persisted_quote is not None
-    persisted_quote.extraction_review_metadata = ExtractionReviewMetadataV1(
-        hidden_details=ExtractionReviewHiddenDetails(
-            unresolved_segments=[
-                ExtractionReviewUnresolvedSegment(
-                    id="unresolved-1",
-                    raw_text="Confirm edging scope",
-                    confidence="low",
-                    source="leftover_classification",
-                )
-            ]
-        ),
-    ).model_dump(mode="json")
-    await db_session.commit()
-
-    patch_response = await client.patch(
-        f"/api/quotes/{quote_id}/extraction-review-metadata",
-        json={"review_hidden_item": "unresolved-1"},
-        headers={"X-CSRF-Token": csrf_token},
-    )
-    assert patch_response.status_code == 200
-    assert patch_response.json()["hidden_detail_state"]["unresolved-1"] == {
-        "reviewed": True,
-        "dismissed": False,
-    }
-
-    detail_response = await client.get(f"/api/quotes/{quote_id}")
-    assert detail_response.status_code == 200
-    payload = detail_response.json()
-    assert payload["extraction_review_metadata"]["hidden_detail_state"]["unresolved-1"] == {
-        "reviewed": True,
-        "dismissed": False,
     }
 
 
@@ -700,23 +574,24 @@ async def test_quote_patch_clears_related_append_suggestions_on_real_field_edits
             pricing_pending=True,
         ),
         hidden_details=ExtractionReviewHiddenDetails(
-            unresolved_segments=[],
-            append_suggestions=[
-                ExtractionReviewAppendSuggestion(
+            items=[
+                ExtractionReviewActionableItem(
                     id="append-note-1",
-                    kind="note",
-                    raw_text="Add customer gate code",
+                    kind="append_suggestion",
+                    field="notes",
+                    reason="append_capture",
                     confidence="medium",
+                    text="Add customer gate code",
                 ),
-                ExtractionReviewAppendSuggestion(
+                ExtractionReviewActionableItem(
                     id="append-pricing-1",
-                    kind="pricing",
-                    raw_text="Total 120",
+                    kind="append_suggestion",
+                    field="explicit_total",
+                    reason="append_capture",
                     confidence="medium",
-                    pricing_field="explicit_total",
+                    text="Total 120",
                 ),
             ],
-            confidence_notes=[],
         ),
     ).model_dump(mode="json")
     await db_session.commit()
@@ -732,14 +607,14 @@ async def test_quote_patch_clears_related_append_suggestions_on_real_field_edits
     assert first_detail_response.status_code == 200
     first_metadata = first_detail_response.json()["extraction_review_metadata"]
     assert first_metadata["review_state"] == {"notes_pending": False, "pricing_pending": True}
-    assert first_metadata["hidden_details"]["append_suggestions"] == [
+    assert first_metadata["hidden_details"]["items"] == [
         {
             "id": "append-pricing-1",
-            "kind": "pricing",
-            "raw_text": "Total 120",
+            "kind": "append_suggestion",
+            "field": "explicit_total",
+            "reason": "append_capture",
             "confidence": "medium",
-            "source": "append_capture",
-            "pricing_field": "explicit_total",
+            "text": "Total 120",
         }
     ]
 
@@ -754,7 +629,7 @@ async def test_quote_patch_clears_related_append_suggestions_on_real_field_edits
     assert second_detail_response.status_code == 200
     second_metadata = second_detail_response.json()["extraction_review_metadata"]
     assert second_metadata["review_state"] == {"notes_pending": False, "pricing_pending": False}
-    assert second_metadata["hidden_details"]["append_suggestions"] == []
+    assert second_metadata["hidden_details"]["items"] == []
 
 
 async def test_append_extraction_sync_cleans_obsolete_pdf_artifact_after_commit(

--- a/backend/app/features/quotes/tests/test_quote_crud.py
+++ b/backend/app/features/quotes/tests/test_quote_crud.py
@@ -72,7 +72,6 @@ async def test_quote_crud_happy_path_with_ordering_and_line_item_replacement(
     assert extraction_payload["transcript"]
     assert isinstance(extraction_payload["line_items"], list)
     assert extraction_payload["line_items"][0]["price"] == 120
-    assert extraction_payload["confidence_notes"] == []
 
     create_response_1 = await client.post(
         "/api/quotes",
@@ -446,9 +445,6 @@ async def test_create_manual_draft_without_customer_persists_empty_draft_and_log
     }
     assert detail_payload["extraction_review_metadata"]["hidden_details"] == {
         "items": [],
-        "unresolved_segments": [],
-        "append_suggestions": [],
-        "confidence_notes": [],
     }
 
     quote_event_names = [

--- a/backend/app/features/quotes/tests/test_quote_extraction.py
+++ b/backend/app/features/quotes/tests/test_quote_extraction.py
@@ -172,7 +172,6 @@ async def test_extract_combined_notes_only_success(client: AsyncClient) -> None:
     assert payload["quote_id"]
     assert payload["transcript"] == "add 10 percent travel surcharge"
     assert payload["line_items"]
-    assert payload["confidence_notes"] == []
 
 
 async def test_extract_combined_sync_passes_initial_mode_to_extraction_integration(
@@ -623,7 +622,6 @@ async def test_extract_combined_clips_and_notes_success(client: AsyncClient) -> 
         "transcript from stitched-1\n\nadd 10 percent travel surcharge"
     )
     assert payload["line_items"]
-    assert payload["confidence_notes"] == []
 
 
 async def test_extract_combined_requires_clip_or_notes(client: AsyncClient) -> None:
@@ -802,7 +800,6 @@ async def test_convert_notes_rejects_when_concurrency_limit_is_exhausted(
                 transcript=notes.transcript,
                 line_items=[],
                 pricing_hints=PricingHints(),
-                confidence_notes=[],
             )
 
     blocking_integration = _BlockingExtractionIntegration()

--- a/backend/app/integrations/extraction.py
+++ b/backend/app/integrations/extraction.py
@@ -998,7 +998,6 @@ def _build_extraction_result_from_candidate(
             else None
         ),
         unresolved_segments=unresolved_segments,
-        confidence_notes=[],
     )
     return _apply_semantic_guard_rules(result)
 
@@ -1042,7 +1041,6 @@ def _build_extraction_result_from_append_candidate(
             else None
         ),
         unresolved_segments=unresolved_segments,
-        confidence_notes=[],
     )
     return _apply_semantic_guard_rules(result)
 
@@ -1211,7 +1209,6 @@ def _log_result_trace(
         line_item_count=len(result.line_items),
         flagged_line_item_count=sum(1 for item in result.line_items if item.flagged),
         unresolved_segment_count=len(result.unresolved_segments),
-        confidence_note_count=len(result.confidence_notes),
         total_present=result.pricing_hints.explicit_total is not None,
         raw_transcript=result.transcript,
         raw_tool_payload=result.model_dump(mode="json"),
@@ -1258,7 +1255,6 @@ def _build_validation_repair_failed_result(*, transcript: str) -> ExtractionResu
         pricing_hints=PricingHints(),
         customer_notes_suggestion=None,
         unresolved_segments=[],
-        confidence_notes=[],
         extraction_tier="degraded",
         extraction_degraded_reason_code=EXTRACTION_DEGRADED_REASON_VALIDATION_REPAIR_FAILED,
     )
@@ -1297,7 +1293,6 @@ def _apply_semantic_guard_rules(result: ExtractionResult) -> ExtractionResult:
         update={
             "line_items": line_items,
             "unresolved_segments": unresolved_segments,
-            "confidence_notes": [],
             "extraction_tier": extraction_tier,
             "extraction_degraded_reason_code": degraded_reason_code,
         }

--- a/backend/app/worker/tests/test_job_registry.py
+++ b/backend/app/worker/tests/test_job_registry.py
@@ -476,7 +476,6 @@ class _SuccessfulExtractionIntegration:
             transcript=transcript,
             line_items=[],
             pricing_hints=PricingHints(),
-            confidence_notes=[],
         )
 
 
@@ -501,7 +500,6 @@ class _SuccessfulSeededLineItemExtractionIntegration:
                 )
             ],
             pricing_hints=PricingHints(explicit_total=100),
-            confidence_notes=[],
         )
 
 
@@ -524,7 +522,6 @@ class _CaptureInputExtractionIntegration:
             transcript=transcript,
             line_items=[],
             pricing_hints=PricingHints(),
-            confidence_notes=[],
         )
 
 
@@ -546,7 +543,6 @@ class _AppendCandidateExtractionIntegration:
                 confidence="medium",
                 source="leftover_classification",
             ),
-            confidence_notes=[],
         )
 
 
@@ -582,7 +578,6 @@ class _ValidationRepairFailedExtractionIntegration:
             transcript=transcript,
             line_items=[],
             pricing_hints=PricingHints(),
-            confidence_notes=[],
             extraction_tier="degraded",
             extraction_degraded_reason_code="validation_repair_failed",
         )

--- a/frontend/src/features/quotes/components/CaptureDetailsSheet.tsx
+++ b/frontend/src/features/quotes/components/CaptureDetailsSheet.tsx
@@ -33,7 +33,7 @@ function formatPricingField(
 }
 
 function buildActionableLabel(item: {
-  kind: "append_suggestion" | "unresolved_segment" | "confidence_note";
+  kind: "append_suggestion" | "unresolved_segment";
   field: "notes" | "explicit_total" | "deposit_amount" | "tax_rate" | "discount" | null;
   reason: string | null;
 }): string {
@@ -46,7 +46,7 @@ function buildActionableLabel(item: {
   if (item.kind === "unresolved_segment") {
     return (item.reason ?? "leftover_classification").replaceAll("_", " ");
   }
-  return "Capture note";
+  return "Capture detail";
 }
 
 export function CaptureDetailsSheet({

--- a/frontend/src/features/quotes/tests/CaptureScreen.test.tsx
+++ b/frontend/src/features/quotes/tests/CaptureScreen.test.tsx
@@ -73,7 +73,7 @@ const mockedJobService = vi.mocked(jobService);
 
 const extractionFixture: ExtractionResult = {
   transcript: "5 yards brown mulch",
-  pipeline_version: "v2",
+  pipeline_version: "v2.5",
   line_items: [
     {
       raw_text: "5 yards brown mulch",
@@ -94,7 +94,6 @@ const extractionFixture: ExtractionResult = {
   },
   customer_notes_suggestion: null,
   unresolved_segments: [],
-  confidence_notes: [],
   extraction_tier: "primary",
   extraction_degraded_reason_code: null,
 };
@@ -105,7 +104,7 @@ const quoteDetailFixture: QuoteDetail = {
   extraction_tier: "primary",
   extraction_degraded_reason_code: null,
   extraction_review_metadata: {
-    pipeline_version: "v2",
+    pipeline_version: "v2.5",
     review_state: {
       notes_pending: false,
       pricing_pending: false,
@@ -120,9 +119,7 @@ const quoteDetailFixture: QuoteDetail = {
       },
     },
     hidden_details: {
-      unresolved_segments: [],
-      append_suggestions: [],
-      confidence_notes: [],
+      items: [],
     },
     hidden_detail_state: {},
     extraction_degraded_reason_code: null,
@@ -600,23 +597,26 @@ describe("CaptureScreen", () => {
     expect(navigateMock).toHaveBeenCalledWith("/documents/quote-manual-home/edit");
   });
 
-  it("submits append extraction from review and requests draft reseed without local confidence-note writes", async () => {
+  it("submits append extraction from review and requests draft reseed", async () => {
     mockedQuoteService.appendExtraction.mockResolvedValueOnce({
       type: "sync",
       quoteId: "quote-1",
-      result: {
-        ...extractionFixture,
-        confidence_notes: ["Backend output remains available for metadata, but review state is sidecar-driven."],
-      },
+      result: extractionFixture,
     });
     mockedQuoteService.getQuote.mockResolvedValueOnce({
       ...quoteDetailFixture,
       extraction_review_metadata: {
         ...quoteDetailFixture.extraction_review_metadata!,
         hidden_details: {
-          unresolved_segments: [],
-          append_suggestions: [],
-          confidence_notes: ["New note"],
+          items: [
+            {
+              id: "append-new-note",
+              kind: "append_suggestion",
+              field: "notes",
+              reason: "append_capture",
+              text: "New note",
+            },
+          ],
         },
         hidden_detail_state: {},
       },
@@ -642,7 +642,6 @@ describe("CaptureScreen", () => {
       state: { reseedDraft: true },
     });
     expect(setDraftMock).not.toHaveBeenCalled();
-    expect(window.localStorage.getItem("stima_review_confidence_notes:quote-1")).toBeNull();
   });
 
   it("submits home capture without customer context and routes when polling returns quote_id", async () => {

--- a/frontend/src/features/quotes/tests/ReviewScreen.test.tsx
+++ b/frontend/src/features/quotes/tests/ReviewScreen.test.tsx
@@ -83,7 +83,7 @@ function makeQuote(overrides: Partial<QuoteDetail> = {}): QuoteDetail {
     deposit_amount: null,
     notes: "Thanks for your business",
     extraction_review_metadata: {
-      pipeline_version: "v2",
+      pipeline_version: "v2.5",
       review_state: {
         notes_pending: false,
         pricing_pending: false,
@@ -98,9 +98,7 @@ function makeQuote(overrides: Partial<QuoteDetail> = {}): QuoteDetail {
         },
       },
       hidden_details: {
-        unresolved_segments: [],
-        append_suggestions: [],
-        confidence_notes: [],
+        items: [],
       },
       hidden_detail_state: {},
       extraction_degraded_reason_code: null,
@@ -262,7 +260,7 @@ beforeEach(() => {
     id: "doc-1",
   } as never);
   mockedQuoteService.updateExtractionReviewMetadata.mockResolvedValue({
-    pipeline_version: "v2",
+    pipeline_version: "v2.5",
     review_state: {
       notes_pending: false,
       pricing_pending: false,
@@ -277,9 +275,7 @@ beforeEach(() => {
       },
     },
     hidden_details: {
-      unresolved_segments: [],
-      append_suggestions: [],
-      confidence_notes: [],
+      items: [],
     },
     hidden_detail_state: {},
     extraction_degraded_reason_code: null,
@@ -422,16 +418,15 @@ describe("DocumentEditScreen", () => {
             pricing_pending: false,
           },
           hidden_details: {
-            unresolved_segments: [
+            items: [
               {
                 id: "unresolved-1",
-                raw_text: "maybe add edging",
-                confidence: "low",
-                source: "leftover_classification",
+                kind: "unresolved_segment",
+                field: null,
+                reason: "leftover_classification",
+                text: "maybe add edging",
               },
             ],
-            append_suggestions: [],
-            confidence_notes: [],
           },
         },
       }),
@@ -449,9 +444,7 @@ describe("DocumentEditScreen", () => {
         extraction_review_metadata: {
           ...makeQuote().extraction_review_metadata!,
           hidden_details: {
-            unresolved_segments: [],
-            append_suggestions: [],
-            confidence_notes: [],
+            items: [],
           },
         },
       }),
@@ -466,17 +459,15 @@ describe("DocumentEditScreen", () => {
         extraction_review_metadata: {
           ...makeQuote().extraction_review_metadata!,
           hidden_details: {
-            unresolved_segments: [],
-            append_suggestions: [
+            items: [
               {
                 id: "append-1",
-                kind: "note",
-                raw_text: "Add gate latch note",
-                confidence: "low",
-                source: "append_capture",
+                kind: "append_suggestion",
+                field: "notes",
+                reason: "append_capture",
+                text: "Add gate latch note",
               },
             ],
-            confidence_notes: [],
           },
         },
       }),
@@ -490,25 +481,22 @@ describe("DocumentEditScreen", () => {
         extraction_review_metadata: {
           ...makeQuote().extraction_review_metadata!,
           hidden_details: {
-            append_suggestions: [
+            items: [
               {
                 id: "append-1",
-                kind: "pricing",
-                raw_text: "discount 25",
-                confidence: "low",
-                source: "append_capture",
-                pricing_field: "discount",
+                kind: "append_suggestion",
+                field: "discount",
+                reason: "append_capture",
+                text: "discount 25",
               },
-            ],
-            unresolved_segments: [
               {
                 id: "unresolved-1",
-                raw_text: "trim rose bed maybe",
-                confidence: "low",
-                source: "typed_conflict",
+                kind: "unresolved_segment",
+                field: null,
+                reason: "typed_conflict",
+                text: "trim rose bed maybe",
               },
             ],
-            confidence_notes: ["Check driveway edging scope."],
           },
         },
         transcript: "Original capture transcript text.",
@@ -537,17 +525,15 @@ describe("DocumentEditScreen", () => {
         extraction_review_metadata: {
           ...makeQuote().extraction_review_metadata!,
           hidden_details: {
-            append_suggestions: [
+            items: [
               {
                 id: "append-1",
-                kind: "note",
-                raw_text: "Add gate latch note",
-                confidence: "low",
-                source: "append_capture",
+                kind: "append_suggestion",
+                field: "notes",
+                reason: "append_capture",
+                text: "Add gate latch note",
               },
             ],
-            unresolved_segments: [],
-            confidence_notes: [],
           },
           hidden_detail_state: {},
         },
@@ -594,17 +580,15 @@ describe("DocumentEditScreen", () => {
       extraction_review_metadata: {
         ...makeQuote().extraction_review_metadata!,
         hidden_details: {
-          append_suggestions: [
+          items: [
             {
               id: "append-2",
-              kind: "note",
-              raw_text: "Add gate latch note",
-              confidence: "low",
-              source: "append_capture",
+              kind: "append_suggestion",
+              field: "notes",
+              reason: "append_capture",
+              text: "Add gate latch note",
             },
           ],
-          unresolved_segments: [],
-          confidence_notes: [],
         },
         hidden_detail_state: {},
       },

--- a/frontend/src/features/quotes/tests/quoteService.extract.test.ts
+++ b/frontend/src/features/quotes/tests/quoteService.extract.test.ts
@@ -15,7 +15,7 @@ const mockedRequest = vi.mocked(request);
 describe("quoteService.extract", () => {
   const extractionPayload = {
     transcript: "typed note only",
-    pipeline_version: "v2" as const,
+    pipeline_version: "v2.5" as const,
     line_items: [],
     pricing_hints: {
       explicit_total: null,
@@ -26,7 +26,6 @@ describe("quoteService.extract", () => {
     },
     customer_notes_suggestion: null,
     unresolved_segments: [],
-    confidence_notes: [],
     extraction_tier: "primary" as const,
     extraction_degraded_reason_code: null,
   };

--- a/frontend/src/features/quotes/tests/quoteService.integration.test.ts
+++ b/frontend/src/features/quotes/tests/quoteService.integration.test.ts
@@ -37,7 +37,6 @@ describe("quoteService integration (MSW)", () => {
             },
           ],
           total: 120,
-          confidence_notes: [],
         });
       }),
     );
@@ -57,7 +56,6 @@ describe("quoteService integration (MSW)", () => {
         },
       ],
       total: 120,
-      confidence_notes: [],
     });
   });
 
@@ -113,7 +111,6 @@ describe("quoteService integration (MSW)", () => {
             transcript: "Mulch and edging",
             line_items: [],
             total: null,
-            confidence_notes: [],
           },
           { status: 200 },
         )),
@@ -128,7 +125,6 @@ describe("quoteService integration (MSW)", () => {
         transcript: "Mulch and edging",
         line_items: [],
         total: null,
-        confidence_notes: [],
       },
     });
   });
@@ -443,7 +439,6 @@ describe("quoteService integration (MSW)", () => {
           transcript: "combined transcript",
           line_items: [],
           total: null,
-          confidence_notes: [],
         });
       }),
     );
@@ -466,7 +461,6 @@ describe("quoteService integration (MSW)", () => {
         transcript: "combined transcript",
         line_items: [],
         total: null,
-        confidence_notes: [],
       },
     });
   });
@@ -483,7 +477,6 @@ describe("quoteService integration (MSW)", () => {
           transcript: capturedCsrfHeader ? "notes only transcript" : "missing csrf",
           line_items: [],
           total: null,
-          confidence_notes: [],
         });
       }),
     );
@@ -497,7 +490,6 @@ describe("quoteService integration (MSW)", () => {
         transcript: "notes only transcript",
         line_items: [],
         total: null,
-        confidence_notes: [],
       },
     });
   });
@@ -514,7 +506,6 @@ describe("quoteService integration (MSW)", () => {
           transcript: capturedCsrfHeader ? "clips only transcript" : "missing csrf",
           line_items: [],
           total: null,
-          confidence_notes: [],
         });
       }),
     );
@@ -530,7 +521,6 @@ describe("quoteService integration (MSW)", () => {
         transcript: "clips only transcript",
         line_items: [],
         total: null,
-        confidence_notes: [],
       },
     });
   });

--- a/frontend/src/features/quotes/types/quote.types.ts
+++ b/frontend/src/features/quotes/types/quote.types.ts
@@ -58,7 +58,6 @@ export interface ExtractionResult {
   pricing_hints: PricingHints;
   customer_notes_suggestion: ExtractionSuggestion | null;
   unresolved_segments: UnresolvedSegment[];
-  confidence_notes: string[];
   extraction_tier: ExtractionTier;
   extraction_degraded_reason_code: string | null;
 }
@@ -188,32 +187,16 @@ export interface PricingSeededFieldMetadata {
 }
 
 export interface ExtractionReviewHiddenDetails {
-  items?: Array<{
+  items: Array<{
     id: string;
-    kind: "append_suggestion" | "unresolved_segment" | "confidence_note";
+    kind: "append_suggestion" | "unresolved_segment";
     field?: "notes" | "explicit_total" | "deposit_amount" | "tax_rate" | "discount" | null;
     reason?: string | null;
     text: string;
   }>;
-  unresolved_segments: Array<{
-    id: string;
-    raw_text: string;
-    confidence: "medium" | "low";
-    source: UnresolvedSegmentSource;
-  }>;
-  append_suggestions: Array<{
-    id: string;
-    kind: "note" | "pricing";
-    raw_text: string;
-    confidence: "medium" | "low";
-    source: "append_capture";
-    pricing_field?: "explicit_total" | "deposit_amount" | "tax_rate" | "discount" | null;
-  }>;
-  confidence_notes: string[];
 }
 
 export interface HiddenItemState {
-  reviewed: boolean;
   dismissed: boolean;
 }
 
@@ -236,7 +219,6 @@ export interface ExtractionReviewMetadata {
 
 export interface ExtractionReviewMetadataUpdateRequest {
   dismiss_hidden_item?: string;
-  review_hidden_item?: string;
   clear_review_state?: {
     notes_pending?: true;
     pricing_pending?: true;

--- a/frontend/src/features/quotes/utils/captureDetails.ts
+++ b/frontend/src/features/quotes/utils/captureDetails.ts
@@ -2,7 +2,7 @@ import type { ExtractionReviewHiddenDetails, HiddenItemState } from "@/features/
 
 export interface CaptureDetailsActionableItem {
   id: string;
-  kind: "append_suggestion" | "unresolved_segment" | "confidence_note";
+  kind: "append_suggestion" | "unresolved_segment";
   field: "notes" | "explicit_total" | "deposit_amount" | "tax_rate" | "discount" | null;
   reason: string | null;
   text: string;
@@ -15,43 +15,13 @@ export function resolveCaptureDetailsActionableItems(
     return [];
   }
 
-  if (Array.isArray(hiddenDetails.items) && hiddenDetails.items.length > 0) {
-    return hiddenDetails.items.map((item) => ({
-      id: item.id,
-      kind: item.kind,
-      field: item.field ?? null,
-      reason: item.reason ?? null,
-      text: item.text,
-    }));
-  }
-
-  const appendSuggestions = hiddenDetails.append_suggestions ?? [];
-  const unresolvedSegments = hiddenDetails.unresolved_segments ?? [];
-  const confidenceNotes = hiddenDetails.confidence_notes ?? [];
-
-  return [
-    ...appendSuggestions.map((suggestion) => ({
-      id: suggestion.id,
-      kind: "append_suggestion" as const,
-      field: (suggestion.pricing_field ?? "notes") as CaptureDetailsActionableItem["field"],
-      reason: suggestion.source,
-      text: suggestion.raw_text,
-    })),
-    ...unresolvedSegments.map((segment) => ({
-      id: segment.id,
-      kind: "unresolved_segment" as const,
-      field: null,
-      reason: segment.source,
-      text: segment.raw_text,
-    })),
-    ...confidenceNotes.map((note, index) => ({
-      id: `legacy-confidence-${index}`,
-      kind: "confidence_note" as const,
-      field: null,
-      reason: "legacy_confidence_note",
-      text: note,
-    })),
-  ];
+  return hiddenDetails.items.map((item) => ({
+    id: item.id,
+    kind: item.kind,
+    field: item.field ?? null,
+    reason: item.reason ?? null,
+    text: item.text,
+  }));
 }
 
 export function hasUndismissedCaptureDetailsItems(

--- a/frontend/src/shared/tests/mocks/handlers.ts
+++ b/frontend/src/shared/tests/mocks/handlers.ts
@@ -212,7 +212,6 @@ export const handlers = [
           },
         ],
         total: 120,
-        confidence_notes: [],
       },
       { status: 200 },
     );
@@ -296,7 +295,6 @@ export const handlers = [
           },
         ],
         total: 120,
-        confidence_notes: [],
       },
       { status: 200 },
     );
@@ -320,7 +318,6 @@ export const handlers = [
             },
           ],
           total: 165,
-          confidence_notes: ["Confirm cleanup scope before sending"],
         },
         { status: 200 },
       );
@@ -347,7 +344,6 @@ export const handlers = [
             },
           ],
           total: 120,
-          confidence_notes: [],
         },
         quote_id: "quote-1",
         created_at: "2026-03-20T00:00:00.000Z",


### PR DESCRIPTION
## Summary
- removed transitional extraction/job response projection and now return the native 2.5 extraction payload
- removed grouped sidecar compatibility schema paths and kept Capture Details metadata on `hidden_details.items` only
- removed reviewed-state compatibility from hidden-item lifecycle (`dismissed` only) and dropped `review_hidden_item` request support
- updated backend/frontend quote contracts, mocks, and tests to remove legacy `confidence_notes` / grouped hidden-detail field dependencies

## Verification
- `cd backend && .venv/bin/pytest app/features/quotes/tests/test_extraction.py app/features/quotes/tests/test_quote_extraction.py app/features/quotes/tests/test_quote_append_extraction.py app/worker/tests/test_job_registry.py -m "not live and not extraction_eval and not extraction_quality" -o cache_dir=.pytest_cache`
- `cd frontend && npx vitest run src/features/quotes/tests/quoteService.extract.test.ts src/features/quotes/tests/quoteService.integration.test.ts src/features/quotes/tests/ReviewScreen.test.tsx`
- `make backend-static-verify`
- `cd frontend && npx tsc --noEmit && npx eslint src/features/quotes`
- `make verify`

Closes #423