### PR TITLE
Task #462: line-item Reorder/Done mode

### DIFF
--- a/frontend/src/features/quotes/components/LineItemCard.tsx
+++ b/frontend/src/features/quotes/components/LineItemCard.tsx
@@ -11,6 +11,8 @@ interface LineItemCardProps {
   flagReason?: string | null;
   disabled?: boolean;
   isDragging?: boolean;
+  isDropSettling?: boolean;
+  isReorderMode?: boolean;
   ariaLabel?: string;
   onEdit: () => void;
   onDelete: () => void;
@@ -26,6 +28,8 @@ export function LineItemCard({
   flagReason,
   disabled = false,
   isDragging = false,
+  isDropSettling = false,
+  isReorderMode = false,
   ariaLabel,
   onEdit,
   onDelete,
@@ -35,13 +39,10 @@ export function LineItemCard({
   const lineItemLabel = description.trim() || "Untitled line item";
   const priceLabel = price !== null ? `$${price.toFixed(2)}` : "—";
   const flagMessage = flagged ? resolveLineItemFlagMessage(flagReason) : null;
-  const overflowItems: OverflowMenuItem[] = [
-    {
-      label: "Edit",
-      icon: "edit",
-      disabled,
-      onSelect: onEdit,
-    },
+  const showDragHandle = isReorderMode;
+  const showOverflowMenu = isReorderMode;
+  const canEditRow = !disabled && !isReorderMode;
+  const overflowItems: OverflowMenuItem[] = showOverflowMenu ? [
     {
       label: "Delete",
       icon: "delete",
@@ -49,31 +50,43 @@ export function LineItemCard({
       disabled,
       onSelect: onDelete,
     },
-  ];
+  ] : [];
 
   return (
     <div
-      className={`flex w-full items-start gap-3 rounded-xl bg-surface-container-lowest p-3 ghost-shadow transition-all ${
+      className={`flex w-full items-start gap-3 rounded-xl bg-surface-container-lowest p-3 ghost-shadow ${
         flagged ? "border border-warning-accent/20" : ""
       } ${
-        isDragging ? "ring-2 ring-primary/30" : ""
+        isReorderMode
+          ? "transition-[transform,box-shadow,background-color] duration-150 ease-out"
+          : "transition-colors"
+      } ${
+        isDragging
+          ? "-translate-y-0.5 scale-[1.01] bg-surface-container-low ring-2 ring-primary/35"
+          : ""
+      } ${
+        isDropSettling ? "ring-2 ring-primary/20" : ""
       }`}
     >
-      <button
-        type="button"
-        aria-label={dragHandleAriaLabel ?? `Reorder line item ${lineItemLabel}`}
-        disabled={disabled}
-        className="mt-1 inline-flex h-9 w-9 shrink-0 cursor-grab touch-none select-none items-center justify-center rounded-full border border-outline-variant/30 text-outline transition-colors hover:bg-surface-container-low active:cursor-grabbing disabled:cursor-not-allowed disabled:opacity-60"
-        onPointerDown={onDragHandlePointerDown}
-      >
-        <span className="material-symbols-outlined text-[1.125rem] leading-none">drag_indicator</span>
-      </button>
+      {showDragHandle ? (
+        <button
+          type="button"
+          aria-label={dragHandleAriaLabel ?? `Reorder line item ${lineItemLabel}`}
+          disabled={disabled}
+          className="mt-1 inline-flex h-9 w-9 shrink-0 cursor-grab touch-none select-none items-center justify-center rounded-full border border-outline-variant/30 text-outline transition-colors hover:bg-surface-container-low active:cursor-grabbing disabled:cursor-not-allowed disabled:opacity-60"
+          onPointerDown={onDragHandlePointerDown}
+        >
+          <span className="material-symbols-outlined text-[1.125rem] leading-none">drag_indicator</span>
+        </button>
+      ) : null}
 
       <button
         type="button"
         aria-label={ariaLabel}
-        disabled={disabled}
-        className="flex min-w-0 flex-1 cursor-pointer items-start justify-between gap-3 rounded-lg p-1 text-left transition-colors hover:bg-surface-container-low/70 disabled:cursor-not-allowed disabled:opacity-60"
+        disabled={!canEditRow}
+        className={`flex min-w-0 flex-1 items-start justify-between gap-3 rounded-lg p-1 text-left transition-colors ${
+          canEditRow ? "cursor-pointer hover:bg-surface-container-low/70" : "cursor-default"
+        } disabled:opacity-60`}
         onClick={onEdit}
       >
         <div className="min-w-0 flex-1">
@@ -97,13 +110,14 @@ export function LineItemCard({
           ) : null}
         </div>
 
-        <div className="mt-0.5 flex shrink-0 items-center gap-2">
+        <div className="mt-0.5 flex shrink-0 items-center">
           <p className="font-bold text-on-surface">{priceLabel}</p>
-          <span className="material-symbols-outlined text-outline">chevron_right</span>
         </div>
       </button>
 
-      <OverflowMenu items={overflowItems} triggerLabel={`Line item actions for ${lineItemLabel}`} />
+      {showOverflowMenu ? (
+        <OverflowMenu items={overflowItems} triggerLabel={`Line item actions for ${lineItemLabel}`} />
+      ) : null}
     </div>
   );
 }

--- a/frontend/src/features/quotes/components/ReviewLineItemsSection.tsx
+++ b/frontend/src/features/quotes/components/ReviewLineItemsSection.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import { LineItemCard } from "@/features/quotes/components/LineItemCard";
 import type { LineItemDraftWithFlags } from "@/features/quotes/types/quote.types";
@@ -22,8 +22,18 @@ export function ReviewLineItemsSection({
   onAddLineItem,
 }: ReviewLineItemsSectionProps): React.ReactElement {
   const hasReachedLineItemLimit = lineItems.length >= DOCUMENT_LINE_ITEMS_MAX_ITEMS;
+  const [isReorderMode, setIsReorderMode] = useState(false);
   const [draggingIndex, setDraggingIndex] = useState<number | null>(null);
+  const [settlingIndex, setSettlingIndex] = useState<number | null>(null);
   const draggingIndexRef = useRef<number | null>(null);
+  const settleTimeoutRef = useRef<number | null>(null);
+  const isReorderModeActive = isReorderMode && !isInteractionLocked;
+
+  useEffect(() => () => {
+    if (settleTimeoutRef.current !== null) {
+      window.clearTimeout(settleTimeoutRef.current);
+    }
+  }, []);
 
   function resolveRowIndexFromPoint(clientX: number, clientY: number): number | null {
     const row = document
@@ -43,16 +53,30 @@ export function ReviewLineItemsSection({
     return parsedIndex;
   }
 
-  function clearDragState(): void {
+  function clearDragState(options?: { settle?: boolean }): void {
+    const draggedIndex = draggingIndexRef.current;
     draggingIndexRef.current = null;
     setDraggingIndex(null);
+    if (settleTimeoutRef.current !== null) {
+      window.clearTimeout(settleTimeoutRef.current);
+      settleTimeoutRef.current = null;
+    }
+    if (options?.settle && draggedIndex !== null) {
+      setSettlingIndex(draggedIndex);
+      settleTimeoutRef.current = window.setTimeout(() => {
+        setSettlingIndex(null);
+        settleTimeoutRef.current = null;
+      }, 180);
+      return;
+    }
+    setSettlingIndex(null);
   }
 
   function handleDragHandlePointerDown(
     index: number,
     event: React.PointerEvent<HTMLButtonElement>,
   ): void {
-    if (isInteractionLocked) {
+    if (isInteractionLocked || !isReorderModeActive) {
       return;
     }
 
@@ -86,7 +110,7 @@ export function ReviewLineItemsSection({
       handleElement.removeEventListener("pointerup", stopPointerTracking);
       handleElement.removeEventListener("pointercancel", stopPointerTracking);
       handleElement.removeEventListener("lostpointercapture", stopPointerTracking);
-      clearDragState();
+      clearDragState({ settle: true });
     }
 
     handleElement.addEventListener("pointermove", handlePointerMove);
@@ -99,17 +123,38 @@ export function ReviewLineItemsSection({
     <section className="space-y-3">
       <div className="flex items-end justify-between">
         <h2 className="font-headline text-xl font-bold tracking-tight text-primary">Line Items</h2>
-        <span className="text-[0.6875rem] uppercase tracking-widest text-outline">
-          {lineItems.length} ITEMS
-        </span>
+        <button
+          type="button"
+          disabled={isInteractionLocked || (!isReorderModeActive && lineItems.length < 2)}
+          className={`inline-flex min-h-9 items-center rounded-full border px-3 py-1 text-xs font-bold uppercase tracking-wide transition-colors ${
+            isReorderModeActive
+              ? "border-primary/40 bg-primary/10 text-primary hover:bg-primary/15"
+              : "border-outline-variant/40 bg-surface-container-lowest text-on-surface hover:bg-surface-container-low"
+          } disabled:cursor-not-allowed disabled:opacity-60`}
+          onClick={() => {
+            clearDragState();
+            setIsReorderMode((currentMode) => !currentMode);
+          }}
+        >
+          {isReorderModeActive ? "Done" : "Reorder"}
+        </button>
       </div>
 
       <div className="space-y-2.5">
         {lineItems.length > 0 ? (
           lineItems.map((lineItem, index) => {
             const displayDescription = lineItem.description || "Untitled line item";
+            const isDraggingRow = draggingIndex === index;
             return (
-              <div key={`review-line-item-${index}`} data-line-item-index={index}>
+              <div
+                key={`review-line-item-${index}`}
+                data-line-item-index={index}
+                className={`transition-transform duration-150 ease-out ${
+                  isReorderModeActive && draggingIndex !== null && !isDraggingRow
+                    ? (index < draggingIndex ? "-translate-y-1" : "translate-y-1")
+                    : ""
+                }`}
+              >
                 <LineItemCard
                   ariaLabel={`Edit line item ${index + 1}: ${displayDescription}`}
                   dragHandleAriaLabel={`Reorder line item ${index + 1}: ${displayDescription}`}
@@ -119,8 +164,15 @@ export function ReviewLineItemsSection({
                   flagged={lineItem.flagged}
                   flagReason={lineItem.flagReason}
                   disabled={isInteractionLocked}
-                  isDragging={draggingIndex === index}
-                  onEdit={() => onEditLineItem(index)}
+                  isReorderMode={isReorderModeActive}
+                  isDragging={isDraggingRow}
+                  isDropSettling={settlingIndex === index}
+                  onEdit={() => {
+                    if (isReorderModeActive) {
+                      return;
+                    }
+                    onEditLineItem(index);
+                  }}
                   onDelete={() => onRequestDeleteLineItem(index)}
                   onDragHandlePointerDown={(event) => handleDragHandlePointerDown(index, event)}
                 />
@@ -138,7 +190,7 @@ export function ReviewLineItemsSection({
         <button
           type="button"
           className="flex w-full cursor-pointer items-center justify-center gap-2 rounded-lg border-2 border-dashed border-outline-variant/30 py-3 text-sm text-on-surface-variant transition-colors hover:bg-surface-container-low disabled:cursor-not-allowed disabled:opacity-60"
-          disabled={isInteractionLocked || hasReachedLineItemLimit}
+          disabled={isInteractionLocked || hasReachedLineItemLimit || isReorderModeActive}
           onClick={onAddLineItem}
         >
           <span className="material-symbols-outlined text-base">add</span>

--- a/frontend/src/features/quotes/tests/LineItemCard.test.tsx
+++ b/frontend/src/features/quotes/tests/LineItemCard.test.tsx
@@ -70,7 +70,7 @@ describe("LineItemCard", () => {
     expect(onEditMock).toHaveBeenCalledTimes(1);
   });
 
-  it("shows overflow actions for edit and delete", () => {
+  it("hides drag, chevron, and overflow affordances in default mode", () => {
     render(
       <LineItemCard
         description="Brown mulch"
@@ -81,8 +81,47 @@ describe("LineItemCard", () => {
       />,
     );
 
+    expect(screen.queryByRole("button", { name: /reorder line item brown mulch/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /line item actions for brown mulch/i })).not.toBeInTheDocument();
+    expect(screen.queryByText("chevron_right")).not.toBeInTheDocument();
+  });
+
+  it("shows reorder affordances and blocks row editing while in reorder mode", () => {
+    const onEditMock = vi.fn();
+    render(
+      <LineItemCard
+        description="Brown mulch"
+        details="5 yards"
+        price={120}
+        ariaLabel="Edit line item Brown mulch"
+        isReorderMode
+        onEdit={onEditMock}
+        onDelete={vi.fn()}
+      />,
+    );
+
+    const editRowButton = screen.getByRole("button", { name: /edit line item brown mulch/i });
+    expect(editRowButton).toBeDisabled();
+    expect(screen.getByRole("button", { name: /reorder line item brown mulch/i })).toBeInTheDocument();
+
+    fireEvent.click(editRowButton);
+    expect(onEditMock).not.toHaveBeenCalled();
+  });
+
+  it("shows delete overflow action while in reorder mode", () => {
+    render(
+      <LineItemCard
+        description="Brown mulch"
+        details="5 yards"
+        price={120}
+        isReorderMode
+        onEdit={vi.fn()}
+        onDelete={vi.fn()}
+      />,
+    );
+
     fireEvent.click(screen.getByRole("button", { name: /line item actions for brown mulch/i }));
-    expect(screen.getByRole("menuitem", { name: /edit/i })).toBeInTheDocument();
     expect(screen.getByRole("menuitem", { name: /delete/i })).toBeInTheDocument();
+    expect(screen.queryByRole("menuitem", { name: /edit/i })).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/features/quotes/tests/ReviewLineItemsSection.test.tsx
+++ b/frontend/src/features/quotes/tests/ReviewLineItemsSection.test.tsx
@@ -1,0 +1,75 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { ReviewLineItemsSection } from "@/features/quotes/components/ReviewLineItemsSection";
+import type { LineItemDraftWithFlags } from "@/features/quotes/types/quote.types";
+
+const SAMPLE_LINE_ITEMS: LineItemDraftWithFlags[] = [
+  {
+    description: "Brown mulch",
+    details: "5 yards",
+    price: 120,
+  },
+  {
+    description: "Cleanup labor",
+    details: null,
+    price: 80,
+  },
+];
+
+function renderSection(options?: { isInteractionLocked?: boolean; onEditLineItem?: (index: number) => void }): void {
+  render(
+    <ReviewLineItemsSection
+      lineItems={SAMPLE_LINE_ITEMS}
+      isInteractionLocked={options?.isInteractionLocked ?? false}
+      onEditLineItem={options?.onEditLineItem ?? vi.fn()}
+      onRequestDeleteLineItem={vi.fn()}
+      onReorderLineItems={vi.fn()}
+      onAddLineItem={vi.fn()}
+    />,
+  );
+}
+
+describe("ReviewLineItemsSection", () => {
+  it("hides drag and row overflow actions in default mode, and row tap opens edit", () => {
+    const onEditLineItem = vi.fn();
+    renderSection({ onEditLineItem });
+
+    expect(screen.getByRole("button", { name: "Reorder" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /reorder line item 1: brown mulch/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /line item actions for brown mulch/i })).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /edit line item 1: brown mulch/i }));
+    expect(onEditLineItem).toHaveBeenCalledWith(0);
+  });
+
+  it("switches to Done mode, shows drag handles, and blocks row edit taps", () => {
+    const onEditLineItem = vi.fn();
+    renderSection({ onEditLineItem });
+
+    fireEvent.click(screen.getByRole("button", { name: "Reorder" }));
+
+    expect(screen.getByRole("button", { name: "Done" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /reorder line item 1: brown mulch/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /line item actions for brown mulch/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /edit line item 1: brown mulch/i })).toBeDisabled();
+
+    fireEvent.click(screen.getByRole("button", { name: /edit line item 1: brown mulch/i }));
+    expect(onEditLineItem).not.toHaveBeenCalled();
+  });
+
+  it("returns to default mode after Done", () => {
+    const onEditLineItem = vi.fn();
+    renderSection({ onEditLineItem });
+
+    fireEvent.click(screen.getByRole("button", { name: "Reorder" }));
+    fireEvent.click(screen.getByRole("button", { name: "Done" }));
+
+    expect(screen.getByRole("button", { name: "Reorder" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /reorder line item 1: brown mulch/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /line item actions for brown mulch/i })).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /edit line item 1: brown mulch/i }));
+    expect(onEditLineItem).toHaveBeenCalledWith(0);
+  });
+});

--- a/frontend/src/features/quotes/tests/ReviewScreen.test.tsx
+++ b/frontend/src/features/quotes/tests/ReviewScreen.test.tsx
@@ -530,28 +530,54 @@ describe("DocumentEditScreen", () => {
     expect(screen.queryByRole("button", { name: /capture more notes/i })).not.toBeInTheDocument();
   });
 
-  it("shows edit/delete in row overflow and requires delete confirmation", async () => {
-    renderScreen();
+  it("shows delete overflow only in reorder mode and requires delete confirmation", async () => {
+    renderScreen({
+      document: makeQuote({
+        line_items: [
+          {
+            id: "line-1",
+            description: "Brown mulch",
+            details: "5 yards",
+            price: 120,
+            sort_order: 0,
+          },
+          {
+            id: "line-2",
+            description: "Cleanup labor",
+            details: "1 hour",
+            price: 80,
+            sort_order: 1,
+          },
+        ],
+      }),
+    });
 
     expect(await screen.findByRole("button", { name: /edit line item 1: brown mulch/i })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /line item actions for brown mulch/i })).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Reorder" }));
+    expect(screen.getByRole("button", { name: "Done" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /edit line item 1: brown mulch/i })).toBeDisabled();
+
     fireEvent.click(screen.getByRole("button", { name: /line item actions for brown mulch/i }));
-    expect(screen.getByRole("menuitem", { name: /edit/i })).toBeInTheDocument();
     expect(screen.getByRole("menuitem", { name: /delete/i })).toBeInTheDocument();
+    expect(screen.queryByRole("menuitem", { name: /edit/i })).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("menuitem", { name: /delete/i }));
     expect(screen.getByRole("dialog", { name: /delete this line item\?/i })).toBeInTheDocument();
-    expect(document.querySelectorAll("[data-line-item-index]").length).toBe(1);
+    expect(document.querySelectorAll("[data-line-item-index]").length).toBe(2);
 
     fireEvent.click(screen.getByRole("button", { name: /keep line item/i }));
     expect(screen.queryByRole("dialog", { name: /delete this line item\?/i })).not.toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /edit line item 1: brown mulch/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /edit line item 1: brown mulch/i })).toBeDisabled();
 
     fireEvent.click(screen.getByRole("button", { name: /line item actions for brown mulch/i }));
     fireEvent.click(screen.getByRole("menuitem", { name: /delete/i }));
     fireEvent.click(screen.getByRole("button", { name: /delete line item/i }));
 
-    expect(document.querySelectorAll("[data-line-item-index]").length).toBe(0);
-    expect(screen.getByText("No line items on this quote yet.")).toBeInTheDocument();
+    expect(document.querySelectorAll("[data-line-item-index]").length).toBe(1);
+    expect(screen.getByText("Cleanup labor")).toBeInTheDocument();
+    expect(screen.queryByText("No line items on this quote yet.")).not.toBeInTheDocument();
   });
 
   it("does not show the capture-details alert icon for transcript-only details", async () => {


### PR DESCRIPTION
## Summary
- add explicit Reorder/Done mode to review line items
- hide drag handle, chevron, and row overflow in default mode
- block row edit interactions during reorder mode and keep reorder local to draft
- add drag held/movement/drop visual feedback for clearer reorder motion
- add/update tests for LineItemCard, ReviewLineItemsSection, and ReviewScreen behaviors

## Verification
- cd frontend && npx vitest run src/features/quotes/tests/ReviewScreen.test.tsx
- cd frontend && npx vitest run src/features/quotes/tests/LineItemCard.test.tsx
- cd frontend && npx vitest run src/features/quotes/tests/ReviewLineItemsSection.test.tsx
- make frontend-verify

Closes #462