### PR TITLE
Task 466: create-from-existing frontend flow

### DIFF
--- a/frontend/src/features/customers/components/CustomerDetailScreen.tsx
+++ b/frontend/src/features/customers/components/CustomerDetailScreen.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
-
 import { useAuth } from "@/features/auth/hooks/useAuth";
 import { CustomerDeleteConfirmModal } from "@/features/customers/components/CustomerDeleteConfirmModal";
 import { CustomerInfoForm } from "@/features/customers/components/CustomerInfoForm";
@@ -8,11 +7,9 @@ import { CustomerDetailLoadingSkeleton } from "@/features/customers/components/C
 import { InvoiceHistoryList } from "@/features/customers/components/InvoiceHistoryList";
 import { QuoteHistoryList } from "@/features/customers/components/QuoteHistoryList";
 import { customerService } from "@/features/customers/services/customerService";
-import type {
-  Customer,
-  CustomerUpdateRequest,
-} from "@/features/customers/types/customer.types";
+import type { Customer, CustomerUpdateRequest } from "@/features/customers/types/customer.types";
 import { invoiceService } from "@/features/invoices/services/invoiceService";
+import { useQuoteCreateFlow } from "@/features/quotes/hooks/useQuoteCreateFlow";
 import { createCaptureLocationState } from "@/features/quotes/utils/workflowNavigation";
 import type { InvoiceListItem } from "@/features/invoices/types/invoice.types";
 import { quoteService } from "@/features/quotes/services/quoteService";
@@ -38,7 +35,6 @@ function getCustomerDraftValues(nextCustomer: Customer): {
     address: nextCustomer.address ?? "",
   };
 }
