### PR TITLE
Task 5: V3 line-item editor and reorder UX

### DIFF
--- a/frontend/src/features/quotes/components/DocumentEditOverlays.tsx
+++ b/frontend/src/features/quotes/components/DocumentEditOverlays.tsx
@@ -14,7 +14,10 @@ interface DocumentEditOverlaysProps {
   lineItemSheetInitialItem: LineItemDraftWithFlags;
   onCloseLineItemSheet: () => void;
   onSaveLineItem: (nextLineItem: LineItemDraftWithFlags) => void;
-  onDeleteLineItem?: () => void;
+  showLineItemDeleteConfirm: boolean;
+  lineItemDeleteDescription: string;
+  onConfirmDeleteLineItem: () => void;
+  onCancelDeleteLineItem: () => void;
   toastMessage: string | null;
   onDismissToast: () => void;
   showLeaveWarning: boolean;
@@ -34,7 +37,10 @@ export function DocumentEditOverlays({
   lineItemSheetInitialItem,
   onCloseLineItemSheet,
   onSaveLineItem,
-  onDeleteLineItem,
+  showLineItemDeleteConfirm,
+  lineItemDeleteDescription,
+  onConfirmDeleteLineItem,
+  onCancelDeleteLineItem,
   toastMessage,
   onDismissToast,
   showLeaveWarning,
@@ -73,7 +79,18 @@ export function DocumentEditOverlays({
           initialLineItem={lineItemSheetInitialItem}
           onClose={onCloseLineItemSheet}
           onSave={onSaveLineItem}
-          onDelete={lineItemSheetState.mode === "edit" ? onDeleteLineItem : undefined}
+        />
+      ) : null}
+
+      {showLineItemDeleteConfirm ? (
+        <ConfirmModal
+          title="Delete this line item?"
+          body={`"${lineItemDeleteDescription}" will be removed from this draft.`}
+          confirmLabel="Delete line item"
+          cancelLabel="Keep line item"
+          onConfirm={onConfirmDeleteLineItem}
+          onCancel={onCancelDeleteLineItem}
+          variant="destructive"
         />
       ) : null}
 

--- a/frontend/src/features/quotes/components/DocumentEditScreenView.tsx
+++ b/frontend/src/features/quotes/components/DocumentEditScreenView.tsx
@@ -43,6 +43,8 @@ interface DocumentEditScreenViewProps {
   onOpenAssignment: () => void;
   onTitleChange: (nextTitle: string) => void;
   onEditLineItem: (lineItemIndex: number) => void;
+  onRequestDeleteLineItem: (lineItemIndex: number) => void;
+  onReorderLineItems: (sourceIndex: number, targetIndex: number) => void;
   onAddLineItem: () => void;
   onTotalChange: (nextTotal: number | null) => void;
   onTaxRateChange: (nextTaxRate: number | null) => void;
@@ -58,7 +60,10 @@ interface DocumentEditScreenViewProps {
   onAssignCustomer: (customerId: string) => Promise<void>;
   onCloseLineItemSheet: () => void;
   onSaveLineItem: (nextLineItem: LineItemDraftWithFlags) => void;
-  onDeleteLineItem?: () => void;
+  showLineItemDeleteConfirm: boolean;
+  lineItemDeleteDescription: string;
+  onConfirmDeleteLineItem: () => void;
+  onCancelDeleteLineItem: () => void;
   onDismissToast: () => void;
   onLeaveConfirm: () => void;
   onLeaveCancel: () => void;
@@ -101,6 +106,8 @@ export function DocumentEditScreenView({
   onOpenAssignment,
   onTitleChange,
   onEditLineItem,
+  onRequestDeleteLineItem,
+  onReorderLineItems,
   onAddLineItem,
   onTotalChange,
   onTaxRateChange,
@@ -116,7 +123,10 @@ export function DocumentEditScreenView({
   onAssignCustomer,
   onCloseLineItemSheet,
   onSaveLineItem,
-  onDeleteLineItem,
+  showLineItemDeleteConfirm,
+  lineItemDeleteDescription,
+  onConfirmDeleteLineItem,
+  onCancelDeleteLineItem,
   onDismissToast,
   onLeaveConfirm,
   onLeaveCancel,
@@ -161,6 +171,8 @@ export function DocumentEditScreenView({
         onRequestAssignment={onOpenAssignment}
         onTitleChange={onTitleChange}
         onEditLineItem={onEditLineItem}
+        onRequestDeleteLineItem={onRequestDeleteLineItem}
+        onReorderLineItems={onReorderLineItems}
         onAddLineItem={onAddLineItem}
         onTotalChange={onTotalChange}
         onTaxRateChange={onTaxRateChange}
@@ -191,7 +203,10 @@ export function DocumentEditScreenView({
         lineItemSheetInitialItem={lineItemSheetInitialItem}
         onCloseLineItemSheet={onCloseLineItemSheet}
         onSaveLineItem={onSaveLineItem}
-        onDeleteLineItem={onDeleteLineItem}
+        showLineItemDeleteConfirm={showLineItemDeleteConfirm}
+        lineItemDeleteDescription={lineItemDeleteDescription}
+        onConfirmDeleteLineItem={onConfirmDeleteLineItem}
+        onCancelDeleteLineItem={onCancelDeleteLineItem}
         toastMessage={toastMessage}
         onDismissToast={onDismissToast}
         showLeaveWarning={showLeaveWarning}

--- a/frontend/src/features/quotes/components/LineItemCard.tsx
+++ b/frontend/src/features/quotes/components/LineItemCard.tsx
@@ -1,4 +1,7 @@
+import type { PointerEvent as ReactPointerEvent } from "react";
+
 import { resolveLineItemFlagMessage } from "@/features/quotes/utils/lineItemFlags";
+import { OverflowMenu, type OverflowMenuItem } from "@/shared/components/OverflowMenu";
 
 interface LineItemCardProps {
   description: string;
@@ -7,8 +10,12 @@ interface LineItemCardProps {
   flagged?: boolean;
   flagReason?: string | null;
   disabled?: boolean;
+  isDragging?: boolean;
   ariaLabel?: string;
-  onClick: () => void;
+  onEdit: () => void;
+  onDelete: () => void;
+  onDragHandlePointerDown?: (event: ReactPointerEvent<HTMLButtonElement>) => void;
+  dragHandleAriaLabel?: string;
 }
 
 export function LineItemCard({
@@ -18,42 +25,85 @@ export function LineItemCard({
   flagged = false,
   flagReason,
   disabled = false,
+  isDragging = false,
   ariaLabel,
-  onClick,
+  onEdit,
+  onDelete,
+  onDragHandlePointerDown,
+  dragHandleAriaLabel,
 }: LineItemCardProps): React.ReactElement {
+  const lineItemLabel = description.trim() || "Untitled line item";
   const priceLabel = price !== null ? `$${price.toFixed(2)}` : "—";
+  const flagMessage = flagged ? resolveLineItemFlagMessage(flagReason) : null;
+  const overflowItems: OverflowMenuItem[] = [
+    {
+      label: "Edit",
+      icon: "edit",
+      disabled,
+      onSelect: onEdit,
+    },
+    {
+      label: "Delete",
+      icon: "delete",
+      tone: "destructive",
+      disabled,
+      onSelect: onDelete,
+    },
+  ];
+
   return (
-    <button
-      type="button"
-      aria-label={ariaLabel}
-      disabled={disabled}
-      className={`flex w-full cursor-pointer items-start justify-between gap-3 rounded-xl bg-surface-container-lowest p-4 text-left ghost-shadow transition-all active:scale-[0.98] active:bg-surface-container-low disabled:cursor-not-allowed disabled:opacity-60 ${
+    <div
+      className={`flex w-full items-start gap-3 rounded-xl bg-surface-container-lowest p-3 ghost-shadow transition-all ${
         flagged ? "border border-warning-accent/20" : ""
+      } ${
+        isDragging ? "ring-2 ring-primary/30" : ""
       }`}
-      onClick={onClick}
     >
-      <div className="flex-1">
-        <div className="flex items-center gap-2">
-          <p className="font-bold text-on-surface">{description}</p>
-          {flagged ? (
-            <span className="rounded bg-warning-container px-2 py-0.5 text-[0.6875rem] font-bold uppercase tracking-wide text-warning">
-              REVIEW
-            </span>
+      <button
+        type="button"
+        aria-label={dragHandleAriaLabel ?? `Reorder line item ${lineItemLabel}`}
+        disabled={disabled}
+        className="mt-1 inline-flex h-9 w-9 shrink-0 cursor-grab touch-none select-none items-center justify-center rounded-full border border-outline-variant/30 text-outline transition-colors hover:bg-surface-container-low active:cursor-grabbing disabled:cursor-not-allowed disabled:opacity-60"
+        onPointerDown={onDragHandlePointerDown}
+      >
+        <span className="material-symbols-outlined text-[1.125rem] leading-none">drag_indicator</span>
+      </button>
+
+      <button
+        type="button"
+        aria-label={ariaLabel}
+        disabled={disabled}
+        className="flex min-w-0 flex-1 cursor-pointer items-start justify-between gap-3 rounded-lg p-1 text-left transition-colors hover:bg-surface-container-low/70 disabled:cursor-not-allowed disabled:opacity-60"
+        onClick={onEdit}
+      >
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            <p className="truncate font-bold text-on-surface">{description}</p>
+            {flagged ? (
+              <span className="rounded bg-warning-container px-2 py-0.5 text-[0.6875rem] font-bold uppercase tracking-wide text-warning">
+                REVIEW
+              </span>
+            ) : null}
+          </div>
+          {details ? <p className="mt-0.5 text-sm text-on-surface-variant">{details}</p> : null}
+          {flagMessage ? (
+            <p
+              title={flagMessage}
+              className="mt-1 inline-flex max-w-full items-center gap-1 text-xs text-warning"
+            >
+              <span className="material-symbols-outlined text-[0.95rem] leading-none">info</span>
+              <span className="truncate">{flagMessage}</span>
+            </p>
           ) : null}
         </div>
-        {details ? <p className="mt-0.5 text-sm text-on-surface-variant">{details}</p> : null}
-      </div>
-      <div className="flex shrink-0 flex-col items-end gap-1">
-        <div className="flex items-center gap-2">
+
+        <div className="mt-0.5 flex shrink-0 items-center gap-2">
           <p className="font-bold text-on-surface">{priceLabel}</p>
           <span className="material-symbols-outlined text-outline">chevron_right</span>
         </div>
-        {flagged ? (
-          <p className="max-w-[14rem] truncate text-right text-[0.6875rem] font-semibold uppercase tracking-wide text-warning">
-            {resolveLineItemFlagMessage(flagReason)}
-          </p>
-        ) : null}
-      </div>
-    </button>
+      </button>
+
+      <OverflowMenu items={overflowItems} triggerLabel={`Line item actions for ${lineItemLabel}`} />
+    </div>
   );
 }

--- a/frontend/src/features/quotes/components/LineItemEditSheet.tsx
+++ b/frontend/src/features/quotes/components/LineItemEditSheet.tsx
@@ -14,7 +14,6 @@ interface LineItemEditSheetProps {
   initialLineItem: LineItemDraftWithFlags;
   onClose: () => void;
   onSave: (nextLineItem: LineItemDraftWithFlags) => void;
-  onDelete?: () => void;
 }
 
 interface ParsedPrice {
@@ -42,7 +41,6 @@ export function LineItemEditSheet({
   initialLineItem,
   onClose,
   onSave,
-  onDelete,
 }: LineItemEditSheetProps): React.ReactElement {
   const descriptionInputRef = useRef<HTMLInputElement>(null);
   const [description, setDescription] = useState(initialLineItem.description);
@@ -167,16 +165,6 @@ export function LineItemEditSheet({
                 Cancel
               </button>
             </div>
-
-            {mode === "edit" && onDelete ? (
-              <button
-                type="button"
-                className="mt-3 inline-flex min-h-12 w-full cursor-pointer items-center justify-center rounded-lg bg-secondary px-4 py-3 text-sm font-semibold text-on-primary transition-all active:scale-[0.98]"
-                onClick={onDelete}
-              >
-                Delete Line Item
-              </button>
-            ) : null}
           </Dialog.Content>
         </div>
       </Dialog.Portal>

--- a/frontend/src/features/quotes/components/ReviewFormContent.tsx
+++ b/frontend/src/features/quotes/components/ReviewFormContent.tsx
@@ -74,6 +74,8 @@ interface ReviewFormContentProps {
   onRequestAssignment: () => void;
   onTitleChange: (nextTitle: string) => void;
   onEditLineItem: (lineItemIndex: number) => void;
+  onRequestDeleteLineItem: (lineItemIndex: number) => void;
+  onReorderLineItems: (sourceIndex: number, targetIndex: number) => void;
   onAddLineItem: () => void;
   onTotalChange: (nextTotal: number | null) => void;
   onTaxRateChange: (nextTaxRate: number | null) => void;
@@ -111,6 +113,8 @@ export function ReviewFormContent({
   onRequestAssignment,
   onTitleChange,
   onEditLineItem,
+  onRequestDeleteLineItem,
+  onReorderLineItems,
   onAddLineItem,
   onTotalChange,
   onTaxRateChange,
@@ -262,6 +266,8 @@ export function ReviewFormContent({
         lineItems={draft.lineItems}
         isInteractionLocked={isInteractionLocked}
         onEditLineItem={onEditLineItem}
+        onRequestDeleteLineItem={onRequestDeleteLineItem}
+        onReorderLineItems={onReorderLineItems}
         onAddLineItem={onAddLineItem}
       />
 

--- a/frontend/src/features/quotes/components/ReviewLineItemsSection.tsx
+++ b/frontend/src/features/quotes/components/ReviewLineItemsSection.tsx
@@ -1,3 +1,5 @@
+import { useRef, useState } from "react";
+
 import { LineItemCard } from "@/features/quotes/components/LineItemCard";
 import type { LineItemDraftWithFlags } from "@/features/quotes/types/quote.types";
 import { DOCUMENT_LINE_ITEMS_MAX_ITEMS } from "@/shared/lib/inputLimits";
@@ -6,6 +8,8 @@ interface ReviewLineItemsSectionProps {
   lineItems: LineItemDraftWithFlags[];
   isInteractionLocked: boolean;
   onEditLineItem: (index: number) => void;
+  onRequestDeleteLineItem: (index: number) => void;
+  onReorderLineItems: (sourceIndex: number, targetIndex: number) => void;
   onAddLineItem: () => void;
 }
 
@@ -13,9 +17,83 @@ export function ReviewLineItemsSection({
   lineItems,
   isInteractionLocked,
   onEditLineItem,
+  onRequestDeleteLineItem,
+  onReorderLineItems,
   onAddLineItem,
 }: ReviewLineItemsSectionProps): React.ReactElement {
   const hasReachedLineItemLimit = lineItems.length >= DOCUMENT_LINE_ITEMS_MAX_ITEMS;
+  const [draggingIndex, setDraggingIndex] = useState<number | null>(null);
+  const draggingIndexRef = useRef<number | null>(null);
+
+  function resolveRowIndexFromPoint(clientX: number, clientY: number): number | null {
+    const row = document
+      .elementFromPoint(clientX, clientY)
+      ?.closest<HTMLElement>("[data-line-item-index]");
+    if (!row) {
+      return null;
+    }
+    const rawIndex = row.dataset.lineItemIndex;
+    if (typeof rawIndex !== "string") {
+      return null;
+    }
+    const parsedIndex = Number.parseInt(rawIndex, 10);
+    if (!Number.isInteger(parsedIndex) || parsedIndex < 0 || parsedIndex >= lineItems.length) {
+      return null;
+    }
+    return parsedIndex;
+  }
+
+  function clearDragState(): void {
+    draggingIndexRef.current = null;
+    setDraggingIndex(null);
+  }
+
+  function handleDragHandlePointerDown(
+    index: number,
+    event: React.PointerEvent<HTMLButtonElement>,
+  ): void {
+    if (isInteractionLocked) {
+      return;
+    }
+
+    event.preventDefault();
+
+    const pointerId = event.pointerId;
+    const handleElement = event.currentTarget;
+    draggingIndexRef.current = index;
+    setDraggingIndex(index);
+
+    handleElement.setPointerCapture(pointerId);
+
+    function handlePointerMove(pointerEvent: PointerEvent): void {
+      const sourceIndex = draggingIndexRef.current;
+      if (sourceIndex === null) {
+        return;
+      }
+
+      const targetIndex = resolveRowIndexFromPoint(pointerEvent.clientX, pointerEvent.clientY);
+      if (targetIndex === null || targetIndex === sourceIndex) {
+        return;
+      }
+
+      onReorderLineItems(sourceIndex, targetIndex);
+      draggingIndexRef.current = targetIndex;
+      setDraggingIndex(targetIndex);
+    }
+
+    function stopPointerTracking(): void {
+      handleElement.removeEventListener("pointermove", handlePointerMove);
+      handleElement.removeEventListener("pointerup", stopPointerTracking);
+      handleElement.removeEventListener("pointercancel", stopPointerTracking);
+      handleElement.removeEventListener("lostpointercapture", stopPointerTracking);
+      clearDragState();
+    }
+
+    handleElement.addEventListener("pointermove", handlePointerMove);
+    handleElement.addEventListener("pointerup", stopPointerTracking);
+    handleElement.addEventListener("pointercancel", stopPointerTracking);
+    handleElement.addEventListener("lostpointercapture", stopPointerTracking);
+  }
 
   return (
     <section className="space-y-3">
@@ -31,17 +109,22 @@ export function ReviewLineItemsSection({
           lineItems.map((lineItem, index) => {
             const displayDescription = lineItem.description || "Untitled line item";
             return (
-              <LineItemCard
-                key={`review-line-item-${index}`}
-                ariaLabel={`Edit line item ${index + 1}: ${displayDescription}`}
-                description={displayDescription}
-                details={lineItem.details}
-                price={lineItem.price}
-                flagged={lineItem.flagged}
-                flagReason={lineItem.flagReason}
-                disabled={isInteractionLocked}
-                onClick={() => onEditLineItem(index)}
-              />
+              <div key={`review-line-item-${index}`} data-line-item-index={index}>
+                <LineItemCard
+                  ariaLabel={`Edit line item ${index + 1}: ${displayDescription}`}
+                  dragHandleAriaLabel={`Reorder line item ${index + 1}: ${displayDescription}`}
+                  description={displayDescription}
+                  details={lineItem.details}
+                  price={lineItem.price}
+                  flagged={lineItem.flagged}
+                  flagReason={lineItem.flagReason}
+                  disabled={isInteractionLocked}
+                  isDragging={draggingIndex === index}
+                  onEdit={() => onEditLineItem(index)}
+                  onDelete={() => onRequestDeleteLineItem(index)}
+                  onDragHandlePointerDown={(event) => handleDragHandlePointerDown(index, event)}
+                />
+              </div>
             );
           })
         ) : (

--- a/frontend/src/features/quotes/components/ReviewScreen.tsx
+++ b/frontend/src/features/quotes/components/ReviewScreen.tsx
@@ -6,7 +6,7 @@ import { DocumentEditScreenView } from "@/features/quotes/components/DocumentEdi
 import { buildDefaultInvoiceDueDate, buildDocumentSnapshotKey, buildSaveValidationMessage, isInvoiceDocument, persistDocumentDraft } from "@/features/quotes/components/documentEditUtils";
 import { useCaptureDetailsWarning } from "@/features/quotes/hooks/useCaptureDetailsWarning";
 import { useHiddenDetailLifecycle } from "@/features/quotes/hooks/useHiddenDetailLifecycle";
-import { applyLineItemSheetDelete, applyLineItemSheetSave, resolveLineItemSheetInitialItem, type ReviewLineItemSheetState } from "@/features/quotes/components/reviewLineItemSheetState";
+import { applyLineItemReorder, applyLineItemSheetDelete, applyLineItemSheetSave, resolveLineItemSheetInitialItem, type ReviewLineItemSheetState } from "@/features/quotes/components/reviewLineItemSheetState";
 import { buildLineItemSubmitState, EMPTY_LINE_ITEM } from "@/features/quotes/components/reviewScreenUtils";
 import { usePersistedReview } from "@/features/quotes/hooks/usePersistedReview";
 import { quoteService } from "@/features/quotes/services/quoteService";
@@ -45,6 +45,7 @@ export function DocumentEditScreen(): React.ReactElement {
   const [isAssigningCustomer, setIsAssigningCustomer] = useState(false);
   const [hasAppliedReseedFromLocation, setHasAppliedReseedFromLocation] = useState(false);
   const [lineItemSheetState, setLineItemSheetState] = useState<ReviewLineItemSheetState | null>(null);
+  const [pendingLineItemDeleteIndex, setPendingLineItemDeleteIndex] = useState<number | null>(null);
   const locationState = useMemo(() => readReviewLocationState(location.state), [location.state]);
   const requiresCustomerAssignment = useMemo(() => {
     if (!document || isInvoiceDocument(document)) {
@@ -347,6 +348,19 @@ export function DocumentEditScreen(): React.ReactElement {
         }
         setLineItemSheetState({ mode: "edit", index: lineItemIndex });
       }}
+      onRequestDeleteLineItem={(lineItemIndex) => {
+        if (isInteractionLocked || !activeDraft.lineItems[lineItemIndex]) {
+          return;
+        }
+        setPendingLineItemDeleteIndex(lineItemIndex);
+      }}
+      onReorderLineItems={(sourceIndex, targetIndex) => {
+        if (isInteractionLocked || sourceIndex === targetIndex) {
+          return;
+        }
+        setToastMessage(null);
+        setDraft((currentDraft) => applyLineItemReorder(currentDraft, sourceIndex, targetIndex));
+      }}
       onAddLineItem={() => {
         if (isInteractionLocked || activeDraft.lineItems.length >= DOCUMENT_LINE_ITEMS_MAX_ITEMS) {
           return;
@@ -385,14 +399,20 @@ export function DocumentEditScreen(): React.ReactElement {
         setDraft((currentDraft) => applyLineItemSheetSave(currentDraft, nextSheetState, nextLineItem));
         setLineItemSheetState(null);
       }}
-      onDeleteLineItem={lineItemSheetState && lineItemSheetState.mode === "edit"
-        ? () => {
-            const nextSheetState = lineItemSheetState;
-            setToastMessage(null);
-            setDraft((currentDraft) => applyLineItemSheetDelete(currentDraft, nextSheetState));
-            setLineItemSheetState(null);
-          }
-        : undefined}
+      showLineItemDeleteConfirm={pendingLineItemDeleteIndex !== null}
+      lineItemDeleteDescription={pendingLineItemDeleteIndex !== null
+        ? (activeDraft.lineItems[pendingLineItemDeleteIndex]?.description.trim() || "Untitled line item")
+        : "Untitled line item"}
+      onConfirmDeleteLineItem={() => {
+        const lineItemIndex = pendingLineItemDeleteIndex;
+        if (lineItemIndex === null) {
+          return;
+        }
+        setToastMessage(null);
+        setDraft((currentDraft) => applyLineItemSheetDelete(currentDraft, { mode: "edit", index: lineItemIndex }));
+        setPendingLineItemDeleteIndex(null);
+      }}
+      onCancelDeleteLineItem={() => setPendingLineItemDeleteIndex(null)}
       onDismissToast={() => setToastMessage(null)}
       onLeaveConfirm={handleLeaveConfirm}
       onLeaveCancel={handleLeaveCancel}

--- a/frontend/src/features/quotes/components/reviewLineItemSheetState.ts
+++ b/frontend/src/features/quotes/components/reviewLineItemSheetState.ts
@@ -85,3 +85,32 @@ export function applyLineItemSheetDelete<TDraft extends DraftWithLineItems>(
     total: syncDraftTotalWithLineItems(draft, nextLineItems),
   };
 }
+
+export function applyLineItemReorder<TDraft extends DraftWithLineItems>(
+  draft: TDraft,
+  sourceIndex: number,
+  targetIndex: number,
+): TDraft {
+  if (
+    sourceIndex === targetIndex
+    || sourceIndex < 0
+    || targetIndex < 0
+    || sourceIndex >= draft.lineItems.length
+    || targetIndex >= draft.lineItems.length
+  ) {
+    return draft;
+  }
+
+  const nextLineItems = [...draft.lineItems];
+  const [movedLineItem] = nextLineItems.splice(sourceIndex, 1);
+  if (!movedLineItem) {
+    return draft;
+  }
+  nextLineItems.splice(targetIndex, 0, movedLineItem);
+
+  return {
+    ...draft,
+    lineItems: nextLineItems,
+    total: syncDraftTotalWithLineItems(draft, nextLineItems),
+  };
+}

--- a/frontend/src/features/quotes/tests/LineItemCard.test.tsx
+++ b/frontend/src/features/quotes/tests/LineItemCard.test.tsx
@@ -10,7 +10,8 @@ describe("LineItemCard", () => {
         description="Brown mulch"
         details="5 yards"
         price={120}
-        onClick={vi.fn()}
+        onEdit={vi.fn()}
+        onDelete={vi.fn()}
       />,
     );
 
@@ -27,11 +28,11 @@ describe("LineItemCard", () => {
         price={120}
         flagged
         flagReason="spoken_money_correction"
-        onClick={vi.fn()}
+        onEdit={vi.fn()}
+        onDelete={vi.fn()}
       />,
     );
 
-    expect(screen.getByRole("button", { name: /brown mulch/i })).toHaveClass("border-warning-accent/20");
     expect(screen.getByText("REVIEW")).toBeInTheDocument();
     expect(
       screen.getByText("Spoken amount was interpreted as dollars instead of cents."),
@@ -44,25 +45,44 @@ describe("LineItemCard", () => {
         description="Cleanup labor"
         details="No separate charge"
         price={null}
-        onClick={vi.fn()}
+        onEdit={vi.fn()}
+        onDelete={vi.fn()}
       />,
     );
 
     expect(screen.getByText("—")).toBeInTheDocument();
   });
 
-  it("fires onClick when card is clicked", () => {
-    const onClickMock = vi.fn();
+  it("fires onEdit when row body is clicked", () => {
+    const onEditMock = vi.fn();
     render(
       <LineItemCard
         description="Brown mulch"
         details="5 yards"
         price={120}
-        onClick={onClickMock}
+        ariaLabel="Edit line item Brown mulch"
+        onEdit={onEditMock}
+        onDelete={vi.fn()}
       />,
     );
 
-    fireEvent.click(screen.getByRole("button", { name: /brown mulch/i }));
-    expect(onClickMock).toHaveBeenCalledTimes(1);
+    fireEvent.click(screen.getByRole("button", { name: /edit line item brown mulch/i }));
+    expect(onEditMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows overflow actions for edit and delete", () => {
+    render(
+      <LineItemCard
+        description="Brown mulch"
+        details="5 yards"
+        price={120}
+        onEdit={vi.fn()}
+        onDelete={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /line item actions for brown mulch/i }));
+    expect(screen.getByRole("menuitem", { name: /edit/i })).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: /delete/i })).toBeInTheDocument();
   });
 });

--- a/frontend/src/features/quotes/tests/LineItemEditSheet.test.tsx
+++ b/frontend/src/features/quotes/tests/LineItemEditSheet.test.tsx
@@ -25,7 +25,6 @@ describe("LineItemEditSheet", () => {
         initialLineItem={makeLineItem()}
         onClose={vi.fn()}
         onSave={vi.fn()}
-        onDelete={vi.fn()}
       />,
     );
 
@@ -34,7 +33,7 @@ describe("LineItemEditSheet", () => {
     expect(screen.getByLabelText(/details/i)).toHaveValue("5 yards");
     expect(screen.getByLabelText(/price/i)).toHaveValue("120");
     expect(screen.getByLabelText(/description/i)).toHaveFocus();
-    expect(screen.getByRole("button", { name: /delete line item/i })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /delete line item/i })).not.toBeInTheDocument();
   });
 
   it("renders add mode with empty fields", () => {
@@ -137,9 +136,7 @@ describe("LineItemEditSheet", () => {
     expect(onClose).toHaveBeenCalledTimes(3);
   });
 
-  it("fires onDelete in edit mode", () => {
-    const onDelete = vi.fn();
-
+  it("uses decimal input mode for price entry", () => {
     render(
       <LineItemEditSheet
         open
@@ -147,11 +144,9 @@ describe("LineItemEditSheet", () => {
         initialLineItem={makeLineItem()}
         onClose={vi.fn()}
         onSave={vi.fn()}
-        onDelete={onDelete}
       />,
     );
 
-    fireEvent.click(screen.getByRole("button", { name: /delete line item/i }));
-    expect(onDelete).toHaveBeenCalledTimes(1);
+    expect(screen.getByLabelText(/price/i)).toHaveAttribute("inputmode", "decimal");
   });
 });

--- a/frontend/src/features/quotes/tests/ReviewScreen.test.tsx
+++ b/frontend/src/features/quotes/tests/ReviewScreen.test.tsx
@@ -530,6 +530,30 @@ describe("DocumentEditScreen", () => {
     expect(screen.queryByRole("button", { name: /capture more notes/i })).not.toBeInTheDocument();
   });
 
+  it("shows edit/delete in row overflow and requires delete confirmation", async () => {
+    renderScreen();
+
+    expect(await screen.findByRole("button", { name: /edit line item 1: brown mulch/i })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /line item actions for brown mulch/i }));
+    expect(screen.getByRole("menuitem", { name: /edit/i })).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: /delete/i })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("menuitem", { name: /delete/i }));
+    expect(screen.getByRole("dialog", { name: /delete this line item\?/i })).toBeInTheDocument();
+    expect(document.querySelectorAll("[data-line-item-index]").length).toBe(1);
+
+    fireEvent.click(screen.getByRole("button", { name: /keep line item/i }));
+    expect(screen.queryByRole("dialog", { name: /delete this line item\?/i })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /edit line item 1: brown mulch/i })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /line item actions for brown mulch/i }));
+    fireEvent.click(screen.getByRole("menuitem", { name: /delete/i }));
+    fireEvent.click(screen.getByRole("button", { name: /delete line item/i }));
+
+    expect(document.querySelectorAll("[data-line-item-index]").length).toBe(0);
+    expect(screen.getByText("No line items on this quote yet.")).toBeInTheDocument();
+  });
+
   it("does not show the capture-details alert icon for transcript-only details", async () => {
     renderScreen({
       document: makeQuote({

--- a/frontend/src/features/quotes/tests/reviewLineItemSheetState.test.ts
+++ b/frontend/src/features/quotes/tests/reviewLineItemSheetState.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { applyLineItemSheetSave } from "@/features/quotes/components/reviewLineItemSheetState";
+import { applyLineItemReorder, applyLineItemSheetSave } from "@/features/quotes/components/reviewLineItemSheetState";
 
 describe("reviewLineItemSheetState", () => {
   it("clears spoken money correction flag when edited price changes", () => {
@@ -63,5 +63,26 @@ describe("reviewLineItemSheetState", () => {
       flagged: true,
       flagReason: "spoken_money_correction",
     });
+  });
+
+  it("reorders line items in local draft order", () => {
+    const nextDraft = applyLineItemReorder(
+      {
+        lineItems: [
+          { description: "First", details: null, price: 10 },
+          { description: "Second", details: null, price: 20 },
+          { description: "Third", details: null, price: 30 },
+        ],
+        total: 60,
+      },
+      0,
+      2,
+    );
+
+    expect(nextDraft.lineItems.map((lineItem) => lineItem.description)).toEqual([
+      "Second",
+      "Third",
+      "First",
+    ]);
   });
 });


### PR DESCRIPTION
## Summary
- add drag-handle line item reordering in Quote Review with local-draft updates only
- replace line-item row interaction with body click to edit plus overflow actions (`Edit`, `Delete`)
- move destructive delete out of the edit sheet into a confirmation modal
- render compact inline flag messaging on review rows, including spoken-money correction annotation
- keep spoken-money flag clearing behavior on manual price edits and add reorder state coverage

## Verification
- `cd frontend && npx vitest run src/features/quotes/tests/ReviewScreen.test.tsx src/features/quotes/tests/LineItemEditSheet.test.tsx src/features/quotes/tests/LineItemRow.test.tsx`
- `cd frontend && npx vitest run src/features/quotes/tests/ReviewScreen.test.tsx src/features/quotes/tests/LineItemEditSheet.test.tsx src/features/quotes/tests/LineItemRow.test.tsx src/features/quotes/tests/LineItemCard.test.tsx src/features/quotes/tests/reviewLineItemSheetState.test.ts`
- `make frontend-verify`

Closes #453