### PR TITLE
Task 454: quiet capture details and review noise reduction

### DIFF
--- a/backend/app/features/quotes/creation/service.py
+++ b/backend/app/features/quotes/creation/service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Literal, Protocol
@@ -15,6 +16,7 @@ from app.features.quotes.models import Document
 from app.features.quotes.review_metadata import build_extraction_review_metadata
 from app.features.quotes.schemas import (
     ExtractionResult,
+    ExtractionSuggestion,
     LineItemDraft,
     PricingFieldName,
     QuoteCreateRequest,
@@ -349,7 +351,143 @@ def _seeded_notes_from_result(extraction_result: ExtractionResult) -> str | None
     if suggestion is None:
         return None
     normalized = suggestion.text.strip()
-    return normalized or None
+    if not normalized:
+        return None
+    if _is_redundant_notes_suggestion(
+        suggestion=suggestion,
+        extraction_result=extraction_result,
+    ):
+        return None
+    return normalized
+
+
+_NOTE_TOKEN_PATTERN = re.compile(r"[a-z0-9]+")
+_NOTE_STOP_WORDS = frozenset(
+    {
+        "a",
+        "an",
+        "and",
+        "at",
+        "for",
+        "from",
+        "in",
+        "is",
+        "it",
+        "of",
+        "on",
+        "or",
+        "the",
+        "to",
+        "with",
+    }
+)
+_NOTES_PRICING_TOKENS = frozenset(
+    {
+        "amount",
+        "cost",
+        "dollar",
+        "dollars",
+        "price",
+        "priced",
+        "subtotal",
+        "tax",
+        "total",
+    }
+)
+_NOTES_UNCERTAINTY_TOKENS = frozenset(
+    {
+        "check",
+        "confirm",
+        "conflict",
+        "maybe",
+        "unclear",
+        "unknown",
+        "verify",
+    }
+)
+
+
+def _is_redundant_notes_suggestion(
+    *,
+    suggestion: ExtractionSuggestion,
+    extraction_result: ExtractionResult,
+) -> bool:
+    normalized_note = _normalize_for_overlap(suggestion.text)
+    if not normalized_note:
+        return True
+
+    note_tokens = _meaningful_tokens(normalized_note)
+    if not note_tokens:
+        return True
+    if _NOTES_PRICING_TOKENS.intersection(note_tokens):
+        return True
+
+    visible_scope_chunks: list[str] = []
+    for line_item in extraction_result.line_items:
+        combined_line_item_text = " ".join(
+            part for part in (line_item.description, line_item.details) if part
+        ).strip()
+        if combined_line_item_text:
+            visible_scope_chunks.append(combined_line_item_text)
+    if _has_substantial_overlap(
+        note_text=normalized_note,
+        note_tokens=note_tokens,
+        candidates=visible_scope_chunks,
+    ):
+        return True
+
+    unresolved_chunks = [segment.raw_text for segment in extraction_result.unresolved_segments]
+    if _has_substantial_overlap(
+        note_text=normalized_note,
+        note_tokens=note_tokens,
+        candidates=unresolved_chunks,
+    ):
+        return True
+
+    if extraction_result.unresolved_segments and _NOTES_UNCERTAINTY_TOKENS.intersection(
+        note_tokens
+    ):
+        return True
+    return False
+
+
+def _has_substantial_overlap(
+    *,
+    note_text: str,
+    note_tokens: set[str],
+    candidates: Sequence[str],
+) -> bool:
+    for candidate in candidates:
+        normalized_candidate = _normalize_for_overlap(candidate)
+        if not normalized_candidate:
+            continue
+        if note_text in normalized_candidate or normalized_candidate in note_text:
+            return True
+
+        candidate_tokens = _meaningful_tokens(normalized_candidate)
+        if not candidate_tokens:
+            continue
+        common_tokens = note_tokens.intersection(candidate_tokens)
+        if len(common_tokens) < 3:
+            continue
+        smaller_size = min(len(note_tokens), len(candidate_tokens))
+        if smaller_size == 0:
+            continue
+        if len(common_tokens) / smaller_size >= 0.6:
+            return True
+    return False
+
+
+def _normalize_for_overlap(value: str) -> str:
+    return " ".join(value.strip().casefold().split())
+
+
+def _meaningful_tokens(value: str) -> set[str]:
+    return {
+        token
+        for token in _NOTE_TOKEN_PATTERN.findall(value)
+        if token not in _NOTE_STOP_WORDS and len(token) > 2
+    }
 
 
 @dataclass(frozen=True, slots=True)

--- a/backend/app/features/quotes/tests/test_creation_service.py
+++ b/backend/app/features/quotes/tests/test_creation_service.py
@@ -16,9 +16,11 @@ from app.features.quotes.creation.service import (
 from app.features.quotes.models import Document
 from app.features.quotes.schemas import (
     ExtractionResult,
+    ExtractionSuggestion,
     LineItemExtractedV2,
     PricingHints,
     QuoteCreateRequest,
+    UnresolvedSegment,
 )
 
 pytestmark = pytest.mark.asyncio
@@ -170,3 +172,140 @@ async def test_create_extracted_draft_prefers_line_item_subtotal_over_conflictin
         item["kind"] == "unresolved_segment" and "total 140" in item["text"].lower()
         for item in hidden_items
     )  # nosec B101 - pytest assertion
+
+
+async def test_create_extracted_draft_does_not_seed_redundant_notes_from_visible_scope() -> None:
+    repository = _CreationRepository()
+    service = QuoteCreationService(
+        repository=cast(QuoteCreationRepositoryProtocol, repository),
+    )
+    extraction_result = ExtractionResult(
+        transcript="trim 6 shrubs - 120 and edge front beds - 80",
+        line_items=[
+            LineItemExtractedV2(
+                raw_text="trim 6 shrubs - 120",
+                description="Trim shrubs",
+                details="6 shrubs",
+                price=120,
+                confidence="medium",
+            ),
+            LineItemExtractedV2(
+                raw_text="edge front beds - 80",
+                description="Edge front beds",
+                details=None,
+                price=80,
+                confidence="medium",
+            ),
+        ],
+        pricing_hints=PricingHints(explicit_total=200),
+        customer_notes_suggestion=ExtractionSuggestion(
+            text="Trim shrubs and edge front beds.",
+            confidence="medium",
+            source="leftover_classification",
+        ),
+    )
+
+    quote = await service.create_extracted_draft(
+        user_id=uuid4(),
+        customer_id=None,
+        extraction_result=extraction_result,
+        source_type="text",
+        commit=False,
+    )
+
+    assert quote.id is not None  # nosec B101 - pytest assertion
+    assert repository.last_create_kwargs is not None  # nosec B101 - pytest assertion
+    assert repository.last_create_kwargs["notes"] is None  # nosec B101 - pytest assertion
+    review_metadata = repository.last_create_kwargs["extraction_review_metadata"]
+    assert isinstance(review_metadata, dict)  # nosec B101 - pytest assertion
+    assert (
+        review_metadata["review_state"]["notes_pending"] is False  # type: ignore[index]
+    )  # nosec B101 - pytest assertion
+    assert (
+        review_metadata["seeded_fields"]["notes"]["seeded"] is False  # type: ignore[index]
+    )  # nosec B101 - pytest assertion
+
+
+async def test_create_extracted_draft_avoids_duplicate_uncertainty_notes() -> None:
+    repository = _CreationRepository()
+    service = QuoteCreationService(
+        repository=cast(QuoteCreationRepositoryProtocol, repository),
+    )
+    extraction_result = ExtractionResult(
+        transcript="mulch 225 maybe skip edging on one side",
+        line_items=[
+            LineItemExtractedV2(
+                raw_text="mulch 225",
+                description="Mulch",
+                details="5 yards",
+                price=225,
+                confidence="medium",
+            )
+        ],
+        pricing_hints=PricingHints(explicit_total=225),
+        customer_notes_suggestion=ExtractionSuggestion(
+            text="Maybe skip edging on one side.",
+            confidence="medium",
+            source="leftover_classification",
+        ),
+        unresolved_segments=[
+            UnresolvedSegment(
+                raw_text="Maybe skip edging on one side.",
+                confidence="medium",
+                source="transcript_conflict",
+            )
+        ],
+    )
+
+    quote = await service.create_extracted_draft(
+        user_id=uuid4(),
+        customer_id=None,
+        extraction_result=extraction_result,
+        source_type="text",
+        commit=False,
+    )
+
+    assert quote.id is not None  # nosec B101 - pytest assertion
+    assert repository.last_create_kwargs is not None  # nosec B101 - pytest assertion
+    assert repository.last_create_kwargs["notes"] is None  # nosec B101 - pytest assertion
+    review_metadata = repository.last_create_kwargs["extraction_review_metadata"]
+    assert isinstance(review_metadata, dict)  # nosec B101 - pytest assertion
+    hidden_items = review_metadata["hidden_details"]["items"]  # type: ignore[index]
+    assert any("skip edging" in item["text"].lower() for item in hidden_items)
+
+
+async def test_create_extracted_draft_voice_mode_does_not_seed_redundant_scope_notes() -> None:
+    repository = _CreationRepository()
+    service = QuoteCreationService(
+        repository=cast(QuoteCreationRepositoryProtocol, repository),
+    )
+    extraction_result = ExtractionResult(
+        transcript="install five yards of mulch at two twenty five",
+        line_items=[
+            LineItemExtractedV2(
+                raw_text="install five yards of mulch at two twenty five",
+                description="Install mulch",
+                details="5 yards",
+                price=225,
+                confidence="medium",
+            )
+        ],
+        pricing_hints=PricingHints(explicit_total=225),
+        customer_notes_suggestion=ExtractionSuggestion(
+            text="Install five yards of mulch.",
+            confidence="medium",
+            source="leftover_classification",
+        ),
+    )
+
+    quote = await service.create_extracted_draft(
+        user_id=uuid4(),
+        customer_id=None,
+        extraction_result=extraction_result,
+        source_type="voice",
+        commit=False,
+    )
+
+    assert quote.id is not None  # nosec B101 - pytest assertion
+    assert repository.last_create_kwargs is not None  # nosec B101 - pytest assertion
+    assert repository.last_create_kwargs["notes"] is None  # nosec B101 - pytest assertion

--- a/backend/app/features/quotes/tests/test_extraction.py
+++ b/backend/app/features/quotes/tests/test_extraction.py
@@ -905,6 +905,68 @@ async def test_guard_flags_line_items_with_price_in_description() -> None:
     assert result.line_items[1].flagged is False
 
 
+async def test_guard_does_not_flag_clean_priced_row_with_matching_price_token() -> None:
+    transcript = "trim 6 shrubs - 120"
+    client = _FakeClient(
+        lambda _: _FakeResponse(
+            content=[
+                {
+                    "type": "tool_use",
+                    "input": {
+                        "transcript": transcript,
+                        "line_items": [
+                            {
+                                "description": "trim 6 shrubs - 120",
+                                "details": None,
+                                "price": 120,
+                            }
+                        ],
+                        "total": 120,
+                    },
+                }
+            ]
+        )
+    )
+    integration = ExtractionIntegration(api_key="test", model="test-model", client=client)
+
+    result = await integration.extract(transcript)
+
+    assert result.line_items[0].flagged is False
+    assert result.line_items[0].flag_reason is None
+
+
+async def test_guard_preserves_spoken_money_correction_flag_reason() -> None:
+    transcript = "price is four fifty for front mulch"
+    client = _FakeClient(
+        lambda _: _FakeResponse(
+            content=[
+                {
+                    "type": "tool_use",
+                    "input": {
+                        "transcript": transcript,
+                        "line_items": [
+                            {
+                                "description": "Front mulch $450",
+                                "details": "price is four fifty for front mulch",
+                                "price": 450,
+                                "flagged": True,
+                                "flag_reason": SPOKEN_MONEY_CORRECTION_FLAG_REASON,
+                            }
+                        ],
+                        "total": 450,
+                    },
+                }
+            ]
+        )
+    )
+    integration = ExtractionIntegration(api_key="test", model="test-model", client=client)
+
+    result = await integration.extract(transcript)
+
+    assert result.line_items[0].flagged is True
+    assert result.line_items[0].flag_reason == SPOKEN_MONEY_CORRECTION_FLAG_REASON
+
+
 async def test_guard_flags_line_items_with_duplicate_details() -> None:
     transcript = TRANSCRIPTS["clean_with_total"]
     client = _FakeClient(

--- a/backend/app/integrations/extraction.py
+++ b/backend/app/integrations/extraction.py
@@ -230,6 +230,10 @@ _BULLET_PREFIX_PATTERN = re.compile(r"^\s*(?:[-*•]|\d+[.)])\s+")
 _HEADING_PATTERN = re.compile(r"^[A-Za-z][A-Za-z0-9 /\-]{0,40}:\s*$")
 _NOTES_HEADING_PATTERN = re.compile(r"^\s*notes?\s*:\s*$", re.IGNORECASE)
 _PRICE_PATTERN = re.compile(r"\$?\s*(\d+(?:\.\d{1,2})?)")
+_EXPLICIT_PRICE_MARKER_PATTERN = re.compile(
+    r"(\$|usd\b|dollars?\b|bucks?\b|price\b|total\b)",
+    re.IGNORECASE,
+)
 _WORD_TOKEN_PATTERN = re.compile(r"[a-z]+(?:'[a-z]+)?")
 
 _SPOKEN_MONEY_ONES: dict[str, int] = {
@@ -1719,7 +1723,7 @@ def _flag_line_items_with_price_in_description(
     line_items: list[LineItemExtractedV2],
 ) -> list[LineItemExtractedV2]:
     flagged_indexes = [
-        index for index, item in enumerate(line_items) if _contains_price_token(item.description)
+        index for index, item in enumerate(line_items) if _should_flag_price_tokens_for_item(item)
     ]
     if not flagged_indexes:
         return line_items
@@ -1789,5 +1793,28 @@ def _append_semantic_unresolved_segment(
     ]
 
 
-def _contains_price_token(text: str) -> bool:
-    return _PRICE_PATTERN.search(text) is not None
+def _should_flag_price_tokens_for_item(item: LineItemExtractedV2) -> bool:
+    tokens = _price_tokens_in_text(item.description)
+    if not tokens:
+        return False
+
+    if item.price is not None and any(
+        _prices_materially_equal(token, item.price) for token in tokens
+    ):
+        return False
+
+    has_explicit_price_marker = _EXPLICIT_PRICE_MARKER_PATTERN.search(item.description) is not None
+    if item.price is not None and len(tokens) == 1 and not has_explicit_price_marker:
+        return False
+
+    return True
+
+
+def _price_tokens_in_text(text: str) -> list[float]:
+    tokens: list[float] = []
+    for match in _PRICE_PATTERN.finditer(text):
+        candidate = _parse_price_value(match.group(1))
+        if candidate is None:
+            continue
+        tokens.append(candidate)
+    return tokens


### PR DESCRIPTION
## Summary
- reduce false-positive line-item flagging for clean priced rows where description price tokens match the extracted price
- suppress redundant note seeding when notes duplicate visible scope, duplicate unresolved detail, or carry pricing/uncertainty noise already represented elsewhere
- add regression coverage for Task #454 fixtures (Case 1/2/3/5) and preserve `spoken_money_correction` rendering behavior

## Verification
- `cd backend && .venv/bin/pytest app/features/quotes/tests/test_extraction.py app/features/quotes/tests/test_extraction_eval.py app/features/quotes/tests/test_quote_extraction.py app/features/quotes/tests/test_creation_service.py -m "not live and not extraction_eval and not extraction_quality" -o cache_dir=.pytest_cache`
- `make backend-static-verify`
- `make backend-verify`
- `cd frontend && npx vitest run src/features/quotes/tests/ReviewScreen.test.tsx`
- `make frontend-verify`

Closes #454