-
 export function CustomerDetailScreen(): React.ReactElement {
   const navigate = useNavigate();
   const { id } = useParams<{ id: string }>();
@@ -84,7 +80,6 @@ export function CustomerDetailScreen(): React.ReactElement {
     if (!customer) {
       return;
     }
-
     populateDraftFields(customer);
     setSaveError(null);
     setSaveSuccess(null);
@@ -183,7 +178,6 @@ export function CustomerDetailScreen(): React.ReactElement {
 
   async function onSaveChanges(event: React.FormEvent<HTMLFormElement>): Promise<void> {
     event.preventDefault();
-
     if (!id) {
       setSaveError("Missing customer id.");
       return;
@@ -264,7 +258,6 @@ export function CustomerDetailScreen(): React.ReactElement {
     if (!value) {
       return fallback;
     }
-
     const trimmedValue = value.trim();
     return trimmedValue || fallback;
   }
@@ -272,6 +265,21 @@ export function CustomerDetailScreen(): React.ReactElement {
   const activeHistoryCount = historyMode === "quotes" ? customerQuotes.length : customerInvoices.length;
   const activeHistoryCountLabel = `${activeHistoryCount} ${activeHistoryCount === 1 ? "ITEM" : "ITEMS"}`;
   const deleteConfirmationMatches = customer ? deleteConfirmationName === customer.name : false;
+  const quoteCreateFlow = useQuoteCreateFlow({
+    customerId: customer?.id,
+    timezone: user?.timezone,
+    entrySheetTitle: "Create document",
+    entrySheetDescription: "Create a new quote or duplicate an existing quote.",
+    onCreateNew: () => {
+      if (!customer) {
+        return;
+      }
+      navigate(`/quotes/capture/${customer.id}`, {
+        state: createCaptureLocationState(`/customers/${customer.id}`),
+      });
+    },
+    onQuoteDuplicated: (quoteId) => navigate(`/documents/${quoteId}/edit`),
+  });
 
   return (
     <main className="min-h-screen bg-background pb-24">
@@ -280,18 +288,15 @@ export function CustomerDetailScreen(): React.ReactElement {
         backLabel="Back to customers"
         onBack={() => navigate("/customers")}
       />
-
       <section className="mx-auto w-full max-w-3xl space-y-4 px-4 pt-20">
         {isLoading ? (
           <div role="status" aria-label="Loading customer" className="space-y-4">
             <CustomerDetailLoadingSkeleton />
           </div>
         ) : null}
-
         {loadError ? (
           <FeedbackMessage variant="error">{loadError}</FeedbackMessage>
         ) : null}
-
         {!isLoading && !loadError && customer ? (
           <>
             {!isEditing ? (
@@ -329,9 +334,7 @@ export function CustomerDetailScreen(): React.ReactElement {
                       type="button"
                       variant="primary"
                       className="flex-1"
-                      onClick={() => navigate(`/quotes/capture/${customer.id}`, {
-                        state: createCaptureLocationState(`/customers/${customer.id}`),
-                      })}
+                      onClick={quoteCreateFlow.openCreateEntry}
                     >
                       Create Document
                     </Button>
@@ -368,7 +371,6 @@ export function CustomerDetailScreen(): React.ReactElement {
                 saveError={saveError}
               />
             )}
-
             <section>
               <div className="mb-2 flex items-center justify-between gap-3">
                 <div
@@ -426,7 +428,7 @@ export function CustomerDetailScreen(): React.ReactElement {
           </>
         ) : null}
       </section>
-
+      {quoteCreateFlow.dialogs}
       {isDeleteConfirmOpen && customer ? (
         <CustomerDeleteConfirmModal
           customerName={customer.name}
@@ -441,7 +443,6 @@ export function CustomerDetailScreen(): React.ReactElement {
           onCancel={closeDeleteConfirmation}
         />
       ) : null}
-
       <BottomNav active="customers" />
       <Toast message={saveSuccess} onDismiss={() => setSaveSuccess(null)} />
     </main>

--- a/frontend/src/features/customers/tests/CustomerDetailScreen.test.tsx
+++ b/frontend/src/features/customers/tests/CustomerDetailScreen.test.tsx
@@ -37,13 +37,23 @@ vi.mock("@/features/customers/services/customerService", () => ({
 vi.mock("@/features/quotes/services/quoteService", () => ({
   quoteService: {
     extract: vi.fn(),
+    createManualDraft: vi.fn(),
     convertNotes: vi.fn(),
     createQuote: vi.fn(),
     listQuotes: vi.fn(),
+    listReuseCandidates: vi.fn(),
+    duplicateQuote: vi.fn(),
     getQuote: vi.fn(),
     updateQuote: vi.fn(),
+    updateExtractionReviewMetadata: vi.fn(),
+    deleteQuote: vi.fn(),
     generatePdf: vi.fn(),
     shareQuote: vi.fn(),
+    revokeShare: vi.fn(),
+    sendQuoteEmail: vi.fn(),
+    markQuoteWon: vi.fn(),
+    markQuoteLost: vi.fn(),
+    convertToInvoice: vi.fn(),
   },
 }));
 
@@ -322,15 +332,73 @@ describe("CustomerDetailScreen", () => {
     expect(screen.getAllByText("—")).toHaveLength(3);
   });
 
-  it("navigates to quote capture for this customer", async () => {
+  it("opens create entry sheet and starts a customer-scoped new quote", async () => {
     renderScreen();
     await screen.findByText("Q-001");
 
     fireEvent.click(screen.getByRole("button", { name: /create document/i }));
+    fireEvent.click(await screen.findByRole("button", { name: "Create new" }));
 
     expect(navigateMock).toHaveBeenCalledWith("/quotes/capture/cust-1", {
       state: { launchOrigin: "/customers/cust-1" },
     });
+  });
+
+  it("duplicates from existing quotes scoped to this customer", async () => {
+    mockedQuoteService.listReuseCandidates.mockResolvedValueOnce([
+      {
+        id: "quote-source-1",
+        title: "Fence Repair",
+        doc_number: "Q-021",
+        customer_id: "cust-1",
+        customer_name: "Alice Johnson",
+        total_amount: 220,
+        created_at: "2026-03-25T00:00:00.000Z",
+        status: "ready",
+        line_item_previews: [{ description: "Fence panel", price: 220 }],
+        line_item_count: 1,
+        more_line_item_count: 0,
+      },
+    ]);
+    mockedQuoteService.duplicateQuote.mockResolvedValueOnce({
+      id: "quote-duplicate-1",
+      customer_id: "cust-1",
+      doc_type: "quote",
+      doc_number: "Q-022",
+      title: "Fence Repair",
+      status: "draft",
+      source_type: "text",
+      transcript: "",
+      total_amount: 220,
+      tax_rate: null,
+      discount_type: null,
+      discount_value: null,
+      deposit_amount: null,
+      notes: null,
+      shared_at: null,
+      share_token: null,
+      line_items: [],
+      created_at: "2026-03-26T00:00:00.000Z",
+      updated_at: "2026-03-26T00:00:00.000Z",
+    });
+
+    renderScreen();
+    await screen.findByText("Q-001");
+
+    fireEvent.click(screen.getByRole("button", { name: /create document/i }));
+    fireEvent.click(await screen.findByRole("button", { name: "Create from existing" }));
+    fireEvent.click(await screen.findByRole("button", { name: /fence repair/i }));
+
+    await waitFor(() => {
+      expect(mockedQuoteService.listReuseCandidates).toHaveBeenCalledWith({
+        customer_id: "cust-1",
+        q: undefined,
+      });
+    });
+    await waitFor(() => {
+      expect(mockedQuoteService.duplicateQuote).toHaveBeenCalledWith("quote-source-1");
+    });
+    expect(navigateMock).toHaveBeenCalledWith("/documents/quote-duplicate-1/edit");
   });
 
   it("renders quote history filtered to this customer and opens preview on click", async () => {

--- a/frontend/src/features/quotes/components/QuoteCreateEntrySheet.tsx
+++ b/frontend/src/features/quotes/components/QuoteCreateEntrySheet.tsx
@@ -1,0 +1,54 @@
+import * as Dialog from "@radix-ui/react-dialog";
+
+interface QuoteCreateEntrySheetProps {
+  open: boolean;
+  onClose: () => void;
+  onCreateNew: () => void;
+  onCreateFromExisting: () => void;
+  title?: string;
+  description?: string;
+}
+
+export function QuoteCreateEntrySheet({
+  open,
+  onClose,
+  onCreateNew,
+  onCreateFromExisting,
+  title = "Create quote",
+  description = "Start fresh or duplicate from an existing quote.",
+}: QuoteCreateEntrySheetProps): React.ReactElement {
+  return (
+    <Dialog.Root open={open} onOpenChange={(nextOpen) => { if (!nextOpen) onClose(); }}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="modal-backdrop fixed inset-0 z-50" />
+        <div className="pointer-events-none fixed inset-0 z-50 flex items-end justify-center px-4 pb-4 sm:items-center sm:pb-0">
+          <Dialog.Content className="modal-shadow pointer-events-auto w-full max-w-md rounded-[1.75rem] border border-outline-variant/20 bg-surface-container-lowest p-6">
+            <Dialog.Title className="font-headline text-xl font-bold tracking-tight text-on-surface">
+              {title}
+            </Dialog.Title>
+            <Dialog.Description className="mt-2 text-sm leading-6 text-on-surface-variant">
+              {description}
+            </Dialog.Description>
+
+            <div className="mt-6 space-y-3">
+              <button
+                type="button"
+                className="inline-flex min-h-12 w-full cursor-pointer items-center justify-center rounded-lg forest-gradient px-4 py-3 text-sm font-semibold text-on-primary transition-all active:scale-[0.98]"
+                onClick={onCreateNew}
+              >
+                Create new
+              </button>
+              <button
+                type="button"
+                className="inline-flex min-h-12 w-full cursor-pointer items-center justify-center rounded-lg border border-outline-variant/30 bg-surface-container-low px-4 py-3 text-sm font-semibold text-on-surface transition-colors hover:bg-surface-container-lowest"
+                onClick={onCreateFromExisting}
+              >
+                Create from existing
+              </button>
+            </div>
+          </Dialog.Content>
+        </div>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/frontend/src/features/quotes/components/QuoteList.tsx
+++ b/frontend/src/features/quotes/components/QuoteList.tsx
@@ -1,9 +1,9 @@
 import { useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
-
 import { useAuth } from "@/features/auth/hooks/useAuth";
 import { invoiceService } from "@/features/invoices/services/invoiceService";
 import type { InvoiceListItem } from "@/features/invoices/types/invoice.types";
+import { useQuoteCreateFlow } from "@/features/quotes/hooks/useQuoteCreateFlow";
 import { quoteService } from "@/features/quotes/services/quoteService";
 import type { QuoteListItem } from "@/features/quotes/types/quote.types";
 import { BottomNav } from "@/shared/components/BottomNav";
@@ -37,7 +37,6 @@ interface DocumentRowsSectionProps {
   rows: DocumentRow[];
   onRowClick: (row: DocumentRow) => void;
 }
-
 const baseRowClasses = "w-full cursor-pointer rounded-xl bg-surface-container-lowest px-4 py-3 text-left ghost-shadow transition active:scale-[0.98] active:bg-surface-container-low";
 const draftRowClasses = "glass-surface w-full cursor-pointer rounded-xl border-l-4 border-warning-accent px-4 py-3 text-left backdrop-blur-md ghost-shadow transition active:scale-[0.98] active:bg-surface-container-low";
 const needsCustomerBadgeClasses = `${statusBadgeBaseClasses} shrink-0 whitespace-nowrap bg-warning-container text-warning`;
@@ -103,7 +102,6 @@ function matchesSearch(
   if (!normalizedSearchQuery) {
     return true;
   }
-
   return (
     (item.customer_name ?? "").toLowerCase().includes(normalizedSearchQuery)
     || item.doc_number.toLowerCase().includes(normalizedSearchQuery)
@@ -203,7 +201,6 @@ export function QuoteList(): React.ReactElement {
     if (!isSearchOpen) {
       return;
     }
-
     const inputElement = document.getElementById("document-search");
     if (inputElement instanceof HTMLInputElement) {
       inputElement.focus();
@@ -211,9 +208,10 @@ export function QuoteList(): React.ReactElement {
   }, [isSearchOpen]);
 
   const normalizedSearchQuery = searchQuery.trim().toLowerCase();
-  const filteredQuotes = useMemo(() => {
-    return quotes.filter((quote) => matchesSearch(quote, normalizedSearchQuery));
-  }, [normalizedSearchQuery, quotes]);
+  const filteredQuotes = useMemo(
+    () => quotes.filter((quote) => matchesSearch(quote, normalizedSearchQuery)),
+    [normalizedSearchQuery, quotes],
+  );
 
   const filteredInvoices = useMemo(
     () => invoices.filter((invoice) => matchesSearch(invoice, normalizedSearchQuery)),
@@ -302,6 +300,11 @@ export function QuoteList(): React.ReactElement {
     })),
     [filteredInvoices, timezone],
   );
+  const quoteCreateFlow = useQuoteCreateFlow({
+    timezone,
+    onCreateNew: () => navigate("/quotes/capture"),
+    onQuoteDuplicated: (quoteId) => navigate(`/documents/${quoteId}/edit`),
+  });
 
   return (
     <main className="min-h-screen bg-background pb-24">
@@ -436,10 +439,11 @@ export function QuoteList(): React.ReactElement {
         type="button"
         aria-label="New quote"
         className="fixed bottom-20 right-4 z-50 flex h-14 w-14 cursor-pointer items-center justify-center rounded-full forest-gradient text-on-primary ghost-shadow transition-all active:scale-95"
-        onClick={() => navigate("/quotes/capture")}
+        onClick={quoteCreateFlow.openCreateEntry}
       >
         <span className="material-symbols-outlined">description</span>
       </button>
+      {quoteCreateFlow.dialogs}
       <BottomNav active="quotes" />
     </main>
   );

--- a/frontend/src/features/quotes/components/QuoteReuseChooser.tsx
+++ b/frontend/src/features/quotes/components/QuoteReuseChooser.tsx
@@ -1,0 +1,296 @@
+import { useEffect, useMemo, useState } from "react";
+import * as Dialog from "@radix-ui/react-dialog";
+
+import { quoteService } from "@/features/quotes/services/quoteService";
+import type { QuoteReuseCandidate } from "@/features/quotes/types/quote.types";
+import { FeedbackMessage } from "@/shared/components/FeedbackMessage";
+import { Input } from "@/shared/components/Input";
+import { StatusBadge } from "@/shared/components/StatusBadge";
+import { formatCurrency, formatDate } from "@/shared/lib/formatters";
+
+interface QuoteReuseChooserProps {
+  open: boolean;
+  customerId?: string;
+  timezone?: string | null;
+  onClose: () => void;
+  onQuoteDuplicated: (quoteId: string) => void;
+}
+
+type ChooserTab = "recent" | "all";
+
+const RECENT_LIMIT = 6;
+
+function buildLoadErrorMessage(error: unknown): string {
+  if (error instanceof Error && error.message.trim().length > 0) {
+    return error.message;
+  }
+  return "Unable to load quotes";
+}
+
+function buildDuplicateErrorMessage(error: unknown): string {
+  if (error instanceof Error && error.message.trim().length > 0) {
+    return error.message;
+  }
+  return "Unable to duplicate quote";
+}
+
+function resolveVisibleCandidates(candidates: QuoteReuseCandidate[], activeTab: ChooserTab): QuoteReuseCandidate[] {
+  if (activeTab === "recent") {
+    return candidates.slice(0, RECENT_LIMIT);
+  }
+  return candidates;
+}
+
+function buildEmptyStateMessage(
+  normalizedSearchQuery: string,
+  activeTab: ChooserTab,
+  hasCustomerScope: boolean,
+): string {
+  if (normalizedSearchQuery) {
+    return "No quotes match your search.";
+  }
+  if (activeTab === "recent") {
+    return hasCustomerScope ? "No recent quotes for this customer." : "No recent quotes yet.";
+  }
+  return hasCustomerScope ? "No quotes found for this customer." : "No quotes available.";
+}
+
+export function QuoteReuseChooser({
+  open,
+  customerId,
+  timezone,
+  onClose,
+  onQuoteDuplicated,
+}: QuoteReuseChooserProps): React.ReactElement {
+  const [activeTab, setActiveTab] = useState<ChooserTab>("recent");
+  const [searchQuery, setSearchQuery] = useState("");
+  const [candidates, setCandidates] = useState<QuoteReuseCandidate[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [duplicateError, setDuplicateError] = useState<string | null>(null);
+  const [duplicatingId, setDuplicatingId] = useState<string | null>(null);
+
+  const normalizedSearchQuery = searchQuery.trim();
+  const visibleCandidates = useMemo(
+    () => resolveVisibleCandidates(candidates, activeTab),
+    [activeTab, candidates],
+  );
+  const emptyStateMessage = buildEmptyStateMessage(
+    normalizedSearchQuery,
+    activeTab,
+    Boolean(customerId),
+  );
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+
+    let isActive = true;
+    setIsLoading(true);
+    setLoadError(null);
+
+    void quoteService.listReuseCandidates({
+      customer_id: customerId,
+      q: normalizedSearchQuery || undefined,
+    })
+      .then((nextCandidates) => {
+        if (isActive) {
+          setCandidates(nextCandidates);
+        }
+      })
+      .catch((error: unknown) => {
+        if (isActive) {
+          setCandidates([]);
+          setLoadError(buildLoadErrorMessage(error));
+        }
+      })
+      .finally(() => {
+        if (isActive) {
+          setIsLoading(false);
+        }
+      });
+
+    return () => {
+      isActive = false;
+    };
+  }, [customerId, normalizedSearchQuery, open]);
+
+  useEffect(() => {
+    if (open) {
+      return;
+    }
+
+    setActiveTab("recent");
+    setSearchQuery("");
+    setCandidates([]);
+    setIsLoading(false);
+    setLoadError(null);
+    setDuplicateError(null);
+    setDuplicatingId(null);
+  }, [open]);
+
+  async function onCandidateSelect(candidateId: string): Promise<void> {
+    setDuplicateError(null);
+    setDuplicatingId(candidateId);
+
+    try {
+      const duplicate = await quoteService.duplicateQuote(candidateId);
+      onQuoteDuplicated(duplicate.id);
+    } catch (error) {
+      setDuplicateError(buildDuplicateErrorMessage(error));
+    } finally {
+      setDuplicatingId(null);
+    }
+  }
+
+  return (
+    <Dialog.Root open={open} onOpenChange={(nextOpen) => { if (!nextOpen) onClose(); }}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="modal-backdrop fixed inset-0 z-50" />
+        <div className="pointer-events-none fixed inset-0 z-50 flex items-end justify-center px-4 pb-4 sm:items-center sm:pb-0">
+          <Dialog.Content className="modal-shadow pointer-events-auto w-full max-w-2xl rounded-[1.75rem] border border-outline-variant/20 bg-surface-container-lowest p-6">
+            <Dialog.Title className="font-headline text-xl font-bold tracking-tight text-on-surface">
+              Create from existing
+            </Dialog.Title>
+            <Dialog.Description className="mt-2 text-sm leading-6 text-on-surface-variant">
+              Pick a quote to duplicate into a new draft.
+            </Dialog.Description>
+
+            <div className="mt-4">
+              <Input
+                label="Search existing quotes"
+                id="quote-reuse-search"
+                hideLabel
+                value={searchQuery}
+                onChange={(event) => setSearchQuery(event.target.value)}
+                placeholder="Search customer, title, or quote ID..."
+              />
+            </div>
+
+            <div className="mt-4 inline-flex rounded-full bg-surface-container-low p-1">
+              <button
+                type="button"
+                aria-pressed={activeTab === "recent"}
+                className={`cursor-pointer rounded-full px-4 py-2 text-sm font-semibold transition ${
+                  activeTab === "recent"
+                    ? "ghost-shadow bg-surface-container-lowest text-primary"
+                    : "text-on-surface-variant"
+                }`}
+                onClick={() => setActiveTab("recent")}
+              >
+                Recent
+              </button>
+              <button
+                type="button"
+                aria-pressed={activeTab === "all"}
+                className={`cursor-pointer rounded-full px-4 py-2 text-sm font-semibold transition ${
+                  activeTab === "all"
+                    ? "ghost-shadow bg-surface-container-lowest text-primary"
+                    : "text-on-surface-variant"
+                }`}
+                onClick={() => setActiveTab("all")}
+              >
+                All Quotes
+              </button>
+            </div>
+
+            <div className="mt-4 max-h-[52vh] space-y-3 overflow-y-auto pr-1">
+              {isLoading ? (
+                <div role="status" aria-label="Loading quotes" className="rounded-xl bg-surface-container-low p-4 text-sm text-on-surface-variant">
+                  Loading quotes...
+                </div>
+              ) : null}
+
+              {loadError ? (
+                <FeedbackMessage variant="error">{loadError}</FeedbackMessage>
+              ) : null}
+
+              {duplicateError ? (
+                <FeedbackMessage variant="error">{duplicateError}</FeedbackMessage>
+              ) : null}
+
+              {!isLoading && !loadError && visibleCandidates.length === 0 ? (
+                <section className="rounded-xl bg-surface-container-low p-4 text-sm text-on-surface-variant">
+                  {emptyStateMessage}
+                </section>
+              ) : null}
+
+              {!isLoading && !loadError ? (
+                <ul className="space-y-3">
+                  {visibleCandidates.map((candidate) => (
+                    <li key={candidate.id}>
+                      <button
+                        type="button"
+                        className="w-full cursor-pointer rounded-xl border border-outline-variant/30 bg-surface-container-low p-4 text-left transition-colors hover:bg-surface-container-lowest disabled:cursor-not-allowed disabled:opacity-70"
+                        disabled={duplicatingId !== null}
+                        onClick={() => { void onCandidateSelect(candidate.id); }}
+                      >
+                        <div className="flex items-baseline justify-between gap-3">
+                          <p className="font-headline font-bold text-on-surface">
+                            {candidate.customer_name ?? "Unassigned"}
+                          </p>
+                          <p className="font-headline font-bold text-on-surface">
+                            {formatCurrency(candidate.total_amount)}
+                          </p>
+                        </div>
+
+                        {candidate.title ? (
+                          <p className="mt-1 text-sm text-on-surface-variant">{candidate.title}</p>
+                        ) : null}
+
+                        <div className="mt-2 flex items-center gap-3">
+                          <p className="text-sm text-on-surface-variant">
+                            {candidate.doc_number}
+                            {" · "}
+                            {formatDate(candidate.created_at, timezone ?? null)}
+                          </p>
+                          <span className="ml-auto">
+                            <StatusBadge variant={candidate.status} />
+                          </span>
+                        </div>
+
+                        {candidate.line_item_previews.length > 0 ? (
+                          <ul className="mt-3 space-y-1">
+                            {candidate.line_item_previews.map((lineItem, index) => (
+                              <li key={`${candidate.id}-preview-${index}`} className="flex items-center justify-between gap-3 text-sm text-on-surface-variant">
+                                <span className="truncate">{lineItem.description}</span>
+                                <span className="shrink-0">{formatCurrency(lineItem.price)}</span>
+                              </li>
+                            ))}
+                          </ul>
+                        ) : (
+                          <p className="mt-3 text-sm text-on-surface-variant">No line items</p>
+                        )}
+
+                        {candidate.more_line_item_count > 0 ? (
+                          <p className="mt-1 text-sm font-semibold text-on-surface-variant">
+                            +{candidate.more_line_item_count} more items
+                          </p>
+                        ) : null}
+
+                        {duplicatingId === candidate.id ? (
+                          <p className="mt-2 text-sm font-semibold text-primary">Duplicating...</p>
+                        ) : null}
+                      </button>
+                    </li>
+                  ))}
+                </ul>
+              ) : null}
+            </div>
+
+            <div className="mt-6">
+              <button
+                type="button"
+                className="inline-flex min-h-12 w-full cursor-pointer items-center justify-center rounded-lg border border-outline-variant/30 bg-surface-container-low px-4 py-3 text-sm font-semibold text-on-surface transition-colors hover:bg-surface-container-lowest"
+                onClick={onClose}
+              >
+                Close
+              </button>
+            </div>
+          </Dialog.Content>
+        </div>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/frontend/src/features/quotes/hooks/useQuoteCreateFlow.tsx
+++ b/frontend/src/features/quotes/hooks/useQuoteCreateFlow.tsx
@@ -1,0 +1,80 @@
+import { useState } from "react";
+
+import { QuoteCreateEntrySheet } from "@/features/quotes/components/QuoteCreateEntrySheet";
+import { QuoteReuseChooser } from "@/features/quotes/components/QuoteReuseChooser";
+
+interface UseQuoteCreateFlowParams {
+  customerId?: string;
+  timezone?: string | null;
+  entrySheetTitle?: string;
+  entrySheetDescription?: string;
+  onCreateNew: () => void;
+  onQuoteDuplicated: (quoteId: string) => void;
+}
+
+interface QuoteCreateFlowController {
+  openCreateEntry: () => void;
+  dialogs: React.ReactElement;
+}
+
+export function useQuoteCreateFlow({
+  customerId,
+  timezone,
+  entrySheetTitle,
+  entrySheetDescription,
+  onCreateNew,
+  onQuoteDuplicated,
+}: UseQuoteCreateFlowParams): QuoteCreateFlowController {
+  const [isCreateEntryOpen, setIsCreateEntryOpen] = useState(false);
+  const [isReuseChooserOpen, setIsReuseChooserOpen] = useState(false);
+
+  function openCreateEntry(): void {
+    setIsCreateEntryOpen(true);
+  }
+
+  function closeCreateEntry(): void {
+    setIsCreateEntryOpen(false);
+  }
+
+  function closeReuseChooser(): void {
+    setIsReuseChooserOpen(false);
+  }
+
+  function onCreateFromExisting(): void {
+    setIsCreateEntryOpen(false);
+    setIsReuseChooserOpen(true);
+  }
+
+  function onCreateNewSelected(): void {
+    setIsCreateEntryOpen(false);
+    onCreateNew();
+  }
+
+  function onQuoteDuplicatedSelected(quoteId: string): void {
+    setIsReuseChooserOpen(false);
+    onQuoteDuplicated(quoteId);
+  }
+
+  return {
+    openCreateEntry,
+    dialogs: (
+      <>
+        <QuoteCreateEntrySheet
+          open={isCreateEntryOpen}
+          title={entrySheetTitle}
+          description={entrySheetDescription}
+          onClose={closeCreateEntry}
+          onCreateNew={onCreateNewSelected}
+          onCreateFromExisting={onCreateFromExisting}
+        />
+        <QuoteReuseChooser
+          open={isReuseChooserOpen}
+          customerId={customerId}
+          timezone={timezone}
+          onClose={closeReuseChooser}
+          onQuoteDuplicated={onQuoteDuplicatedSelected}
+        />
+      </>
+    ),
+  };
+}

--- a/frontend/src/features/quotes/services/quoteService.ts
+++ b/frontend/src/features/quotes/services/quoteService.ts
@@ -9,6 +9,7 @@ import type {
   QuoteCreateRequest,
   QuoteExtractResponse,
   QuoteListItem,
+  QuoteReuseCandidate,
   QuoteUpdateRequest,
 } from "@/features/quotes/types/quote.types";
 import { buildIdempotencyKey } from "@/shared/lib/idempotency";
@@ -118,8 +119,26 @@ function listQuotes(params?: { customer_id?: string }): Promise<QuoteListItem[]>
   return request<QuoteListItem[]>(`/api/quotes${query}`);
 }
 
+function listReuseCandidates(params?: { customer_id?: string; q?: string }): Promise<QuoteReuseCandidate[]> {
+  const queryParams = new URLSearchParams();
+  if (params?.customer_id) {
+    queryParams.set("customer_id", params.customer_id);
+  }
+  if (params?.q?.trim()) {
+    queryParams.set("q", params.q.trim());
+  }
+  const query = queryParams.toString();
+  return request<QuoteReuseCandidate[]>(`/api/quotes/reuse-candidates${query ? `?${query}` : ""}`);
+}
+
 function getQuote(id: string): Promise<QuoteDetail> {
   return request<QuoteDetail>(`/api/quotes/${id}`);
+}
+
+function duplicateQuote(id: string): Promise<Quote> {
+  return request<Quote>(`/api/quotes/${id}/duplicate`, {
+    method: "POST",
+  });
 }
 
 function updateQuote(id: string, data: QuoteUpdateRequest): Promise<Quote> {
@@ -202,6 +221,8 @@ export const quoteService = {
   convertNotes,
   createQuote,
   listQuotes,
+  listReuseCandidates,
+  duplicateQuote,
   getQuote,
   updateQuote,
   updateExtractionReviewMetadata,

--- a/frontend/src/features/quotes/tests/QuoteList.test.tsx
+++ b/frontend/src/features/quotes/tests/QuoteList.test.tsx
@@ -21,13 +21,24 @@ vi.mock("react-router-dom", async () => {
 
 vi.mock("@/features/quotes/services/quoteService", () => ({
   quoteService: {
+    extract: vi.fn(),
+    createManualDraft: vi.fn(),
     convertNotes: vi.fn(),
     createQuote: vi.fn(),
     listQuotes: vi.fn(),
+    listReuseCandidates: vi.fn(),
+    duplicateQuote: vi.fn(),
     getQuote: vi.fn(),
     updateQuote: vi.fn(),
+    updateExtractionReviewMetadata: vi.fn(),
+    deleteQuote: vi.fn(),
     generatePdf: vi.fn(),
     shareQuote: vi.fn(),
+    revokeShare: vi.fn(),
+    sendQuoteEmail: vi.fn(),
+    markQuoteWon: vi.fn(),
+    markQuoteLost: vi.fn(),
+    convertToInvoice: vi.fn(),
   },
 }));
 
@@ -475,15 +486,71 @@ describe("QuoteList", () => {
     expect(within(screen.getByRole("navigation")).getByRole("button", { name: /quotes/i })).toHaveClass("text-primary");
   });
 
-  it("navigates to new quote when FAB is clicked", async () => {
+  it("opens create entry sheet and starts a new quote from the create action", async () => {
     mockedQuoteService.listQuotes.mockResolvedValueOnce([makeQuoteListItem()]);
 
     renderScreen();
     await screen.findByText(/Q-001/);
 
     fireEvent.click(screen.getByRole("button", { name: "New quote" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Create new" }));
 
     expect(navigateMock).toHaveBeenCalledWith("/quotes/capture");
+  });
+
+  it("duplicates a selected quote from chooser and navigates to document edit", async () => {
+    mockedQuoteService.listQuotes.mockResolvedValueOnce([makeQuoteListItem()]);
+    mockedQuoteService.listReuseCandidates.mockResolvedValueOnce([
+      {
+        id: "quote-source-1",
+        title: "Spring Cleanup",
+        doc_number: "Q-099",
+        customer_id: "cust-1",
+        customer_name: "Alice Johnson",
+        total_amount: 320,
+        created_at: "2026-03-25T00:00:00.000Z",
+        status: "ready",
+        line_item_previews: [
+          { description: "Mulch", price: 120 },
+          { description: "Edge trim", price: 200 },
+        ],
+        line_item_count: 2,
+        more_line_item_count: 0,
+      },
+    ]);
+    mockedQuoteService.duplicateQuote.mockResolvedValueOnce({
+      id: "quote-duplicated-1",
+      customer_id: "cust-1",
+      doc_type: "quote",
+      doc_number: "Q-100",
+      title: "Spring Cleanup",
+      status: "draft",
+      source_type: "text",
+      transcript: "",
+      total_amount: 320,
+      tax_rate: null,
+      discount_type: null,
+      discount_value: null,
+      deposit_amount: null,
+      notes: null,
+      shared_at: null,
+      share_token: null,
+      line_items: [],
+      created_at: "2026-03-26T00:00:00.000Z",
+      updated_at: "2026-03-26T00:00:00.000Z",
+    });
+
+    renderScreen();
+    await screen.findByText(/Q-001/);
+
+    fireEvent.click(screen.getByRole("button", { name: "New quote" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Create from existing" }));
+    fireEvent.click(await screen.findByRole("button", { name: /spring cleanup/i }));
+
+    await waitFor(() => {
+      expect(mockedQuoteService.duplicateQuote).toHaveBeenCalledWith("quote-source-1");
+    });
+    expect(navigateMock).toHaveBeenCalledWith("/documents/quote-duplicated-1/edit");
   });
 
   it("renders invoice empty state when no invoices are returned", async () => {

--- a/frontend/src/features/quotes/tests/QuoteReuseChooser.test.tsx
+++ b/frontend/src/features/quotes/tests/QuoteReuseChooser.test.tsx
@@ -1,0 +1,137 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { QuoteReuseChooser } from "@/features/quotes/components/QuoteReuseChooser";
+import { quoteService } from "@/features/quotes/services/quoteService";
+
+vi.mock("@/features/quotes/services/quoteService", () => ({
+  quoteService: {
+    listReuseCandidates: vi.fn(),
+    duplicateQuote: vi.fn(),
+  },
+}));
+
+const mockedQuoteService = vi.mocked(quoteService);
+
+function makeReuseCandidate() {
+  return {
+    id: "quote-1",
+    title: "Backyard Refresh",
+    doc_number: "Q-001",
+    customer_id: "cust-1",
+    customer_name: "Evergreen Landscaping",
+    total_amount: 750,
+    created_at: "2026-03-25T00:00:00.000Z",
+    status: "shared" as const,
+    line_item_previews: [
+      { description: "Design plan", price: 120 },
+      { description: "Material staging", price: 240 },
+      { description: "Install edging", price: 310 },
+    ],
+    line_item_count: 4,
+    more_line_item_count: 1,
+  };
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("QuoteReuseChooser", () => {
+  it("renders reuse candidates with preview rows and overflow count", async () => {
+    mockedQuoteService.listReuseCandidates.mockResolvedValueOnce([makeReuseCandidate()]);
+
+    render(
+      <QuoteReuseChooser
+        open
+        timezone="UTC"
+        onClose={vi.fn()}
+        onQuoteDuplicated={vi.fn()}
+      />,
+    );
+
+    expect(await screen.findByRole("button", { name: /backyard refresh/i })).toBeInTheDocument();
+    expect(screen.getByText("Evergreen Landscaping")).toBeInTheDocument();
+    expect(screen.getByText(/Q-001\s*·\s*Mar 25, 2026/)).toBeInTheDocument();
+    expect(screen.getByText("Design plan")).toBeInTheDocument();
+    expect(screen.getByText("+1 more items")).toBeInTheDocument();
+    expect(mockedQuoteService.listReuseCandidates).toHaveBeenCalledWith({
+      customer_id: undefined,
+      q: undefined,
+    });
+  });
+
+  it("passes customer scope and search query to reuse-candidates API", async () => {
+    mockedQuoteService.listReuseCandidates.mockResolvedValue([]);
+
+    render(
+      <QuoteReuseChooser
+        open
+        customerId="cust-1"
+        timezone="UTC"
+        onClose={vi.fn()}
+        onQuoteDuplicated={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(mockedQuoteService.listReuseCandidates).toHaveBeenCalledWith({
+        customer_id: "cust-1",
+        q: undefined,
+      });
+    });
+
+    fireEvent.change(screen.getByLabelText("Search existing quotes"), {
+      target: { value: "evergreen" },
+    });
+
+    await waitFor(() => {
+      expect(mockedQuoteService.listReuseCandidates).toHaveBeenCalledWith({
+        customer_id: "cust-1",
+        q: "evergreen",
+      });
+    });
+  });
+
+  it("duplicates the selected quote and reports the new id", async () => {
+    const onQuoteDuplicated = vi.fn();
+    mockedQuoteService.listReuseCandidates.mockResolvedValueOnce([makeReuseCandidate()]);
+    mockedQuoteService.duplicateQuote.mockResolvedValueOnce({
+      id: "quote-2",
+      customer_id: "cust-1",
+      doc_type: "quote",
+      doc_number: "Q-002",
+      title: "Backyard Refresh",
+      status: "draft",
+      source_type: "text",
+      transcript: "",
+      total_amount: 750,
+      tax_rate: null,
+      discount_type: null,
+      discount_value: null,
+      deposit_amount: null,
+      notes: null,
+      shared_at: null,
+      share_token: null,
+      line_items: [],
+      created_at: "2026-03-26T00:00:00.000Z",
+      updated_at: "2026-03-26T00:00:00.000Z",
+    });
+
+    render(
+      <QuoteReuseChooser
+        open
+        timezone="UTC"
+        onClose={vi.fn()}
+        onQuoteDuplicated={onQuoteDuplicated}
+      />,
+    );
+
+    fireEvent.click(await screen.findByRole("button", { name: /backyard refresh/i }));
+
+    await waitFor(() => {
+      expect(mockedQuoteService.duplicateQuote).toHaveBeenCalledWith("quote-1");
+    });
+    expect(onQuoteDuplicated).toHaveBeenCalledWith("quote-2");
+  });
+});

--- a/frontend/src/features/quotes/types/quote.types.ts
+++ b/frontend/src/features/quotes/types/quote.types.ts
@@ -224,6 +224,25 @@ export interface QuoteListItem {
   created_at: string;
 }
 
+export interface QuoteReuseLineItemPreview {
+  description: string;
+  price: number | null;
+}
+
+export interface QuoteReuseCandidate {
+  id: string;
+  title: string | null;
+  doc_number: string;
+  customer_id: string | null;
+  customer_name: string | null;
+  total_amount: number | null;
+  created_at: string;
+  status: QuoteStatus;
+  line_item_previews: QuoteReuseLineItemPreview[];
+  line_item_count: number;
+  more_line_item_count: number;
+}
+
 export interface QuoteCreateRequest {
   customer_id: string;
   title: string | null;


### PR DESCRIPTION
## Summary
- add a create-entry sheet (`Create new` / `Create from existing`) for the home quote FAB and customer `Create Document` action
- add a reuse chooser modal with `Recent` and `All Quotes` views, search, line-item previews, and duplicate-in-place behavior
- wire chooser selection to `POST /api/quotes/{id}/duplicate` and navigate to `/documents/{newId}/edit`
- add frontend quote service/type support for reuse-candidates and duplicate endpoints
- add and update tests for quote list flow, customer flow, and chooser behavior

## Verification
- `cd frontend && npx vitest run src/features/quotes/tests/QuoteList.test.tsx`
- `cd frontend && npx vitest run src/features/quotes/tests/QuoteReuseChooser.test.tsx`
- `cd frontend && npx vitest run src/features/customers/tests/CustomerDetailScreen.test.tsx`
- `cd frontend && npx eslint src/features/quotes src/features/customers`
- `make frontend-verify`

Closes #466