### PR TITLE
Task #465: Add quote reuse candidates backend endpoint

### DIFF
--- a/backend/app/features/quotes/api.py
+++ b/backend/app/features/quotes/api.py
@@ -58,6 +58,7 @@ from app.features.quotes.schemas import (
     QuoteDetailResponse,
     QuoteListItemResponse,
     QuoteResponse,
+    QuoteReuseCandidateResponse,
     QuoteUpdateRequest,
 )
 from app.features.quotes.service import QuoteService, QuoteServiceError
@@ -412,6 +413,22 @@ async def list_quotes(
     """List quotes for the authenticated user."""
     quotes = await quote_service.list_quotes(user, customer_id=customer_id)
     return [QuoteListItemResponse.model_validate(quote) for quote in quotes]
+
+
+@router.get("/reuse-candidates", response_model=list[QuoteReuseCandidateResponse])
+async def list_quote_reuse_candidates(
+    user: Annotated[User, Depends(get_current_user)],
+    quote_service: Annotated[QuoteService, Depends(get_quote_service)],
+    customer_id: Annotated[UUID | None, Query()] = None,
+    q: Annotated[str | None, Query()] = None,
+) -> list[QuoteReuseCandidateResponse]:
+    """List quote reuse candidates with capped line-item previews."""
+    candidates = await quote_service.list_quote_reuse_candidates(
+        user,
+        customer_id=customer_id,
+        q=q,
+    )
+    return [QuoteReuseCandidateResponse.model_validate(candidate) for candidate in candidates]
 
 
 @router.get("/{quote_id}", response_model=QuoteDetailResponse)

--- a/backend/app/features/quotes/repository.py
+++ b/backend/app/features/quotes/repository.py
@@ -9,7 +9,7 @@ from typing import Any, cast
 from uuid import UUID
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
-from sqlalchemy import delete, func, select, update
+from sqlalchemy import delete, func, or_, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import aliased, selectinload
 
@@ -117,6 +117,31 @@ class QuoteListItemSummary:
     requires_customer_assignment: bool
     can_reassign_customer: bool
     created_at: datetime
+
+
+@dataclass(slots=True)
+class QuoteReuseLineItemPreview:
+    """Minimal line item preview payload for quote reuse cards."""
+
+    description: str
+    price: Decimal | None
+
+
+@dataclass(slots=True)
+class QuoteReuseCandidateSummary:
+    """Quote summary payload tailored for reuse candidate selection."""
+
+    id: UUID
+    title: str | None
+    doc_number: str
+    customer_id: UUID | None
+    customer_name: str | None
+    total_amount: Decimal | None
+    created_at: datetime
+    status: str
+    line_item_previews: list[QuoteReuseLineItemPreview]
+    line_item_count: int
+    more_line_item_count: int
 
 
 @dataclass(slots=True)
@@ -287,6 +312,102 @@ class QuoteRepository:
             )
             for row in result
         ]
