### PR TITLE
Task #475: fix draft review save compatibility for manual + duplicate quotes

### DIFF
--- a/backend/app/features/quotes/creation/service.py
+++ b/backend/app/features/quotes/creation/service.py
@@ -288,8 +288,8 @@ class QuoteCreationService:
                 description=line_item.description,
                 details=line_item.details,
                 price=document_field_float_or_none(line_item.price),
-                flagged=line_item.flagged,
-                flag_reason=line_item.flag_reason,
+                flagged=False,
+                flag_reason=None,
             )
             for line_item in source_quote.line_items
         ]

--- a/backend/app/features/quotes/tests/test_quote_duplication.py
+++ b/backend/app/features/quotes/tests/test_quote_duplication.py
@@ -148,6 +148,7 @@ async def test_duplicate_quote_copies_fields_and_resets_state(
     assert duplicate_payload["shared_at"] is None
     assert duplicate_payload["share_token"] is None
 
+    assert any(item["flagged"] is True for item in patched_source_payload["line_items"])
     assert len(duplicate_payload["line_items"]) == len(patched_source_payload["line_items"])
     for duplicate_item, source_item in zip(
         duplicate_payload["line_items"],
@@ -158,8 +159,8 @@ async def test_duplicate_quote_copies_fields_and_resets_state(
         assert duplicate_item["description"] == source_item["description"]
         assert duplicate_item["details"] == source_item["details"]
         assert duplicate_item["price"] == source_item["price"]
-        assert duplicate_item["flagged"] == source_item["flagged"]
-        assert duplicate_item["flag_reason"] == source_item["flag_reason"]
+        assert duplicate_item["flagged"] is False
+        assert duplicate_item["flag_reason"] is None
         assert duplicate_item["sort_order"] == source_item["sort_order"]
 
     source_detail_response = await client.get(f"/api/quotes/{source_quote_id}")
@@ -189,6 +190,8 @@ async def test_duplicate_quote_copies_fields_and_resets_state(
         "pricing_pending": False,
     }
     assert duplicate_detail["extraction_review_metadata"]["hidden_details"] == {"items": []}
+    assert all(item["flagged"] is False for item in duplicate_detail["line_items"])
+    assert all(item["flag_reason"] is None for item in duplicate_detail["line_items"])
 
     duplicate_document = await db_session.get(Document, UUID(duplicate_payload["id"]))
     assert duplicate_document is not None

--- a/frontend/src/features/quotes/components/documentEditUtils.ts
+++ b/frontend/src/features/quotes/components/documentEditUtils.ts
@@ -81,7 +81,6 @@ export async function persistDocumentDraft(options: {
 
   const payload: QuoteUpdateRequest = {
     title: normalizeOptionalTitle(draft.title),
-    transcript: draft.transcript ?? "",
     line_items: lineItemsForSubmit,
     total_amount: draft.total,
     tax_rate: draft.taxRate,
@@ -90,6 +89,9 @@ export async function persistDocumentDraft(options: {
     deposit_amount: draft.depositAmount,
     notes: draft.notes.trim().length > 0 ? draft.notes.trim() : null,
     doc_type: draft.docType,
+    ...(draft.transcript.trim().length > 0
+      ? { transcript: draft.transcript }
+      : {}),
     ...(draft.docType === "invoice" && draft.dueDate.trim().length > 0
       ? { due_date: draft.dueDate }
       : {}),

--- a/frontend/src/features/quotes/tests/ReviewScreen.test.tsx
+++ b/frontend/src/features/quotes/tests/ReviewScreen.test.tsx
@@ -818,6 +818,44 @@ describe("DocumentEditScreen", () => {
     });
   });
 
+  it("omits transcript from quote updates when draft transcript is empty or whitespace", async () => {
+    renderScreen({
+      document: makeQuote({
+        transcript: "   \n\t  ",
+      }),
+    });
+
+    fireEvent.click(await screen.findByRole("button", { name: /continue to preview/i }));
+
+    await waitFor(() => {
+      expect(mockedQuoteService.updateQuote).toHaveBeenCalledTimes(1);
+    });
+
+    const payload = mockedQuoteService.updateQuote.mock.calls[0]?.[1] as Record<string, unknown>;
+    expect(payload).toBeDefined();
+    expect(payload).not.toHaveProperty("transcript");
+  });
+
+  it("keeps transcript in quote updates when draft transcript has non-whitespace content", async () => {
+    renderScreen({
+      document: makeQuote({
+        transcript: "  Captured transcript text.  ",
+      }),
+    });
+
+    fireEvent.click(await screen.findByRole("button", { name: /continue to preview/i }));
+
+    await waitFor(() => {
+      expect(mockedQuoteService.updateQuote).toHaveBeenCalledTimes(1);
+    });
+
+    const payload = mockedQuoteService.updateQuote.mock.calls[0]?.[1] as Record<string, unknown>;
+    expect(payload).toBeDefined();
+    expect(payload).toMatchObject({
+      transcript: "  Captured transcript text.  ",
+    });
+  });
+
   it("saves invoice edits through invoice endpoint when document starts as invoice", async () => {
     renderScreen({ document: makeInvoice() });
 


### PR DESCRIPTION
## Summary
- omit `transcript` from quote PATCH payloads when the draft transcript is empty/whitespace in review save/continue
- reset duplicated quote line-item review flags to `flagged=false` and `flag_reason=null`
- add regression coverage for both behaviors in review and duplication tests

## Verification
- cd frontend && npx vitest run src/features/quotes/tests/ReviewScreen.test.tsx
- cd backend && .venv/bin/pytest app/features/quotes/tests/test_quote_duplication.py -x --tb=short
- make backend-static-verify
- make frontend-verify
- make backend-verify

Closes #475