### PR TITLE
ci: pin and retry backend ffmpeg setup

### DIFF
--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -91,7 +91,7 @@ jobs:
             ffmpeg-version: 7.0.2
           attempt_limit: 3
           attempt_delay: 15000
-          time_out: 180000
+          time_out: 25000
       - name: FFmpeg diagnostics
         run: |
           ffmpeg -version

--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -83,10 +83,15 @@ jobs:
           python-version: '3.13'
           cache: 'pip'
           cache-dependency-path: backend/requirements.txt
-      - name: Setup ffmpeg
-        uses: FedericoCarboni/setup-ffmpeg@37062fbf7149fc5578d6c57e08aed62458b375d6 # v3.1
+      - name: Setup ffmpeg with retry
+        uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3.8.0
         with:
-          ffmpeg-version: release
+          action: FedericoCarboni/setup-ffmpeg@37062fbf7149fc5578d6c57e08aed62458b375d6
+          with: |
+            ffmpeg-version: 7.0.2
+          attempt_limit: 3
+          attempt_delay: 15000
+          time_out: 180000
       - name: FFmpeg diagnostics
         run: |
           ffmpeg -version

--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -91,7 +91,6 @@ jobs:
             ffmpeg-version: 7.0.2
           attempt_limit: 3
           attempt_delay: 15000
-          time_out: 25000
       - name: FFmpeg diagnostics
         run: |
           ffmpeg -version


### PR DESCRIPTION
## Summary
- wrap backend CI ffmpeg setup in `Wandalen/wretry.action` to absorb transient fetch failures
- pin retry wrapper to full commit SHA `e68c23e6309f2871ca8ae4763e7629b9c258e1ea` (`v3.8.0`)
- pin ffmpeg version to explicit `7.0.2` while preserving existing diagnostics and backend test job behavior

## Verification
- `python3` YAML parse check for `.github/workflows/backend-test.yml`
- diff validation that `SECRET_KEY`, `TEST_REDIS_URL`, postgres/redis services, `make backend-test-verify`, and diagnostics remain present
- `git ls-remote --tags https://github.com/Wandalen/wretry.action.git` to confirm pinned SHA mapping (`v3`/`v3.8.0^{}`)

Closes #441