### PR TITLE
docs(skills): add repo-local domain/planning playbooks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,10 @@ Read only touched docs:
 
 If control-plane rules, issue labels, execution mode, Spec/Task lifecycle, or branching requirements are unclear, read `docs/ISSUES_WORKFLOW.md` before changing process, creating/closing issues, or branching strategy.
 
+## Optional Repo-Local Playbooks
+
+Optional repo-local playbooks under `skills/` can be loaded when helpful for planning or execution refinement. They are portable wrappers around Stima-specific workflow habits, not source-of-truth replacements. If a `skills/*.md` playbook conflicts with canonical repo docs, the repo docs win.
+
 ## Nested AGENTS Discovery
 
 Many tools auto-inject root `AGENTS.md` only. Route to subtree rules explicitly:

--- a/skills/architecture-audit.md
+++ b/skills/architecture-audit.md
@@ -1,0 +1,29 @@
+# Playbook: Architecture Audit
+This is a portable procedural playbook. It is not runtime-loaded unless your tooling explicitly loads it.
+
+Use this for periodic architecture review or before planning a focused refactor.
+
+1. Identify the narrow area under review before recommending changes.
+2. Read the current contracts/docs for that area first.
+3. Look for:
+   - shallow modules with large surfaces
+   - business logic split across too many layers
+   - boundary leakage between API/services/repositories/integrations
+   - dependencies that block easy testing
+   - external integrations without a clean port/adapter seam
+4. Classify dependencies where useful:
+   - in-process
+   - local-substitutable
+   - remote but owned
+   - true external
+5. Recommend changes in concrete terms:
+   - what to deepen
+   - what boundary to redraw
+   - where to introduce a port/adapter
+   - what tests become easier afterward
+6. Prefer incremental refactors over large rewrites.
+7. Tie recommendations back to Stima-specific pain points when relevant, such as extraction flow, provider seams, background jobs, or document-generation boundaries.
+
+Output should be a short audit with prioritized findings, expected payoff, and the smallest worthwhile next refactor.
+
+Repo docs win over this playbook if wording conflicts.

--- a/skills/design-interface.md
+++ b/skills/design-interface.md
@@ -1,0 +1,30 @@
+# Playbook: Design an Interface
+This is a portable procedural playbook. It is not runtime-loaded unless your tooling explicitly loads it.
+
+Use this only when the operator explicitly asks for an interface-design pass, especially when the module boundary is the hard part.
+
+1. Gather requirements first:
+   - what problem the module solves
+   - who the callers are
+   - what operations are needed
+   - what constraints matter
+   - what should stay hidden internally
+2. Check the repo for nearby patterns before proposing new shapes.
+3. Produce 2-4 materially different interface designs.
+4. For each design, show:
+   - interface shape
+   - small usage example
+   - what complexity is hidden
+   - major trade-offs
+5. Compare the designs in prose, focusing on:
+   - simplicity
+   - correctness pressure
+   - depth vs shallow surface area
+   - fit with existing Stima patterns
+   - testability at the boundary
+6. Recommend one design and explain why.
+7. If no design is clearly better, say what decision input is still missing.
+
+Do not make this an automatic workflow step. This is an optional design aid for tricky boundaries.
+
+Repo docs win over this playbook if wording conflicts.

--- a/skills/domain-pass.md
+++ b/skills/domain-pass.md
@@ -1,0 +1,30 @@
+# Playbook: Domain Pass
+This is a portable procedural playbook. It is not runtime-loaded unless your tooling explicitly loads it.
+
+Use this when a feature changes product language, lifecycle semantics, or cross-layer domain concepts.
+
+1. Read `CONTEXT.md` first when present.
+2. Read the current planning control docs before proposing changes:
+   - `AGENTS.md`
+   - `docs/ISSUES_WORKFLOW.md`
+   - `docs/workflow/IMPLEMENT.md`
+   - `docs/template/KICKOFF.md`
+3. Challenge overloaded or conflicting terms immediately.
+4. Prefer Stima product language over implementation jargon.
+5. Stress-test language with concrete scenarios and edge cases.
+6. If code or docs can answer a terminology claim, check them.
+7. Update `CONTEXT.md` inline as terms are resolved; do not batch glossary edits.
+8. Record Decision Locks in the controlling issue when the work needs a scoped decision.
+9. Suggest an ADR only when all three are true:
+   - hard to reverse
+   - surprising without context
+   - real trade-off between plausible options
+10. After language is stable, hand off to normal issue/spec drafting or an optional `skills/grill-plan.md` pass.
+
+Output should be concise and include:
+- resolved canonical terms
+- avoided synonyms when important
+- open ambiguities that still need a decision
+- whether an ADR is warranted or not
+
+Repo docs win over this playbook if wording conflicts.

