### PR TITLE
docs: workflow Domain Pass and approval learning handoff upgrade

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,7 @@ Read in order:
 ### C) Plan / Create Issues / Choose Mode
 Read:
 1. `docs/ISSUES_WORKFLOW.md` (authoritative for control plane)
-2. `docs/template/KICKOFF.md` section 2 for planning-only kickoff format
+2. `docs/template/KICKOFF.md` section 2 for planning-only kickoff format; use section 1.5 for Domain Pass prompt text when applicable
 3. `CONTEXT.md` for current product/domain terminology
 4. Additional planning docs only when needed by touched scope
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,7 @@ Read in order:
 ### C) Plan / Create Issues / Choose Mode
 Read:
 1. `docs/ISSUES_WORKFLOW.md` (authoritative for control plane)
-2. `docs/template/KICKOFF.md` section 2 for planning-only kickoff format; use section 1.5 for Domain Pass prompt text when applicable
+2. `docs/template/KICKOFF.md` section 1.5 for Domain Pass prompt text when applicable, and section 2 for planning-only kickoff format
 3. `CONTEXT.md` for current product/domain terminology
 4. Additional planning docs only when needed by touched scope
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,10 @@ Read in order:
 Read:
 1. `docs/ISSUES_WORKFLOW.md` (authoritative for control plane)
 2. `docs/template/KICKOFF.md` section 2 for planning-only kickoff format
-3. Additional planning docs only when needed by touched scope
+3. `CONTEXT.md` for current product/domain terminology
+4. Additional planning docs only when needed by touched scope
+
+If the feature introduces or changes business terms, lifecycle state meaning, or crosses layer/service boundaries, run a Domain Pass before issue drafting — see `docs/ISSUES_WORKFLOW.md` "When Domain Pass Is Required". Reflect resolved terms consistently in issue titles, summaries, acceptance criteria, and PR descriptions.
 
 ### D) Docs / Architecture / Pattern Work
 Read only touched docs:

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,48 @@
+# CONTEXT.md — Stima Domain Language
+
+## Purpose
+
+Canonical glossary for Stima's product and domain language. Agents, reviewers, and operators should check this file when naming concepts, writing issue titles, or building acceptance criteria. Keep entries focused on user-meaningful product concepts — not implementation structure.
+
+Update inline during planning discussions as terms are resolved. Do not add backlog tasks or implementation details here.
+
+## Language
+
+| Term | Definition |
+| --- | --- |
+| **Capture** | The act of uploading or photographing a source document (invoice, proposal, handwritten quote) that will be processed by the system. A Capture creates a Job. |
+| **Extraction** | The automated process of reading a Capture and identifying structured data (line items, totals, provider info) from it. Extraction runs as a background Job. Narrow to the structured-data-parsing step only — not the full Capture-to-Quote pipeline. |
+| **Quote Draft** | The intermediate representation of an extracted or manually entered quote, still under review. A Quote Draft can be edited before being confirmed as a Quote. Prefer the full term in issue titles to avoid confusion with "Quote". |
+| **Quote** | A confirmed, finalized record representing a vendor's price offer for a set of Line Items. A Quote is what gets compared, shared, and acted on. |
+| **Review** | The user-facing step where a Quote Draft is inspected, corrected, and approved before becoming a Quote. Review is an explicit user action. When ambiguous, use "Quote Review" to distinguish from code/PR review. |
+| **Share** | The act of creating, reusing, copying, or distributing an active public link for a confirmed Quote or Invoice so stakeholders can view it. A Share can later be revoked or rotated; sharing does not itself end the editing lifecycle unless a separate status/lifecycle rule says so. |
+| **Line Item** | A single row in a Quote or Quote Draft, representing one product, service, or charge with a quantity and price. |
+| **Notes** | Free-text annotations attached to a Quote, Quote Draft, or Line Item, intended to persist human context that extraction cannot capture. |
+| **Customer Match** | The process of linking a Capture or Quote to an existing Customer record, either automatically or via user confirmation. |
+| **Customer** | A person or business entity that receives quotes. A Customer can have many Quotes. |
+| **Provider** | A vendor or supplier who provides pricing. Quotes originate from Providers. |
+| **Job** | A background task that processes a Capture through Extraction, tracking state and progress for async work. |
+
+## Relationships
+
+```
+Customer → (many) Quotes
+Provider → (many) Quotes
+Capture → Job → Extraction → Quote Draft → (Review) → Quote → (Share link)
+Quote → (many) Line Items
+Quote → Notes
+Line Item → Notes
+```
+
+## Example Dialogue
+
+- "The Capture failed because the image was too dark" — the upload/photo step failed, not the extraction.
+- "Extraction returned three Line Items" — the system identified three rows in the source document.
+- "The user is in Review" — the user is on the Quote Draft review screen, correcting extracted data.
+- "The Quote is ready to Share" — the Quote has been confirmed and can have an active public link created or reused.
+
+## Flagged Ambiguities
+
+- **"Quote" vs "Quote Draft"**: In casual use, "quote" sometimes means "quote draft." Use the full term in issue titles and acceptance criteria.
+- **"Review"**: Overloaded — can mean the product step (user reviews a Quote Draft) or a code/PR review. Use "Quote Review" or "document review" if the context is ambiguous.
+- **"Extraction"**: Sometimes used loosely for the entire Capture-to-Quote pipeline. Keep it scoped to the structured-data-parsing step only.

