### PR TITLE
Task #463: enforce sheet-only line-item delete entrypoint

### DIFF
--- a/frontend/src/features/quotes/components/DocumentEditOverlays.tsx
+++ b/frontend/src/features/quotes/components/DocumentEditOverlays.tsx
@@ -14,6 +14,7 @@ interface DocumentEditOverlaysProps {
   lineItemSheetInitialItem: LineItemDraftWithFlags;
   onCloseLineItemSheet: () => void;
   onSaveLineItem: (nextLineItem: LineItemDraftWithFlags) => void;
+  onRequestDeleteLineItemFromSheet: () => void;
   showLineItemDeleteConfirm: boolean;
   lineItemDeleteDescription: string;
   onConfirmDeleteLineItem: () => void;
@@ -37,6 +38,7 @@ export function DocumentEditOverlays({
   lineItemSheetInitialItem,
   onCloseLineItemSheet,
   onSaveLineItem,
+  onRequestDeleteLineItemFromSheet,
   showLineItemDeleteConfirm,
   lineItemDeleteDescription,
   onConfirmDeleteLineItem,
@@ -79,6 +81,7 @@ export function DocumentEditOverlays({
           initialLineItem={lineItemSheetInitialItem}
           onClose={onCloseLineItemSheet}
           onSave={onSaveLineItem}
+          onRequestDelete={lineItemSheetState.mode === "edit" ? onRequestDeleteLineItemFromSheet : undefined}
         />
       ) : null}
 

--- a/frontend/src/features/quotes/components/DocumentEditScreenView.tsx
+++ b/frontend/src/features/quotes/components/DocumentEditScreenView.tsx
@@ -42,7 +42,6 @@ interface DocumentEditScreenViewProps {
   onOpenAssignment: () => void;
   onTitleChange: (nextTitle: string) => void;
   onEditLineItem: (lineItemIndex: number) => void;
-  onRequestDeleteLineItem: (lineItemIndex: number) => void;
   onReorderLineItems: (sourceIndex: number, targetIndex: number) => void;
   onAddLineItem: () => void;
   onTotalChange: (nextTotal: number | null) => void;
@@ -59,6 +58,7 @@ interface DocumentEditScreenViewProps {
   onAssignCustomer: (customerId: string) => Promise<void>;
   onCloseLineItemSheet: () => void;
   onSaveLineItem: (nextLineItem: LineItemDraftWithFlags) => void;
+  onRequestDeleteLineItemFromSheet: () => void;
   showLineItemDeleteConfirm: boolean;
   lineItemDeleteDescription: string;
   onConfirmDeleteLineItem: () => void;
@@ -105,7 +105,6 @@ export function DocumentEditScreenView({
   onOpenAssignment,
   onTitleChange,
   onEditLineItem,
-  onRequestDeleteLineItem,
   onReorderLineItems,
   onAddLineItem,
   onTotalChange,
@@ -122,6 +121,7 @@ export function DocumentEditScreenView({
   onAssignCustomer,
   onCloseLineItemSheet,
   onSaveLineItem,
+  onRequestDeleteLineItemFromSheet,
   showLineItemDeleteConfirm,
   lineItemDeleteDescription,
   onConfirmDeleteLineItem,
@@ -169,7 +169,6 @@ export function DocumentEditScreenView({
         onRequestAssignment={onOpenAssignment}
         onTitleChange={onTitleChange}
         onEditLineItem={onEditLineItem}
-        onRequestDeleteLineItem={onRequestDeleteLineItem}
         onReorderLineItems={onReorderLineItems}
         onAddLineItem={onAddLineItem}
         onTotalChange={onTotalChange}
@@ -201,6 +200,7 @@ export function DocumentEditScreenView({
         lineItemSheetInitialItem={lineItemSheetInitialItem}
         onCloseLineItemSheet={onCloseLineItemSheet}
         onSaveLineItem={onSaveLineItem}
+        onRequestDeleteLineItemFromSheet={onRequestDeleteLineItemFromSheet}
         showLineItemDeleteConfirm={showLineItemDeleteConfirm}
         lineItemDeleteDescription={lineItemDeleteDescription}
         onConfirmDeleteLineItem={onConfirmDeleteLineItem}

--- a/frontend/src/features/quotes/components/LineItemCard.tsx
+++ b/frontend/src/features/quotes/components/LineItemCard.tsx
@@ -1,7 +1,6 @@
 import type { PointerEvent as ReactPointerEvent } from "react";
 
 import { resolveLineItemFlagMessage } from "@/features/quotes/utils/lineItemFlags";
-import { OverflowMenu, type OverflowMenuItem } from "@/shared/components/OverflowMenu";
 
 interface LineItemCardProps {
   description: string;
@@ -15,7 +14,6 @@ interface LineItemCardProps {
   isReorderMode?: boolean;
   ariaLabel?: string;
   onEdit: () => void;
-  onDelete: () => void;
   onDragHandlePointerDown?: (event: ReactPointerEvent<HTMLButtonElement>) => void;
   dragHandleAriaLabel?: string;
 }
@@ -32,7 +30,6 @@ export function LineItemCard({
   isReorderMode = false,
   ariaLabel,
   onEdit,
-  onDelete,
   onDragHandlePointerDown,
   dragHandleAriaLabel,
 }: LineItemCardProps): React.ReactElement {
@@ -40,17 +37,7 @@ export function LineItemCard({
   const priceLabel = price !== null ? `$${price.toFixed(2)}` : "—";
   const flagMessage = flagged ? resolveLineItemFlagMessage(flagReason) : null;
   const showDragHandle = isReorderMode;
-  const showOverflowMenu = isReorderMode;
   const canEditRow = !disabled && !isReorderMode;
-  const overflowItems: OverflowMenuItem[] = showOverflowMenu ? [
-    {
-      label: "Delete",
-      icon: "delete",
-      tone: "destructive",
-      disabled,
-      onSelect: onDelete,
-    },
-  ] : [];
 
   return (
     <div
@@ -114,10 +101,6 @@ export function LineItemCard({
           <p className="font-bold text-on-surface">{priceLabel}</p>
         </div>
       </button>
-
-      {showOverflowMenu ? (
-        <OverflowMenu items={overflowItems} triggerLabel={`Line item actions for ${lineItemLabel}`} />
-      ) : null}
     </div>
   );
 }

--- a/frontend/src/features/quotes/components/LineItemEditSheet.tsx
+++ b/frontend/src/features/quotes/components/LineItemEditSheet.tsx
@@ -14,6 +14,7 @@ interface LineItemEditSheetProps {
   initialLineItem: LineItemDraftWithFlags;
   onClose: () => void;
   onSave: (nextLineItem: LineItemDraftWithFlags) => void;
+  onRequestDelete?: () => void;
 }
 
 interface ParsedPrice {
@@ -41,6 +42,7 @@ export function LineItemEditSheet({
   initialLineItem,
   onClose,
   onSave,
+  onRequestDelete,
 }: LineItemEditSheetProps): React.ReactElement {
   const descriptionInputRef = useRef<HTMLInputElement>(null);
   const [description, setDescription] = useState(initialLineItem.description);
@@ -51,7 +53,7 @@ export function LineItemEditSheet({
   const [formError, setFormError] = useState<string | null>(null);
   const title = mode === "edit" ? "Edit Line Item" : "Add Line Item";
 
-  function handleSave(): void {
+  function dismissWithAutosave(): void {
     const trimmedDescription = description.trim();
     if (trimmedDescription.length === 0) {
       setFormError("Description is required.");
@@ -71,10 +73,18 @@ export function LineItemEditSheet({
       details: details.trim().length > 0 ? details.trim() : null,
       price: parsedPrice.value,
     });
+    onClose();
   }
 
   return (
-    <Dialog.Root open={open} onOpenChange={(nextOpen) => { if (!nextOpen) onClose(); }}>
+    <Dialog.Root
+      open={open}
+      onOpenChange={(nextOpen) => {
+        if (!nextOpen) {
+          dismissWithAutosave();
+        }
+      }}
+    >
       <Dialog.Portal>
         <Dialog.Overlay
           data-testid="line-item-edit-sheet-overlay"
@@ -88,9 +98,21 @@ export function LineItemEditSheet({
               descriptionInputRef.current?.focus();
             }}
           >
-            <Dialog.Title className="font-headline text-xl font-bold tracking-tight text-on-surface">
-              {title}
-            </Dialog.Title>
+            <div className="flex items-start justify-between gap-4">
+              <Dialog.Title className="font-headline text-xl font-bold tracking-tight text-on-surface">
+                {title}
+              </Dialog.Title>
+              {mode === "edit" && onRequestDelete ? (
+                <button
+                  type="button"
+                  aria-label="Delete line item"
+                  className="inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-full border border-error/30 bg-error-container/40 text-error transition-colors hover:bg-error-container/60"
+                  onClick={onRequestDelete}
+                >
+                  <span className="material-symbols-outlined text-[1.125rem] leading-none">delete</span>
+                </button>
+              ) : null}
+            </div>
             <Dialog.Description className="mt-2 text-sm leading-6 text-on-surface-variant">
               Update details now. Changes stay local until you save the review draft.
             </Dialog.Description>
@@ -111,7 +133,12 @@ export function LineItemEditSheet({
                   type="text"
                   maxLength={LINE_ITEM_DESCRIPTION_MAX_CHARS}
                   value={description}
-                  onChange={(event) => setDescription(event.target.value)}
+                  onChange={(event) => {
+                    setDescription(event.target.value);
+                    if (formError) {
+                      setFormError(null);
+                    }
+                  }}
                   className="w-full rounded-lg bg-surface-container-high px-4 py-3 font-body text-sm text-on-surface placeholder:text-outline transition-all focus:bg-surface-container-lowest focus:outline-none focus:ring-2 focus:ring-primary/30"
                 />
               </section>
@@ -125,10 +152,15 @@ export function LineItemEditSheet({
                 </div>
                 <textarea
                   id="line-item-sheet-details"
-                  rows={3}
+                  rows={2}
                   maxLength={LINE_ITEM_DETAILS_MAX_CHARS}
                   value={details}
-                  onChange={(event) => setDetails(event.target.value)}
+                  onChange={(event) => {
+                    setDetails(event.target.value);
+                    if (formError) {
+                      setFormError(null);
+                    }
+                  }}
                   className="w-full rounded-lg border border-outline-variant/30 bg-surface-container-high p-4 text-sm text-on-surface placeholder:text-outline/70 outline-none transition-all focus:border-primary focus:bg-surface-container-lowest focus:ring-2 focus:ring-primary/20"
                 />
               </section>
@@ -143,27 +175,15 @@ export function LineItemEditSheet({
                   inputMode="decimal"
                   placeholder="$ 0.00"
                   value={priceInput}
-                  onChange={(event) => setPriceInput(event.target.value)}
+                  onChange={(event) => {
+                    setPriceInput(event.target.value);
+                    if (formError) {
+                      setFormError(null);
+                    }
+                  }}
                   className="w-full rounded-lg bg-surface-container-high px-4 py-3 font-body text-sm text-on-surface placeholder:text-outline transition-all focus:bg-surface-container-lowest focus:outline-none focus:ring-2 focus:ring-primary/30"
                 />
               </section>
-            </div>
-
-            <div className="mt-6 flex flex-col gap-3">
-              <button
-                type="button"
-                className="inline-flex min-h-12 cursor-pointer items-center justify-center rounded-lg px-4 py-3 text-sm font-semibold forest-gradient text-on-primary transition-all active:scale-[0.98]"
-                onClick={handleSave}
-              >
-                Save
-              </button>
-              <button
-                type="button"
-                className="inline-flex min-h-12 cursor-pointer items-center justify-center rounded-lg border border-outline-variant/30 bg-surface-container-low px-4 py-3 text-sm font-semibold text-on-surface transition-colors hover:bg-surface-container-lowest"
-                onClick={onClose}
-              >
-                Cancel
-              </button>
             </div>
           </Dialog.Content>
         </div>

--- a/frontend/src/features/quotes/components/ReviewFormContent.tsx
+++ b/frontend/src/features/quotes/components/ReviewFormContent.tsx
@@ -74,7 +74,6 @@ interface ReviewFormContentProps {
   onRequestAssignment: () => void;
   onTitleChange: (nextTitle: string) => void;
   onEditLineItem: (lineItemIndex: number) => void;
-  onRequestDeleteLineItem: (lineItemIndex: number) => void;
   onReorderLineItems: (sourceIndex: number, targetIndex: number) => void;
   onAddLineItem: () => void;
   onTotalChange: (nextTotal: number | null) => void;
@@ -113,7 +112,6 @@ export function ReviewFormContent({
   onRequestAssignment,
   onTitleChange,
   onEditLineItem,
-  onRequestDeleteLineItem,
   onReorderLineItems,
   onAddLineItem,
   onTotalChange,
@@ -266,7 +264,6 @@ export function ReviewFormContent({
         lineItems={draft.lineItems}
         isInteractionLocked={isInteractionLocked}
         onEditLineItem={onEditLineItem}
-        onRequestDeleteLineItem={onRequestDeleteLineItem}
         onReorderLineItems={onReorderLineItems}
         onAddLineItem={onAddLineItem}
       />

--- a/frontend/src/features/quotes/components/ReviewLineItemsSection.tsx
+++ b/frontend/src/features/quotes/components/ReviewLineItemsSection.tsx
@@ -8,7 +8,6 @@ interface ReviewLineItemsSectionProps {
   lineItems: LineItemDraftWithFlags[];
   isInteractionLocked: boolean;
   onEditLineItem: (index: number) => void;
-  onRequestDeleteLineItem: (index: number) => void;
   onReorderLineItems: (sourceIndex: number, targetIndex: number) => void;
   onAddLineItem: () => void;
 }
@@ -17,7 +16,6 @@ export function ReviewLineItemsSection({
   lineItems,
   isInteractionLocked,
   onEditLineItem,
-  onRequestDeleteLineItem,
   onReorderLineItems,
   onAddLineItem,
 }: ReviewLineItemsSectionProps): React.ReactElement {
@@ -173,7 +171,6 @@ export function ReviewLineItemsSection({
                     }
                     onEditLineItem(index);
                   }}
-                  onDelete={() => onRequestDeleteLineItem(index)}
                   onDragHandlePointerDown={(event) => handleDragHandlePointerDown(index, event)}
                 />
               </div>

--- a/frontend/src/features/quotes/components/ReviewScreen.tsx
+++ b/frontend/src/features/quotes/components/ReviewScreen.tsx
@@ -348,12 +348,6 @@ export function DocumentEditScreen(): React.ReactElement {
         }
         setLineItemSheetState({ mode: "edit", index: lineItemIndex });
       }}
-      onRequestDeleteLineItem={(lineItemIndex) => {
-        if (isInteractionLocked || !activeDraft.lineItems[lineItemIndex]) {
-          return;
-        }
-        setPendingLineItemDeleteIndex(lineItemIndex);
-      }}
       onReorderLineItems={(sourceIndex, targetIndex) => {
         if (isInteractionLocked || sourceIndex === targetIndex) {
           return;
@@ -399,6 +393,18 @@ export function DocumentEditScreen(): React.ReactElement {
         setDraft((currentDraft) => applyLineItemSheetSave(currentDraft, nextSheetState, nextLineItem));
         setLineItemSheetState(null);
       }}
+      onRequestDeleteLineItemFromSheet={() => {
+        const nextSheetState = lineItemSheetState;
+        if (
+          isInteractionLocked
+          || !nextSheetState
+          || nextSheetState.mode !== "edit"
+          || !activeDraft.lineItems[nextSheetState.index]
+        ) {
+          return;
+        }
+        setPendingLineItemDeleteIndex(nextSheetState.index);
+      }}
       showLineItemDeleteConfirm={pendingLineItemDeleteIndex !== null}
       lineItemDeleteDescription={pendingLineItemDeleteIndex !== null
         ? (activeDraft.lineItems[pendingLineItemDeleteIndex]?.description.trim() || "Untitled line item")
@@ -410,6 +416,10 @@ export function DocumentEditScreen(): React.ReactElement {
         }
         setToastMessage(null);
         setDraft((currentDraft) => applyLineItemSheetDelete(currentDraft, { mode: "edit", index: lineItemIndex }));
+        setLineItemSheetState((currentState) =>
+          currentState?.mode === "edit" && currentState.index === lineItemIndex
+            ? null
+            : currentState);
         setPendingLineItemDeleteIndex(null);
       }}
       onCancelDeleteLineItem={() => setPendingLineItemDeleteIndex(null)}

--- a/frontend/src/features/quotes/tests/LineItemCard.test.tsx
+++ b/frontend/src/features/quotes/tests/LineItemCard.test.tsx
@@ -11,7 +11,6 @@ describe("LineItemCard", () => {
         details="5 yards"
         price={120}
         onEdit={vi.fn()}
-        onDelete={vi.fn()}
       />,
     );
 
@@ -29,7 +28,6 @@ describe("LineItemCard", () => {
         flagged
         flagReason="spoken_money_correction"
         onEdit={vi.fn()}
-        onDelete={vi.fn()}
       />,
     );
 
@@ -46,7 +44,6 @@ describe("LineItemCard", () => {
         details="No separate charge"
         price={null}
         onEdit={vi.fn()}
-        onDelete={vi.fn()}
       />,
     );
 
@@ -62,7 +59,6 @@ describe("LineItemCard", () => {
         price={120}
         ariaLabel="Edit line item Brown mulch"
         onEdit={onEditMock}
-        onDelete={vi.fn()}
       />,
     );
 
@@ -77,7 +73,6 @@ describe("LineItemCard", () => {
         details="5 yards"
         price={120}
         onEdit={vi.fn()}
-        onDelete={vi.fn()}
       />,
     );
 
@@ -96,7 +91,6 @@ describe("LineItemCard", () => {
         ariaLabel="Edit line item Brown mulch"
         isReorderMode
         onEdit={onEditMock}
-        onDelete={vi.fn()}
       />,
     );
 
@@ -108,7 +102,7 @@ describe("LineItemCard", () => {
     expect(onEditMock).not.toHaveBeenCalled();
   });
 
-  it("shows delete overflow action while in reorder mode", () => {
+  it("does not render row overflow trigger while in reorder mode", () => {
     render(
       <LineItemCard
         description="Brown mulch"
@@ -116,12 +110,9 @@ describe("LineItemCard", () => {
         price={120}
         isReorderMode
         onEdit={vi.fn()}
-        onDelete={vi.fn()}
       />,
     );
 
-    fireEvent.click(screen.getByRole("button", { name: /line item actions for brown mulch/i }));
-    expect(screen.getByRole("menuitem", { name: /delete/i })).toBeInTheDocument();
-    expect(screen.queryByRole("menuitem", { name: /edit/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /line item actions for brown mulch/i })).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/features/quotes/tests/LineItemEditSheet.test.tsx
+++ b/frontend/src/features/quotes/tests/LineItemEditSheet.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 
@@ -17,7 +17,7 @@ function makeLineItem(overrides: Partial<LineItemDraftWithFlags> = {}): LineItem
 }
 
 describe("LineItemEditSheet", () => {
-  it("renders edit mode with current values and focuses description", () => {
+  it("renders edit mode values, focuses description, and shows top-right trash", () => {
     render(
       <LineItemEditSheet
         open
@@ -25,18 +25,20 @@ describe("LineItemEditSheet", () => {
         initialLineItem={makeLineItem()}
         onClose={vi.fn()}
         onSave={vi.fn()}
+        onRequestDelete={vi.fn()}
       />,
     );
 
-    expect(screen.getByRole("dialog", { name: /edit line item/i })).toBeInTheDocument();
+    const dialog = screen.getByRole("dialog", { name: /edit line item/i });
+    expect(dialog).toBeInTheDocument();
     expect(screen.getByLabelText(/description/i)).toHaveValue("Brown mulch");
     expect(screen.getByLabelText(/details/i)).toHaveValue("5 yards");
     expect(screen.getByLabelText(/price/i)).toHaveValue("120");
     expect(screen.getByLabelText(/description/i)).toHaveFocus();
-    expect(screen.queryByRole("button", { name: /delete line item/i })).not.toBeInTheDocument();
+    expect(within(dialog).getByRole("button", { name: /delete line item/i })).toBeInTheDocument();
   });
 
-  it("renders add mode with empty fields", () => {
+  it("renders add mode without sheet trash", () => {
     render(
       <LineItemEditSheet
         open
@@ -47,76 +49,17 @@ describe("LineItemEditSheet", () => {
       />,
     );
 
-    expect(screen.getByRole("dialog", { name: /add line item/i })).toBeInTheDocument();
+    const dialog = screen.getByRole("dialog", { name: /add line item/i });
+    expect(dialog).toBeInTheDocument();
     expect(screen.getByLabelText(/description/i)).toHaveValue("");
     expect(screen.getByLabelText(/details/i)).toHaveValue("");
     expect(screen.getByLabelText(/price/i)).toHaveValue("");
-    expect(screen.queryByRole("button", { name: /delete line item/i })).not.toBeInTheDocument();
+    expect(within(dialog).queryByRole("button", { name: /delete line item/i })).not.toBeInTheDocument();
   });
 
-  it("validates required description and blocks save", () => {
-    const onSave = vi.fn();
-
-    render(
-      <LineItemEditSheet
-        open
-        mode="edit"
-        initialLineItem={makeLineItem()}
-        onClose={vi.fn()}
-        onSave={onSave}
-      />,
-    );
-
-    fireEvent.change(screen.getByLabelText(/description/i), { target: { value: "   " } });
-    fireEvent.click(screen.getByRole("button", { name: /^save$/i }));
-
-    expect(screen.getByRole("alert")).toHaveTextContent("Description is required.");
-    expect(onSave).not.toHaveBeenCalled();
-  });
-
-  it("saves with nullable price and trimmed values", () => {
-    const onSave = vi.fn();
-
-    render(
-      <LineItemEditSheet
-        open
-        mode="edit"
-        initialLineItem={makeLineItem()}
-        onClose={vi.fn()}
-        onSave={onSave}
-      />,
-    );
-
-    fireEvent.change(screen.getByLabelText(/description/i), { target: { value: " Premium mulch " } });
-    fireEvent.change(screen.getByLabelText(/details/i), { target: { value: " 6 yards " } });
-    fireEvent.change(screen.getByLabelText(/price/i), { target: { value: " " } });
-    fireEvent.click(screen.getByRole("button", { name: /^save$/i }));
-
-    expect(onSave).toHaveBeenCalledWith({
-      description: "Premium mulch",
-      details: "6 yards",
-      price: null,
-      flagged: true,
-      flagReason: "Needs review",
-    });
-  });
-
-  it("does not render an included/no-charge checkbox", () => {
-    render(
-      <LineItemEditSheet
-        open
-        mode="edit"
-        initialLineItem={makeLineItem()}
-        onClose={vi.fn()}
-        onSave={vi.fn()}
-      />,
-    );
-
-    expect(screen.queryByLabelText(/included \/ no-charge item/i)).not.toBeInTheDocument();
-  });
-
-  it("dismisses via cancel, escape, and backdrop", async () => {
+  it("blocks dismiss with a validation error when description is blank", async () => {
     const user = userEvent.setup();
+    const onSave = vi.fn();
     const onClose = vi.fn();
 
     render(
@@ -125,18 +68,75 @@ describe("LineItemEditSheet", () => {
         mode="edit"
         initialLineItem={makeLineItem()}
         onClose={onClose}
-        onSave={vi.fn()}
+        onSave={onSave}
+        onRequestDelete={vi.fn()}
       />,
     );
 
-    fireEvent.click(screen.getByRole("button", { name: /cancel/i }));
-    fireEvent.keyDown(screen.getByLabelText(/description/i), { key: "Escape" });
+    fireEvent.change(screen.getByLabelText(/description/i), { target: { value: "   " } });
     await user.click(screen.getByTestId("line-item-edit-sheet-overlay"));
 
-    expect(onClose).toHaveBeenCalledTimes(3);
+    expect(screen.getByRole("alert")).toHaveTextContent("Description is required.");
+    expect(onSave).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
   });
 
-  it("uses decimal input mode for price entry", () => {
+  it("blocks dismiss with a validation error when price is invalid", async () => {
+    const user = userEvent.setup();
+    const onSave = vi.fn();
+    const onClose = vi.fn();
+
+    render(
+      <LineItemEditSheet
+        open
+        mode="edit"
+        initialLineItem={makeLineItem()}
+        onClose={onClose}
+        onSave={onSave}
+        onRequestDelete={vi.fn()}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText(/price/i), { target: { value: "12x" } });
+    await user.click(screen.getByTestId("line-item-edit-sheet-overlay"));
+
+    expect(screen.getByRole("alert")).toHaveTextContent("Enter a valid number for price.");
+    expect(onSave).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("autosaves trimmed values on valid dismiss", async () => {
+    const user = userEvent.setup();
+    const onSave = vi.fn();
+    const onClose = vi.fn();
+
+    render(
+      <LineItemEditSheet
+        open
+        mode="edit"
+        initialLineItem={makeLineItem()}
+        onClose={onClose}
+        onSave={onSave}
+        onRequestDelete={vi.fn()}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText(/description/i), { target: { value: " Premium mulch " } });
+    fireEvent.change(screen.getByLabelText(/details/i), { target: { value: " 6 yards " } });
+    fireEvent.change(screen.getByLabelText(/price/i), { target: { value: " " } });
+    await user.click(screen.getByTestId("line-item-edit-sheet-overlay"));
+
+    expect(onSave).toHaveBeenCalledWith({
+      description: "Premium mulch",
+      details: "6 yards",
+      price: null,
+      flagged: true,
+      flagReason: "Needs review",
+    });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps decimal input mode and 2-row details field", () => {
     render(
       <LineItemEditSheet
         open
@@ -144,9 +144,29 @@ describe("LineItemEditSheet", () => {
         initialLineItem={makeLineItem()}
         onClose={vi.fn()}
         onSave={vi.fn()}
+        onRequestDelete={vi.fn()}
       />,
     );
 
     expect(screen.getByLabelText(/price/i)).toHaveAttribute("inputmode", "decimal");
+    expect(screen.getByLabelText(/details/i)).toHaveAttribute("rows", "2");
+  });
+
+  it("fires delete callback from top-right trash action", () => {
+    const onRequestDelete = vi.fn();
+
+    render(
+      <LineItemEditSheet
+        open
+        mode="edit"
+        initialLineItem={makeLineItem()}
+        onClose={vi.fn()}
+        onSave={vi.fn()}
+        onRequestDelete={onRequestDelete}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /delete line item/i }));
+    expect(onRequestDelete).toHaveBeenCalledTimes(1);
   });
 });

--- a/frontend/src/features/quotes/tests/ReviewLineItemsSection.test.tsx
+++ b/frontend/src/features/quotes/tests/ReviewLineItemsSection.test.tsx
@@ -23,7 +23,6 @@ function renderSection(options?: { isInteractionLocked?: boolean; onEditLineItem
       lineItems={SAMPLE_LINE_ITEMS}
       isInteractionLocked={options?.isInteractionLocked ?? false}
       onEditLineItem={options?.onEditLineItem ?? vi.fn()}
-      onRequestDeleteLineItem={vi.fn()}
       onReorderLineItems={vi.fn()}
       onAddLineItem={vi.fn()}
     />,
@@ -43,7 +42,7 @@ describe("ReviewLineItemsSection", () => {
     expect(onEditLineItem).toHaveBeenCalledWith(0);
   });
 
-  it("switches to Done mode, shows drag handles, and blocks row edit taps", () => {
+  it("switches to Done mode, shows drag handles, hides row overflow, and blocks row edit taps", () => {
     const onEditLineItem = vi.fn();
     renderSection({ onEditLineItem });
 
@@ -51,7 +50,7 @@ describe("ReviewLineItemsSection", () => {
 
     expect(screen.getByRole("button", { name: "Done" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /reorder line item 1: brown mulch/i })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /line item actions for brown mulch/i })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /line item actions for brown mulch/i })).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: /edit line item 1: brown mulch/i })).toBeDisabled();
 
     fireEvent.click(screen.getByRole("button", { name: /edit line item 1: brown mulch/i }));

--- a/frontend/src/features/quotes/tests/ReviewScreen.test.tsx
+++ b/frontend/src/features/quotes/tests/ReviewScreen.test.tsx
@@ -530,7 +530,7 @@ describe("DocumentEditScreen", () => {
     expect(screen.queryByRole("button", { name: /capture more notes/i })).not.toBeInTheDocument();
   });
 
-  it("shows delete overflow only in reorder mode and requires delete confirmation", async () => {
+  it("removes row overflow in both list modes and deletes via sheet trash with confirmation", async () => {
     renderScreen({
       document: makeQuote({
         line_items: [
@@ -558,22 +558,27 @@ describe("DocumentEditScreen", () => {
     fireEvent.click(screen.getByRole("button", { name: "Reorder" }));
     expect(screen.getByRole("button", { name: "Done" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /edit line item 1: brown mulch/i })).toBeDisabled();
+    expect(screen.queryByRole("button", { name: /line item actions for brown mulch/i })).not.toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole("button", { name: /line item actions for brown mulch/i }));
-    expect(screen.getByRole("menuitem", { name: /delete/i })).toBeInTheDocument();
-    expect(screen.queryByRole("menuitem", { name: /edit/i })).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Done" }));
+    fireEvent.click(screen.getByRole("button", { name: /edit line item 1: brown mulch/i }));
 
-    fireEvent.click(screen.getByRole("menuitem", { name: /delete/i }));
-    expect(screen.getByRole("dialog", { name: /delete this line item\?/i })).toBeInTheDocument();
+    const editSheet = screen.getByRole("dialog", { name: /edit line item/i });
+    expect(editSheet).toBeInTheDocument();
+    fireEvent.click(within(editSheet).getByRole("button", { name: /delete line item/i }));
+    const deleteConfirmDialog = screen.getByRole("dialog", { name: /delete this line item\?/i });
+    expect(deleteConfirmDialog).toBeInTheDocument();
     expect(document.querySelectorAll("[data-line-item-index]").length).toBe(2);
 
     fireEvent.click(screen.getByRole("button", { name: /keep line item/i }));
     expect(screen.queryByRole("dialog", { name: /delete this line item\?/i })).not.toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /edit line item 1: brown mulch/i })).toBeDisabled();
+    expect(screen.getByRole("dialog", { name: /edit line item/i })).toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole("button", { name: /line item actions for brown mulch/i }));
-    fireEvent.click(screen.getByRole("menuitem", { name: /delete/i }));
-    fireEvent.click(screen.getByRole("button", { name: /delete line item/i }));
+    fireEvent.click(within(editSheet).getByRole("button", { name: /delete line item/i }));
+    fireEvent.click(
+      within(screen.getByRole("dialog", { name: /delete this line item\?/i }))
+        .getByRole("button", { name: /delete line item/i }),
+    );
 
     expect(document.querySelectorAll("[data-line-item-index]").length).toBe(1);
     expect(screen.getByText("Cleanup labor")).toBeInTheDocument();


### PR DESCRIPTION
## Summary
- remove row overflow delete entrypoints from `LineItemCard` in all list modes (default and Reorder/Done)
- route line-item delete initiation to the `LineItemEditSheet` top-right trash action for existing items
- preserve the existing delete confirmation modal flow as the single confirmation path
- update `ReviewScreen`, `ReviewLineItemsSection`, and `LineItemCard` tests to assert no row overflow trigger in either mode
- update `LineItemEditSheet` tests to assert delete remains reachable via sheet trash and invalid dismiss is blocked

## Verification
- `cd frontend && npx vitest run src/features/quotes/tests/LineItemEditSheet.test.tsx src/features/quotes/tests/LineItemCard.test.tsx src/features/quotes/tests/ReviewLineItemsSection.test.tsx src/features/quotes/tests/ReviewScreen.test.tsx`
- `cd frontend && npx tsc --noEmit`
- `cd frontend && npx eslint src/features/quotes/components/LineItemCard.tsx src/features/quotes/components/LineItemEditSheet.tsx src/features/quotes/components/ReviewLineItemsSection.tsx src/features/quotes/components/ReviewFormContent.tsx src/features/quotes/components/DocumentEditScreenView.tsx src/features/quotes/components/DocumentEditOverlays.tsx src/features/quotes/components/ReviewScreen.tsx src/features/quotes/tests/LineItemCard.test.tsx src/features/quotes/tests/LineItemEditSheet.test.tsx src/features/quotes/tests/ReviewLineItemsSection.test.tsx src/features/quotes/tests/ReviewScreen.test.tsx`
- `make frontend-verify`

Closes #463