--- a/skills/grill-plan.md
+++ b/skills/grill-plan.md
@@ -1,0 +1,28 @@
+# Playbook: Grill a Plan
+This is a portable procedural playbook. It is not runtime-loaded unless your tooling explicitly loads it.
+
+Use this after terminology is reasonably stable and you want to pressure-test execution.
+
+1. Read the relevant plan/spec/Task first.
+2. Read `CONTEXT.md` when present so you do not re-open already resolved language without cause.
+3. Read the execution control docs when needed:
+   - `docs/ISSUES_WORKFLOW.md`
+   - `docs/workflow/IMPLEMENT.md`
+   - `docs/workflow/VERIFY.md`
+4. Ask one question at a time.
+5. For each question, provide the recommended answer.
+6. Prefer questions about:
+   - failure modes
+   - edge cases
+   - sequencing/dependencies
+   - rollback or migration risks
+   - acceptance gaps
+   - verification blind spots
+   - contradictions between the plan and current code/docs
+7. If the repo or code can answer the question, inspect that instead of asking blindly.
+8. Do not turn this into a glossary session unless the plan clearly conflicts with `CONTEXT.md`.
+9. When the plan is strong enough, summarize the remaining risks and the most important first verification target.
+
+Keep the session practical. The goal is to make the Task or Spec safer to execute, not to maximize questioning for its own sake.
+
+Repo docs win over this playbook if wording conflicts.

--- a/skills/tdd-boundaries.md
+++ b/skills/tdd-boundaries.md
@@ -1,0 +1,23 @@
+# Playbook: TDD at the Boundaries
+This is a portable procedural playbook. It is not runtime-loaded unless your tooling explicitly loads it.
+
+Use this when selective test-first work would clarify a risky behavior boundary.
+
+1. Identify the public behavior or contract that matters most.
+2. Write the first test at that boundary, not inside helpers or private implementation details.
+3. Prefer integration-style tests that exercise real code paths through the public interface.
+4. Keep mocks/fakes at true external boundaries only.
+5. Use red -> green -> refactor when it improves clarity; do not force TDD where it adds ceremony without insight.
+6. Good candidates include:
+   - auth/security-sensitive flows
+   - extraction or formatting rules
+   - API request/response contracts
+   - queue/job behavior
+   - PDF/document generation invariants
+   - regression-prone bug fixes
+7. Bad candidates include brittle tests that assert internal call structure, private helpers, or mock-heavy implementation details.
+8. When done, record the exact verification commands needed using `docs/workflow/VERIFY.md`.
+
+This playbook supports the repo's selective TDD stance: strict at the edges, flexible in the middle.
+
+Repo docs win over this playbook if wording conflicts.


### PR DESCRIPTION
## Summary

- Adds five Stima-specific playbooks under `skills/`: `domain-pass.md`, `grill-plan.md`, `design-interface.md`, `architecture-audit.md`, `tdd-boundaries.md`
- Each uses the concise portable-playbook style of existing repo-local skills, defers to canonical repo docs, and includes the standard repo-docs-win footer
- Adds one low-noise discoverability note in `AGENTS.md` (`## Optional Repo-Local Playbooks`)

## Verification

Tier 1 — all green:
```
rg "^# Playbook:" skills/*.md          ✓ 5 new + 4 existing headers found
rg "portable procedural playbook"       ✓ all 5 new files match
rg "Repo docs win"                      ✓ all 5 new files match
rg "canonical repo docs" AGENTS.md     ✓ discoverability note found
rg "CONTEXT.md|ISSUES_WORKFLOW..."     ✓ domain-pass and grill-plan wire to repo docs
```

Tier 3: `make template-verify` — passed (0 disallowed token matches)

## PR checklist

- [x] PR references this issue (`Closes #447`)
- [x] Docs updated where playbook guidance changed
- [x] Verification results reported by tier

Closes #447