### PR TITLE
Fix persisted subtotal authority during quote draft hydration

### DIFF
--- a/frontend/src/features/quotes/hooks/persistedDocumentDraft.ts
+++ b/frontend/src/features/quotes/hooks/persistedDocumentDraft.ts
@@ -1,10 +1,7 @@
 import type { InvoiceDetail } from "@/features/invoices/types/invoice.types";
 import type { LineItemDraftWithFlags, QuoteDetail } from "@/features/quotes/types/quote.types";
-import {
-  calculatePricingFromPersisted,
-  resolveLineItemSum,
-  type DiscountType,
-} from "@/shared/lib/pricing";
+import { resolveLineItemAuthoritativeSubtotal } from "@/features/quotes/utils/lineItemDraftTotals";
+import { calculatePricingFromPersisted, type DiscountType, type PricingFields } from "@/shared/lib/pricing";
 
 const EDIT_STORAGE_KEY = "stima_document_edit";
 
@@ -160,9 +157,28 @@ export function clearDocumentDraftFromStorage(): void {
   window.sessionStorage.removeItem(EDIT_STORAGE_KEY);
 }
 
-export function mapQuoteToEditDraft(quote: QuoteDetail): DocumentEditDraft {
-  const lineItemSum = resolveLineItemSum(quote.line_items.map((item) => item.price));
+function resolvePersistedDraftSubtotal(
+  pricing: PricingFields,
+  lineItems: LineItemDraftWithFlags[],
+): number | null {
+  const authoritativeSubtotal = resolveLineItemAuthoritativeSubtotal(lineItems);
   const breakdown = calculatePricingFromPersisted(
+    pricing,
+    authoritativeSubtotal.definesSubtotal ? authoritativeSubtotal.subtotal : null,
+  );
+  return breakdown.subtotal ?? pricing.totalAmount;
+}
+
+export function mapQuoteToEditDraft(quote: QuoteDetail): DocumentEditDraft {
+  const lineItems = quote.line_items.map((item) => ({
+    description: item.description,
+    details: item.details,
+    price: item.price,
+    priceStatus: item.price_status,
+    flagged: item.flagged,
+    flagReason: item.flag_reason,
+  }));
+  const total = resolvePersistedDraftSubtotal(
     {
       totalAmount: quote.total_amount,
       taxRate: quote.tax_rate,
@@ -170,7 +186,7 @@ export function mapQuoteToEditDraft(quote: QuoteDetail): DocumentEditDraft {
       discountValue: quote.discount_value,
       depositAmount: quote.deposit_amount,
     },
-    lineItemSum,
+    lineItems,
   );
 
   return {
@@ -178,15 +194,8 @@ export function mapQuoteToEditDraft(quote: QuoteDetail): DocumentEditDraft {
     docType: quote.doc_type === "invoice" ? "invoice" : "quote",
     title: quote.title?.trim() ?? "",
     transcript: quote.transcript,
-    lineItems: quote.line_items.map((item) => ({
-      description: item.description,
-      details: item.details,
-      price: item.price,
-      priceStatus: item.price_status,
-      flagged: item.flagged,
-      flagReason: item.flag_reason,
-    })),
-    total: breakdown.subtotal ?? quote.total_amount,
+    lineItems,
+    total,
     taxRate: quote.tax_rate,
     discountType: quote.discount_type,
     discountValue: quote.discount_value,
@@ -197,8 +206,13 @@ export function mapQuoteToEditDraft(quote: QuoteDetail): DocumentEditDraft {
 }
 
 export function mapInvoiceToEditDraft(invoice: InvoiceDetail): DocumentEditDraft {
-  const lineItemSum = resolveLineItemSum(invoice.line_items.map((item) => item.price));
-  const breakdown = calculatePricingFromPersisted(
+  const lineItems = invoice.line_items.map((item) => ({
+    description: item.description,
+    details: item.details,
+    price: item.price,
+    priceStatus: item.price_status ?? (item.price !== null ? "priced" : "unknown"),
+  }));
+  const total = resolvePersistedDraftSubtotal(
     {
       totalAmount: invoice.total_amount,
       taxRate: invoice.tax_rate,
@@ -206,7 +220,7 @@ export function mapInvoiceToEditDraft(invoice: InvoiceDetail): DocumentEditDraft
       discountValue: invoice.discount_value,
       depositAmount: invoice.deposit_amount,
     },
-    lineItemSum,
+    lineItems,
   );
 
   return {
@@ -214,13 +228,8 @@ export function mapInvoiceToEditDraft(invoice: InvoiceDetail): DocumentEditDraft
     docType: "invoice",
     title: invoice.title ?? "",
     transcript: "",
-    lineItems: invoice.line_items.map((item) => ({
-      description: item.description,
-      details: item.details,
-      price: item.price,
-      priceStatus: item.price_status ?? (item.price !== null ? "priced" : "unknown"),
-    })),
-    total: breakdown.subtotal ?? invoice.total_amount,
+    lineItems,
+    total,
     taxRate: invoice.tax_rate,
     discountType: invoice.discount_type,
     discountValue: invoice.discount_value,

--- a/frontend/src/features/quotes/tests/ReviewScreen.test.tsx
+++ b/frontend/src/features/quotes/tests/ReviewScreen.test.tsx
@@ -312,6 +312,92 @@ describe("DocumentEditScreen", () => {
     expect(draft.lineItems[0]?.priceStatus).toBe("included");
   });
 
+  it("hydrates priced + included quote rows with an authoritative subtotal", () => {
+    const quote = makeQuote({
+      total_amount: null,
+      line_items: [
+        {
+          id: "line-priced",
+          description: "Mulch",
+          details: "3 yards",
+          price: 120,
+          price_status: "priced",
+          sort_order: 0,
+        },
+        {
+          id: "line-included",
+          description: "Cleanup",
+          details: "Included in project scope",
+          price: null,
+          price_status: "included",
+          sort_order: 1,
+        },
+      ],
+    });
+
+    const draft = mapQuoteToEditDraft(quote);
+    expect(draft.total).toBe(120);
+  });
+
+  it("keeps quote subtotal null when unknown rows are present and no backend total exists", () => {
+    const quote = makeQuote({
+      total_amount: null,
+      line_items: [
+        {
+          id: "line-priced",
+          description: "Mulch",
+          details: "3 yards",
+          price: 120,
+          price_status: "priced",
+          sort_order: 0,
+        },
+        {
+          id: "line-unknown",
+          description: "Edging",
+          details: "Need to confirm exact material cost",
+          price: null,
+          price_status: "unknown",
+          sort_order: 1,
+        },
+      ],
+    });
+
+    const draft = mapQuoteToEditDraft(quote);
+    expect(draft.total).toBeNull();
+  });
+
+  it("keeps quote subtotal null when all rows are unknown or included", () => {
+    const unknownOnlyQuote = makeQuote({
+      total_amount: null,
+      line_items: [
+        {
+          id: "line-unknown",
+          description: "Edging",
+          details: "Need to confirm exact material cost",
+          price: null,
+          price_status: "unknown",
+          sort_order: 0,
+        },
+      ],
+    });
+    const includedOnlyQuote = makeQuote({
+      total_amount: null,
+      line_items: [
+        {
+          id: "line-included",
+          description: "Cleanup",
+          details: "Included in project scope",
+          price: null,
+          price_status: "included",
+          sort_order: 0,
+        },
+      ],
+    });
+
+    expect(mapQuoteToEditDraft(unknownOnlyQuote).total).toBeNull();
+    expect(mapQuoteToEditDraft(includedOnlyQuote).total).toBeNull();
+  });
+
   it("disables invoice type when no customer is selected", async () => {
     renderScreen({
       document: makeQuote({
@@ -620,6 +706,40 @@ describe("DocumentEditScreen", () => {
       }));
     });
     expect(navigateMock).toHaveBeenCalledWith("/invoices/doc-1", { replace: true });
+  });
+
+  it("keeps total_amount null when saving unknown-price quotes without pricing edits", async () => {
+    renderScreen({
+      document: makeQuote({
+        total_amount: null,
+        line_items: [
+          {
+            id: "line-priced",
+            description: "Mulch",
+            details: "3 yards",
+            price: 120,
+            price_status: "priced",
+            sort_order: 0,
+          },
+          {
+            id: "line-unknown",
+            description: "Edging",
+            details: "Need to confirm exact material cost",
+            price: null,
+            price_status: "unknown",
+            sort_order: 1,
+          },
+        ],
+      }),
+    });
+
+    fireEvent.click(await screen.findByRole("button", { name: /continue to preview/i }));
+
+    await waitFor(() => {
+      expect(mockedQuoteService.updateQuote).toHaveBeenCalledWith("doc-1", expect.objectContaining({
+        total_amount: null,
+      }));
+    });
   });
 
   it("saves invoice edits through invoice endpoint when document starts as invoice", async () => {

--- a/frontend/src/features/quotes/utils/lineItemDraftTotals.ts
+++ b/frontend/src/features/quotes/utils/lineItemDraftTotals.ts
@@ -7,6 +7,11 @@ interface DraftLineItemTotalsState {
   total: number | null;
 }
 
+export interface LineItemAuthoritativeSubtotal {
+  definesSubtotal: boolean;
+  subtotal: number | null;
+}
+
 export function syncDraftTotalWithLineItems(
   currentState: DraftLineItemTotalsState,
   nextLineItems: LineItemDraftWithFlags[],
@@ -26,10 +31,9 @@ export function syncDraftTotalWithLineItems(
   return nextDerivedSubtotal.subtotal;
 }
 
-function resolveLineItemAuthoritativeSubtotal(lineItems: LineItemDraftWithFlags[]): {
-  definesSubtotal: boolean;
-  subtotal: number | null;
-} {
+export function resolveLineItemAuthoritativeSubtotal(
+  lineItems: LineItemDraftWithFlags[],
+): LineItemAuthoritativeSubtotal {
   const substantiveLineItems = lineItems.filter(hasLineItemContent);
   if (substantiveLineItems.length === 0) {
     return { definesSubtotal: true, subtotal: null };


### PR DESCRIPTION
## Summary
- align persisted edit-draft subtotal hydration with `price_status`-aware authoritative subtotal semantics
- reuse `lineItemDraftTotals` authoritative subtotal resolution during quote/invoice draft mapping so unknown rows no longer synthesize subtotals
- add focused review-screen coverage for quote hydration and save behavior with `priced|included|unknown` line-item combinations

## Verification
- `cd frontend && npx vitest run src/features/quotes/tests/ReviewScreen.test.tsx src/features/quotes/tests/lineItemDraftTotals.test.ts src/features/quotes/tests/usePersistedReview.test.tsx`
- `cd frontend && npx tsc --noEmit && npx eslint src/features/quotes`
- `make frontend-verify`

Closes #434