### PR TITLE
Task 451: V3 Spoken Money Normalization and Guards

### DIFF
--- a/backend/app/features/quotes/mutation/service.py
+++ b/backend/app/features/quotes/mutation/service.py
@@ -16,6 +16,7 @@ from app.features.quotes.review_metadata import (
     normalize_extraction_review_metadata,
 )
 from app.features.quotes.schemas import (
+    SPOKEN_MONEY_CORRECTION_FLAG_REASON,
     ExtractionReviewMetadataUpdateRequest,
     ExtractionReviewMetadataV1,
     LineItemDraft,
@@ -153,9 +154,15 @@ class QuoteMutationService:
             has_linked_invoice=has_linked_invoice,
         )
 
-        next_line_items = (
-            data.line_items if "line_items" in data.model_fields_set else quote.line_items
+        updated_line_items = (
+            _clear_spoken_money_flag_on_manual_price_edit(
+                previous_line_items=quote.line_items,
+                next_line_items=data.line_items,
+            )
+            if "line_items" in data.model_fields_set
+            else None
         )
+        next_line_items = updated_line_items if updated_line_items is not None else quote.line_items
         line_items_define_subtotal, derived_line_item_subtotal = (
             derive_document_subtotal_from_line_items(next_line_items)
         )
@@ -273,7 +280,7 @@ class QuoteMutationService:
                 update_deposit_amount="deposit_amount" in data.model_fields_set,
                 notes=data.notes,
                 update_notes="notes" in data.model_fields_set,
-                line_items=data.line_items,
+                line_items=updated_line_items,
                 replace_line_items="line_items" in data.model_fields_set,
                 extraction_review_metadata=(
                     next_extraction_review_metadata.model_dump(mode="json")
@@ -447,6 +454,44 @@ def _resolve_next_extraction_review_metadata_for_update(
     del quote, notes_changed, pricing_changed
     # V3 removes append suggestions, so regular quote edits no longer mutate hidden details.
     return None, False
+
+
+def _clear_spoken_money_flag_on_manual_price_edit(
+    *,
+    previous_line_items: Sequence[object],
+    next_line_items: Sequence[LineItemDraft] | None,
+) -> list[LineItemDraft] | None:
+    if next_line_items is None:
+        return None
+
+    updated_items = list(next_line_items)
+    for index, candidate in enumerate(updated_items):
+        if index >= len(previous_line_items):
+            continue
+
+        previous = previous_line_items[index]
+        previous_flagged = bool(getattr(previous, "flagged", False))
+        previous_reason = cast(str | None, getattr(previous, "flag_reason", None))
+        if not previous_flagged or previous_reason != SPOKEN_MONEY_CORRECTION_FLAG_REASON:
+            continue
+
+        previous_price = document_field_float_or_none(getattr(previous, "price", None))
+        if _prices_materially_equal(previous_price, candidate.price):
+            continue
+
+        updated_items[index] = candidate.model_copy(
+            update={
+                "flagged": False,
+                "flag_reason": None,
+            }
+        )
+    return updated_items
+
+
+def _prices_materially_equal(left: float | None, right: float | None) -> bool:
+    if left is None or right is None:
+        return left is None and right is None
+    return abs(left - right) < 0.01
 
 
 def _normalized_optional_text(value: str | None) -> str | None:

--- a/backend/app/features/quotes/schemas.py
+++ b/backend/app/features/quotes/schemas.py
@@ -29,6 +29,9 @@ def _normalize_optional_title(value: object) -> object:
     return trimmed or None
 
 
+SPOKEN_MONEY_CORRECTION_FLAG_REASON = "spoken_money_correction"
+
+
 class LineItemDraft(BaseModel):
     """Editable line item payload used for quote creation and updates."""
 
@@ -103,6 +106,14 @@ class CaptureSegmentHints(BaseModel):
     looks_like_heading: bool
     looks_like_notes_heading: bool
     looks_like_line_item: bool
+    spoken_money_hints: list[SpokenMoneyHint] = Field(default_factory=list)
+
+
+class SpokenMoneyHint(BaseModel):
+    """High-confidence spoken-money phrase interpreted as a dollar amount."""
+
+    phrase: str = Field(min_length=1, max_length=EXTRACTION_TRANSCRIPT_MAX_CHARS)
+    amount: float = Field(gt=0)
 
 
 class CaptureSegment(BaseModel):

--- a/backend/app/features/quotes/tests/test_extraction.py
+++ b/backend/app/features/quotes/tests/test_extraction.py
@@ -13,7 +13,10 @@ import pytest
 
 import app.integrations.extraction as extraction_module
 from app.features.quotes.review_metadata import build_hidden_item_id
-from app.features.quotes.schemas import PreparedCaptureInput
+from app.features.quotes.schemas import (
+    SPOKEN_MONEY_CORRECTION_FLAG_REASON,
+    PreparedCaptureInput,
+)
 from app.features.quotes.tests.fixtures.transcripts import TRANSCRIPTS
 from app.integrations.extraction import (
     EXTRACTION_TOOL_SCHEMA,
@@ -982,3 +985,162 @@ async def test_extract_preserves_mixed_provenance_in_model_request_payload() -> 
     assert request_payload["prepared_capture_input"]["source_type"] == "voice+text"
     assert request_payload["prepared_capture_input"]["raw_typed_notes"] == "typed note text"
     assert request_payload["prepared_capture_input"]["raw_transcript"] == "voice transcript text"
+
+
+@pytest.mark.parametrize(
+    ("transcript", "expected_amounts"),
+    [
+        ("price is four fifty", [450.0]),
+        ("for two seventy five", [275.0]),
+        ("fifteen hundred total", [1500.0]),
+        ("arrive at four fifty", []),
+        ("around four thirty", []),
+        ("four fifty-pound bags", []),
+        ("four fifty main street", []),
+        ("four dollars and fifty cents", []),
+    ],
+)
+async def test_spoken_money_parser_filters_to_supported_price_contexts(
+    transcript: str,
+    expected_amounts: list[float],
+) -> None:
+    hints = extraction_module._extract_spoken_money_hints(transcript)  # noqa: SLF001
+    assert [hint.amount for hint in hints] == expected_amounts
+
+
+async def test_extract_includes_spoken_money_hints_in_capture_segments() -> None:
+    transcript = "Price is four fifty for mulch."
+    captured_messages: list[str] = []
+
+    def _factory(kwargs: dict[str, object]) -> _FakeResponse:
+        messages = kwargs["messages"]
+        assert isinstance(messages, list)
+        assert messages
+        first_message = messages[0]
+        assert isinstance(first_message, dict)
+        content = first_message["content"]
+        assert isinstance(content, str)
+        captured_messages.append(content)
+        return _FakeResponse(
+            content=[
+                {
+                    "type": "tool_use",
+                    "input": {
+                        "transcript": transcript,
+                        "line_items": [],
+                        "total": None,
+                    },
+                }
+            ]
+        )
+
+    integration = ExtractionIntegration(
+        api_key="test",
+        model="test-model",
+        client=_FakeClient(_factory),
+    )
+    await integration.extract(transcript)
+
+    assert captured_messages
+    request_payload = json.loads(captured_messages[0])
+    segment_hints = request_payload["capture_segments"][0]["hints"]["spoken_money_hints"]
+    assert segment_hints == [{"phrase": "four fifty", "amount": 450.0}]
+
+
+async def test_guard_corrects_obvious_spoken_money_cents_hundreds_mismatch() -> None:
+    transcript = "Price is four fifty for front mulch."
+    client = _FakeClient(
+        lambda _: _FakeResponse(
+            content=[
+                {
+                    "type": "tool_use",
+                    "input": {
+                        "transcript": transcript,
+                        "line_items": [
+                            {
+                                "description": "Front mulch",
+                                "details": "price is four fifty for front mulch",
+                                "price": 4.5,
+                            }
+                        ],
+                        "total": None,
+                    },
+                }
+            ]
+        )
+    )
+    integration = ExtractionIntegration(api_key="test", model="test-model", client=client)
+
+    result = await integration.extract(transcript)
+
+    assert result.line_items[0].price == 450
+    assert result.line_items[0].flagged is True
+    assert result.line_items[0].flag_reason == SPOKEN_MONEY_CORRECTION_FLAG_REASON
+
+
+async def test_guard_noops_when_provider_price_already_matches_spoken_hint() -> None:
+    transcript = "Price is four fifty for front mulch."
+    client = _FakeClient(
+        lambda _: _FakeResponse(
+            content=[
+                {
+                    "type": "tool_use",
+                    "input": {
+                        "transcript": transcript,
+                        "line_items": [
+                            {
+                                "description": "Front mulch",
+                                "details": "price is four fifty for front mulch",
+                                "price": 450,
+                            }
+                        ],
+                        "total": None,
+                    },
+                }
+            ]
+        )
+    )
+    integration = ExtractionIntegration(api_key="test", model="test-model", client=client)
+
+    result = await integration.extract(transcript)
+
+    assert result.line_items[0].price == 450
+    assert result.line_items[0].flagged is False
+    assert result.line_items[0].flag_reason is None
+
+
+async def test_guard_applies_at_most_one_correction_per_spoken_hint() -> None:
+    transcript = "Price is four fifty for front mulch."
+    client = _FakeClient(
+        lambda _: _FakeResponse(
+            content=[
+                {
+                    "type": "tool_use",
+                    "input": {
+                        "transcript": transcript,
+                        "line_items": [
+                            {
+                                "description": "Front mulch",
+                                "details": "price is four fifty for front mulch",
+                                "price": 4.5,
+                            },
+                            {
+                                "description": "Side mulch",
+                                "details": "price is four fifty for front mulch",
+                                "price": 4.5,
+                            },
+                        ],
+                        "total": None,
+                    },
+                }
+            ]
+        )
+    )
+    integration = ExtractionIntegration(api_key="test", model="test-model", client=client)
+
+    result = await integration.extract(transcript)
+
+    assert result.line_items[0].price == 450
+    assert result.line_items[0].flag_reason == SPOKEN_MONEY_CORRECTION_FLAG_REASON
+    assert result.line_items[1].price == 4.5
+    assert result.line_items[1].flagged is False

--- a/backend/app/features/quotes/tests/test_quote_extraction.py
+++ b/backend/app/features/quotes/tests/test_quote_extraction.py
@@ -735,6 +735,74 @@ async def test_extract_combined_clips_only_success(client: AsyncClient) -> None:
     assert payload["line_items"][0]["flag_reason"]
 
 
+async def test_manual_price_edit_clears_spoken_money_correction_flag(
+    client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    original_extract = _MockExtractionIntegration.extract
+
+    async def _extract_with_spoken_money_flag(
+        self,
+        notes: PreparedCaptureInput | str,
+        *,
+        mode: ExtractionMode = "initial",
+    ) -> ExtractionResult:
+        transcript = (
+            notes.transcript.strip() if isinstance(notes, PreparedCaptureInput) else notes.strip()
+        )
+        if transcript != "spoken money correction check":
+            return await original_extract(self, notes, mode=mode)
+        return ExtractionResult(
+            transcript=transcript,
+            line_items=[
+                LineItemExtractedV2(
+                    raw_text="price is four fifty for mulch",
+                    description="Brown mulch",
+                    details="price is four fifty for mulch",
+                    price=450,
+                    flagged=True,
+                    flag_reason="spoken_money_correction",
+                    confidence="medium",
+                )
+            ],
+            pricing_hints=PricingHints(explicit_total=450),
+        )
+
+    monkeypatch.setattr(_MockExtractionIntegration, "extract", _extract_with_spoken_money_flag)
+    csrf_token = await _register_and_login(client, _credentials())
+    app.state.arq_pool = None
+
+    extract_response = await client.post(
+        "/api/quotes/extract",
+        files=[("notes", (None, "spoken money correction check"))],
+        headers={"X-CSRF-Token": csrf_token},
+    )
+    assert extract_response.status_code == 200
+    quote_id = extract_response.json()["quote_id"]
+
+    patch_response = await client.patch(
+        f"/api/quotes/{quote_id}",
+        json={
+            "line_items": [
+                {
+                    "description": "Brown mulch",
+                    "details": "price is four fifty for mulch",
+                    "price": 500,
+                    "flagged": True,
+                    "flag_reason": "spoken_money_correction",
+                }
+            ]
+        },
+        headers={"X-CSRF-Token": csrf_token},
+    )
+
+    assert patch_response.status_code == 200
+    patched_line_item = patch_response.json()["line_items"][0]
+    assert patched_line_item["price"] == 500
+    assert patched_line_item["flagged"] is False
+    assert patched_line_item["flag_reason"] is None
+
+
 async def test_extract_combined_rejects_empty_clip_with_400(
     client: AsyncClient,
 ) -> None:

--- a/backend/app/integrations/extraction.py
+++ b/backend/app/integrations/extraction.py
@@ -16,6 +16,7 @@ from anthropic import AsyncAnthropic
 from pydantic import ValidationError
 
 from app.features.quotes.schemas import (
+    SPOKEN_MONEY_CORRECTION_FLAG_REASON,
     AppendExtractionCandidate,
     AppendUnresolvedItem,
     CaptureSegment,
@@ -28,6 +29,7 @@ from app.features.quotes.schemas import (
     PreparedCaptureInput,
     PricingCandidates,
     PricingHints,
+    SpokenMoneyHint,
     UnresolvedItem,
     UnresolvedSegment,
     UnresolvedSegmentSource,
@@ -228,6 +230,101 @@ _BULLET_PREFIX_PATTERN = re.compile(r"^\s*(?:[-*•]|\d+[.)])\s+")
 _HEADING_PATTERN = re.compile(r"^[A-Za-z][A-Za-z0-9 /\-]{0,40}:\s*$")
 _NOTES_HEADING_PATTERN = re.compile(r"^\s*notes?\s*:\s*$", re.IGNORECASE)
 _PRICE_PATTERN = re.compile(r"\$?\s*(\d+(?:\.\d{1,2})?)")
+_WORD_TOKEN_PATTERN = re.compile(r"[a-z]+(?:'[a-z]+)?")
+
+_SPOKEN_MONEY_ONES: dict[str, int] = {
+    "one": 1,
+    "two": 2,
+    "three": 3,
+    "four": 4,
+    "five": 5,
+    "six": 6,
+    "seven": 7,
+    "eight": 8,
+    "nine": 9,
+}
+_SPOKEN_MONEY_TEENS: dict[str, int] = {
+    "ten": 10,
+    "eleven": 11,
+    "twelve": 12,
+    "thirteen": 13,
+    "fourteen": 14,
+    "fifteen": 15,
+    "sixteen": 16,
+    "seventeen": 17,
+    "eighteen": 18,
+    "nineteen": 19,
+}
+_SPOKEN_MONEY_TENS: dict[str, int] = {
+    "twenty": 20,
+    "thirty": 30,
+    "forty": 40,
+    "fifty": 50,
+    "sixty": 60,
+    "seventy": 70,
+    "eighty": 80,
+    "ninety": 90,
+}
+_SPOKEN_MONEY_ADJACENCY_SKIP = frozenset(
+    {
+        "am",
+        "pm",
+        "o'clock",
+        "morning",
+        "afternoon",
+        "pound",
+        "pounds",
+        "gallon",
+        "gallons",
+        "foot",
+        "feet",
+        "inch",
+        "inches",
+        "percent",
+        "street",
+        "st",
+        "ave",
+        "avenue",
+        "road",
+        "rd",
+        "bags",
+        "drums",
+    }
+)
+_SPOKEN_MONEY_TIME_VERBS = frozenset(
+    {
+        "arrive",
+        "arrived",
+        "arriving",
+        "meet",
+        "meets",
+        "meeting",
+        "met",
+        "call",
+        "calls",
+        "called",
+    }
+)
+_SPOKEN_MONEY_CONTEXT_PREPOSITIONS = frozenset({"is", "for", "at"})
+_SPOKEN_MONEY_CONTEXT_KEYWORDS = frozenset(
+    {
+        "price",
+        "priced",
+        "cost",
+        "costs",
+        "charge",
+        "charges",
+        "total",
+        "dollar",
+        "dollars",
+        "buck",
+        "bucks",
+        "quote",
+        "quoted",
+        "amount",
+    }
+)
+_SPOKEN_MONEY_NON_CONTEXT_TENS = frozenset({"thirty", "forty"})
 
 _RETRY_BASE_DELAY_SECONDS = 0.25
 _RETRY_MAX_DELAY_SECONDS = 2.0
@@ -256,6 +353,14 @@ class _ExtractionTierConfig:
     tier: Literal["primary", "fallback"]
     model_id: str
     prompt_variant: str
+
+
+@dataclass(frozen=True, slots=True)
+class _SpokenMoneyHint:
+    phrase: str
+    amount: float
+    start_token_index: int
+    end_token_index: int
 
 
 _LAST_CALL_METADATA_VAR: contextvars.ContextVar[ExtractionCallMetadata | None] = (
@@ -860,6 +965,10 @@ def _build_segment_hints(*, raw_text: str, normalized_text: str) -> CaptureSegme
     price_value = (
         _parse_price_value(explicit_price_match.group(1)) if explicit_price_match else None
     )
+    spoken_money_hints = [
+        SpokenMoneyHint(phrase=hint.phrase, amount=hint.amount)
+        for hint in _extract_spoken_money_hints(normalized_text)
+    ]
     looks_like_heading = _HEADING_PATTERN.match(raw_text) is not None
     looks_like_notes_heading = _NOTES_HEADING_PATTERN.match(raw_text) is not None
     looks_like_line_item = _BULLET_PREFIX_PATTERN.match(raw_text) is not None or (
@@ -871,6 +980,7 @@ def _build_segment_hints(*, raw_text: str, normalized_text: str) -> CaptureSegme
         looks_like_heading=looks_like_heading,
         looks_like_notes_heading=looks_like_notes_heading,
         looks_like_line_item=looks_like_line_item,
+        spoken_money_hints=spoken_money_hints,
     )
 
 
@@ -879,6 +989,151 @@ def _parse_price_value(candidate: str) -> float | None:
         return float(candidate)
     except ValueError:
         return None
+
+
+def _extract_spoken_money_hints(text: str) -> list[_SpokenMoneyHint]:
+    tokens = list(_WORD_TOKEN_PATTERN.finditer(text.casefold()))
+    if not tokens:
+        return []
+
+    words = [token.group(0) for token in tokens]
+    hints: list[_SpokenMoneyHint] = []
+    seen: set[tuple[int, int, float]] = set()
+
+    for start_index in range(len(words)):
+        parsed = _parse_spoken_money_phrase(words, start_index)
+        if parsed is None:
+            continue
+        amount, end_index, is_extreme_shape = parsed
+        if _has_spoken_money_adjacency_skip(
+            words=words,
+            start=start_index,
+            end=end_index,
+        ):
+            continue
+        if _looks_like_time_or_non_money_phrase(
+            words=words,
+            start=start_index,
+            end=end_index,
+        ):
+            continue
+        has_money_context = _has_spoken_money_context(
+            words=words,
+            start=start_index,
+            end=end_index,
+        )
+        if not has_money_context and not is_extreme_shape:
+            continue
+        key = (start_index, end_index, float(amount))
+        if key in seen:
+            continue
+        seen.add(key)
+        hints.append(
+            _SpokenMoneyHint(
+                phrase=" ".join(words[start_index:end_index]),
+                amount=float(amount),
+                start_token_index=start_index,
+                end_token_index=end_index,
+            )
+        )
+    return hints
+
+
+def _parse_spoken_money_phrase(
+    words: list[str],
+    start: int,
+) -> tuple[int, int, bool] | None:
+    if start + 1 >= len(words):
+        return None
+
+    first = words[start]
+    second = words[start + 1]
+
+    if first in _SPOKEN_MONEY_ONES and second in _SPOKEN_MONEY_TENS:
+        amount = (_SPOKEN_MONEY_ONES[first] * 100) + _SPOKEN_MONEY_TENS[second]
+        end = start + 2
+        if end < len(words) and words[end] in _SPOKEN_MONEY_ONES:
+            amount += _SPOKEN_MONEY_ONES[words[end]]
+            end += 1
+        is_extreme_shape = second not in _SPOKEN_MONEY_NON_CONTEXT_TENS
+        return amount, end, is_extreme_shape
+
+    prefix = _parse_spoken_under_hundred(words, start)
+    if prefix is None:
+        return None
+    prefix_value, prefix_consumed = prefix
+    hundred_index = start + prefix_consumed
+    if hundred_index >= len(words) or words[hundred_index] != "hundred":
+        return None
+
+    amount = prefix_value * 100
+    end = hundred_index + 1
+    suffix = _parse_spoken_under_hundred(words, end)
+    if suffix is not None:
+        suffix_value, suffix_consumed = suffix
+        amount += suffix_value
+        end += suffix_consumed
+    return amount, end, True
+
+
+def _parse_spoken_under_hundred(words: list[str], start: int) -> tuple[int, int] | None:
+    if start >= len(words):
+        return None
+    token = words[start]
+    if token in _SPOKEN_MONEY_TEENS:
+        return _SPOKEN_MONEY_TEENS[token], 1
+    if token in _SPOKEN_MONEY_TENS:
+        value = _SPOKEN_MONEY_TENS[token]
+        consumed = 1
+        next_index = start + 1
+        if next_index < len(words) and words[next_index] in _SPOKEN_MONEY_ONES:
+            value += _SPOKEN_MONEY_ONES[words[next_index]]
+            consumed += 1
+        return value, consumed
+    if token in _SPOKEN_MONEY_ONES:
+        return _SPOKEN_MONEY_ONES[token], 1
+    return None
+
+
+def _has_spoken_money_context(*, start: int, end: int, words: list[str]) -> bool:
+    if start > 0 and words[start - 1] in _SPOKEN_MONEY_CONTEXT_PREPOSITIONS:
+        return True
+    if end < len(words) and words[end] in {"total", "dollars", "bucks"}:
+        return True
+
+    context_start = max(0, start - 3)
+    context_end = min(len(words), end + 3)
+    return any(word in _SPOKEN_MONEY_CONTEXT_KEYWORDS for word in words[context_start:context_end])
+
+
+def _has_spoken_money_adjacency_skip(*, start: int, end: int, words: list[str]) -> bool:
+    previous_word = words[start - 1] if start > 0 else None
+    next_word = words[end] if end < len(words) else None
+    next_next_word = words[end + 1] if end + 1 < len(words) else None
+
+    if previous_word in _SPOKEN_MONEY_ADJACENCY_SKIP:
+        return True
+    if next_word in _SPOKEN_MONEY_ADJACENCY_SKIP:
+        return True
+    if next_word == "bucks" and next_next_word == "per":
+        return True
+    if next_next_word in {"street", "st", "avenue", "ave", "road", "rd"}:
+        return True
+    return False
+
+
+def _looks_like_time_or_non_money_phrase(*, start: int, end: int, words: list[str]) -> bool:
+    previous_word = words[start - 1] if start > 0 else None
+    previous_two_word = words[start - 2] if start > 1 else None
+    next_word = words[end] if end < len(words) else None
+
+    if previous_word in {"around", "about"}:
+        return True
+    if next_word in {"am", "pm", "o'clock", "morning", "afternoon"}:
+        return True
+    if previous_word == "at" and previous_two_word in _SPOKEN_MONEY_TIME_VERBS:
+        return True
+    return False
 
 
 def _coerce_initial_candidate_payload(payload: dict[str, Any]) -> dict[str, Any]:
@@ -1285,6 +1540,10 @@ def _apply_semantic_guard_rules(result: ExtractionResult) -> ExtractionResult:
             source="leftover_classification",
         )
 
+    line_items = _apply_spoken_money_correction_guard(
+        line_items=line_items,
+        transcript=result.transcript,
+    )
     line_items = _flag_line_items_with_price_in_description(line_items)
     line_items = _flag_line_items_with_duplicate_details(line_items)
     line_items = _apply_duplicate_line_item_flags(line_items)
@@ -1316,6 +1575,115 @@ def _should_warn_for_total_without_priced_items(result: ExtractionResult) -> boo
         and bool(result.line_items)
         and not any(item.price is not None for item in result.line_items)
     )
+
+
+def _apply_spoken_money_correction_guard(
+    *,
+    line_items: list[LineItemExtractedV2],
+    transcript: str,
+) -> list[LineItemExtractedV2]:
+    if not line_items:
+        return line_items
+
+    spoken_hints = _extract_spoken_money_hints(transcript)
+    if not spoken_hints:
+        return line_items
+
+    updated_items = list(line_items)
+    used_indexes: set[int] = set()
+
+    for hint in spoken_hints:
+        matched_index = _resolve_spoken_money_match_index(
+            line_items=updated_items,
+            hint=hint,
+            used_indexes=used_indexes,
+        )
+        if matched_index is None:
+            log_extraction_trace(
+                _TRACE_EVENT_NAME,
+                stage="semantic_guard",
+                outcome="spoken_money_orphan_hint",
+                spoken_money_phrase=hint.phrase,
+                spoken_money_amount=hint.amount,
+            )
+            continue
+
+        used_indexes.add(matched_index)
+        existing = updated_items[matched_index]
+        if _prices_materially_equal(existing.price, hint.amount):
+            continue
+        if not _looks_like_cents_hundreds_misread(existing.price, hint.amount):
+            continue
+
+        updated_items[matched_index] = existing.model_copy(
+            update={
+                "price": hint.amount,
+                "flagged": True,
+                "flag_reason": SPOKEN_MONEY_CORRECTION_FLAG_REASON,
+            }
+        )
+
+    return updated_items
+
+
+def _resolve_spoken_money_match_index(
+    *,
+    line_items: list[LineItemExtractedV2],
+    hint: _SpokenMoneyHint,
+    used_indexes: set[int],
+) -> int | None:
+    phrase_matches: list[int] = []
+    cents_misread_matches: list[int] = []
+
+    for index, item in enumerate(line_items):
+        if index in used_indexes:
+            continue
+        if _hint_phrase_matches_line_item(item=item, hint_phrase=hint.phrase):
+            phrase_matches.append(index)
+            continue
+        if _looks_like_cents_hundreds_misread(item.price, hint.amount):
+            cents_misread_matches.append(index)
+
+    if phrase_matches:
+        return phrase_matches[0]
+    if len(cents_misread_matches) == 1:
+        return cents_misread_matches[0]
+    return None
+
+
+def _hint_phrase_matches_line_item(
+    *,
+    item: LineItemExtractedV2,
+    hint_phrase: str,
+) -> bool:
+    line_item_text = " ".join(
+        part
+        for part in (
+            item.raw_text,
+            item.description,
+            item.details,
+        )
+        if part
+    )
+    normalized_line_item = _WHITESPACE_PATTERN.sub(" ", line_item_text).strip().casefold()
+    return hint_phrase in normalized_line_item
+
+
+def _looks_like_cents_hundreds_misread(
+    candidate_price: float | None,
+    hint_amount: float,
+) -> bool:
+    if candidate_price is None:
+        return False
+    if hint_amount < 100:
+        return False
+    return abs((candidate_price * 100) - hint_amount) < 0.01
+
+
+def _prices_materially_equal(left: float | None, right: float | None) -> bool:
+    if left is None or right is None:
+        return left is None and right is None
+    return abs(left - right) < 0.01
 
 
 def _apply_duplicate_line_item_flags(

--- a/frontend/src/features/quotes/components/LineItemCard.tsx
+++ b/frontend/src/features/quotes/components/LineItemCard.tsx
@@ -1,8 +1,11 @@
+import { resolveLineItemFlagMessage } from "@/features/quotes/utils/lineItemFlags";
+
 interface LineItemCardProps {
   description: string;
   details: string | null;
   price: number | null;
   flagged?: boolean;
+  flagReason?: string | null;
   disabled?: boolean;
   ariaLabel?: string;
   onClick: () => void;
@@ -13,6 +16,7 @@ export function LineItemCard({
   details,
   price,
   flagged = false,
+  flagReason,
   disabled = false,
   ariaLabel,
   onClick,
@@ -39,9 +43,16 @@ export function LineItemCard({
         </div>
         {details ? <p className="mt-0.5 text-sm text-on-surface-variant">{details}</p> : null}
       </div>
-      <div className="flex shrink-0 items-center gap-2">
-        <p className="font-bold text-on-surface">{priceLabel}</p>
-        <span className="material-symbols-outlined text-outline">chevron_right</span>
+      <div className="flex shrink-0 flex-col items-end gap-1">
+        <div className="flex items-center gap-2">
+          <p className="font-bold text-on-surface">{priceLabel}</p>
+          <span className="material-symbols-outlined text-outline">chevron_right</span>
+        </div>
+        {flagged ? (
+          <p className="max-w-[14rem] truncate text-right text-[0.6875rem] font-semibold uppercase tracking-wide text-warning">
+            {resolveLineItemFlagMessage(flagReason)}
+          </p>
+        ) : null}
       </div>
     </button>
   );

--- a/frontend/src/features/quotes/components/LineItemRow.tsx
+++ b/frontend/src/features/quotes/components/LineItemRow.tsx
@@ -1,4 +1,5 @@
 import type { LineItemDraftWithFlags } from "@/features/quotes/types/quote.types";
+import { resolveLineItemFlagMessage } from "@/features/quotes/utils/lineItemFlags";
 
 interface LineItemRowProps {
   rowId: string;
@@ -25,7 +26,7 @@ export function LineItemRow({
     <div className="rounded-md border border-outline-variant p-4">
       {item.flagged ? (
         <p className="mb-3 rounded-md border border-warning-accent/40 bg-warning-container px-3 py-2 text-sm text-warning">
-          {item.flagReason ?? "This item may need review"}
+          {resolveLineItemFlagMessage(item.flagReason)}
         </p>
       ) : null}
       <div className="grid gap-3 md:grid-cols-[1.3fr_1.3fr_0.8fr_auto] md:items-end">

--- a/frontend/src/features/quotes/components/ReviewLineItemsSection.tsx
+++ b/frontend/src/features/quotes/components/ReviewLineItemsSection.tsx
@@ -38,6 +38,7 @@ export function ReviewLineItemsSection({
                 details={lineItem.details}
                 price={lineItem.price}
                 flagged={lineItem.flagged}
+                flagReason={lineItem.flagReason}
                 disabled={isInteractionLocked}
                 onClick={() => onEditLineItem(index)}
               />

--- a/frontend/src/features/quotes/components/reviewLineItemSheetState.ts
+++ b/frontend/src/features/quotes/components/reviewLineItemSheetState.ts
@@ -1,4 +1,5 @@
 import type { LineItemDraftWithFlags } from "@/features/quotes/types/quote.types";
+import { shouldClearSpokenMoneyFlagOnPriceEdit } from "@/features/quotes/utils/lineItemFlags";
 import { syncDraftTotalWithLineItems } from "@/features/quotes/utils/lineItemDraftTotals";
 import { DOCUMENT_LINE_ITEMS_MAX_ITEMS } from "@/shared/lib/inputLimits";
 
@@ -32,8 +33,22 @@ export function applyLineItemSheetSave<TDraft extends DraftWithLineItems>(
       return draft;
     }
 
+    const previousLineItem = draft.lineItems[sheetState.index];
+    const normalizedNextLineItem = shouldClearSpokenMoneyFlagOnPriceEdit({
+      previousFlagged: previousLineItem?.flagged,
+      previousFlagReason: previousLineItem?.flagReason,
+      previousPrice: previousLineItem?.price ?? null,
+      nextPrice: nextLineItem.price,
+    })
+      ? {
+          ...nextLineItem,
+          flagged: false,
+          flagReason: null,
+        }
+      : nextLineItem;
+
     const nextLineItems = draft.lineItems.map((lineItem, index) =>
-      (index === sheetState.index ? nextLineItem : lineItem));
+      (index === sheetState.index ? normalizedNextLineItem : lineItem));
 
     return {
       ...draft,

--- a/frontend/src/features/quotes/components/reviewScreenUtils.ts
+++ b/frontend/src/features/quotes/components/reviewScreenUtils.ts
@@ -4,6 +4,7 @@ import type {
   LineItemDraft,
   LineItemDraftWithFlags,
 } from "@/features/quotes/types/quote.types";
+import { resolveLineItemFlagMessage } from "@/features/quotes/utils/lineItemFlags";
 import { normalizeOptionalTitle } from "@/features/quotes/utils/normalizeOptionalTitle";
 
 export const EMPTY_LINE_ITEM: LineItemDraftWithFlags = {
@@ -79,7 +80,7 @@ export function getReviewMessages(draft: QuoteDraft): string[] {
     }
 
     const lineItemLabel = lineItem.description.trim() || `Line item ${index + 1}`;
-    const reason = lineItem.flagReason?.trim() || "Needs manual review before generating the quote.";
+    const reason = resolveLineItemFlagMessage(lineItem.flagReason);
     return [`${lineItemLabel}: ${reason}`];
   });
 

--- a/frontend/src/features/quotes/tests/LineItemCard.test.tsx
+++ b/frontend/src/features/quotes/tests/LineItemCard.test.tsx
@@ -26,12 +26,16 @@ describe("LineItemCard", () => {
         details="5 yards"
         price={120}
         flagged
+        flagReason="spoken_money_correction"
         onClick={vi.fn()}
       />,
     );
 
     expect(screen.getByRole("button", { name: /brown mulch/i })).toHaveClass("border-warning-accent/20");
     expect(screen.getByText("REVIEW")).toBeInTheDocument();
+    expect(
+      screen.getByText("Spoken amount was interpreted as dollars instead of cents."),
+    ).toBeInTheDocument();
   });
 
   it("renders em dash when price is blank", () => {

--- a/frontend/src/features/quotes/tests/LineItemRow.test.tsx
+++ b/frontend/src/features/quotes/tests/LineItemRow.test.tsx
@@ -72,6 +72,27 @@ describe("LineItemRow", () => {
     expect(screen.getByText("Unit phrasing may be ambiguous")).toBeInTheDocument();
   });
 
+  it("renders spoken money correction copy for reserved reason token", () => {
+    render(
+      <LineItemRow
+        rowId="line-item-10a"
+        item={{
+          description: "Mulch",
+          details: "5 yards",
+          price: 450,
+          flagged: true,
+          flagReason: "spoken_money_correction",
+        }}
+        onChange={vi.fn()}
+        onDelete={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByText("Spoken amount was interpreted as dollars instead of cents."),
+    ).toBeInTheDocument();
+  });
+
   it("renders fallback inline warning when flagged without reason", () => {
     render(
       <LineItemRow

--- a/frontend/src/features/quotes/tests/reviewLineItemSheetState.test.ts
+++ b/frontend/src/features/quotes/tests/reviewLineItemSheetState.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+
+import { applyLineItemSheetSave } from "@/features/quotes/components/reviewLineItemSheetState";
+
+describe("reviewLineItemSheetState", () => {
+  it("clears spoken money correction flag when edited price changes", () => {
+    const nextDraft = applyLineItemSheetSave(
+      {
+        lineItems: [
+          {
+            description: "Mulch",
+            details: "front beds",
+            price: 450,
+            flagged: true,
+            flagReason: "spoken_money_correction",
+          },
+        ],
+        total: 450,
+      },
+      { mode: "edit", index: 0 },
+      {
+        description: "Mulch",
+        details: "front beds",
+        price: 500,
+        flagged: true,
+        flagReason: "spoken_money_correction",
+      },
+    );
+
+    expect(nextDraft.lineItems[0]).toMatchObject({
+      price: 500,
+      flagged: false,
+      flagReason: null,
+    });
+  });
+
+  it("keeps spoken money correction flag when price is unchanged", () => {
+    const nextDraft = applyLineItemSheetSave(
+      {
+        lineItems: [
+          {
+            description: "Mulch",
+            details: "front beds",
+            price: 450,
+            flagged: true,
+            flagReason: "spoken_money_correction",
+          },
+        ],
+        total: 450,
+      },
+      { mode: "edit", index: 0 },
+      {
+        description: "Mulch",
+        details: "front beds and driveway",
+        price: 450,
+        flagged: true,
+        flagReason: "spoken_money_correction",
+      },
+    );
+
+    expect(nextDraft.lineItems[0]).toMatchObject({
+      price: 450,
+      flagged: true,
+      flagReason: "spoken_money_correction",
+    });
+  });
+});

--- a/frontend/src/features/quotes/utils/lineItemFlags.ts
+++ b/frontend/src/features/quotes/utils/lineItemFlags.ts
@@ -1,0 +1,30 @@
+export const SPOKEN_MONEY_CORRECTION_FLAG_REASON = "spoken_money_correction";
+
+export function resolveLineItemFlagMessage(flagReason: string | null | undefined): string {
+  const normalizedReason = flagReason?.trim();
+  if (normalizedReason === SPOKEN_MONEY_CORRECTION_FLAG_REASON) {
+    return "Spoken amount was interpreted as dollars instead of cents.";
+  }
+  return normalizedReason || "This item may need review";
+}
+
+export function shouldClearSpokenMoneyFlagOnPriceEdit(params: {
+  previousFlagged?: boolean;
+  previousFlagReason?: string | null;
+  previousPrice: number | null;
+  nextPrice: number | null;
+}): boolean {
+  const {
+    previousFlagged = false,
+    previousFlagReason,
+    previousPrice,
+    nextPrice,
+  } = params;
+  if (!previousFlagged || previousFlagReason !== SPOKEN_MONEY_CORRECTION_FLAG_REASON) {
+    return false;
+  }
+  if (previousPrice === null || nextPrice === null) {
+    return previousPrice !== nextPrice;
+  }
+  return Math.abs(previousPrice - nextPrice) >= 0.01;
+}


### PR DESCRIPTION
## Summary
- add deterministic spoken-money phrase parsing and pre-extraction segment hints for narrow `four fifty`/`fifteen hundred` style phrases
- add post-extraction spoken-money correction guard with no-op/orphan/one-correction-per-hint protections and adjacency/time/address skips
- reserve `spoken_money_correction` as a backend flag reason and clear that flag automatically when a manual price edit changes the corrected row
- surface spoken-money correction copy inline in main Review line-item rows near price, while preserving existing fallback flag messaging
- add backend and frontend tests for parser guards, correction behavior, manual flag clearing, and UI rendering

## Verification
- `cd backend && .venv/bin/pytest app/features/quotes/tests/test_extraction.py app/features/quotes/tests/test_quote_extraction.py -m "not live and not extraction_eval and not extraction_quality" -o cache_dir=.pytest_cache`
- `cd frontend && ./node_modules/.bin/vitest run src/features/quotes/tests/LineItemRow.test.tsx src/features/quotes/tests/ReviewScreen.test.tsx`
- `cd frontend && ./node_modules/.bin/vitest run src/features/quotes/tests/LineItemCard.test.tsx src/features/quotes/tests/reviewLineItemSheetState.test.ts`
- `make backend-static-verify`
- `make backend-verify`
- `make frontend-verify`

Closes #451