--- a/docs/ISSUES_WORKFLOW.md
+++ b/docs/ISSUES_WORKFLOW.md
@@ -122,6 +122,23 @@ Test-focused tasks must include a **"Do NOT duplicate"** section listing what is
 
 Dev tooling, CI fixes, proxy config, and startup scripts that don't fit cleanly in a feature task should be scoped into the task where they are discovered or into the hardening pass. Don't leave them unowned — if the work is needed to make the feature work end-to-end, it belongs in a task.
 
+## When Domain Pass Is Required
+
+Run a Domain Pass (using the `domain-model` skill or the prompt in `docs/template/KICKOFF.md`) before issue creation when any of the following are true:
+
+- the feature introduces a new core noun or overloaded term
+- the feature changes lifecycle or state meaning
+- the feature crosses backend/frontend/provider boundaries
+- the feature affects user-facing business terminology
+- the feature creates a new service or module boundary
+- the feature is `gated` or otherwise high-risk
+
+Skip it for purely visual polish, isolated bug fixes with stable terminology, and low-risk `fast`-mode maintenance where terminology is unchanged.
+
+Domain Pass output should be reflected in `CONTEXT.md` (resolved terms) and used consistently in issue titles, acceptance criteria, and PR descriptions. Decision Locks should use canonical terms from `CONTEXT.md`.
+
+ADRs remain optional and rare — only create one when the decision is hard to reverse, surprising without context, and the result of a real trade-off.
+
 ## Definition Of Ready
 
 A Task is ready when:
@@ -133,6 +150,7 @@ A Task is ready when:
 - for backend-coupled work: Decision Locks are checked in the controlling issue (Task in `single`, Spec in `gated`)
 - for no-contract refactors: parity lock checklist is explicitly listed in acceptance criteria
 - for bug fixes, backend business logic, contract-sensitive behavior, and stateful/cross-layer changes: the first test/assertion to add is identified when practical
+- for domain-affecting work: glossary terms are resolved in `CONTEXT.md` or explicitly called out as open questions in the issue
 
 ## Definition Of Done
 

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -13,6 +13,8 @@ Stima workflow index: use this file to route into implementation, review, and ve
 | Rule type | Authoritative source |
 | --- | --- |
 | Execution control plane (modes, DoR/DoD, branching, issue lifecycle) | `docs/ISSUES_WORKFLOW.md` |
+| Product/domain language and glossary | `CONTEXT.md` |
+| Domain Pass — when required and how | `docs/ISSUES_WORKFLOW.md` "When Domain Pass Is Required" + `docs/workflow/IMPLEMENT.md` "Domain Pass" |
 | Kickoff prompts and reviewer output contract | `docs/template/KICKOFF.md` |
 | Implementation-loop guidance | `docs/workflow/IMPLEMENT.md` |
 | Review-loop guidance | `docs/workflow/REVIEW.md` |

--- a/docs/template/KICKOFF.md
+++ b/docs/template/KICKOFF.md
@@ -86,6 +86,22 @@ Deliver:
 4. Return concise patch summary + targeted verification + follow-up (if any).
 ```
 
+## 1.5) Optional: Domain Pass and Post-Domain Grill-Me
+
+Use these before issue creation when the feature introduces or changes business terms, lifecycle state meaning, or crosses layer/service boundaries. See `docs/ISSUES_WORKFLOW.md` "When Domain Pass Is Required" for full qualifying criteria.
+
+**Domain Pass prompt:**
+
+```text
+Run a domain pass on <feature/plan>. Challenge terminology against the repo's current language, cross-check against code, update CONTEXT.md inline when terms are resolved, and only suggest an ADR if the decision is hard to reverse, surprising without context, and the result of a real trade-off.
+```
+
+**Post-domain grill-me prompt** (use after Domain Pass when execution risk or edge cases remain):
+
+```text
+Now grill this updated plan for execution risk, hidden edge cases, sequencing problems, and verification gaps. Ask one question at a time and recommend an answer for each.
+```
+
 ## 2) Planning-Only Kickoff (No Code Changes)
 
 ```text
@@ -130,11 +146,12 @@ Required output shape remains authoritative:
 The approving reviewer generates this once in the same `APPROVED` response.
 
 ```text
+Learning handoff:
+- Concept primer: <plain-language explanation of the underlying idea before this PR's specifics>
 - What changed: <2-3 sentences max>
 - Why it was done this way: <brief rationale>
 - Tradeoff or pattern worth learning: <one point>
-- What to review first: <how a junior operator should read the diff>
-
-Code pointers:
-- `path:line-line — why it matters`
+- How to review this kind of change: <what a junior operator should inspect first next time>
 ```