+
+    async def list_reuse_candidates(
+        self,
+        user_id: UUID,
+        *,
+        customer_id: UUID | None = None,
+        q: str | None = None,
+    ) -> list[QuoteReuseCandidateSummary]:
+        """Return quote summaries with capped line-item previews for reuse pickers."""
+        statement = (
+            select(
+                Document.id,
+                Document.title,
+                Document.doc_number,
+                Document.customer_id,
+                Customer.name.label("customer_name"),
+                Document.total_amount,
+                Document.created_at,
+                Document.status,
+            )
+            .outerjoin(Customer, Customer.id == Document.customer_id)
+            .where(
+                Document.user_id == user_id,
+                Document.doc_type == _QUOTE_DOC_TYPE,
+            )
+            .order_by(Document.created_at.desc(), Document.doc_sequence.desc())
+        )
+        if customer_id is not None:
+            statement = statement.where(Document.customer_id == customer_id)
+
+        normalized_query = (q or "").strip()
+        if normalized_query:
+            like_pattern = f"%{normalized_query}%"
+            statement = statement.where(
+                or_(
+                    Customer.name.ilike(like_pattern),
+                    Document.title.ilike(like_pattern),
+                    Document.doc_number.ilike(like_pattern),
+                )
+            )
+
+        result = await self._session.execute(statement)
+        quote_rows = result.all()
+        if not quote_rows:
+            return []
+
+        quote_ids = [row.id for row in quote_rows]
+        line_item_result = await self._session.execute(
+            select(
+                LineItem.document_id,
+                LineItem.description,
+                LineItem.price,
+            )
+            .where(LineItem.document_id.in_(quote_ids))
+            .order_by(
+                LineItem.document_id.asc(),
+                LineItem.sort_order.asc(),
+                LineItem.created_at.asc(),
+            )
+        )
+
+        line_item_count_by_quote: dict[UUID, int] = {}
+        previews_by_quote: dict[UUID, list[QuoteReuseLineItemPreview]] = {}
+        for line_item_row in line_item_result:
+            quote_id = line_item_row.document_id
+            line_item_count_by_quote[quote_id] = line_item_count_by_quote.get(quote_id, 0) + 1
+            previews = previews_by_quote.setdefault(quote_id, [])
+            if len(previews) < 3:
+                previews.append(
+                    QuoteReuseLineItemPreview(
+                        description=line_item_row.description,
+                        price=line_item_row.price,
+                    )
+                )
+
+        candidates: list[QuoteReuseCandidateSummary] = []
+        for row in quote_rows:
+            previews = previews_by_quote.get(row.id, [])
+            line_item_count = line_item_count_by_quote.get(row.id, 0)
+            status = row.status.value if isinstance(row.status, QuoteStatus) else str(row.status)
+            candidates.append(
+                QuoteReuseCandidateSummary(
+                    id=row.id,
+                    title=row.title,
+                    doc_number=row.doc_number,
+                    customer_id=row.customer_id,
+                    customer_name=row.customer_name,
+                    total_amount=row.total_amount,
+                    created_at=row.created_at,
+                    status=status,
+                    line_item_previews=previews,
+                    line_item_count=line_item_count,
+                    more_line_item_count=max(line_item_count - len(previews), 0),
+                )
+            )
+        return candidates
 
     async def get_by_id(self, quote_id: UUID, user_id: UUID) -> Document | None:
         """Return one quote owned by a user, including line items."""

--- a/backend/app/features/quotes/schemas.py
+++ b/backend/app/features/quotes/schemas.py
@@ -662,6 +662,33 @@ class PublicLineItemResponse(BaseModel):
     price: float | None
 
 
+class QuoteReuseLineItemPreviewResponse(BaseModel):
+    """Line-item preview payload shown in quote reuse candidate cards."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    description: str
+    price: float | None
+
+
+class QuoteReuseCandidateResponse(BaseModel):
+    """Serializable quote reuse candidate returned by chooser-specific listing."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+    title: str | None
+    doc_number: str
+    customer_id: UUID | None
+    customer_name: str | None
+    total_amount: float | None
+    created_at: datetime
+    status: str
+    line_item_previews: list[QuoteReuseLineItemPreviewResponse]
+    line_item_count: int
+    more_line_item_count: int
+
+
 class QuoteListItemResponse(BaseModel):
     """Serializable quote summary payload returned by the quote list endpoint."""
 

--- a/backend/app/features/quotes/service.py
+++ b/backend/app/features/quotes/service.py
@@ -25,6 +25,7 @@ from app.features.quotes.repository import (
     QuoteDetailRow,
     QuoteListItemSummary,
     QuoteRenderContext,
+    QuoteReuseCandidateSummary,
     QuoteViewTransition,
 )
 from app.features.quotes.schemas import (
@@ -53,6 +54,13 @@ class QuoteRepositoryProtocol(Protocol):
         user_id: UUID,
         customer_id: UUID | None = None,
     ) -> list[QuoteListItemSummary]: ...
+    async def list_reuse_candidates(
+        self,
+        user_id: UUID,
+        *,
+        customer_id: UUID | None = None,
+        q: str | None = None,
+    ) -> list[QuoteReuseCandidateSummary]: ...
 
     async def get_by_id(self, quote_id: UUID, user_id: UUID) -> Document | None: ...
     async def get_by_id_for_update(self, quote_id: UUID, user_id: UUID) -> Document | None: ...
@@ -273,6 +281,20 @@ class QuoteService:
         return await self._repository.list_by_user(
             _resolve_user_id(user),
             customer_id=customer_id,
+        )
+
+    async def list_quote_reuse_candidates(
+        self,
+        user: User,
+        *,
+        customer_id: UUID | None = None,
+        q: str | None = None,
+    ) -> list[QuoteReuseCandidateSummary]:
+        """List quote reuse candidates with capped line-item previews."""
+        return await self._repository.list_reuse_candidates(
+            _resolve_user_id(user),
+            customer_id=customer_id,
+            q=q,
         )
 
     async def get_quote(self, user: User, quote_id: UUID) -> Document:

