### PR TITLE
Finalize extraction/job contract cleanup with sidecar compatibility safety

### DIFF
--- a/backend/app/features/jobs/schemas.py
+++ b/backend/app/features/jobs/schemas.py
@@ -9,6 +9,7 @@ from pydantic import BaseModel, ConfigDict
 
 from app.features.jobs.models import JobRecord, JobStatus, JobType
 from app.features.quotes.schemas import (
+    ExtractionResponse,
     ExtractionResult,
 )
 
@@ -26,7 +27,7 @@ class JobRecordResponse(BaseModel):
     status: JobStatus
     attempts: int
     terminal_error: str | None
-    extraction_result: ExtractionResult | None = None
+    extraction_result: ExtractionResponse | None = None
     quote_id: UUID | None = None
     created_at: datetime
     updated_at: datetime
@@ -38,9 +39,11 @@ def job_record_to_response(record: JobRecord) -> JobRecordResponse:
     if record.job_type != JobType.EXTRACTION:
         return response
 
-    updates: dict[str, UUID | ExtractionResult | None] = {
+    updates: dict[str, UUID | ExtractionResponse | None] = {
         "quote_id": record.document_id if record.status == JobStatus.SUCCESS else None
     }
     if record.status == JobStatus.SUCCESS and record.result_json is not None:
-        updates["extraction_result"] = ExtractionResult.model_validate_json(record.result_json)
+        updates["extraction_result"] = ExtractionResponse.from_internal_result(
+            ExtractionResult.model_validate_json(record.result_json)
+        )
     return response.model_copy(update=updates)

--- a/backend/app/features/jobs/tests/test_jobs_api.py
+++ b/backend/app/features/jobs/tests/test_jobs_api.py
@@ -59,7 +59,6 @@ async def test_get_job_status_returns_owned_extraction_result(
     assert payload["quote_id"] == str(quote.id)  # nosec B101 - pytest assertion
     assert payload["extraction_result"] == {  # nosec B101 - pytest assertion
         "transcript": "mulch the beds",
-        "pipeline_version": "v2",
         "line_items": [],
         "pricing_hints": {
             "explicit_total": None,
@@ -69,7 +68,6 @@ async def test_get_job_status_returns_owned_extraction_result(
             "discount_value": None,
         },
         "customer_notes_suggestion": None,
-        "unresolved_segments": [],
         "extraction_tier": "primary",
         "extraction_degraded_reason_code": None,
     }

--- a/backend/app/features/quotes/api.py
+++ b/backend/app/features/quotes/api.py
@@ -42,7 +42,7 @@ from app.features.quotes.review_metadata import normalize_extraction_review_meta
 from app.features.quotes.schemas import (
     ConvertNotesRequest,
     DiscountType,
-    ExtractionResult,
+    ExtractionResponse,
     ExtractionReviewMetadataUpdateRequest,
     ExtractionReviewMetadataV1,
     LineItemResponse,
@@ -152,7 +152,7 @@ async def _parse_upload_clips(clips: list[UploadFile]) -> list[CaptureAudioClip]
 
 @router.post(
     "/convert-notes",
-    response_model=ExtractionResult,
+    response_model=ExtractionResponse,
     dependencies=[Depends(require_csrf)],
 )
 @limiter.limit(lambda: get_settings().quote_text_extraction_rate_limit, key_func=get_user_key)
@@ -161,13 +161,13 @@ async def convert_notes(
     payload: ConvertNotesRequest,
     user: Annotated[User, Depends(get_current_user)],
     extraction_service: Annotated[ExtractionService, Depends(get_extraction_service)],
-) -> ExtractionResult:
+) -> ExtractionResponse:
     """Convert notes into extraction output without creating a persisted draft."""
     del request
     async with extraction_capacity_guard(user.id):
         try:
             extraction = await extraction_service.convert_notes(payload.notes)
-            return extraction
+            return ExtractionResponse.from_internal_result(extraction)
         except QuoteServiceError as exc:
             raise HTTPException(status_code=exc.status_code, detail=exc.detail) from exc
 
@@ -300,9 +300,9 @@ async def extract_combined(
             capture_detail=capture_detail,
             extraction_result=extraction,
         )
-        return PersistedExtractionResponse(
+        return PersistedExtractionResponse.from_internal_persisted_result(
             quote_id=quote.id,
-            **extraction.model_dump(),
+            result=extraction,
         )
 
     try:
@@ -412,9 +412,9 @@ async def append_extraction(
             customer_id=updated_quote.customer_id,
             detail=capture_detail,
         )
-        return PersistedExtractionResponse(
+        return PersistedExtractionResponse.from_internal_persisted_result(
             quote_id=updated_quote.id,
-            **merged_extraction.model_dump(),
+            result=merged_extraction,
         )
 
     try:

--- a/backend/app/features/quotes/schemas.py
+++ b/backend/app/features/quotes/schemas.py
@@ -340,6 +340,38 @@ class ExtractionResult(ExtractionResultV2):
         return self.pricing_hints.explicit_total
 
 
+class ExtractionResponse(BaseModel):
+    """Public extraction contract returned by quote extract and job APIs."""
+
+    transcript: str = Field(min_length=1, max_length=EXTRACTION_TRANSCRIPT_MAX_CHARS)
+    line_items: list[LineItemExtracted] = Field(
+        default_factory=list,
+        max_length=DOCUMENT_LINE_ITEMS_MAX_ITEMS,
+    )
+    pricing_hints: PricingHints = Field(default_factory=PricingHints)
+    customer_notes_suggestion: ExtractionSuggestion | None = None
+    extraction_tier: Literal["primary", "degraded"] = "primary"
+    extraction_degraded_reason_code: str | None = None
+
+    @classmethod
+    def from_internal_result(cls, result: ExtractionResult) -> ExtractionResponse:
+        """Project internal extraction metadata into the public contract shape."""
+        return cls.model_validate(
+            {
+                "transcript": result.transcript,
+                "line_items": [item.model_dump(mode="json") for item in result.line_items],
+                "pricing_hints": result.pricing_hints.model_dump(mode="json"),
+                "customer_notes_suggestion": (
+                    None
+                    if result.customer_notes_suggestion is None
+                    else result.customer_notes_suggestion.model_dump(mode="json")
+                ),
+                "extraction_tier": result.extraction_tier,
+                "extraction_degraded_reason_code": result.extraction_degraded_reason_code,
+            }
+        )
+
+
 PricingFieldName = Literal["explicit_total", "deposit_amount", "tax_rate", "discount"]
 
 
@@ -428,6 +460,133 @@ class HiddenItemState(BaseModel):
     dismissed: bool = False
 
 
+def _normalize_legacy_hidden_details_payload(value: object) -> object:
+    if not isinstance(value, dict):
+        return value
+
+    payload = dict(value)
+    hidden_details_payload = _coerce_mapping(payload.get("hidden_details"))
+
+    normalized_items: list[dict[str, Any]] = []
+    normalized_items.extend(
+        _coerce_items_list(hidden_details_payload.get("items") if hidden_details_payload else None)
+    )
+    normalized_items.extend(
+        _normalize_legacy_append_suggestions(
+            hidden_details_payload.get("append_suggestions") if hidden_details_payload else None
+        )
+    )
+    normalized_items.extend(
+        _normalize_legacy_unresolved_segments(
+            hidden_details_payload.get("unresolved_segments") if hidden_details_payload else None
+        )
+    )
+    normalized_items.extend(_normalize_legacy_append_suggestions(payload.get("append_suggestions")))
+    normalized_items.extend(
+        _normalize_legacy_unresolved_segments(payload.get("unresolved_segments"))
+    )
+
+    if normalized_items:
+        payload["hidden_details"] = {"items": normalized_items}
+
+    payload.pop("append_suggestions", None)
+    payload.pop("unresolved_segments", None)
+    return payload
+
+
+def _coerce_mapping(value: object) -> dict[str, Any] | None:
+    if isinstance(value, dict):
+        return dict(value)
+    model_dump = getattr(value, "model_dump", None)
+    if not callable(model_dump):
+        return None
+    dumped = model_dump(mode="json")
+    return dict(dumped) if isinstance(dumped, dict) else None
+
+
+def _coerce_items_list(value: object) -> list[dict[str, Any]]:
+    if not isinstance(value, list):
+        return []
+    items: list[dict[str, Any]] = []
+    for candidate in value:
+        coerced = _coerce_mapping(candidate)
+        if coerced is not None:
+            items.append(coerced)
+    return items
+
+
+def _normalize_legacy_append_suggestions(value: object) -> list[dict[str, Any]]:
+    if not isinstance(value, list):
+        return []
+    normalized: list[dict[str, Any]] = []
+    for index, candidate in enumerate(value):
+        payload = _coerce_mapping(candidate)
+        if payload is None:
+            continue
+        text = (
+            payload.get("text") if isinstance(payload.get("text"), str) else payload.get("raw_text")
+        )
+        if not isinstance(text, str) or text.strip() == "":
+            continue
+        kind = payload.get("kind") if isinstance(payload.get("kind"), str) else None
+        pricing_field = (
+            payload.get("pricing_field") if isinstance(payload.get("pricing_field"), str) else None
+        )
+        field: str | None
+        if pricing_field in {"explicit_total", "deposit_amount", "tax_rate", "discount"}:
+            field = pricing_field
+        elif kind == "pricing":
+            field = None
+        else:
+            field = "notes"
+        confidence = payload.get("confidence")
+        item_id = payload.get("id") if isinstance(payload.get("id"), str) else None
+        normalized.append(
+            {
+                "id": item_id or f"legacy-append:{index}",
+                "kind": "append_suggestion",
+                "field": field,
+                "reason": (
+                    payload.get("source")
+                    if isinstance(payload.get("source"), str)
+                    else "append_capture"
+                ),
+                "confidence": confidence if confidence in {"medium", "low"} else None,
+                "text": text.strip(),
+            }
+        )
+    return normalized
+
+
+def _normalize_legacy_unresolved_segments(value: object) -> list[dict[str, Any]]:
+    if not isinstance(value, list):
+        return []
+    normalized: list[dict[str, Any]] = []
+    for index, candidate in enumerate(value):
+        payload = _coerce_mapping(candidate)
+        if payload is None:
+            continue
+        text = (
+            payload.get("text") if isinstance(payload.get("text"), str) else payload.get("raw_text")
+        )
+        if not isinstance(text, str) or text.strip() == "":
+            continue
+        source = payload.get("source") if isinstance(payload.get("source"), str) else None
+        confidence = payload.get("confidence")
+        item_id = payload.get("id") if isinstance(payload.get("id"), str) else None
+        normalized.append(
+            {
+                "id": item_id or f"legacy-unresolved:{index}",
+                "kind": "unresolved_segment",
+                "field": None,
+                "reason": source,
+                "confidence": confidence if confidence in {"medium", "low"} else None,
+                "text": text.strip(),
+            }
+        )
+    return normalized
+
+
 class ExtractionReviewMetadataV1(BaseModel):
     """Sidecar metadata persisted for V2 extraction review behavior."""
 
@@ -439,6 +598,10 @@ class ExtractionReviewMetadataV1(BaseModel):
     )
     hidden_detail_state: dict[str, HiddenItemState] = Field(default_factory=dict)
     extraction_degraded_reason_code: str | None = None
+
+    _normalize_legacy_hidden_details = model_validator(mode="before")(
+        _normalize_legacy_hidden_details_payload
+    )
 
     @classmethod
     def model_validate_with_defaults(
@@ -461,10 +624,21 @@ class ExtractionReviewMetadataV1(BaseModel):
         return metadata
 
 
-class PersistedExtractionResponse(ExtractionResult):
+class PersistedExtractionResponse(ExtractionResponse):
     """Successful unified extraction response with the persisted draft id."""
 
     quote_id: UUID
+
+    @classmethod
+    def from_internal_persisted_result(
+        cls,
+        *,
+        quote_id: UUID,
+        result: ExtractionResult,
+    ) -> PersistedExtractionResponse:
+        """Build persisted extraction responses from the internal extraction contract."""
+        public_payload = ExtractionResponse.from_internal_result(result).model_dump(mode="json")
+        return cls(quote_id=quote_id, **public_payload)
 
 
 class ConvertNotesRequest(BaseModel):

--- a/backend/app/features/quotes/tests/test_quote_append_extraction.py
+++ b/backend/app/features/quotes/tests/test_quote_append_extraction.py
@@ -85,6 +85,57 @@ async def test_extraction_review_metadata_accepts_items_only_hidden_details() ->
     assert metadata.hidden_details.items[0].text == "Add gate note"
 
 
+async def test_extraction_review_metadata_normalizes_legacy_grouped_hidden_details() -> None:
+    metadata = ExtractionReviewMetadataV1.model_validate_with_defaults(
+        {
+            "pipeline_version": "v2",
+            "hidden_details": {
+                "append_suggestions": [
+                    {
+                        "id": "append-note-legacy",
+                        "kind": "note",
+                        "raw_text": "Add gate note",
+                        "confidence": "medium",
+                        "source": "append_capture",
+                    }
+                ],
+                "unresolved_segments": [
+                    {
+                        "id": "unresolved-legacy",
+                        "raw_text": "Need to confirm edging cost",
+                        "confidence": "low",
+                        "source": "typed_conflict",
+                    }
+                ],
+            },
+            "hidden_detail_state": {
+                "append-note-legacy": {"dismissed": True},
+            },
+        },
+        extraction_degraded_reason_code=None,
+    )
+
+    assert metadata.hidden_details.model_dump(mode="json")["items"] == [
+        {
+            "id": "append-note-legacy",
+            "kind": "append_suggestion",
+            "field": "notes",
+            "reason": "append_capture",
+            "confidence": "medium",
+            "text": "Add gate note",
+        },
+        {
+            "id": "unresolved-legacy",
+            "kind": "unresolved_segment",
+            "field": None,
+            "reason": "typed_conflict",
+            "confidence": "low",
+            "text": "Need to confirm edging cost",
+        },
+    ]
+    assert metadata.hidden_detail_state["append-note-legacy"].dismissed is True
+
+
 async def test_append_extraction_sync_retryable_failure_uses_degraded_append_semantics(
     client: AsyncClient,
     monkeypatch: pytest.MonkeyPatch,

--- a/backend/app/features/quotes/tests/test_quote_extraction.py
+++ b/backend/app/features/quotes/tests/test_quote_extraction.py
@@ -57,6 +57,17 @@ _override_extraction_service_dependency = quotes_test_module._override_extractio
 _reset_rate_limiter = quotes_test_module._reset_rate_limiter
 
 
+def _assert_public_extraction_contract(payload: dict[str, object]) -> None:
+    assert "pipeline_version" not in payload
+    assert "unresolved_segments" not in payload
+    line_items = payload.get("line_items")
+    assert isinstance(line_items, list)
+    for line_item in line_items:
+        assert isinstance(line_item, dict)
+        assert "raw_text" not in line_item
+        assert "confidence" not in line_item
+
+
 async def test_convert_notes_returns_422_for_extraction_errors(
     client: AsyncClient,
 ) -> None:
@@ -95,6 +106,7 @@ async def test_convert_notes_can_return_flagged_line_items(client: AsyncClient) 
 
     assert response.status_code == 200
     payload = response.json()
+    _assert_public_extraction_contract(payload)
     assert payload["line_items"][0]["flagged"] is True
     assert payload["line_items"][0]["flag_reason"]
 
@@ -170,6 +182,7 @@ async def test_extract_combined_notes_only_success(client: AsyncClient) -> None:
 
     assert response.status_code == 200
     payload = response.json()
+    _assert_public_extraction_contract(payload)
     assert payload["quote_id"]
     assert payload["transcript"] == "add 10 percent travel surcharge"
     assert payload["line_items"]
@@ -450,6 +463,8 @@ async def test_extract_combined_async_worker_persists_draft_and_returns_quote_id
     assert status_payload["status"] == "success"
     assert status_payload["quote_id"] is not None
     assert status_payload["document_id"] == status_payload["quote_id"]
+    assert status_payload["extraction_result"] is not None
+    _assert_public_extraction_contract(status_payload["extraction_result"])
     assert status_payload["extraction_result"]["transcript"] == "mulch the front beds"
 
     quote_response = await client.get(f"/api/quotes/{status_payload['quote_id']}")
@@ -510,6 +525,8 @@ async def test_extract_combined_async_final_retryable_failure_persists_degraded_
     status_payload = status_response.json()
     assert status_payload["status"] == "success"
     assert status_payload["quote_id"] is not None
+    assert status_payload["extraction_result"] is not None
+    _assert_public_extraction_contract(status_payload["extraction_result"])
     assert status_payload["extraction_result"]["line_items"] == []
     assert status_payload["extraction_result"]["extraction_tier"] == "degraded"
     assert (

--- a/frontend/src/features/quotes/tests/CaptureScreen.test.tsx
+++ b/frontend/src/features/quotes/tests/CaptureScreen.test.tsx
@@ -73,16 +73,13 @@ const mockedJobService = vi.mocked(jobService);
 
 const extractionFixture: ExtractionResult = {
   transcript: "5 yards brown mulch",
-  pipeline_version: "v2.5",
   line_items: [
     {
-      raw_text: "5 yards brown mulch",
       description: "Brown mulch",
       details: "5 yards",
       price: 120,
       flagged: true,
       flag_reason: "Unit phrasing may be ambiguous",
-      confidence: "medium",
     },
   ],
   pricing_hints: {
@@ -93,7 +90,6 @@ const extractionFixture: ExtractionResult = {
     discount_value: null,
   },
   customer_notes_suggestion: null,
-  unresolved_segments: [],
   extraction_tier: "primary",
   extraction_degraded_reason_code: null,
 };

--- a/frontend/src/features/quotes/tests/quoteService.extract.test.ts
+++ b/frontend/src/features/quotes/tests/quoteService.extract.test.ts
@@ -15,7 +15,6 @@ const mockedRequest = vi.mocked(request);
 describe("quoteService.extract", () => {
   const extractionPayload = {
     transcript: "typed note only",
-    pipeline_version: "v2.5" as const,
     line_items: [],
     pricing_hints: {
       explicit_total: null,
@@ -25,7 +24,6 @@ describe("quoteService.extract", () => {
       discount_value: null,
     },
     customer_notes_suggestion: null,
-    unresolved_segments: [],
     extraction_tier: "primary" as const,
     extraction_degraded_reason_code: null,
   };

--- a/frontend/src/features/quotes/types/quote.types.ts
+++ b/frontend/src/features/quotes/types/quote.types.ts
@@ -13,8 +13,6 @@ export interface LineItemDraft {
 }
 
 export interface LineItemExtracted extends LineItemDraft {
-  raw_text?: string;
-  confidence?: PlacementConfidence;
   flagged?: boolean;
   flag_reason?: string | null;
 }
@@ -45,19 +43,11 @@ export interface ExtractionSuggestion {
   source: UnresolvedSegmentSource;
 }
 
-export interface UnresolvedSegment {
-  raw_text: string;
-  confidence: "medium" | "low";
-  source: UnresolvedSegmentSource;
-}
-
 export interface ExtractionResult {
   transcript: string;
-  pipeline_version: "v2" | "v2.5";
   line_items: LineItemExtracted[];
   pricing_hints: PricingHints;
   customer_notes_suggestion: ExtractionSuggestion | null;
-  unresolved_segments: UnresolvedSegment[];
   extraction_tier: ExtractionTier;
   extraction_degraded_reason_code: string | null;
 }


### PR DESCRIPTION
## Summary
- split internal extraction result DTOs from public extraction/job response DTOs so API contracts no longer expose legacy V2-only fields (`pipeline_version`, `unresolved_segments`, line-item `raw_text`/`confidence`)
- route quote extraction endpoints and jobs API serialization through the new public extraction response shape
- add bounded sidecar compatibility normalization that maps legacy grouped hidden metadata (`append_suggestions` / `unresolved_segments`) into `hidden_details.items`
- update backend/frontend extraction contract tests and frontend extraction types to match the final response shape

## Compatibility Safety
- legacy sidecar grouped payloads are still readable via normalization in `ExtractionReviewMetadataV1` model validation
- explicit removal condition: remove this compatibility path once environments are audited and all persisted sidecar rows are confirmed `hidden_details.items`-only

## Verification
- `cd backend && .venv/bin/pytest app/features/quotes/tests/test_extraction.py app/features/quotes/tests/test_quote_extraction.py app/features/quotes/tests/test_quote_append_extraction.py app/worker/tests/test_job_registry.py -m "not live and not extraction_eval and not extraction_quality" -o cache_dir=.pytest_cache`
- `cd frontend && npx vitest run src/features/quotes/tests/quoteService.extract.test.ts src/features/quotes/tests/quoteService.integration.test.ts src/features/quotes/tests/ReviewScreen.test.tsx`
- `make backend-static-verify`
- `cd frontend && npx tsc --noEmit && npx eslint src/features/quotes`
- `make verify`

Closes #435