+
+Keep the concept primer to 2-4 sentences. Natural file mentions are allowed when they help the explanation, but dedicated code-pointer blocks are not required.

--- a/docs/workflow/IMPLEMENT.md
+++ b/docs/workflow/IMPLEMENT.md
@@ -19,13 +19,41 @@ Core defaults:
 Every feature follows:
 
 1. Whiteboard
-2. Document
-3. Implement
-4. Verify
-5. Review handoff
-6. Patch (if needed)
-7. In-chat learning handoff in the approving review response
-8. Finalize
+2. Domain Pass (qualifying work only — see Domain Pass section below)
+3. Draft/update spec or issue
+4. Implement
+5. Verify
+6. Review handoff
+7. Patch (if needed)
+8. In-chat learning handoff in the approving review response
+9. Finalize
+
+## Domain Pass (Conditional Planning Step)
+
+Run a Domain Pass before issue creation when any of the following are true:
+
+- the feature introduces a new core noun or overloaded term
+- the feature changes lifecycle or state meaning
+- the feature crosses backend/frontend/provider boundaries
+- the feature affects user-facing business terminology
+- the feature creates a new service or module boundary
+- the feature is `gated` or otherwise high-risk
+
+Skip it for:
+
+- purely visual polish
+- isolated bug fixes with stable terminology
+- low-risk maintenance in `fast` mode unless terminology changed
+
+Domain Pass prompt (copy-paste):
+
+```text
+Run a domain pass on <feature/plan>. Challenge terminology against the repo's current language, cross-check against code, update CONTEXT.md inline when terms are resolved, and only suggest an ADR if the decision is hard to reverse, surprising without context, and the result of a real trade-off.
+```
+
+After a Domain Pass, run `grill-me` for execution-risk and edge-case pressure testing when risk or complexity remains. See `docs/template/KICKOFF.md` for copy-paste Domain Pass and post-domain grill-me prompts.
+
+Resolved terms should be reflected in `CONTEXT.md` and carried through to issue titles, acceptance criteria, and PR descriptions.
 
 ## Operator Flow Optimization
 

--- a/docs/workflow/REVIEW.md
+++ b/docs/workflow/REVIEW.md
@@ -55,9 +55,10 @@ The lightweight tutoring handoff is generated once, by the approving reviewer, i
 - Do not generate a second learning handoff after approval is relayed back; the implementation agent finalizes after approval.
 - Do not create a separate markdown handoff unless explicitly requested.
 - Keep it ephemeral and practical, not archival documentation.
-- Keep it to 4 short bullets:
-  - what changed
-  - why it was done this way
-  - one tradeoff or pattern worth learning
-  - what to review first
-- Add 3-6 code pointers using `path:line-line — why it matters` format.
+- Use the five-part format from `docs/template/KICKOFF.md` section 4 (single source of truth):
+  - Concept primer (2-4 sentences, plain-language explanation of the underlying idea)
+  - What changed
+  - Why it was done this way
+  - Tradeoff or pattern worth learning
+  - How to review this kind of change
+- Natural file mentions are allowed when they help the explanation; dedicated code-pointer blocks are not required.


### PR DESCRIPTION
## Summary

- Adds root `CONTEXT.md` with Stima-specific product/domain glossary seed (Capture, Extraction, Quote Draft, Quote, Review, Share, Line Item, Notes, Customer Match, Customer, Provider, Job)
- Introduces conditional Domain Pass planning step in `IMPLEMENT.md` and `ISSUES_WORKFLOW.md` — required for features that introduce new terms, change lifecycle meaning, or cross layer boundaries; skipped for polish/maintenance
- Routes `AGENTS.md` path C to `CONTEXT.md` and Domain Pass when applicable
- Adds optional Domain Pass and post-domain grill-me copy-paste prompts to `KICKOFF.md`
- Updates `KICKOFF.md` section 4 and `REVIEW.md` learning handoff to 5-part Concept-primer-first format; removes code-pointer block
- Adds `CONTEXT.md` and Domain Pass to `WORKFLOW.md` source-of-truth table

No changes to execution modes, Task/Spec/PR lifecycle, branch rules, or verification tiers.

## Verification

**Tier 1 (docs-only task — Tier 3 make verify not applicable):**

```
rg -n "Code pointers|3-6 code pointers|What to review first|Domain Pass|CONTEXT.md" AGENTS.md docs .github skills plans
→ 0 matches for stale language; Domain Pass and CONTEXT.md wired in correct locations
```

Manual checks:
- `docs/WORKFLOW.md` remains a thin index ✓
- `CONTEXT.md` contains product concepts only (no `repository`, `DTO`, `worker module`) ✓
- `KICKOFF.md` section 4 and `REVIEW.md` agree on 5-part handoff; REVIEW.md defers to KICKOFF.md as single source ✓
- `ISSUES_WORKFLOW.md` has explicit skip criteria — Domain Pass not mandatory for every task ✓
- External skill references are prompt text only; no vendored files ✓

Closes #445