--- a/backend/app/features/quotes/tests/test_quote_reuse_candidates.py
+++ b/backend/app/features/quotes/tests/test_quote_reuse_candidates.py
@@ -1,0 +1,244 @@
+"""Quote reuse candidates API behavior tests."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.features.quotes.models import QuoteStatus
+from app.features.quotes.tests import test_quotes as quotes_test_module
+from app.features.quotes.tests.support.helpers import (
+    _create_customer,
+    _credentials,
+    _register_and_login,
+    _set_quote_status,
+)
+
+pytestmark = pytest.mark.asyncio
+
+# Reuse existing fixture wiring/helpers from test_quotes to preserve behavior.
+_reset_email_delivery_fallback_cache = quotes_test_module._reset_email_delivery_fallback_cache
+_override_storage_service_dependency = quotes_test_module._override_storage_service_dependency
+_override_quote_service_dependency = quotes_test_module._override_quote_service_dependency
+_override_extraction_service_dependency = quotes_test_module._override_extraction_service_dependency
+_reset_rate_limiter = quotes_test_module._reset_rate_limiter
+
+
+async def _create_quote_with_line_items(
+    client: AsyncClient,
+    csrf_token: str,
+    *,
+    customer_id: str,
+    title: str | None,
+    line_items: list[dict[str, Any]],
+    total_amount: float | None,
+) -> dict[str, Any]:
+    response = await client.post(
+        "/api/quotes",
+        json={
+            "customer_id": customer_id,
+            "title": title,
+            "transcript": f"{title or 'Reusable quote'} transcript",
+            "line_items": line_items,
+            "total_amount": total_amount,
+            "notes": None,
+            "source_type": "text",
+        },
+        headers={"X-CSRF-Token": csrf_token},
+    )
+    assert response.status_code == 201
+    return response.json()
+
+
+async def _create_manual_draft(
+    client: AsyncClient,
+    csrf_token: str,
+) -> dict[str, Any]:
+    response = await client.post(
+        "/api/quotes/manual-draft",
+        json={},
+        headers={"X-CSRF-Token": csrf_token},
+    )
+    assert response.status_code == 201
+    return response.json()
+
+
+async def test_reuse_candidates_return_capped_previews_and_keep_quote_list_contract(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    csrf_token = await _register_and_login(client, _credentials())
+    customer_id = await _create_customer(client, csrf_token, name="Evergreen Landscaping")
+
+    reusable_quote = await _create_quote_with_line_items(
+        client,
+        csrf_token,
+        customer_id=customer_id,
+        title="Backyard Refresh",
+        line_items=[
+            {"description": "Design plan", "details": None, "price": 120},
+            {"description": "Material staging", "details": None, "price": 240},
+            {"description": "Install edging", "details": None, "price": 310},
+            {"description": "Final cleanup", "details": None, "price": 80},
+        ],
+        total_amount=750,
+    )
+    await _set_quote_status(db_session, reusable_quote["id"], QuoteStatus.SHARED)
+
+    unassigned_draft = await _create_manual_draft(client, csrf_token)
+    unassigned_patch_response = await client.patch(
+        f"/api/quotes/{unassigned_draft['id']}",
+        json={
+            "title": "Unassigned follow-up",
+            "line_items": [
+                {"description": "Soil testing", "details": None, "price": 95},
+                {"description": "Drainage check", "details": None, "price": None},
+            ],
+            "total_amount": 95,
+            "notes": None,
+        },
+        headers={"X-CSRF-Token": csrf_token},
+    )
+    assert unassigned_patch_response.status_code == 200
+    unassigned_payload = unassigned_patch_response.json()
+
+    deleted_quote = await _create_quote_with_line_items(
+        client,
+        csrf_token,
+        customer_id=customer_id,
+        title="Delete me",
+        line_items=[{"description": "Cleanup", "details": None, "price": 50}],
+        total_amount=50,
+    )
+    deleted_response = await client.delete(
+        f"/api/quotes/{deleted_quote['id']}",
+        headers={"X-CSRF-Token": csrf_token},
+    )
+    assert deleted_response.status_code == 204
+
+    reuse_response = await client.get("/api/quotes/reuse-candidates")
+    assert reuse_response.status_code == 200
+    reuse_payload = reuse_response.json()
+
+    assert [candidate["id"] for candidate in reuse_payload] == [
+        unassigned_payload["id"],
+        reusable_quote["id"],
+    ]
+
+    by_id = {candidate["id"]: candidate for candidate in reuse_payload}
+
+    reusable_candidate = by_id[reusable_quote["id"]]
+    assert reusable_candidate["status"] == "shared"
+    assert reusable_candidate["line_item_previews"] == [
+        {"description": "Design plan", "price": 120},
+        {"description": "Material staging", "price": 240},
+        {"description": "Install edging", "price": 310},
+    ]
+    assert reusable_candidate["line_item_count"] == 4
+    assert reusable_candidate["more_line_item_count"] == 1
+
+    unassigned_candidate = by_id[unassigned_payload["id"]]
+    assert unassigned_candidate["status"] == "draft"
+    assert unassigned_candidate["customer_id"] is None
+    assert unassigned_candidate["customer_name"] is None
+    assert unassigned_candidate["line_item_previews"] == [
+        {"description": "Soil testing", "price": 95},
+        {"description": "Drainage check", "price": None},
+    ]
+    assert unassigned_candidate["line_item_count"] == 2
+    assert unassigned_candidate["more_line_item_count"] == 0
+
+    list_response = await client.get("/api/quotes")
+    assert list_response.status_code == 200
+    for item in list_response.json():
+        assert "line_items" not in item
+
+
+async def test_reuse_candidates_can_filter_by_customer_id(client: AsyncClient) -> None:
+    csrf_token = await _register_and_login(client, _credentials())
+    customer_a_id = await _create_customer(client, csrf_token, name="Customer A")
+    customer_b_id = await _create_customer(client, csrf_token, name="Customer B")
+
+    quote_a = await _create_quote_with_line_items(
+        client,
+        csrf_token,
+        customer_id=customer_a_id,
+        title="Customer A Quote",
+        line_items=[{"description": "Mulch", "details": None, "price": 180}],
+        total_amount=180,
+    )
+    await _create_quote_with_line_items(
+        client,
+        csrf_token,
+        customer_id=customer_b_id,
+        title="Customer B Quote",
+        line_items=[{"description": "Stone", "details": None, "price": 220}],
+        total_amount=220,
+    )
+
+    response = await client.get(
+        "/api/quotes/reuse-candidates",
+        params={"customer_id": customer_a_id},
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    assert [candidate["id"] for candidate in payload] == [quote_a["id"]]
+    assert payload[0]["customer_id"] == customer_a_id
+    assert payload[0]["customer_name"] == "Customer A"
+
+
+async def test_reuse_candidates_query_matches_customer_title_and_doc_number(
+    client: AsyncClient,
+) -> None:
+    csrf_token = await _register_and_login(client, _credentials())
+    evergreen_customer_id = await _create_customer(
+        client,
+        csrf_token,
+        name="Evergreen Holdings",
+    )
+    summit_customer_id = await _create_customer(
+        client,
+        csrf_token,
+        name="Summit Builders",
+    )
+
+    evergreen_quote = await _create_quote_with_line_items(
+        client,
+        csrf_token,
+        customer_id=evergreen_customer_id,
+        title="Deck Rebuild Phase 1",
+        line_items=[{"description": "Demo", "details": None, "price": 600}],
+        total_amount=600,
+    )
+    summit_quote = await _create_quote_with_line_items(
+        client,
+        csrf_token,
+        customer_id=summit_customer_id,
+        title="Fence Repair",
+        line_items=[{"description": "Repair", "details": None, "price": 300}],
+        total_amount=300,
+    )
+
+    by_customer_name = await client.get(
+        "/api/quotes/reuse-candidates",
+        params={"q": "evergreen"},
+    )
+    assert by_customer_name.status_code == 200
+    assert [candidate["id"] for candidate in by_customer_name.json()] == [evergreen_quote["id"]]
+
+    by_title = await client.get(
+        "/api/quotes/reuse-candidates",
+        params={"q": "  rebuild phase 1  "},
+    )
+    assert by_title.status_code == 200
+    assert [candidate["id"] for candidate in by_title.json()] == [evergreen_quote["id"]]
+
+    by_doc_number = await client.get(
+        "/api/quotes/reuse-candidates",
+        params={"q": summit_quote["doc_number"].lower()},
+    )
+    assert by_doc_number.status_code == 200
+    assert [candidate["id"] for candidate in by_doc_number.json()] == [summit_quote["id"]]


### PR DESCRIPTION
## Summary
- add GET /api/quotes/reuse-candidates for chooser-specific quote reuse cards
- return capped line_item_previews (first 3), line_item_count, and more_line_item_count without changing GET /api/quotes
- support optional customer_id and q filters (customer name, title, doc number)
- add API integration tests for previews, counts, filters, lifecycle inclusion, and list endpoint regression guard

## Verification
- cd backend && .venv/bin/pytest app/features/quotes/tests/test_quote_reuse_candidates.py -x --tb=short
- make backend-static-verify
- make backend-verify

Closes #465
