### PR TITLE
Task #464: Add backend quote duplication endpoint

### DIFF
--- a/backend/app/features/quotes/api.py
+++ b/backend/app/features/quotes/api.py
@@ -228,6 +228,32 @@ async def create_manual_draft(
 
 
 @router.post(
+    "/{quote_id}/duplicate",
+    response_model=QuoteResponse,
+    status_code=status.HTTP_201_CREATED,
+    dependencies=[Depends(require_csrf)],
+)
+async def duplicate_quote(
+    quote_id: UUID,
+    user: Annotated[User, Depends(get_current_user)],
+    quote_service: Annotated[QuoteService, Depends(get_quote_service)],
+) -> QuoteResponse:
+    """Duplicate one quote into a new manual-style draft for the authenticated user."""
+    try:
+        quote = await quote_service.duplicate_quote(user, quote_id)
+    except QuoteServiceError as exc:
+        raise HTTPException(status_code=exc.status_code, detail=exc.detail) from exc
+
+    log_event(
+        "quote.created",
+        user_id=user.id,
+        quote_id=quote.id,
+        customer_id=quote.customer_id,
+    )
+    return QuoteResponse.model_validate(quote)
+
+
+@router.post(
     "/extract",
     response_model=PersistedExtractionResponse | JobRecordResponse,
     dependencies=[Depends(require_csrf)],

--- a/backend/app/features/quotes/creation/service.py
+++ b/backend/app/features/quotes/creation/service.py
@@ -36,6 +36,7 @@ class QuoteCreationRepositoryProtocol(Protocol):
     """Repository behavior required by quote creation orchestration."""
 
     async def customer_exists_for_user(self, *, user_id: UUID, customer_id: UUID) -> bool: ...
+    async def get_by_id(self, quote_id: UUID, user_id: UUID) -> Document | None: ...
 
     async def create(
         self,
@@ -266,6 +267,63 @@ class QuoteCreationService:
             await self._repository.rollback()
             raise QuoteServiceError(
                 detail="Unable to save manual draft right now. Please try again.",
+                status_code=503,
+            ) from exc
+
+        return quote
+
+    async def duplicate_quote(
+        self,
+        *,
+        user_id: UUID,
+        quote_id: UUID,
+    ) -> Document:
+        """Duplicate one user-owned quote into a new manual-style draft quote."""
+        source_quote = await self._repository.get_by_id(quote_id, user_id)
+        if source_quote is None:
+            raise QuoteServiceError(detail="Not found", status_code=404)
+
+        copied_line_items = [
+            LineItemDraft(
+                description=line_item.description,
+                details=line_item.details,
+                price=document_field_float_or_none(line_item.price),
+                flagged=line_item.flagged,
+                flag_reason=line_item.flag_reason,
+            )
+            for line_item in source_quote.line_items
+        ]
+
+        try:
+            quote = await self._create_quote_document(
+                user_id=user_id,
+                customer_id=source_quote.customer_id,
+                title=source_quote.title,
+                transcript="",
+                line_items=copied_line_items,
+                total_amount=document_field_float_or_none(source_quote.total_amount),
+                tax_rate=document_field_float_or_none(source_quote.tax_rate),
+                discount_type=source_quote.discount_type,
+                discount_value=document_field_float_or_none(source_quote.discount_value),
+                deposit_amount=document_field_float_or_none(source_quote.deposit_amount),
+                notes=source_quote.notes,
+                source_type="text",
+            )
+        except QuoteServiceError:
+            raise
+        except Exception as exc:  # noqa: BLE001
+            await self._repository.rollback()
+            raise QuoteServiceError(
+                detail="Unable to duplicate quote right now. Please try again.",
+                status_code=503,
+            ) from exc
+
+        try:
+            await self._repository.commit()
+        except Exception as exc:  # noqa: BLE001
+            await self._repository.rollback()
+            raise QuoteServiceError(
+                detail="Unable to duplicate quote right now. Please try again.",
                 status_code=503,
             ) from exc
 

--- a/backend/app/features/quotes/service.py
+++ b/backend/app/features/quotes/service.py
@@ -257,6 +257,13 @@ class QuoteService:
             customer_id=customer_id,
         )
 
+    async def duplicate_quote(self, user: User, quote_id: UUID) -> Document:
+        """Duplicate one user-owned quote into a new draft quote."""
+        return await self._creation_service.duplicate_quote(
+            user_id=_resolve_user_id(user),
+            quote_id=quote_id,
+        )
+
     async def list_quotes(
         self,
         user: User,

--- a/backend/app/features/quotes/tests/test_quote_auth_csrf.py
+++ b/backend/app/features/quotes/tests/test_quote_auth_csrf.py
@@ -51,6 +51,7 @@ _reset_rate_limiter = quotes_test_module._reset_rate_limiter
             {"notes": "updated"},
         ),
         ("delete", "/api/quotes/00000000-0000-0000-0000-000000000000", None),
+        ("post", "/api/quotes/00000000-0000-0000-0000-000000000000/duplicate", None),
         ("post", "/api/quotes/00000000-0000-0000-0000-000000000000/pdf", None),
         ("post", "/api/quotes/00000000-0000-0000-0000-000000000000/share", None),
         ("post", "/api/quotes/00000000-0000-0000-0000-000000000000/send-email", None),
@@ -227,6 +228,17 @@ async def test_delete_quote_requires_csrf(client: AsyncClient) -> None:
     quote_id = create_response.json()["id"]
 
     response = await client.delete(f"/api/quotes/{quote_id}")
+
+    assert response.status_code == 403
+    assert response.json() == {"detail": "CSRF token missing"}
+
+
+async def test_duplicate_quote_requires_csrf(client: AsyncClient) -> None:
+    csrf_token = await _register_and_login(client, _credentials())
+    customer_id = await _create_customer(client, csrf_token)
+    quote = await _create_quote(client, csrf_token, customer_id)
+
+    response = await client.post(f"/api/quotes/{quote['id']}/duplicate")
 
     assert response.status_code == 403
     assert response.json() == {"detail": "CSRF token missing"}

--- a/backend/app/features/quotes/tests/test_quote_duplication.py
+++ b/backend/app/features/quotes/tests/test_quote_duplication.py
@@ -1,0 +1,231 @@
+"""Quote duplication API behavior tests."""
+
+from __future__ import annotations
+
+from uuid import UUID, uuid4
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.features.quotes.models import Document, QuoteStatus
+from app.features.quotes.tests import test_quotes as quotes_test_module
+from app.features.quotes.tests.support.helpers import (
+    _create_customer,
+    _create_quote,
+    _credentials,
+    _register_and_login,
+)
+
+pytestmark = pytest.mark.asyncio
+
+# Reuse existing fixture wiring/helpers from test_quotes to preserve behavior.
+_reset_email_delivery_fallback_cache = quotes_test_module._reset_email_delivery_fallback_cache
+_override_storage_service_dependency = quotes_test_module._override_storage_service_dependency
+_override_quote_service_dependency = quotes_test_module._override_quote_service_dependency
+_override_extraction_service_dependency = quotes_test_module._override_extraction_service_dependency
+_reset_rate_limiter = quotes_test_module._reset_rate_limiter
+
+
+async def test_duplicate_quote_copies_fields_and_resets_state(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    csrf_token = await _register_and_login(client, _credentials())
+    customer_id = await _create_customer(client, csrf_token)
+
+    extract_response = await client.post(
+        "/api/quotes/extract",
+        files=[
+            ("clips", ("clip-1.webm", b"voice-capture", "audio/webm")),
+            ("customer_id", (None, customer_id)),
+        ],
+        headers={"X-CSRF-Token": csrf_token},
+    )
+    assert extract_response.status_code == 200
+    source_quote_id = extract_response.json()["quote_id"]
+
+    patch_response = await client.patch(
+        f"/api/quotes/{source_quote_id}",
+        json={
+            "title": "Spring Cleanup",
+            "line_items": [
+                {
+                    "description": "Mulch install",
+                    "details": "5 yards",
+                    "price": 220,
+                    "flagged": True,
+                    "flag_reason": "Unit not confirmed",
+                },
+                {
+                    "description": "Bed edging",
+                    "details": "front and side beds",
+                    "price": 55,
+                    "flagged": False,
+                    "flag_reason": None,
+                },
+            ],
+            "total_amount": 260,
+            "tax_rate": 0.0825,
+            "discount_type": "fixed",
+            "discount_value": 15,
+            "deposit_amount": 50,
+            "notes": "Customer asked for Friday start.",
+        },
+        headers={"X-CSRF-Token": csrf_token},
+    )
+    assert patch_response.status_code == 200
+    patched_source_payload = patch_response.json()
+
+    source_document = await db_session.get(Document, UUID(source_quote_id))
+    assert source_document is not None
+    source_document.extraction_tier = "degraded"
+    source_document.extraction_degraded_reason_code = "provider_timeout"
+    source_document.extraction_review_metadata = {
+        "review_state": {"notes_pending": True, "pricing_pending": True},
+        "hidden_details": {
+            "items": [
+                {
+                    "id": "x-1",
+                    "kind": "unresolved_segment",
+                    "field": None,
+                    "reason": "transcript_conflict",
+                    "confidence": "low",
+                    "text": "Needs follow-up confirmation.",
+                }
+            ]
+        },
+    }
+    source_document.pdf_artifact_path = "artifacts/source-quote.pdf"
+    source_document.pdf_url = "https://example.test/source-quote.pdf"
+    source_document.pdf_artifact_job_id = uuid4()
+    source_document.pdf_artifact_revision = 7
+    await db_session.commit()
+
+    share_response = await client.post(
+        f"/api/quotes/{source_quote_id}/share",
+        headers={"X-CSRF-Token": csrf_token},
+    )
+    assert share_response.status_code == 200
+    assert share_response.json()["status"] == "shared"
+    assert share_response.json()["share_token"] is not None
+
+    mark_won_response = await client.post(
+        f"/api/quotes/{source_quote_id}/mark-won",
+        headers={"X-CSRF-Token": csrf_token},
+    )
+    assert mark_won_response.status_code == 200
+    assert mark_won_response.json()["status"] == "approved"
+
+    convert_response = await client.post(
+        f"/api/quotes/{source_quote_id}/convert-to-invoice",
+        headers={"X-CSRF-Token": csrf_token},
+    )
+    assert convert_response.status_code == 201
+    assert convert_response.json()["source_document_id"] == source_quote_id
+
+    duplicate_response = await client.post(
+        f"/api/quotes/{source_quote_id}/duplicate",
+        headers={"X-CSRF-Token": csrf_token},
+    )
+    assert duplicate_response.status_code == 201
+    duplicate_payload = duplicate_response.json()
+
+    assert duplicate_payload["id"] != source_quote_id
+    assert duplicate_payload["doc_number"] != patched_source_payload["doc_number"]
+    assert duplicate_payload["doc_number"].startswith("Q-")
+    assert duplicate_payload["status"] == "draft"
+    assert duplicate_payload["customer_id"] == patched_source_payload["customer_id"]
+    assert duplicate_payload["title"] == patched_source_payload["title"]
+    assert duplicate_payload["source_type"] == "text"
+    assert duplicate_payload["transcript"] == ""
+    assert duplicate_payload["total_amount"] == patched_source_payload["total_amount"]
+    assert duplicate_payload["tax_rate"] == patched_source_payload["tax_rate"]
+    assert duplicate_payload["discount_type"] == patched_source_payload["discount_type"]
+    assert duplicate_payload["discount_value"] == patched_source_payload["discount_value"]
+    assert duplicate_payload["deposit_amount"] == patched_source_payload["deposit_amount"]
+    assert duplicate_payload["notes"] == patched_source_payload["notes"]
+    assert duplicate_payload["shared_at"] is None
+    assert duplicate_payload["share_token"] is None
+
+    assert len(duplicate_payload["line_items"]) == len(patched_source_payload["line_items"])
+    for duplicate_item, source_item in zip(
+        duplicate_payload["line_items"],
+        patched_source_payload["line_items"],
+        strict=True,
+    ):
+        assert duplicate_item["id"] != source_item["id"]
+        assert duplicate_item["description"] == source_item["description"]
+        assert duplicate_item["details"] == source_item["details"]
+        assert duplicate_item["price"] == source_item["price"]
+        assert duplicate_item["flagged"] == source_item["flagged"]
+        assert duplicate_item["flag_reason"] == source_item["flag_reason"]
+        assert duplicate_item["sort_order"] == source_item["sort_order"]
+
+    source_detail_response = await client.get(f"/api/quotes/{source_quote_id}")
+    assert source_detail_response.status_code == 200
+    source_detail = source_detail_response.json()
+    assert source_detail["status"] == "approved"
+    assert source_detail["source_type"] == "voice"
+    assert source_detail["transcript"] != ""
+    assert source_detail["share_token"] is not None
+    assert source_detail["linked_invoice"] is not None
+    assert source_detail["extraction_tier"] == "degraded"
+    assert source_detail["extraction_degraded_reason_code"] == "provider_timeout"
+
+    duplicate_detail_response = await client.get(f"/api/quotes/{duplicate_payload['id']}")
+    assert duplicate_detail_response.status_code == 200
+    duplicate_detail = duplicate_detail_response.json()
+    assert duplicate_detail["status"] == "draft"
+    assert duplicate_detail["source_type"] == "text"
+    assert duplicate_detail["transcript"] == ""
+    assert duplicate_detail["share_token"] is None
+    assert duplicate_detail["has_active_share"] is False
+    assert duplicate_detail["linked_invoice"] is None
+    assert duplicate_detail["extraction_tier"] is None
+    assert duplicate_detail["extraction_degraded_reason_code"] is None
+    assert duplicate_detail["extraction_review_metadata"]["review_state"] == {
+        "notes_pending": False,
+        "pricing_pending": False,
+    }
+    assert duplicate_detail["extraction_review_metadata"]["hidden_details"] == {"items": []}
+
+    duplicate_document = await db_session.get(Document, UUID(duplicate_payload["id"]))
+    assert duplicate_document is not None
+    assert duplicate_document.status == QuoteStatus.DRAFT
+    assert duplicate_document.source_document_id is None
+    assert duplicate_document.share_token is None
+    assert duplicate_document.shared_at is None
+    assert duplicate_document.pdf_url is None
+    assert duplicate_document.pdf_artifact_path is None
+    assert duplicate_document.pdf_artifact_job_id is None
+    assert duplicate_document.pdf_artifact_revision == 0
+    assert duplicate_document.extraction_tier is None
+    assert duplicate_document.extraction_degraded_reason_code is None
+    assert duplicate_document.extraction_review_metadata is None
+
+
+async def test_duplicate_quote_rejects_missing_or_foreign_source(
+    client: AsyncClient,
+) -> None:
+    first_user_csrf = await _register_and_login(client, _credentials())
+    customer_id = await _create_customer(client, first_user_csrf)
+    quote = await _create_quote(client, first_user_csrf, customer_id)
+
+    second_user_credentials = _credentials()
+    second_user_credentials["email"] = "duplicate-other-user@example.com"
+    second_user_csrf = await _register_and_login(client, second_user_credentials)
+
+    foreign_quote_response = await client.post(
+        f"/api/quotes/{quote['id']}/duplicate",
+        headers={"X-CSRF-Token": second_user_csrf},
+    )
+    assert foreign_quote_response.status_code == 404
+    assert foreign_quote_response.json() == {"detail": "Not found"}
+
+    missing_quote_response = await client.post(
+        f"/api/quotes/{uuid4()}/duplicate",
+        headers={"X-CSRF-Token": second_user_csrf},
+    )
+    assert missing_quote_response.status_code == 404
+    assert missing_quote_response.json() == {"detail": "Not found"}


### PR DESCRIPTION
## Summary
- add `POST /api/quotes/{quote_id}/duplicate` to create a new draft quote from an existing quote
- implement duplication orchestration in quote service/creation layers with owner-only access checks
- preserve copy/reset semantics for duplicated drafts (copy customer/title/line items/pricing/notes, reset share/invoice/pdf/outcome/extraction state, clear transcript)
- add duplication behavior tests and auth/CSRF coverage for the new route

## Verification
- `cd backend && .venv/bin/pytest app/features/quotes/tests/test_quote_duplication.py app/features/quotes/tests/test_quote_auth_csrf.py -k duplicate -x --tb=short`
- `make backend-static-verify`
- `make backend-verify`

Closes #464