### PR TITLE
Task #436: Extraction 2.5 cross-layer regression hardening

### DIFF
--- a/backend/app/features/quotes/tests/test_quote_append_extraction.py
+++ b/backend/app/features/quotes/tests/test_quote_append_extraction.py
@@ -483,6 +483,80 @@ async def test_append_extraction_withholds_ambiguous_explicit_total_when_tax_can
     ]
 
 
+async def test_append_extraction_included_scope_keeps_single_conflicting_total_suggestion(
+    client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def _extract_included_scope_with_conflicting_total(
+        self,
+        notes: str,
+        *,
+        mode: ExtractionMode = "initial",
+    ) -> ExtractionResult:  # noqa: ANN001
+        del self, notes, mode
+        return ExtractionResult(
+            transcript="append included scope conflicting total",
+            line_items=[
+                LineItemExtractedV2(
+                    raw_text="Cleanup labor included",
+                    description="Cleanup labor",
+                    details="Included / no charge",
+                    price=None,
+                    price_status="included",
+                    confidence="medium",
+                )
+            ],
+            pricing_hints=PricingHints(explicit_total=500),
+        )
+
+    monkeypatch.setattr(
+        _MockExtractionIntegration,
+        "extract",
+        _extract_included_scope_with_conflicting_total,
+    )
+
+    csrf_token = await _register_and_login(client, _credentials())
+    customer_id = await _create_customer(client, csrf_token)
+    quote = await _create_quote(client, csrf_token, customer_id)
+    quote_id = quote["id"]
+    app.state.arq_pool = None
+
+    first_append_response = await client.post(
+        f"/api/quotes/{quote_id}/append-extraction",
+        files=[("notes", (None, "append included scope conflicting total"))],
+        headers={"X-CSRF-Token": csrf_token},
+    )
+    second_append_response = await client.post(
+        f"/api/quotes/{quote_id}/append-extraction",
+        files=[("notes", (None, "append included scope conflicting total"))],
+        headers={"X-CSRF-Token": csrf_token},
+    )
+
+    assert first_append_response.status_code == 200
+    assert second_append_response.status_code == 200
+
+    detail_response = await client.get(f"/api/quotes/{quote_id}")
+    assert detail_response.status_code == 200
+    payload = detail_response.json()
+    assert payload["total_amount"] == 55
+    included_rows = [
+        item for item in payload["line_items"] if item["description"] == "Cleanup labor"
+    ]
+    assert len(included_rows) == 1
+    assert all(
+        item["price"] is None and item["price_status"] == "included" for item in included_rows
+    )
+
+    explicit_total_suggestions = [
+        item
+        for item in payload["extraction_review_metadata"]["hidden_details"]["items"]
+        if item["kind"] == "append_suggestion"
+        and item["field"] == "explicit_total"
+        and item["text"] == "Total 500"
+    ]
+    assert len(explicit_total_suggestions) == 1
+
+
 async def test_append_extraction_resurfaces_previously_dismissed_matching_suggestion(
     client: AsyncClient,
     db_session: AsyncSession,

--- a/backend/app/features/quotes/tests/test_quote_extraction.py
+++ b/backend/app/features/quotes/tests/test_quote_extraction.py
@@ -242,6 +242,111 @@ async def test_extract_combined_persists_included_price_status_from_provider(
     assert detail_payload["line_items"][0]["price_status"] == "included"
 
 
+async def test_extract_combined_preserves_mixed_price_status_rows_across_reload(
+    client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    original_extract = _MockExtractionIntegration.extract
+
+    async def _extract_mixed_price_status_rows(
+        self,
+        notes: PreparedCaptureInput | str,
+        *,
+        mode: ExtractionMode = "initial",
+    ) -> ExtractionResult:
+        transcript = (
+            notes.transcript.strip() if isinstance(notes, PreparedCaptureInput) else notes.strip()
+        )
+        if transcript != "mixed price status regression check":
+            return await original_extract(self, notes, mode=mode)
+        return ExtractionResult(
+            transcript=transcript,
+            line_items=[
+                LineItemExtractedV2(
+                    raw_text="Mulch 120",
+                    description="Mulch",
+                    details="3 yards",
+                    price=120,
+                    price_status="priced",
+                    confidence="medium",
+                ),
+                LineItemExtractedV2(
+                    raw_text="Cleanup included",
+                    description="Cleanup",
+                    details="Included / no charge",
+                    price=None,
+                    price_status="included",
+                    confidence="medium",
+                ),
+                LineItemExtractedV2(
+                    raw_text="Edging TBD",
+                    description="Edging",
+                    details="Need exact material cost",
+                    price=None,
+                    price_status="unknown",
+                    confidence="low",
+                ),
+            ],
+            pricing_hints=PricingHints(explicit_total=180),
+        )
+
+    monkeypatch.setattr(_MockExtractionIntegration, "extract", _extract_mixed_price_status_rows)
+    csrf_token = await _register_and_login(client, _credentials())
+    app.state.arq_pool = None
+
+    response = await client.post(
+        "/api/quotes/extract",
+        files=[("notes", (None, "mixed price status regression check"))],
+        headers={"X-CSRF-Token": csrf_token},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert [item["price_status"] for item in payload["line_items"]] == [
+        "priced",
+        "included",
+        "unknown",
+    ]
+    assert payload["line_items"][2]["price"] is None
+
+    quote_id = payload["quote_id"]
+    detail_response = await client.get(f"/api/quotes/{quote_id}")
+    assert detail_response.status_code == 200
+    detail_payload = detail_response.json()
+    assert [item["price_status"] for item in detail_payload["line_items"]] == [
+        "priced",
+        "included",
+        "unknown",
+    ]
+    assert detail_payload["line_items"][2]["price"] is None
+    assert detail_payload["total_amount"] == 180
+    assert detail_payload["extraction_review_metadata"]["review_state"]["pricing_pending"] is True
+
+    patch_response = await client.patch(
+        f"/api/quotes/{quote_id}",
+        json={"title": "Review mixed pricing"},
+        headers={"X-CSRF-Token": csrf_token},
+    )
+    assert patch_response.status_code == 200
+    patched_payload = patch_response.json()
+    assert [item["price_status"] for item in patched_payload["line_items"]] == [
+        "priced",
+        "included",
+        "unknown",
+    ]
+
+    reloaded_detail_response = await client.get(f"/api/quotes/{quote_id}")
+    assert reloaded_detail_response.status_code == 200
+    reloaded_detail_payload = reloaded_detail_response.json()
+    assert [item["price_status"] for item in reloaded_detail_payload["line_items"]] == [
+        "priced",
+        "included",
+        "unknown",
+    ]
+    assert reloaded_detail_payload["line_items"][2]["price"] is None
+    assert reloaded_detail_payload["total_amount"] == 180
+
+
 async def test_extract_combined_sync_passes_initial_mode_to_extraction_integration(
     client: AsyncClient,
     monkeypatch: pytest.MonkeyPatch,

--- a/docs/PATTERNS.md
+++ b/docs/PATTERNS.md
@@ -78,6 +78,18 @@ Record conventions that already exist in code.
 - Event-log DB persistence is disabled by default in backend test fixtures to avoid background-task coupling.
 - External-provider tests are opt-in via `@pytest.mark.live` and excluded from default verify (`-m "not live"`).
 
+## Extraction DTO Layering And Subtotal Authority
+- Keep extraction flow contracts split across four DTO layers:
+  - provider candidate DTO (integration request/response contract)
+  - internal applied extraction result (service/domain write contract)
+  - extraction/job response DTO (public API payload contract)
+  - review sidecar metadata DTO (persisted review-state and hidden-actionable lifecycle)
+- Avoid convenience pass-through mappings that reintroduce provider/internal-only fields into public extraction or job responses.
+- Treat subtotal authority as `price_status`-aware:
+  - null-price `unknown` rows block authoritative subtotal derivation
+  - null-price `included` rows do not block subtotal derivation when priced rows exist
+  - unknown/included statuses must survive persistence, hydration, and save/reload round trips unless an operator explicitly edits them
+
 ## Quote and invoice API integration tests (layout)
 
 - Quote and invoice **HTTP API** behavior tests live in **cohort modules** under `backend/app/features/quotes/tests/` and `backend/app/features/invoices/tests/`. Examples: `test_quote_crud.py`, `test_quote_outcomes.py`, `test_quote_to_invoice.py`, `test_quote_email.py`, `test_quote_auth_csrf.py`, `test_quote_extraction.py`, `test_quote_append_extraction.py`, `test_invoice_api.py`, `test_invoice_doc_type.py`, `test_invoice_outcomes.py`, `test_invoice_email.py`. Pick the file that matches the behavior or route under test.

--- a/frontend/src/features/quotes/tests/ReviewScreen.test.tsx
+++ b/frontend/src/features/quotes/tests/ReviewScreen.test.tsx
@@ -708,7 +708,7 @@ describe("DocumentEditScreen", () => {
     expect(navigateMock).toHaveBeenCalledWith("/invoices/doc-1", { replace: true });
   });
 
-  it("keeps total_amount null when saving unknown-price quotes without pricing edits", async () => {
+  it("keeps total_amount null and preserves null-price statuses when saving without pricing edits", async () => {
     renderScreen({
       document: makeQuote({
         total_amount: null,
@@ -722,12 +722,20 @@ describe("DocumentEditScreen", () => {
             sort_order: 0,
           },
           {
+            id: "line-included",
+            description: "Cleanup",
+            details: "Included / no charge",
+            price: null,
+            price_status: "included",
+            sort_order: 1,
+          },
+          {
             id: "line-unknown",
             description: "Edging",
             details: "Need to confirm exact material cost",
             price: null,
             price_status: "unknown",
-            sort_order: 1,
+            sort_order: 2,
           },
         ],
       }),
@@ -738,6 +746,18 @@ describe("DocumentEditScreen", () => {
     await waitFor(() => {
       expect(mockedQuoteService.updateQuote).toHaveBeenCalledWith("doc-1", expect.objectContaining({
         total_amount: null,
+        line_items: expect.arrayContaining([
+          expect.objectContaining({
+            description: "Cleanup",
+            price: null,
+            price_status: "included",
+          }),
+          expect.objectContaining({
+            description: "Edging",
+            price: null,
+            price_status: "unknown",
+          }),
+        ]),
       }));
     });
   });


### PR DESCRIPTION
## Summary
- add a backend extraction regression covering mixed `priced` + `included` + `unknown` line items with explicit total candidate and reload/save round-trips
- add a backend append regression covering included-scope append with conflicting explicit total and hidden actionable dedupe behavior
- strengthen Review screen test coverage so persisted save payloads preserve null-price `included`/`unknown` statuses alongside null subtotal
- document extraction DTO layering and `price_status`-aware subtotal authority in patterns docs

## Verification
- `cd backend && .venv/bin/pytest app/features/quotes/tests/test_quote_extraction.py app/features/quotes/tests/test_quote_append_extraction.py app/shared/tests/test_pricing.py -m "not live and not extraction_eval and not extraction_quality" -o cache_dir=.pytest_cache`
- `cd frontend && npx vitest run src/features/quotes/tests/ReviewScreen.test.tsx src/features/quotes/tests/usePersistedReview.test.tsx src/features/quotes/tests/lineItemDraftTotals.test.ts`
- `make backend-static-verify`
- `cd frontend && npx tsc --noEmit && npx eslint src/features/quotes`
- `make verify`

Closes #436