### PR TITLE
Task #467: Add line-item catalog backend CRUD APIs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ backend-static-verify: ## Run backend boundaries, lint, type checks, and securit
 		.venv/bin/ruff check . --cache-dir .ruff_cache && \
 		.venv/bin/ruff format --check . && \
 		.venv/bin/mypy . --cache-dir .mypy_cache && \
-		.venv/bin/bandit -r app/ -x app/core/tests,app/features/auth/tests,app/features/customers/tests,app/features/invoices/tests,app/features/profile/tests,app/features/quotes/tests,app/shared/tests
+		.venv/bin/bandit -r app/ -x app/core/tests,app/features/auth/tests,app/features/customers/tests,app/features/invoices/tests,app/features/line_item_catalog/tests,app/features/profile/tests,app/features/quotes/tests,app/shared/tests
 
 backend-test-verify: ## Run backend pytest suite (excluding live/eval markers)
 	@test -x backend/.venv/bin/pytest || (echo "Missing backend/.venv. Run: cd backend && python3 -m venv .venv && .venv/bin/pip install -r requirements.txt" && exit 1)

--- a/backend/alembic/versions/20260420_0027_add_line_item_catalog_items_table.py
+++ b/backend/alembic/versions/20260420_0027_add_line_item_catalog_items_table.py
@@ -1,0 +1,64 @@
+"""Add line-item catalog items table.
+
+Revision ID: 20260420_0027
+Revises: 20260418_0026
+Create Date: 2026-04-20
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = "20260420_0027"
+down_revision: str | None = "20260418_0026"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "line_item_catalog_items",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("user_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("title", sa.String(length=255), nullable=False),
+        sa.Column("details", sa.Text(), nullable=True),
+        sa.Column("default_price", sa.Numeric(precision=10, scale=2), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.CheckConstraint("btrim(title) <> ''", name="ck_line_item_catalog_items_title_non_blank"),
+        sa.CheckConstraint(
+            "default_price IS NULL OR default_price >= 0",
+            name="ck_line_item_catalog_items_default_price_non_negative",
+        ),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        op.f("ix_line_item_catalog_items_user_id"),
+        "line_item_catalog_items",
+        ["user_id"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        op.f("ix_line_item_catalog_items_user_id"),
+        table_name="line_item_catalog_items",
+    )
+    op.drop_table("line_item_catalog_items")

--- a/backend/app/features/line_item_catalog/__init__.py
+++ b/backend/app/features/line_item_catalog/__init__.py
@@ -1,0 +1,1 @@
+"""Line-item catalog feature package."""

--- a/backend/app/features/line_item_catalog/api.py
+++ b/backend/app/features/line_item_catalog/api.py
@@ -1,0 +1,103 @@
+"""Line-item catalog API endpoints."""
+
+from __future__ import annotations
+
+from typing import Annotated
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, status
+
+from app.features.auth.models import User
+from app.features.line_item_catalog.schemas import (
+    LineItemCatalogCreateRequest,
+    LineItemCatalogItemResponse,
+    LineItemCatalogUpdateRequest,
+)
+from app.features.line_item_catalog.service import (
+    LineItemCatalogService,
+    LineItemCatalogServiceError,
+)
+from app.shared.dependencies import (
+    get_current_user,
+    get_line_item_catalog_service,
+    require_csrf,
+)
+
+router = APIRouter(prefix="/line-item-catalog", tags=["line-item-catalog"])
+
+
+@router.get("", response_model=list[LineItemCatalogItemResponse])
+async def list_line_item_catalog(
+    user: Annotated[User, Depends(get_current_user)],
+    line_item_catalog_service: Annotated[
+        LineItemCatalogService,
+        Depends(get_line_item_catalog_service),
+    ],
+) -> list[LineItemCatalogItemResponse]:
+    """List line-item catalog entries for the authenticated user."""
+    items = await line_item_catalog_service.list_items(user)
+    return [LineItemCatalogItemResponse.model_validate(item) for item in items]
+
+
+@router.post(
+    "",
+    response_model=LineItemCatalogItemResponse,
+    status_code=status.HTTP_201_CREATED,
+    dependencies=[Depends(require_csrf)],
+)
+async def create_line_item_catalog(
+    payload: LineItemCatalogCreateRequest,
+    user: Annotated[User, Depends(get_current_user)],
+    line_item_catalog_service: Annotated[
+        LineItemCatalogService,
+        Depends(get_line_item_catalog_service),
+    ],
+) -> LineItemCatalogItemResponse:
+    """Create one line-item catalog entry for the authenticated user."""
+    try:
+        item = await line_item_catalog_service.create_item(user, payload)
+    except LineItemCatalogServiceError as exc:
+        raise HTTPException(status_code=exc.status_code, detail=exc.detail) from exc
+    return LineItemCatalogItemResponse.model_validate(item)
+
+
+@router.patch(
+    "/{item_id}",
+    response_model=LineItemCatalogItemResponse,
+    dependencies=[Depends(require_csrf)],
+)
+async def update_line_item_catalog(
+    item_id: UUID,
+    payload: LineItemCatalogUpdateRequest,
+    user: Annotated[User, Depends(get_current_user)],
+    line_item_catalog_service: Annotated[
+        LineItemCatalogService,
+        Depends(get_line_item_catalog_service),
+    ],
+) -> LineItemCatalogItemResponse:
+    """Update one line-item catalog entry for the authenticated user."""
+    try:
+        item = await line_item_catalog_service.update_item(user, item_id, payload)
+    except LineItemCatalogServiceError as exc:
+        raise HTTPException(status_code=exc.status_code, detail=exc.detail) from exc
+    return LineItemCatalogItemResponse.model_validate(item)
+
+
+@router.delete(
+    "/{item_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    dependencies=[Depends(require_csrf)],
+)
+async def delete_line_item_catalog(
+    item_id: UUID,
+    user: Annotated[User, Depends(get_current_user)],
+    line_item_catalog_service: Annotated[
+        LineItemCatalogService,
+        Depends(get_line_item_catalog_service),
+    ],
+) -> None:
+    """Delete one line-item catalog entry for the authenticated user."""
+    try:
+        await line_item_catalog_service.delete_item(user, item_id)
+    except LineItemCatalogServiceError as exc:
+        raise HTTPException(status_code=exc.status_code, detail=exc.detail) from exc

--- a/backend/app/features/line_item_catalog/models.py
+++ b/backend/app/features/line_item_catalog/models.py
@@ -1,0 +1,46 @@
+"""Line-item catalog persistence model."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from decimal import Decimal
+from uuid import UUID, uuid4
+
+import sqlalchemy as sa
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.database import Base
+
+
+class LineItemCatalogItem(Base):
+    """Reusable line-item preset owned by one authenticated user."""
+
+    __tablename__ = "line_item_catalog_items"
+    __table_args__ = (
+        sa.CheckConstraint("btrim(title) <> ''", name="ck_line_item_catalog_items_title_non_blank"),
+        sa.CheckConstraint(
+            "default_price IS NULL OR default_price >= 0",
+            name="ck_line_item_catalog_items_default_price_non_negative",
+        ),
+    )
+
+    id: Mapped[UUID] = mapped_column(sa.Uuid, primary_key=True, default=uuid4)
+    user_id: Mapped[UUID] = mapped_column(
+        sa.ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    title: Mapped[str] = mapped_column(sa.String(255), nullable=False)
+    details: Mapped[str | None] = mapped_column(sa.Text, nullable=True)
+    default_price: Mapped[Decimal | None] = mapped_column(sa.Numeric(10, 2), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        sa.DateTime(timezone=True),
+        nullable=False,
+        server_default=sa.func.now(),
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        sa.DateTime(timezone=True),
+        nullable=False,
+        server_default=sa.func.now(),
+        onupdate=sa.func.now(),
+    )

--- a/backend/app/features/line_item_catalog/repository.py
+++ b/backend/app/features/line_item_catalog/repository.py
@@ -1,0 +1,81 @@
+"""Line-item catalog repository operations."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.features.line_item_catalog.models import LineItemCatalogItem
+
+
+class LineItemCatalogRepository:
+    """Persist and query line-item presets with async SQLAlchemy sessions."""
+
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def list_by_user(self, user_id: UUID) -> list[LineItemCatalogItem]:
+        """Return all catalog items owned by the given user newest-first."""
+        result = await self._session.scalars(
+            select(LineItemCatalogItem)
+            .where(LineItemCatalogItem.user_id == user_id)
+            .order_by(LineItemCatalogItem.created_at.desc(), LineItemCatalogItem.id.desc())
+        )
+        return list(result)
+
+    async def get_by_id(
+        self,
+        item_id: UUID,
+        user_id: UUID,
+    ) -> LineItemCatalogItem | None:
+        """Return one user-owned catalog item."""
+        result = await self._session.execute(
+            select(LineItemCatalogItem).where(
+                LineItemCatalogItem.id == item_id,
+                LineItemCatalogItem.user_id == user_id,
+            )
+        )
+        return result.scalar_one_or_none()
+
+    async def create(
+        self,
+        *,
+        user_id: UUID,
+        title: str,
+        details: str | None,
+        default_price: Decimal | None,
+    ) -> LineItemCatalogItem:
+        """Create a catalog item for one user."""
+        item = LineItemCatalogItem(
+            user_id=user_id,
+            title=title,
+            details=details,
+            default_price=default_price,
+        )
+        self._session.add(item)
+        await self._session.flush()
+        await self._session.refresh(item)
+        return item
+
+    async def update(
+        self,
+        item: LineItemCatalogItem,
+        **fields: str | Decimal | None,
+    ) -> LineItemCatalogItem:
+        """Apply field updates to one catalog item."""
+        for field_name, value in fields.items():
+            setattr(item, field_name, value)
+        await self._session.flush()
+        await self._session.refresh(item)
+        return item
+
+    async def delete(self, item: LineItemCatalogItem) -> None:
+        """Delete one catalog item entity."""
+        await self._session.delete(item)
+
+    async def commit(self) -> None:
+        """Commit pending catalog writes."""
+        await self._session.commit()

--- a/backend/app/features/line_item_catalog/schemas.py
+++ b/backend/app/features/line_item_catalog/schemas.py
@@ -1,0 +1,62 @@
+"""Request and response schemas for line-item catalog endpoints."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from decimal import Decimal
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+
+def _normalize_required_title(value: str) -> str:
+    trimmed = value.strip()
+    if not trimmed:
+        raise ValueError("title cannot be blank")
+    return trimmed
+
+
+def _normalize_optional_title(value: object) -> object:
+    if value is None or not isinstance(value, str):
+        return value
+    return _normalize_required_title(value)
+
+
+class LineItemCatalogCreateRequest(BaseModel):
+    """Request payload for catalog item creation."""
+
+    title: str = Field(min_length=1, max_length=255)
+    details: str | None = None
+    default_price: Decimal | None = Field(default=None, ge=0)
+
+    _normalize_title = field_validator("title", mode="before")(_normalize_required_title)
+
+
+class LineItemCatalogUpdateRequest(BaseModel):
+    """Request payload for partial catalog item updates."""
+
+    title: str | None = Field(default=None, min_length=1, max_length=255)
+    details: str | None = None
+    default_price: Decimal | None = Field(default=None, ge=0)
+
+    _normalize_title = field_validator("title", mode="before")(_normalize_optional_title)
+
+    @model_validator(mode="after")
+    def validate_title_is_not_null_when_provided(self) -> LineItemCatalogUpdateRequest:
+        """Reject explicit null for title while still allowing omitted field."""
+        if "title" in self.model_fields_set and self.title is None:
+            raise ValueError("title cannot be null")
+        return self
+
+
+class LineItemCatalogItemResponse(BaseModel):
+    """Serializable catalog item payload returned by API endpoints."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+    title: str
+    details: str | None
+    default_price: Decimal | None
+    created_at: datetime
+    updated_at: datetime

--- a/backend/app/features/line_item_catalog/service.py
+++ b/backend/app/features/line_item_catalog/service.py
@@ -1,0 +1,107 @@
+"""Line-item catalog service orchestration."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Protocol
+from uuid import UUID
+
+from app.features.auth.models import User
+from app.features.line_item_catalog.models import LineItemCatalogItem
+from app.features.line_item_catalog.schemas import (
+    LineItemCatalogCreateRequest,
+    LineItemCatalogUpdateRequest,
+)
+
+
+class LineItemCatalogServiceError(Exception):
+    """Catalog-domain exception mapped to an HTTP status code."""
+
+    def __init__(self, *, detail: str, status_code: int) -> None:
+        super().__init__(detail)
+        self.detail = detail
+        self.status_code = status_code
+
+
+class LineItemCatalogRepositoryProtocol(Protocol):
+    """Structural protocol for line-item catalog repository dependencies."""
+
+    async def list_by_user(self, user_id: UUID) -> list[LineItemCatalogItem]: ...
+
+    async def get_by_id(
+        self,
+        item_id: UUID,
+        user_id: UUID,
+    ) -> LineItemCatalogItem | None: ...
+
+    async def create(
+        self,
+        *,
+        user_id: UUID,
+        title: str,
+        details: str | None,
+        default_price: Decimal | None,
+    ) -> LineItemCatalogItem: ...
+
+    async def update(
+        self,
+        item: LineItemCatalogItem,
+        **fields: str | Decimal | None,
+    ) -> LineItemCatalogItem: ...
+
+    async def delete(self, item: LineItemCatalogItem) -> None: ...
+
+    async def commit(self) -> None: ...
+
+
+class LineItemCatalogService:
+    """Coordinate line-item catalog domain rules with persistence operations."""
+
+    def __init__(self, repository: LineItemCatalogRepositoryProtocol) -> None:
+        self._repository = repository
+
+    async def list_items(self, user: User) -> list[LineItemCatalogItem]:
+        """Return all catalog items for the authenticated user."""
+        return await self._repository.list_by_user(user.id)
+
+    async def create_item(
+        self,
+        user: User,
+        data: LineItemCatalogCreateRequest,
+    ) -> LineItemCatalogItem:
+        """Create a catalog item owned by the authenticated user."""
+        item = await self._repository.create(
+            user_id=user.id,
+            title=data.title,
+            details=data.details,
+            default_price=data.default_price,
+        )
+        await self._repository.commit()
+        return item
+
+    async def update_item(
+        self,
+        user: User,
+        item_id: UUID,
+        data: LineItemCatalogUpdateRequest,
+    ) -> LineItemCatalogItem:
+        """Update one user-owned catalog item or raise not found."""
+        item = await self._repository.get_by_id(item_id, user.id)
+        if item is None:
+            raise LineItemCatalogServiceError(detail="Not found", status_code=404)
+
+        update_fields = data.model_dump(exclude_unset=True)
+        if not update_fields:
+            return item
+
+        updated_item = await self._repository.update(item, **update_fields)
+        await self._repository.commit()
+        return updated_item
+
+    async def delete_item(self, user: User, item_id: UUID) -> None:
+        """Delete one user-owned catalog item or raise not found."""
+        item = await self._repository.get_by_id(item_id, user.id)
+        if item is None:
+            raise LineItemCatalogServiceError(detail="Not found", status_code=404)
+        await self._repository.delete(item)
+        await self._repository.commit()

--- a/backend/app/features/line_item_catalog/tests/__init__.py
+++ b/backend/app/features/line_item_catalog/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Line-item catalog feature tests."""

--- a/backend/app/features/line_item_catalog/tests/test_line_item_catalog_api.py
+++ b/backend/app/features/line_item_catalog/tests/test_line_item_catalog_api.py
@@ -1,0 +1,269 @@
+"""Line-item catalog API behavior tests for CRUD and ownership scoping."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from uuid import uuid4
+
+import pytest
+from httpx import AsyncClient
+
+from app.features.auth.service import CSRF_COOKIE_NAME
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_line_item_catalog_crud_flow(client: AsyncClient) -> None:
+    csrf_token = await _register_and_login(client, _credentials())
+
+    create_response = await client.post(
+        "/api/line-item-catalog",
+        json={
+            "title": "  Spring Cleanup  ",
+            "details": None,
+            "default_price": None,
+        },
+        headers={"X-CSRF-Token": csrf_token},
+    )
+
+    assert create_response.status_code == 201
+    created_item = create_response.json()
+    item_id = created_item["id"]
+    assert created_item["title"] == "Spring Cleanup"
+    assert created_item["details"] is None
+    assert created_item["default_price"] is None
+
+    list_response = await client.get("/api/line-item-catalog")
+    assert list_response.status_code == 200
+    listed_items = list_response.json()
+    assert len(listed_items) == 1
+    assert listed_items[0]["id"] == item_id
+
+    update_response = await client.patch(
+        f"/api/line-item-catalog/{item_id}",
+        json={
+            "title": "  Mulch Refresh  ",
+            "details": "Front beds and tree rings",
+            "default_price": 225.5,
+        },
+        headers={"X-CSRF-Token": csrf_token},
+    )
+
+    assert update_response.status_code == 200
+    updated_item = update_response.json()
+    assert updated_item["title"] == "Mulch Refresh"
+    assert updated_item["details"] == "Front beds and tree rings"
+    assert updated_item["default_price"] == "225.50"
+
+    delete_response = await client.delete(
+        f"/api/line-item-catalog/{item_id}",
+        headers={"X-CSRF-Token": csrf_token},
+    )
+
+    assert delete_response.status_code == 204
+    assert delete_response.content == b""
+
+    final_list_response = await client.get("/api/line-item-catalog")
+    assert final_list_response.status_code == 200
+    assert final_list_response.json() == []
+
+
+async def test_list_line_item_catalog_returns_newest_first(client: AsyncClient) -> None:
+    csrf_token = await _register_and_login(client, _credentials())
+
+    first_item = await _create_catalog_item(
+        client,
+        csrf_token,
+        {"title": "First item", "details": None, "default_price": 10},
+    )
+    second_item = await _create_catalog_item(
+        client,
+        csrf_token,
+        {"title": "Second item", "details": None, "default_price": 20},
+    )
+
+    response = await client.get("/api/line-item-catalog")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert {item["id"] for item in payload} == {first_item["id"], second_item["id"]}
+
+    created_at_values = [datetime.fromisoformat(item["created_at"]) for item in payload]
+    assert created_at_values == sorted(created_at_values, reverse=True)
+
+
+async def test_list_line_item_catalog_is_scoped_to_authenticated_user(
+    client: AsyncClient,
+) -> None:
+    csrf_token_user_a = await _register_and_login(client, _credentials())
+    await _create_catalog_item(
+        client,
+        csrf_token_user_a,
+        {"title": "User A item", "details": None, "default_price": 33},
+    )
+
+    await _register_and_login(client, _credentials())
+    response = await client.get("/api/line-item-catalog")
+
+    assert response.status_code == 200
+    assert response.json() == []
+
+
+async def test_patch_line_item_catalog_returns_404_for_different_users_item(
+    client: AsyncClient,
+) -> None:
+    csrf_token_user_a = await _register_and_login(client, _credentials())
+    created_item = await _create_catalog_item(
+        client,
+        csrf_token_user_a,
+        {"title": "User A item", "details": None, "default_price": 99},
+    )
+
+    csrf_token_user_b = await _register_and_login(client, _credentials())
+    response = await client.patch(
+        f"/api/line-item-catalog/{created_item['id']}",
+        json={"title": "Hijacked"},
+        headers={"X-CSRF-Token": csrf_token_user_b},
+    )
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Not found"}
+
+
+async def test_delete_line_item_catalog_returns_404_for_different_users_item(
+    client: AsyncClient,
+) -> None:
+    csrf_token_user_a = await _register_and_login(client, _credentials())
+    created_item = await _create_catalog_item(
+        client,
+        csrf_token_user_a,
+        {"title": "User A item", "details": None, "default_price": 99},
+    )
+
+    csrf_token_user_b = await _register_and_login(client, _credentials())
+    response = await client.delete(
+        f"/api/line-item-catalog/{created_item['id']}",
+        headers={"X-CSRF-Token": csrf_token_user_b},
+    )
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Not found"}
+
+
+async def test_post_line_item_catalog_rejects_blank_title(client: AsyncClient) -> None:
+    csrf_token = await _register_and_login(client, _credentials())
+
+    response = await client.post(
+        "/api/line-item-catalog",
+        json={"title": "   ", "details": None, "default_price": 12},
+        headers={"X-CSRF-Token": csrf_token},
+    )
+
+    assert response.status_code == 422
+
+
+async def test_patch_line_item_catalog_rejects_blank_title(client: AsyncClient) -> None:
+    csrf_token = await _register_and_login(client, _credentials())
+    created_item = await _create_catalog_item(
+        client,
+        csrf_token,
+        {"title": "Original item", "details": None, "default_price": 99},
+    )
+
+    response = await client.patch(
+        f"/api/line-item-catalog/{created_item['id']}",
+        json={"title": " "},
+        headers={"X-CSRF-Token": csrf_token},
+    )
+
+    assert response.status_code == 422
+
+
+async def test_post_line_item_catalog_rejects_negative_default_price(
+    client: AsyncClient,
+) -> None:
+    csrf_token = await _register_and_login(client, _credentials())
+
+    response = await client.post(
+        "/api/line-item-catalog",
+        json={"title": "Cleanup", "details": "notes", "default_price": -1},
+        headers={"X-CSRF-Token": csrf_token},
+    )
+
+    assert response.status_code == 422
+
+
+async def test_patch_line_item_catalog_rejects_negative_default_price(
+    client: AsyncClient,
+) -> None:
+    csrf_token = await _register_and_login(client, _credentials())
+    created_item = await _create_catalog_item(
+        client,
+        csrf_token,
+        {"title": "Cleanup", "details": "notes", "default_price": 10},
+    )
+
+    response = await client.patch(
+        f"/api/line-item-catalog/{created_item['id']}",
+        json={"default_price": -1},
+        headers={"X-CSRF-Token": csrf_token},
+    )
+
+    assert response.status_code == 422
+
+
+async def test_post_line_item_catalog_accepts_nullable_details_and_default_price(
+    client: AsyncClient,
+) -> None:
+    csrf_token = await _register_and_login(client, _credentials())
+
+    response = await client.post(
+        "/api/line-item-catalog",
+        json={"title": "Seasonal Touch-up", "details": None, "default_price": None},
+        headers={"X-CSRF-Token": csrf_token},
+    )
+
+    assert response.status_code == 201
+    payload = response.json()
+    assert payload["details"] is None
+    assert payload["default_price"] is None
+
+
+async def test_get_line_item_catalog_requires_authentication(client: AsyncClient) -> None:
+    client.cookies.clear()
+
+    response = await client.get("/api/line-item-catalog")
+
+    assert response.status_code == 401
+
+
+async def _register_and_login(client: AsyncClient, credentials: dict[str, str]) -> str:
+    register_response = await client.post("/api/auth/register", json=credentials)
+    assert register_response.status_code == 201
+    login_response = await client.post("/api/auth/login", json=credentials)
+    assert login_response.status_code == 200
+    csrf_token = client.cookies.get(CSRF_COOKIE_NAME)
+    assert csrf_token is not None
+    return csrf_token
+
+
+async def _create_catalog_item(
+    client: AsyncClient,
+    csrf_token: str,
+    payload: dict[str, object],
+) -> dict[str, object]:
+    response = await client.post(
+        "/api/line-item-catalog",
+        json=payload,
+        headers={"X-CSRF-Token": csrf_token},
+    )
+    assert response.status_code == 201
+    return response.json()
+
+
+def _credentials() -> dict[str, str]:
+    suffix = uuid4().hex[:12]
+    return {
+        "email": f"user-{suffix}@example.com",
+        "password": "StrongPass123!",
+    }

--- a/backend/app/features/registry.py
+++ b/backend/app/features/registry.py
@@ -6,4 +6,5 @@ from app.features.auth import models as auth_models  # noqa: F401
 from app.features.customers import models as customer_models  # noqa: F401
 from app.features.event_logs import models as event_log_models  # noqa: F401
 from app.features.jobs import models as job_models  # noqa: F401
+from app.features.line_item_catalog import models as line_item_catalog_models  # noqa: F401
 from app.features.quotes import models as quote_models  # noqa: F401

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -26,6 +26,7 @@ from app.features.customers.api import router as customer_router
 from app.features.invoices.api import router as invoice_router
 from app.features.jobs.api import router as jobs_router
 from app.features.jobs.reaper import run_stale_extraction_job_reaper
+from app.features.line_item_catalog.api import router as line_item_catalog_router
 from app.features.profile.api import router as profile_router
 from app.features.quotes.api import public_router as quote_public_router
 from app.features.quotes.api import router as quote_router
@@ -155,6 +156,11 @@ def create_app() -> FastAPI:
     app.include_router(profile_router, prefix="/api", dependencies=[Depends(bind_request_context)])
     app.include_router(
         customer_router,
+        prefix="/api",
+        dependencies=[Depends(bind_request_context)],
+    )
+    app.include_router(
+        line_item_catalog_router,
         prefix="/api",
         dependencies=[Depends(bind_request_context)],
     )

--- a/backend/app/shared/dependencies.py
+++ b/backend/app/shared/dependencies.py
@@ -30,6 +30,8 @@ from app.features.invoices.repository import InvoiceRepository
 from app.features.invoices.service import InvoiceService
 from app.features.jobs.repository import JobRepository
 from app.features.jobs.service import JobService
+from app.features.line_item_catalog.repository import LineItemCatalogRepository
+from app.features.line_item_catalog.service import LineItemCatalogService
 from app.features.profile.repository import ProfileRepository
 from app.features.profile.service import ProfileService
 from app.features.quotes.email_delivery_service import QuoteEmailDeliveryService
@@ -144,6 +146,13 @@ def get_customer_service(
         pdf_artifact_repository=PdfArtifactRepository(db),
         storage_service=storage_service,
     )
+
+
+def get_line_item_catalog_service(
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> LineItemCatalogService:
+    """Build a request-scoped line-item catalog service wired to the DB session."""
+    return LineItemCatalogService(repository=LineItemCatalogRepository(db))
 
 
 def get_quote_service(


### PR DESCRIPTION
## Summary
- add new `line_item_catalog` backend feature module with SQLAlchemy model, repository, service, schemas, and API routes
- add migration `20260420_0027` creating `line_item_catalog_items` with ownership FK and DB constraints for non-blank titles and non-negative `default_price`
- wire feature into router/dependency/model registry and add end-to-end API integration tests for CRUD, validation, and ownership boundaries
- update backend static bandit excludes to cover the new feature test path

## Verification
- `cd backend && .venv/bin/pytest app/features/line_item_catalog/tests/test_line_item_catalog_api.py -x --tb=short`
- `make backend-static-verify`
- `cd backend && .venv/bin/alembic upgrade head`
- `make backend-verify`

Closes #467