### PR TITLE
Task 461: review/preview cleanup for linked invoice + convert flow

### DIFF
--- a/frontend/src/features/quotes/components/DocumentEditScreenView.tsx
+++ b/frontend/src/features/quotes/components/DocumentEditScreenView.tsx
@@ -5,7 +5,6 @@ import { isInvoiceDocument } from "@/features/quotes/components/documentEditUtil
 import type { ReviewLineItemSheetState } from "@/features/quotes/components/reviewLineItemSheetState";
 import { type DocumentEditDraft, type PersistedEditableDocument } from "@/features/quotes/hooks/usePersistedReview";
 import type { ExtractionReviewHiddenDetails, ExtractionTier, HiddenItemState, LineItemDraftWithFlags } from "@/features/quotes/types/quote.types";
-import { HOME_ROUTE } from "@/features/quotes/utils/workflowNavigation";
 import { WorkflowScreenHeader } from "@/shared/components/WorkflowScreenHeader";
 
 interface DocumentEditScreenViewProps {
@@ -142,7 +141,6 @@ export function DocumentEditScreenView({
         subtitle={document.doc_number}
         backLabel={backLabel}
         onBack={() => onRequestNavigation({ to: backTarget, replace: true })}
-        onExitHome={() => onRequestNavigation({ to: HOME_ROUTE, replace: true })}
       />
 
       <ReviewFormContent

--- a/frontend/src/features/quotes/components/LinkedInvoiceCard.tsx
+++ b/frontend/src/features/quotes/components/LinkedInvoiceCard.tsx
@@ -5,75 +5,46 @@ import { formatCurrency, formatDate } from "@/shared/lib/formatters";
 interface LinkedInvoiceCardProps {
   linkedInvoice: LinkedInvoiceSummary | null;
   timezone?: string | null;
-  isConverting: boolean;
-  onConvert: () => Promise<void>;
   onOpenInvoice: (invoiceId: string) => void;
-  lowEmphasis?: boolean;
 }
 
 export function LinkedInvoiceCard({
   linkedInvoice,
   timezone,
-  isConverting,
-  onConvert,
   onOpenInvoice,
-  lowEmphasis = false,
 }: LinkedInvoiceCardProps): React.ReactElement | null {
-  const sectionClassName = "mt-3 px-4";
-  const cardClassName = lowEmphasis
-    ? "ghost-shadow rounded-lg border border-outline-variant/30 bg-surface-container-low p-4"
-    : "ghost-shadow rounded-lg border border-outline-variant/30 bg-surface-container-lowest p-4";
-  const convertButtonClassName = "mt-3 inline-flex w-full cursor-pointer items-center justify-center gap-2 rounded-lg border border-outline px-4 py-3 text-sm font-semibold text-on-surface transition-all active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-40";
+  if (!linkedInvoice) {
+    return null;
+  }
+
+  const dueDateLabel = linkedInvoice.due_date
+    ? `Due ${formatDate(`${linkedInvoice.due_date}T00:00:00.000Z`, timezone)}`
+    : "No due date";
 
   return (
-    <section className={sectionClassName}>
-      <div className={cardClassName}>
-        <div className="flex items-start justify-between gap-3">
-          <div className="min-w-0">
-            <p className="text-[0.6875rem] font-bold uppercase tracking-widest text-outline">
-              Linked Invoice
-            </p>
-            <p className="mt-1.5 font-semibold text-on-surface">
-              {linkedInvoice ? linkedInvoice.doc_number : "No invoice yet"}
-            </p>
-            {linkedInvoice ? (
-              <p className="mt-1 text-sm text-on-surface-variant">
-                {[
-                  linkedInvoice.due_date
-                    ? `Due ${formatDate(`${linkedInvoice.due_date}T00:00:00.000Z`, timezone)}`
-                    : "No due date",
-                  formatCurrency(linkedInvoice.total_amount),
-                  `Created ${formatDate(linkedInvoice.created_at, timezone)}`,
-                ].join(" · ")}
-              </p>
-            ) : null}
-          </div>
-
-          {linkedInvoice ? <StatusBadge variant={linkedInvoice.status} /> : null}
+    <section className="mt-3 px-4">
+      <button
+        type="button"
+        onClick={() => onOpenInvoice(linkedInvoice.id)}
+        aria-label={`Open linked invoice ${linkedInvoice.doc_number}`}
+        className="ghost-shadow flex w-full cursor-pointer items-center justify-between gap-3 rounded-lg border border-outline-variant/30 bg-surface-container-lowest px-4 py-3 text-left transition-all hover:bg-surface-container-low active:scale-[0.99]"
+      >
+        <div className="min-w-0">
+          <p className="text-[0.6875rem] font-bold uppercase tracking-widest text-outline">
+            Linked Invoice
+          </p>
+          <p className="mt-1.5 font-semibold text-on-surface">
+            {linkedInvoice.doc_number}
+          </p>
+          <p className="mt-1 text-sm text-on-surface-variant">
+            {[dueDateLabel, formatCurrency(linkedInvoice.total_amount)].join(" · ")}
+          </p>
         </div>
-
-        {linkedInvoice ? (
-          <button
-            type="button"
-            className="mt-4 inline-flex cursor-pointer items-center gap-2 text-sm font-semibold text-primary"
-            onClick={() => onOpenInvoice(linkedInvoice.id)}
-          >
-            Open invoice
-            <span className="material-symbols-outlined text-base">arrow_forward</span>
-          </button>
-        ) : (
-          <button
-            type="button"
-            className={convertButtonClassName}
-            onClick={() => {
-              void onConvert();
-            }}
-            disabled={isConverting}
-          >
-            {isConverting ? "Loading..." : "Convert to Invoice"}
-          </button>
-        )}
-      </div>
+        <div className="flex items-center gap-2 pl-2">
+          <StatusBadge variant={linkedInvoice.status} />
+          <span className="material-symbols-outlined text-on-surface-variant">arrow_forward</span>
+        </div>
+      </button>
     </section>
   );
 }

--- a/frontend/src/features/quotes/components/QuotePreview.tsx
+++ b/frontend/src/features/quotes/components/QuotePreview.tsx
@@ -56,7 +56,6 @@ export function QuotePreview(): React.ReactElement {
   const requiresCustomerAssignment = quote
     ? (quote.requires_customer_assignment ?? quote.customer_id === null)
     : false;
-  const showDraftInvoicePromptBelowActions = Boolean(quote && actionState === "draft" && !quote.linked_invoice);
   const {
     invoiceError,
     isConvertingInvoice,
@@ -135,9 +134,13 @@ export function QuotePreview(): React.ReactElement {
 
   const overflowItems = buildOverflowItems({
     hasQuote: Boolean(quote),
+    hasLinkedInvoice: Boolean(quote?.linked_invoice),
     hasActiveShare: Boolean(quote?.has_active_share),
     actionState,
     isBusy,
+    onConvertToInvoice: () => {
+      void onConvertToInvoice();
+    },
     onRevokeShareRequest: () => setShowRevokeShareConfirm(true),
     onDeleteRequest: () => setShowDeleteConfirm(true),
     onMarkWonRequest: () => setShowMarkWonConfirm(true),
@@ -210,11 +213,9 @@ export function QuotePreview(): React.ReactElement {
                 clientContact={clientContact}
               />
             ) : null}
-            {quote && !showDraftInvoicePromptBelowActions ? (
+            {quote?.linked_invoice ? (
               <LinkedInvoiceCard
                 linkedInvoice={quote.linked_invoice}
-                isConverting={isConvertingInvoice}
-                onConvert={onConvertToInvoice}
                 onOpenInvoice={(invoiceId) => navigate(`/invoices/${invoiceId}`)}
               />
             ) : null}
@@ -240,16 +241,6 @@ export function QuotePreview(): React.ReactElement {
               outcomeError={outcomeError}
               shareMessage={shareMessage}
             />
-
-            {quote && showDraftInvoicePromptBelowActions ? (
-              <LinkedInvoiceCard
-                linkedInvoice={quote.linked_invoice}
-                isConverting={isConvertingInvoice}
-                onConvert={onConvertToInvoice}
-                onOpenInvoice={(invoiceId) => navigate(`/invoices/${invoiceId}`)}
-                lowEmphasis
-              />
-            ) : null}
 
             {deleteError ? (
               <div className="mx-4 mt-3">

--- a/frontend/src/features/quotes/components/quotePreview.helpers.ts
+++ b/frontend/src/features/quotes/components/quotePreview.helpers.ts
@@ -114,9 +114,11 @@ export function getSendEmailErrorMessage(error: unknown): string {
 
 interface BuildOverflowItemsArgs {
   hasQuote: boolean;
+  hasLinkedInvoice: boolean;
   hasActiveShare: boolean;
   actionState: QuotePreviewActionState;
   isBusy: boolean;
+  onConvertToInvoice: () => void;
   onRevokeShareRequest: () => void;
   onDeleteRequest: () => void;
   onMarkWonRequest: () => void;
@@ -125,9 +127,11 @@ interface BuildOverflowItemsArgs {
 
 export function buildOverflowItems({
   hasQuote,
+  hasLinkedInvoice,
   hasActiveShare,
   actionState,
   isBusy,
+  onConvertToInvoice,
   onRevokeShareRequest,
   onDeleteRequest,
   onMarkWonRequest,
@@ -215,6 +219,15 @@ export function buildOverflowItems({
       tone: "destructive",
       disabled: isBusy,
       onSelect: onRevokeShareRequest,
+    });
+  }
+
+  if (!hasLinkedInvoice) {
+    items.unshift({
+      label: "Convert to Invoice",
+      icon: "receipt_long",
+      disabled: isBusy,
+      onSelect: onConvertToInvoice,
     });
   }
 

--- a/frontend/src/features/quotes/tests/QuotePreview.test.tsx
+++ b/frontend/src/features/quotes/tests/QuotePreview.test.tsx
@@ -285,7 +285,7 @@ describe("QuotePreview", () => {
     },
   );
 
-  it.each(["ready", "shared", "viewed", "approved", "declined"] as const)(
+  it.each(["draft", "ready", "shared", "viewed", "approved", "declined"] as const)(
     "shows convert to invoice for %s quotes without a linked invoice",
     async (status) => {
       mockedQuoteService.getQuote.mockResolvedValueOnce(
@@ -295,12 +295,12 @@ describe("QuotePreview", () => {
       renderScreen();
 
       await screen.findByRole("heading", { name: "Test Customer" });
-      expect(screen.getByRole("button", { name: /convert to invoice/i })).toBeInTheDocument();
-      expect(screen.getByText("No invoice yet")).toBeInTheDocument();
+      await openOverflowMenu();
+      expect(screen.getByRole("menuitem", { name: /convert to invoice/i })).toBeInTheDocument();
     },
   );
 
-  it("demotes draft convert-to-invoice UI below the quote actions", async () => {
+  it("does not render an empty linked-invoice card when no linked invoice exists", async () => {
     mockedQuoteService.getQuote.mockResolvedValueOnce(
       makeQuoteDetail({ status: "draft", share_token: null }),
     );
@@ -308,30 +308,8 @@ describe("QuotePreview", () => {
     renderScreen();
 
     await screen.findByRole("heading", { name: "Test Customer" });
-    const generatePdfButton = screen.getByRole("button", { name: /generate pdf/i });
-    const convertButton = screen.getByRole("button", { name: /convert to invoice/i });
-
-    expect(generatePdfButton.compareDocumentPosition(convertButton) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
-    expect(generatePdfButton).toHaveClass("forest-gradient");
-    expect(convertButton).not.toHaveClass("forest-gradient");
-    expect(convertButton).toHaveClass("border");
-    expect(screen.getByText("No invoice yet")).toBeInTheDocument();
-    expect(screen.queryByText(/fine-tune the due date before sharing/i)).not.toBeInTheDocument();
-  });
-
-  it("keeps convert to invoice secondary when the quote is ready", async () => {
-    mockedQuoteService.getQuote.mockResolvedValueOnce(
-      makeQuoteDetail({ status: "ready", share_token: "share-token-1" }),
-    );
-
-    renderScreen();
-
-    await screen.findByRole("heading", { name: "Test Customer" });
-    const convertButton = screen.getByRole("button", { name: /convert to invoice/i });
-
-    expect(convertButton).not.toHaveClass("forest-gradient");
-    expect(convertButton).toHaveClass("border");
-    expect(screen.queryByText(/fine-tune the due date before sharing/i)).not.toBeInTheDocument();
+    expect(screen.queryByText("No invoice yet")).not.toBeInTheDocument();
+    expect(screen.queryByText("Linked Invoice")).not.toBeInTheDocument();
   });
 
   it.each(["draft", "ready", "shared", "viewed", "approved", "declined"] as const)(
@@ -355,12 +333,38 @@ describe("QuotePreview", () => {
       renderScreen();
 
       await screen.findByRole("heading", { name: "Test Customer" });
-      expect(screen.getByText("I-001")).toBeInTheDocument();
-      expect(screen.getByText("Sent")).toBeInTheDocument();
-      expect(screen.getByRole("button", { name: /open invoice/i })).toBeInTheDocument();
-      expect(screen.queryByRole("button", { name: /convert to invoice/i })).not.toBeInTheDocument();
+      const linkedInvoiceRow = screen.getByRole("button", { name: /open linked invoice i-001/i });
+      expect(within(linkedInvoiceRow).getByText("I-001")).toBeInTheDocument();
+      expect(within(linkedInvoiceRow).getByText("Sent")).toBeInTheDocument();
+      expect(within(linkedInvoiceRow).getByText(/Due/i)).toBeInTheDocument();
+      expect(within(linkedInvoiceRow).getByText(/\$120\.00/)).toBeInTheDocument();
+      expect(within(linkedInvoiceRow).queryByText(/Created/i)).not.toBeInTheDocument();
+      await openOverflowMenu();
+      expect(screen.queryByRole("menuitem", { name: /convert to invoice/i })).not.toBeInTheDocument();
     },
   );
+
+  it("opens invoice detail when the linked-invoice row is tapped", async () => {
+    mockedQuoteService.getQuote.mockResolvedValueOnce(
+      makeQuoteDetail({
+        status: "ready",
+        share_token: "share-token-1",
+        linked_invoice: {
+          id: "invoice-1",
+          doc_number: "I-001",
+          status: "sent",
+          due_date: "2026-04-19",
+          total_amount: 120,
+          created_at: "2026-03-20T00:00:00.000Z",
+        },
+      }),
+    );
+
+    renderScreen();
+
+    fireEvent.click(await screen.findByRole("button", { name: /open linked invoice i-001/i }));
+    expect(await screen.findByText("Invoice Detail Screen")).toBeInTheDocument();
+  });
 
   it("converts a draft quote to an invoice and navigates to the invoice detail screen", async () => {
     mockedQuoteService.getQuote.mockResolvedValueOnce(
@@ -369,7 +373,9 @@ describe("QuotePreview", () => {
 
     renderScreen();
 
-    fireEvent.click(await screen.findByRole("button", { name: /convert to invoice/i }));
+    await screen.findByRole("heading", { name: "Test Customer" });
+    await openOverflowMenu();
+    fireEvent.click(screen.getByRole("menuitem", { name: /convert to invoice/i }));
 
     await waitFor(() => {
       expect(mockedQuoteService.convertToInvoice).toHaveBeenCalledWith("quote-1");
@@ -402,7 +408,9 @@ describe("QuotePreview", () => {
 
     renderScreen();
 
-    fireEvent.click(await screen.findByRole("button", { name: /convert to invoice/i }));
+    await screen.findByRole("heading", { name: "Test Customer" });
+    await openOverflowMenu();
+    fireEvent.click(screen.getByRole("menuitem", { name: /convert to invoice/i }));
 
     await waitFor(() => {
       expect(mockedQuoteService.convertToInvoice).toHaveBeenCalledWith("quote-1");

--- a/frontend/src/features/quotes/tests/ReviewScreen.test.tsx
+++ b/frontend/src/features/quotes/tests/ReviewScreen.test.tsx
@@ -813,6 +813,13 @@ describe("DocumentEditScreen", () => {
     expect(navigateMock).toHaveBeenCalledWith("/quotes/doc-1/preview", { replace: true });
   });
 
+  it("keeps back navigation and removes the top-right exit action", async () => {
+    renderScreen();
+
+    expect(await screen.findByRole("button", { name: /back to quotes/i })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /exit to home/i })).not.toBeInTheDocument();
+  });
+
   it("uses unsaved-change confirmation before navigating back", async () => {
     const { clearDraftMock } = renderScreen();
 


### PR DESCRIPTION
## Summary
- remove the review screen top-right exit action and keep back-navigation behavior intact
- move **Convert to Invoice** into the preview overflow menu when no linked invoice exists
- render linked invoice UI only when a linked invoice exists, as a compact clickable row (no created-date copy on this surface)
- update quote preview/review tests to lock the new behavior

## Verification
- `cd frontend && npx vitest run src/features/quotes/tests/QuotePreview.test.tsx`
- `cd frontend && npx vitest run src/features/quotes/tests/ReviewScreen.test.tsx`
- `make frontend-verify`

Closes #461