### PR TITLE
Task 468: integrate line-item catalog frontend flow

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -19,6 +19,7 @@ import { InvoiceDetailScreen } from "@/features/invoices/components/InvoiceDetai
 import { LandingPage } from "@/features/marketing/components/LandingPage";
 import { PublicQuotePage } from "@/features/public/components/PublicQuotePage";
 import { OnboardingForm } from "@/features/profile/components/OnboardingForm";
+import { LineItemCatalogSettingsScreen } from "@/features/line-item-catalog/components/LineItemCatalogSettingsScreen";
 import { CaptureScreen } from "@/features/quotes/components/CaptureScreen";
 import { DocumentEditScreen } from "@/features/quotes/components/ReviewScreen";
 import { QuoteList } from "@/features/quotes/components/QuoteList";
@@ -130,6 +131,7 @@ export default function App(): React.ReactElement {
         <Route path="/customers/new" element={<CustomerCreateScreen />} />
         <Route path="/customers/:id" element={<CustomerDetailScreen />} />
         <Route path="/settings" element={<SettingsScreen />} />
+        <Route path="/settings/line-item-catalog" element={<LineItemCatalogSettingsScreen />} />
         <Route path="/invoices/:id" element={<InvoiceDetailScreen />} />
         <Route path="/invoices/:id/edit" element={<InvoiceEditRedirect />} />
         <Route path="/invoices/:id/edit/line-items/:lineItemIndex/edit" element={<InvoiceEditRedirect />} />

--- a/frontend/src/features/line-item-catalog/components/LineItemCatalogSettingsScreen.tsx
+++ b/frontend/src/features/line-item-catalog/components/LineItemCatalogSettingsScreen.tsx
@@ -1,0 +1,343 @@
+import { useEffect, useMemo, useState } from "react";
+import { useNavigate } from "react-router-dom";
+
+import { lineItemCatalogService } from "@/features/line-item-catalog/services/lineItemCatalogService";
+import type { LineItemCatalogItem } from "@/features/line-item-catalog/types/lineItemCatalog.types";
+import { BottomNav } from "@/shared/components/BottomNav";
+import { Button } from "@/shared/components/Button";
+import { ConfirmModal } from "@/shared/components/ConfirmModal";
+import { FeedbackMessage } from "@/shared/components/FeedbackMessage";
+import { ScreenHeader } from "@/shared/components/ScreenHeader";
+import { Toast } from "@/shared/components/Toast";
+
+interface ParsedPriceInput {
+  value: number | null;
+  error: string | null;
+}
+
+function parsePriceInput(priceInput: string): ParsedPriceInput {
+  const trimmed = priceInput.trim();
+  if (trimmed.length === 0) {
+    return { value: null, error: null };
+  }
+
+  const parsed = Number(trimmed);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    return { value: null, error: "Default price must be a non-negative number." };
+  }
+
+  return { value: parsed, error: null };
+}
+
+function toPriceInput(value: number | null): string {
+  if (value === null) {
+    return "";
+  }
+  return value.toString();
+}
+
+function formatPriceLabel(value: number | null): string {
+  if (value === null) {
+    return "No default price";
+  }
+  return `$${value.toFixed(2)}`;
+}
+
+export function LineItemCatalogSettingsScreen(): React.ReactElement {
+  const navigate = useNavigate();
+  const [items, setItems] = useState<LineItemCatalogItem[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [title, setTitle] = useState("");
+  const [details, setDetails] = useState("");
+  const [defaultPriceInput, setDefaultPriceInput] = useState("");
+  const [activeItemId, setActiveItemId] = useState<string | null>(null);
+  const [formError, setFormError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [itemPendingDelete, setItemPendingDelete] = useState<LineItemCatalogItem | null>(null);
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [toastMessage, setToastMessage] = useState<string | null>(null);
+
+  const isEditMode = activeItemId !== null;
+
+  useEffect(() => {
+    let isActive = true;
+
+    async function loadItems(): Promise<void> {
+      setIsLoading(true);
+      setLoadError(null);
+      try {
+        const nextItems = await lineItemCatalogService.listItems();
+        if (isActive) {
+          setItems(nextItems);
+        }
+      } catch (error) {
+        const message = error instanceof Error ? error.message : "Unable to load line item catalog";
+        if (isActive) {
+          setLoadError(message);
+        }
+      } finally {
+        if (isActive) {
+          setIsLoading(false);
+        }
+      }
+    }
+
+    void loadItems();
+
+    return () => {
+      isActive = false;
+    };
+  }, []);
+
+  const sortedItems = useMemo(() => {
+    return [...items].sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+  }, [items]);
+
+  function resetForm(): void {
+    setActiveItemId(null);
+    setTitle("");
+    setDetails("");
+    setDefaultPriceInput("");
+    setFormError(null);
+  }
+
+  async function handleSubmit(event: React.FormEvent<HTMLFormElement>): Promise<void> {
+    event.preventDefault();
+    setFormError(null);
+
+    const trimmedTitle = title.trim();
+    if (trimmedTitle.length === 0) {
+      setFormError("Title is required.");
+      return;
+    }
+
+    const parsedPrice = parsePriceInput(defaultPriceInput);
+    if (parsedPrice.error) {
+      setFormError(parsedPrice.error);
+      return;
+    }
+
+    const normalizedDetails = details.trim();
+    const nextDetails = normalizedDetails.length > 0 ? normalizedDetails : null;
+
+    setIsSubmitting(true);
+    try {
+      if (activeItemId) {
+        const updatedItem = await lineItemCatalogService.updateItem(activeItemId, {
+          title: trimmedTitle,
+          details: nextDetails,
+          defaultPrice: parsedPrice.value,
+        });
+        setItems((currentItems) =>
+          currentItems.map((item) => (item.id === updatedItem.id ? updatedItem : item)),
+        );
+        setToastMessage("Catalog item updated.");
+      } else {
+        const createdItem = await lineItemCatalogService.createItem({
+          title: trimmedTitle,
+          details: nextDetails,
+          defaultPrice: parsedPrice.value,
+        });
+        setItems((currentItems) => [createdItem, ...currentItems]);
+        setToastMessage("Catalog item created.");
+      }
+      resetForm();
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Unable to save catalog item";
+      setFormError(message);
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  function startEdit(item: LineItemCatalogItem): void {
+    setActiveItemId(item.id);
+    setTitle(item.title);
+    setDetails(item.details ?? "");
+    setDefaultPriceInput(toPriceInput(item.defaultPrice));
+    setFormError(null);
+  }
+
+  async function confirmDelete(): Promise<void> {
+    if (!itemPendingDelete) {
+      return;
+    }
+
+    setIsDeleting(true);
+    setFormError(null);
+    try {
+      await lineItemCatalogService.deleteItem(itemPendingDelete.id);
+      setItems((currentItems) =>
+        currentItems.filter((item) => item.id !== itemPendingDelete.id),
+      );
+      if (activeItemId === itemPendingDelete.id) {
+        resetForm();
+      }
+      setToastMessage("Catalog item deleted.");
+      setItemPendingDelete(null);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Unable to delete catalog item";
+      setFormError(message);
+    } finally {
+      setIsDeleting(false);
+    }
+  }
+
+  return (
+    <main className="min-h-screen bg-background pb-24 pt-16">
+      <ScreenHeader
+        title="Line Item Catalog"
+        backLabel="Back to settings"
+        onBack={() => navigate("/settings")}
+      />
+
+      <section className="mx-auto w-full max-w-3xl space-y-4 px-4 pt-4">
+        {isLoading ? (
+          <p role="status" className="text-sm text-on-surface-variant">
+            Loading catalog items...
+          </p>
+        ) : null}
+
+        {!isLoading && loadError ? (
+          <FeedbackMessage variant="error">{loadError}</FeedbackMessage>
+        ) : null}
+
+        {!isLoading && !loadError ? (
+          <>
+            <section className="ghost-shadow rounded-xl bg-surface-container-lowest p-6">
+              <h2 className="text-[0.6875rem] font-bold uppercase tracking-widest text-outline">
+                {isEditMode ? "Edit Catalog Item" : "Add Catalog Item"}
+              </h2>
+
+              <form className="mt-4 space-y-3" onSubmit={(event) => void handleSubmit(event)}>
+                {formError ? <FeedbackMessage variant="error">{formError}</FeedbackMessage> : null}
+
+                <div className="space-y-1">
+                  <label htmlFor="line-item-catalog-title" className="text-sm font-medium text-on-surface">
+                    Title
+                  </label>
+                  <input
+                    id="line-item-catalog-title"
+                    type="text"
+                    value={title}
+                    onChange={(event) => setTitle(event.target.value)}
+                    className="w-full rounded-lg bg-surface-container-high px-4 py-3 font-body text-sm text-on-surface transition-all focus:bg-surface-container-lowest focus:outline-none focus:ring-2 focus:ring-primary/30"
+                  />
+                </div>
+
+                <div className="space-y-1">
+                  <label htmlFor="line-item-catalog-details" className="text-sm font-medium text-on-surface">
+                    Details (optional)
+                  </label>
+                  <textarea
+                    id="line-item-catalog-details"
+                    rows={3}
+                    value={details}
+                    onChange={(event) => setDetails(event.target.value)}
+                    className="w-full rounded-lg border border-outline-variant/30 bg-surface-container-high p-4 text-sm text-on-surface outline-none transition-all focus:border-primary focus:bg-surface-container-lowest focus:ring-2 focus:ring-primary/20"
+                  />
+                </div>
+
+                <div className="space-y-1">
+                  <label htmlFor="line-item-catalog-default-price" className="text-sm font-medium text-on-surface">
+                    Default price (optional)
+                  </label>
+                  <input
+                    id="line-item-catalog-default-price"
+                    type="text"
+                    inputMode="decimal"
+                    value={defaultPriceInput}
+                    onChange={(event) => setDefaultPriceInput(event.target.value)}
+                    placeholder="0.00"
+                    className="w-full rounded-lg bg-surface-container-high px-4 py-3 font-body text-sm text-on-surface transition-all focus:bg-surface-container-lowest focus:outline-none focus:ring-2 focus:ring-primary/30"
+                  />
+                </div>
+
+                <div className="flex flex-wrap gap-2 pt-1">
+                  <Button
+                    type="submit"
+                    className="min-w-[9rem] px-4 py-2"
+                    isLoading={isSubmitting}
+                  >
+                    {isEditMode ? "Update Item" : "Create Item"}
+                  </Button>
+                  {isEditMode ? (
+                    <button
+                      type="button"
+                      className="inline-flex min-h-10 items-center justify-center rounded-lg border border-outline-variant/40 px-4 py-2 text-sm font-semibold text-on-surface transition-colors hover:bg-surface-container-low"
+                      onClick={resetForm}
+                    >
+                      Cancel
+                    </button>
+                  ) : null}
+                </div>
+              </form>
+            </section>
+
+            <section className="rounded-xl bg-surface-container-low p-4">
+              <h2 className="text-[0.6875rem] font-bold uppercase tracking-widest text-outline">
+                Saved Items
+              </h2>
+              {sortedItems.length === 0 ? (
+                <p className="mt-3 text-sm text-on-surface-variant">
+                  No catalog items yet. Create one to reuse it in quote line items.
+                </p>
+              ) : (
+                <div className="mt-3 space-y-2">
+                  {sortedItems.map((item) => (
+                    <article
+                      key={item.id}
+                      className="rounded-lg border border-outline-variant/20 bg-surface-container-lowest p-3"
+                    >
+                      <div className="flex items-start justify-between gap-3">
+                        <div className="min-w-0 space-y-1">
+                          <h3 className="truncate text-sm font-semibold text-on-surface">{item.title}</h3>
+                          <p className="text-xs text-on-surface-variant">{formatPriceLabel(item.defaultPrice)}</p>
+                          {item.details ? (
+                            <p className="text-sm text-on-surface-variant">{item.details}</p>
+                          ) : null}
+                        </div>
+                        <div className="flex gap-2">
+                          <button
+                            type="button"
+                            className="inline-flex min-h-9 items-center justify-center rounded-lg border border-outline-variant/40 px-3 text-xs font-semibold text-on-surface transition-colors hover:bg-surface-container-low"
+                            onClick={() => startEdit(item)}
+                          >
+                            Edit
+                          </button>
+                          <button
+                            type="button"
+                            className="inline-flex min-h-9 items-center justify-center rounded-lg border border-error/30 px-3 text-xs font-semibold text-error transition-colors hover:bg-error-container/40"
+                            onClick={() => setItemPendingDelete(item)}
+                          >
+                            Delete
+                          </button>
+                        </div>
+                      </div>
+                    </article>
+                  ))}
+                </div>
+              )}
+            </section>
+          </>
+        ) : null}
+      </section>
+
+      <BottomNav active="settings" />
+      <Toast message={toastMessage} onDismiss={() => setToastMessage(null)} />
+
+      {itemPendingDelete ? (
+        <ConfirmModal
+          title="Delete catalog item?"
+          body={`"${itemPendingDelete.title}" will be removed from your catalog.`}
+          confirmLabel={isDeleting ? "Deleting..." : "Delete"}
+          cancelLabel="Cancel"
+          onConfirm={() => void confirmDelete()}
+          onCancel={() => setItemPendingDelete(null)}
+          variant="destructive"
+        />
+      ) : null}
+    </main>
+  );
+}

--- a/frontend/src/features/line-item-catalog/services/lineItemCatalogService.ts
+++ b/frontend/src/features/line-item-catalog/services/lineItemCatalogService.ts
@@ -1,0 +1,92 @@
+import type {
+  LineItemCatalogCreateRequest,
+  LineItemCatalogItem,
+  LineItemCatalogUpdateRequest,
+} from "@/features/line-item-catalog/types/lineItemCatalog.types";
+import { request } from "@/shared/lib/http";
+
+interface LineItemCatalogApiItem {
+  id: string;
+  title: string;
+  details: string | null;
+  default_price: string | number | null;
+  created_at: string;
+  updated_at: string;
+}
+
+function parseDefaultPrice(value: string | number | null): number | null {
+  if (value === null) {
+    return null;
+  }
+
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? value : null;
+  }
+
+  const parsed = Number.parseFloat(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function mapItem(apiItem: LineItemCatalogApiItem): LineItemCatalogItem {
+  return {
+    id: apiItem.id,
+    title: apiItem.title,
+    details: apiItem.details,
+    defaultPrice: parseDefaultPrice(apiItem.default_price),
+    createdAt: apiItem.created_at,
+    updatedAt: apiItem.updated_at,
+  };
+}
+
+function listItems(): Promise<LineItemCatalogItem[]> {
+  return request<LineItemCatalogApiItem[]>("/api/line-item-catalog").then((items) =>
+    items.map(mapItem),
+  );
+}
+
+function createItem(data: LineItemCatalogCreateRequest): Promise<LineItemCatalogItem> {
+  return request<LineItemCatalogApiItem>("/api/line-item-catalog", {
+    method: "POST",
+    body: {
+      title: data.title,
+      details: data.details,
+      default_price: data.defaultPrice,
+    },
+  }).then(mapItem);
+}
+
+function updateItem(id: string, data: LineItemCatalogUpdateRequest): Promise<LineItemCatalogItem> {
+  const payload: {
+    title?: string;
+    details?: string | null;
+    default_price?: number | null;
+  } = {};
+
+  if (data.title !== undefined) {
+    payload.title = data.title;
+  }
+  if (data.details !== undefined) {
+    payload.details = data.details;
+  }
+  if (data.defaultPrice !== undefined) {
+    payload.default_price = data.defaultPrice;
+  }
+
+  return request<LineItemCatalogApiItem>(`/api/line-item-catalog/${id}`, {
+    method: "PATCH",
+    body: payload,
+  }).then(mapItem);
+}
+
+function deleteItem(id: string): Promise<void> {
+  return request<null>(`/api/line-item-catalog/${id}`, {
+    method: "DELETE",
+  }).then(() => undefined);
+}
+
+export const lineItemCatalogService = {
+  listItems,
+  createItem,
+  updateItem,
+  deleteItem,
+};

--- a/frontend/src/features/line-item-catalog/types/lineItemCatalog.types.ts
+++ b/frontend/src/features/line-item-catalog/types/lineItemCatalog.types.ts
@@ -1,0 +1,20 @@
+export interface LineItemCatalogItem {
+  id: string;
+  title: string;
+  details: string | null;
+  defaultPrice: number | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface LineItemCatalogCreateRequest {
+  title: string;
+  details: string | null;
+  defaultPrice: number | null;
+}
+
+export interface LineItemCatalogUpdateRequest {
+  title?: string;
+  details?: string | null;
+  defaultPrice?: number | null;
+}

--- a/frontend/src/features/quotes/components/DocumentEditOverlays.tsx
+++ b/frontend/src/features/quotes/components/DocumentEditOverlays.tsx
@@ -2,6 +2,7 @@ import { LineItemEditSheet } from "@/features/quotes/components/LineItemEditShee
 import { ReviewCustomerAssignmentSheet } from "@/features/quotes/components/ReviewCustomerAssignmentSheet";
 import type { ReviewLineItemSheetState } from "@/features/quotes/components/reviewLineItemSheetState";
 import type { LineItemDraftWithFlags } from "@/features/quotes/types/quote.types";
+import type { LineItemCatalogItem } from "@/features/line-item-catalog/types/lineItemCatalog.types";
 import { ConfirmModal } from "@/shared/components/ConfirmModal";
 import { Toast } from "@/shared/components/Toast";
 
@@ -14,6 +15,12 @@ interface DocumentEditOverlaysProps {
   lineItemSheetInitialItem: LineItemDraftWithFlags;
   onCloseLineItemSheet: () => void;
   onSaveLineItem: (nextLineItem: LineItemDraftWithFlags) => void;
+  onSaveLineItemToCatalog: (lineItem: {
+    title: string;
+    details: string | null;
+    defaultPrice: number | null;
+  }) => Promise<void>;
+  onLoadLineItemCatalogItems: () => Promise<LineItemCatalogItem[]>;
   onRequestDeleteLineItemFromSheet: () => void;
   showLineItemDeleteConfirm: boolean;
   lineItemDeleteDescription: string;
@@ -38,6 +45,8 @@ export function DocumentEditOverlays({
   lineItemSheetInitialItem,
   onCloseLineItemSheet,
   onSaveLineItem,
+  onSaveLineItemToCatalog,
+  onLoadLineItemCatalogItems,
   onRequestDeleteLineItemFromSheet,
   showLineItemDeleteConfirm,
   lineItemDeleteDescription,
@@ -81,6 +90,8 @@ export function DocumentEditOverlays({
           initialLineItem={lineItemSheetInitialItem}
           onClose={onCloseLineItemSheet}
           onSave={onSaveLineItem}
+          onSaveToCatalog={onSaveLineItemToCatalog}
+          onLoadCatalogItems={onLoadLineItemCatalogItems}
           onRequestDelete={lineItemSheetState.mode === "edit" ? onRequestDeleteLineItemFromSheet : undefined}
         />
       ) : null}

--- a/frontend/src/features/quotes/components/DocumentEditOverlays.tsx
+++ b/frontend/src/features/quotes/components/DocumentEditOverlays.tsx
@@ -19,7 +19,8 @@ interface DocumentEditOverlaysProps {
     title: string;
     details: string | null;
     defaultPrice: number | null;
-  }) => Promise<void>;
+  }) => Promise<LineItemCatalogItem>;
+  onDeleteLineItemFromCatalog: (id: string) => Promise<void>;
   onLoadLineItemCatalogItems: () => Promise<LineItemCatalogItem[]>;
   onRequestDeleteLineItemFromSheet: () => void;
   showLineItemDeleteConfirm: boolean;
@@ -46,6 +47,7 @@ export function DocumentEditOverlays({
   onCloseLineItemSheet,
   onSaveLineItem,
   onSaveLineItemToCatalog,
+  onDeleteLineItemFromCatalog,
   onLoadLineItemCatalogItems,
   onRequestDeleteLineItemFromSheet,
   showLineItemDeleteConfirm,
@@ -91,6 +93,7 @@ export function DocumentEditOverlays({
           onClose={onCloseLineItemSheet}
           onSave={onSaveLineItem}
           onSaveToCatalog={onSaveLineItemToCatalog}
+          onDeleteFromCatalog={onDeleteLineItemFromCatalog}
           onLoadCatalogItems={onLoadLineItemCatalogItems}
           onRequestDelete={lineItemSheetState.mode === "edit" ? onRequestDeleteLineItemFromSheet : undefined}
         />

--- a/frontend/src/features/quotes/components/DocumentEditScreenView.tsx
+++ b/frontend/src/features/quotes/components/DocumentEditScreenView.tsx
@@ -5,6 +5,7 @@ import { isInvoiceDocument } from "@/features/quotes/components/documentEditUtil
 import type { ReviewLineItemSheetState } from "@/features/quotes/components/reviewLineItemSheetState";
 import { type DocumentEditDraft, type PersistedEditableDocument } from "@/features/quotes/hooks/usePersistedReview";
 import type { ExtractionReviewHiddenDetails, ExtractionTier, HiddenItemState, LineItemDraftWithFlags } from "@/features/quotes/types/quote.types";
+import type { LineItemCatalogItem } from "@/features/line-item-catalog/types/lineItemCatalog.types";
 import { WorkflowScreenHeader } from "@/shared/components/WorkflowScreenHeader";
 
 interface DocumentEditScreenViewProps {
@@ -58,6 +59,12 @@ interface DocumentEditScreenViewProps {
   onAssignCustomer: (customerId: string) => Promise<void>;
   onCloseLineItemSheet: () => void;
   onSaveLineItem: (nextLineItem: LineItemDraftWithFlags) => void;
+  onSaveLineItemToCatalog: (lineItem: {
+    title: string;
+    details: string | null;
+    defaultPrice: number | null;
+  }) => Promise<void>;
+  onLoadLineItemCatalogItems: () => Promise<LineItemCatalogItem[]>;
   onRequestDeleteLineItemFromSheet: () => void;
   showLineItemDeleteConfirm: boolean;
   lineItemDeleteDescription: string;
@@ -121,6 +128,8 @@ export function DocumentEditScreenView({
   onAssignCustomer,
   onCloseLineItemSheet,
   onSaveLineItem,
+  onSaveLineItemToCatalog,
+  onLoadLineItemCatalogItems,
   onRequestDeleteLineItemFromSheet,
   showLineItemDeleteConfirm,
   lineItemDeleteDescription,
@@ -200,6 +209,8 @@ export function DocumentEditScreenView({
         lineItemSheetInitialItem={lineItemSheetInitialItem}
         onCloseLineItemSheet={onCloseLineItemSheet}
         onSaveLineItem={onSaveLineItem}
+        onSaveLineItemToCatalog={onSaveLineItemToCatalog}
+        onLoadLineItemCatalogItems={onLoadLineItemCatalogItems}
         onRequestDeleteLineItemFromSheet={onRequestDeleteLineItemFromSheet}
         showLineItemDeleteConfirm={showLineItemDeleteConfirm}
         lineItemDeleteDescription={lineItemDeleteDescription}

--- a/frontend/src/features/quotes/components/DocumentEditScreenView.tsx
+++ b/frontend/src/features/quotes/components/DocumentEditScreenView.tsx
@@ -63,7 +63,8 @@ interface DocumentEditScreenViewProps {
     title: string;
     details: string | null;
     defaultPrice: number | null;
-  }) => Promise<void>;
+  }) => Promise<LineItemCatalogItem>;
+  onDeleteLineItemFromCatalog: (id: string) => Promise<void>;
   onLoadLineItemCatalogItems: () => Promise<LineItemCatalogItem[]>;
   onRequestDeleteLineItemFromSheet: () => void;
   showLineItemDeleteConfirm: boolean;
@@ -129,6 +130,7 @@ export function DocumentEditScreenView({
   onCloseLineItemSheet,
   onSaveLineItem,
   onSaveLineItemToCatalog,
+  onDeleteLineItemFromCatalog,
   onLoadLineItemCatalogItems,
   onRequestDeleteLineItemFromSheet,
   showLineItemDeleteConfirm,
@@ -210,6 +212,7 @@ export function DocumentEditScreenView({
         onCloseLineItemSheet={onCloseLineItemSheet}
         onSaveLineItem={onSaveLineItem}
         onSaveLineItemToCatalog={onSaveLineItemToCatalog}
+        onDeleteLineItemFromCatalog={onDeleteLineItemFromCatalog}
         onLoadLineItemCatalogItems={onLoadLineItemCatalogItems}
         onRequestDeleteLineItemFromSheet={onRequestDeleteLineItemFromSheet}
         showLineItemDeleteConfirm={showLineItemDeleteConfirm}

--- a/frontend/src/features/quotes/components/LineItemCatalogTabPanel.tsx
+++ b/frontend/src/features/quotes/components/LineItemCatalogTabPanel.tsx
@@ -1,0 +1,80 @@
+import type { LineItemCatalogItem } from "@/features/line-item-catalog/types/lineItemCatalog.types";
+import { FeedbackMessage } from "@/shared/components/FeedbackMessage";
+
+interface LineItemCatalogTabPanelProps {
+  loadState: "idle" | "loading" | "loaded" | "error";
+  loadError: string | null;
+  items: LineItemCatalogItem[];
+  onRetry: () => void;
+  onInsertItem: (item: LineItemCatalogItem) => void;
+}
+
+function formatCatalogPrice(value: number | null): string {
+  if (value === null) {
+    return "No default price";
+  }
+  return `$${value.toFixed(2)}`;
+}
+
+export function LineItemCatalogTabPanel({
+  loadState,
+  loadError,
+  items,
+  onRetry,
+  onInsertItem,
+}: LineItemCatalogTabPanelProps): React.ReactElement {
+  return (
+    <div id="line-item-tabpanel-catalog" role="tabpanel" className="space-y-2">
+      {loadState === "loading" ? (
+        <p role="status" className="text-sm text-on-surface-variant">Loading catalog items...</p>
+      ) : null}
+
+      {loadState === "error" && loadError ? (
+        <div className="space-y-2">
+          <FeedbackMessage variant="error">{loadError}</FeedbackMessage>
+          <button
+            type="button"
+            className="inline-flex min-h-9 items-center rounded-lg border border-outline-variant/40 px-3 text-xs font-semibold text-on-surface transition-colors hover:bg-surface-container-low"
+            onClick={onRetry}
+          >
+            Retry
+          </button>
+        </div>
+      ) : null}
+
+      {loadState === "loaded" && items.length === 0 ? (
+        <p className="rounded-lg bg-surface-container-high p-4 text-sm text-on-surface-variant">
+          No catalog items yet. Save one from the Manual tab or from another line item.
+        </p>
+      ) : null}
+
+      {loadState === "loaded" && items.length > 0 ? (
+        <ul className="max-h-56 space-y-2 overflow-y-auto pr-1">
+          {items.map((item) => (
+            <li
+              key={item.id}
+              className="rounded-lg border border-outline-variant/20 bg-surface-container-high p-3"
+            >
+              <div className="flex items-start justify-between gap-3">
+                <div className="min-w-0">
+                  <p className="truncate text-sm font-semibold text-on-surface">{item.title}</p>
+                  <p className="text-xs text-on-surface-variant">{formatCatalogPrice(item.defaultPrice)}</p>
+                  {item.details ? (
+                    <p className="mt-1 text-sm text-on-surface-variant">{item.details}</p>
+                  ) : null}
+                </div>
+                <button
+                  type="button"
+                  className="inline-flex min-h-9 shrink-0 items-center rounded-lg border border-primary/40 px-3 text-xs font-semibold text-primary transition-colors hover:bg-primary/10"
+                  onClick={() => onInsertItem(item)}
+                >
+                  Insert
+                </button>
+              </div>
+            </li>
+          ))}
+        </ul>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/src/features/quotes/components/LineItemEditSheet.tsx
+++ b/frontend/src/features/quotes/components/LineItemEditSheet.tsx
@@ -135,7 +135,7 @@ export function LineItemEditSheet({
   }
 
   function dismissWithAutosave(): void {
-    if (!showManualFields) {
+    if (mode === "add") {
       onClose();
       return;
     }
@@ -145,6 +145,13 @@ export function LineItemEditSheet({
       return;
     }
 
+    onSave(parsedLineItem);
+    onClose();
+  }
+
+  function addLineItemAndClose(): void {
+    const parsedLineItem = parseManualLineItem();
+    if (!parsedLineItem) return;
     onSave(parsedLineItem);
     onClose();
   }
@@ -262,6 +269,16 @@ export function LineItemEditSheet({
                     >
                       {bookmarkIcon}
                     </span>
+                  </button>
+                ) : null}
+                {mode === "add" && showManualFields ? (
+                  <button
+                    type="button"
+                    aria-label="Add line item"
+                    className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-primary/30 bg-primary/5 text-primary transition-colors hover:bg-primary/10"
+                    onClick={addLineItemAndClose}
+                  >
+                    <span className="material-symbols-outlined text-base leading-none">check</span>
                   </button>
                 ) : null}
                 {mode === "edit" && onRequestDelete ? (

--- a/frontend/src/features/quotes/components/LineItemEditSheet.tsx
+++ b/frontend/src/features/quotes/components/LineItemEditSheet.tsx
@@ -1,6 +1,7 @@
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import * as Dialog from "@radix-ui/react-dialog";
 
+import type { LineItemCatalogItem } from "@/features/line-item-catalog/types/lineItemCatalog.types";
 import type { LineItemDraftWithFlags } from "@/features/quotes/types/quote.types";
 import { FeedbackMessage } from "@/shared/components/FeedbackMessage";
 import {
@@ -14,6 +15,12 @@ interface LineItemEditSheetProps {
   initialLineItem: LineItemDraftWithFlags;
   onClose: () => void;
   onSave: (nextLineItem: LineItemDraftWithFlags) => void;
+  onSaveToCatalog?: (lineItem: {
+    title: string;
+    details: string | null;
+    defaultPrice: number | null;
+  }) => Promise<void>;
+  onLoadCatalogItems?: () => Promise<LineItemCatalogItem[]>;
   onRequestDelete?: () => void;
 }
 
@@ -21,6 +28,10 @@ interface ParsedPrice {
   value: number | null;
   valid: boolean;
 }
+
+type AddLineItemTab = "manual" | "catalog";
+
+type CatalogLoadState = "idle" | "loading" | "loaded" | "error";
 
 function parsePrice(value: string): ParsedPrice {
   const trimmed = value.trim();
@@ -36,12 +47,21 @@ function parsePrice(value: string): ParsedPrice {
   return { value: parsed, valid: true };
 }
 
+function formatCatalogPrice(value: number | null): string {
+  if (value === null) {
+    return "No default price";
+  }
+  return `$${value.toFixed(2)}`;
+}
+
 export function LineItemEditSheet({
   open,
   mode,
   initialLineItem,
   onClose,
   onSave,
+  onSaveToCatalog,
+  onLoadCatalogItems,
   onRequestDelete,
 }: LineItemEditSheetProps): React.ReactElement {
   const descriptionInputRef = useRef<HTMLInputElement>(null);
@@ -51,27 +71,114 @@ export function LineItemEditSheet({
     initialLineItem.price == null ? "" : initialLineItem.price.toString(),
   );
   const [formError, setFormError] = useState<string | null>(null);
+  const [activeAddTab, setActiveAddTab] = useState<AddLineItemTab>("manual");
+  const [catalogItems, setCatalogItems] = useState<LineItemCatalogItem[]>([]);
+  const [catalogLoadState, setCatalogLoadState] = useState<CatalogLoadState>("idle");
+  const [catalogLoadError, setCatalogLoadError] = useState<string | null>(null);
+  const [isSavingToCatalog, setIsSavingToCatalog] = useState(false);
   const title = mode === "edit" ? "Edit Line Item" : "Add Line Item";
+  const showManualFields = mode === "edit" || activeAddTab === "manual";
 
-  function dismissWithAutosave(): void {
+  useEffect(() => {
+    if (mode !== "add") {
+      return;
+    }
+    setActiveAddTab("manual");
+  }, [mode]);
+
+  async function loadCatalogItems(): Promise<void> {
+    if (
+      !onLoadCatalogItems
+      || catalogLoadState === "loading"
+      || catalogLoadState === "loaded"
+    ) {
+      return;
+    }
+
+    setCatalogLoadState("loading");
+    setCatalogLoadError(null);
+    try {
+      const items = await onLoadCatalogItems();
+      setCatalogItems(items);
+      setCatalogLoadState("loaded");
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Unable to load catalog items";
+      setCatalogLoadError(message);
+      setCatalogLoadState("error");
+    }
+  }
+
+  function parseManualLineItem(): LineItemDraftWithFlags | null {
     const trimmedDescription = description.trim();
     if (trimmedDescription.length === 0) {
       setFormError("Description is required.");
-      return;
+      return null;
     }
 
     const parsedPrice = parsePrice(priceInput);
     if (!parsedPrice.valid) {
       setFormError("Enter a valid number for price.");
-      return;
+      return null;
     }
 
     setFormError(null);
-    onSave({
+    return {
       ...initialLineItem,
       description: trimmedDescription,
       details: details.trim().length > 0 ? details.trim() : null,
       price: parsedPrice.value,
+    };
+  }
+
+  function dismissWithAutosave(): void {
+    if (!showManualFields) {
+      onClose();
+      return;
+    }
+
+    const parsedLineItem = parseManualLineItem();
+    if (!parsedLineItem) {
+      return;
+    }
+
+    onSave(parsedLineItem);
+    onClose();
+  }
+
+  async function saveToCatalog(): Promise<void> {
+    if (!onSaveToCatalog || !showManualFields || isSavingToCatalog) {
+      return;
+    }
+
+    const parsedLineItem = parseManualLineItem();
+    if (!parsedLineItem) {
+      return;
+    }
+
+    setIsSavingToCatalog(true);
+    try {
+      await onSaveToCatalog({
+        title: parsedLineItem.description,
+        details: parsedLineItem.details ?? null,
+        defaultPrice: parsedLineItem.price,
+      });
+      setFormError(null);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Unable to save line item to catalog";
+      setFormError(message);
+    } finally {
+      setIsSavingToCatalog(false);
+    }
+  }
+
+  function handleInsertCatalogItem(item: LineItemCatalogItem): void {
+    setFormError(null);
+    onSave({
+      description: item.title,
+      details: item.details,
+      price: item.defaultPrice,
+      flagged: false,
+      flagReason: null,
     });
     onClose();
   }
@@ -95,95 +202,225 @@ export function LineItemEditSheet({
             className="modal-shadow pointer-events-auto w-full max-w-md rounded-[1.75rem] border border-outline-variant/20 bg-surface-container-lowest p-6"
             onOpenAutoFocus={(event) => {
               event.preventDefault();
-              descriptionInputRef.current?.focus();
+              if (showManualFields) {
+                descriptionInputRef.current?.focus();
+              }
             }}
           >
             <div className="flex items-start justify-between gap-4">
               <Dialog.Title className="font-headline text-xl font-bold tracking-tight text-on-surface">
                 {title}
               </Dialog.Title>
-              {mode === "edit" && onRequestDelete ? (
-                <button
-                  type="button"
-                  aria-label="Delete line item"
-                  className="inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-full border border-error/30 bg-error-container/40 text-error transition-colors hover:bg-error-container/60"
-                  onClick={onRequestDelete}
-                >
-                  <span className="material-symbols-outlined text-[1.125rem] leading-none">delete</span>
-                </button>
-              ) : null}
+              <div className="flex items-center gap-2">
+                {onSaveToCatalog ? (
+                  <button
+                    type="button"
+                    aria-label="Save to catalog"
+                    className="inline-flex min-h-10 items-center gap-1 rounded-full border border-primary/30 bg-primary/5 px-3 text-xs font-bold uppercase tracking-wide text-primary transition-colors hover:bg-primary/10 disabled:cursor-not-allowed disabled:opacity-60"
+                    disabled={isSavingToCatalog || !showManualFields}
+                    onClick={() => {
+                      void saveToCatalog();
+                    }}
+                  >
+                    <span className="material-symbols-outlined text-base leading-none">bookmark_add</span>
+                    {isSavingToCatalog ? "Saving" : "Save"}
+                  </button>
+                ) : null}
+                {mode === "edit" && onRequestDelete ? (
+                  <button
+                    type="button"
+                    aria-label="Delete line item"
+                    className="inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-full border border-error/30 bg-error-container/40 text-error transition-colors hover:bg-error-container/60"
+                    onClick={onRequestDelete}
+                  >
+                    <span className="material-symbols-outlined text-[1.125rem] leading-none">delete</span>
+                  </button>
+                ) : null}
+              </div>
             </div>
             <Dialog.Description className="mt-2 text-sm leading-6 text-on-surface-variant">
-              Update details now. Changes stay local until you save the review draft.
+              {showManualFields
+                ? "Update details now. Changes stay local until you save the review draft."
+                : "Choose a saved catalog item to insert into this draft."}
             </Dialog.Description>
 
             <div className="mt-4 space-y-4">
               {formError ? <FeedbackMessage variant="error">{formError}</FeedbackMessage> : null}
 
-              <section className="space-y-2">
-                <div className="flex items-end justify-between">
-                  <label htmlFor="line-item-sheet-description" className="font-headline text-sm font-bold text-on-surface">
-                    Description
-                  </label>
-                  <span className="text-xs font-bold uppercase text-primary">Required</span>
+              {mode === "add" ? (
+                <div
+                  role="tablist"
+                  aria-label="Add line item mode"
+                  className="grid grid-cols-2 rounded-full bg-surface-container-high p-1"
+                >
+                  <button
+                    id="line-item-tab-manual"
+                    role="tab"
+                    type="button"
+                    aria-controls="line-item-tabpanel-manual"
+                    aria-selected={activeAddTab === "manual"}
+                    className={`rounded-full px-3 py-2 text-xs font-bold uppercase tracking-wide transition-colors ${
+                      activeAddTab === "manual"
+                        ? "bg-surface-container-lowest text-primary"
+                        : "text-on-surface-variant hover:text-on-surface"
+                    }`}
+                    onClick={() => {
+                      setFormError(null);
+                      setActiveAddTab("manual");
+                    }}
+                  >
+                    Manual
+                  </button>
+                  <button
+                    id="line-item-tab-catalog"
+                    role="tab"
+                    type="button"
+                    aria-controls="line-item-tabpanel-catalog"
+                    aria-selected={activeAddTab === "catalog"}
+                    className={`rounded-full px-3 py-2 text-xs font-bold uppercase tracking-wide transition-colors ${
+                      activeAddTab === "catalog"
+                        ? "bg-surface-container-lowest text-primary"
+                        : "text-on-surface-variant hover:text-on-surface"
+                    }`}
+                    onClick={() => {
+                      setFormError(null);
+                      setActiveAddTab("catalog");
+                      void loadCatalogItems();
+                    }}
+                  >
+                    Catalog
+                  </button>
                 </div>
-                <input
-                  id="line-item-sheet-description"
-                  ref={descriptionInputRef}
-                  type="text"
-                  maxLength={LINE_ITEM_DESCRIPTION_MAX_CHARS}
-                  value={description}
-                  onChange={(event) => {
-                    setDescription(event.target.value);
-                    if (formError) {
-                      setFormError(null);
-                    }
-                  }}
-                  className="w-full rounded-lg bg-surface-container-high px-4 py-3 font-body text-sm text-on-surface placeholder:text-outline transition-all focus:bg-surface-container-lowest focus:outline-none focus:ring-2 focus:ring-primary/30"
-                />
-              </section>
+              ) : null}
 
-              <section className="space-y-2">
-                <div className="flex items-end justify-between">
-                  <label htmlFor="line-item-sheet-details" className="font-headline text-sm font-bold text-on-surface">
-                    Details
-                  </label>
-                  <span className="text-xs font-bold uppercase text-outline">Optional</span>
+              {showManualFields ? (
+                <div id="line-item-tabpanel-manual" role={mode === "add" ? "tabpanel" : undefined} className="space-y-4">
+                  <section className="space-y-2">
+                    <div className="flex items-end justify-between">
+                      <label htmlFor="line-item-sheet-description" className="font-headline text-sm font-bold text-on-surface">
+                        Description
+                      </label>
+                      <span className="text-xs font-bold uppercase text-primary">Required</span>
+                    </div>
+                    <input
+                      id="line-item-sheet-description"
+                      ref={descriptionInputRef}
+                      type="text"
+                      maxLength={LINE_ITEM_DESCRIPTION_MAX_CHARS}
+                      value={description}
+                      onChange={(event) => {
+                        setDescription(event.target.value);
+                        if (formError) {
+                          setFormError(null);
+                        }
+                      }}
+                      className="w-full rounded-lg bg-surface-container-high px-4 py-3 font-body text-sm text-on-surface placeholder:text-outline transition-all focus:bg-surface-container-lowest focus:outline-none focus:ring-2 focus:ring-primary/30"
+                    />
+                  </section>
+
+                  <section className="space-y-2">
+                    <div className="flex items-end justify-between">
+                      <label htmlFor="line-item-sheet-details" className="font-headline text-sm font-bold text-on-surface">
+                        Details
+                      </label>
+                      <span className="text-xs font-bold uppercase text-outline">Optional</span>
+                    </div>
+                    <textarea
+                      id="line-item-sheet-details"
+                      rows={2}
+                      maxLength={LINE_ITEM_DETAILS_MAX_CHARS}
+                      value={details}
+                      onChange={(event) => {
+                        setDetails(event.target.value);
+                        if (formError) {
+                          setFormError(null);
+                        }
+                      }}
+                      className="w-full rounded-lg border border-outline-variant/30 bg-surface-container-high p-4 text-sm text-on-surface placeholder:text-outline/70 outline-none transition-all focus:border-primary focus:bg-surface-container-lowest focus:ring-2 focus:ring-primary/20"
+                    />
+                  </section>
+
+                  <section className="space-y-2">
+                    <label htmlFor="line-item-sheet-price" className="font-headline text-sm font-bold text-on-surface">
+                      Price
+                    </label>
+                    <input
+                      id="line-item-sheet-price"
+                      type="text"
+                      inputMode="decimal"
+                      placeholder="$ 0.00"
+                      value={priceInput}
+                      onChange={(event) => {
+                        setPriceInput(event.target.value);
+                        if (formError) {
+                          setFormError(null);
+                        }
+                      }}
+                      className="w-full rounded-lg bg-surface-container-high px-4 py-3 font-body text-sm text-on-surface placeholder:text-outline transition-all focus:bg-surface-container-lowest focus:outline-none focus:ring-2 focus:ring-primary/30"
+                    />
+                  </section>
                 </div>
-                <textarea
-                  id="line-item-sheet-details"
-                  rows={2}
-                  maxLength={LINE_ITEM_DETAILS_MAX_CHARS}
-                  value={details}
-                  onChange={(event) => {
-                    setDetails(event.target.value);
-                    if (formError) {
-                      setFormError(null);
-                    }
-                  }}
-                  className="w-full rounded-lg border border-outline-variant/30 bg-surface-container-high p-4 text-sm text-on-surface placeholder:text-outline/70 outline-none transition-all focus:border-primary focus:bg-surface-container-lowest focus:ring-2 focus:ring-primary/20"
-                />
-              </section>
+              ) : (
+                <div
+                  id="line-item-tabpanel-catalog"
+                  role={mode === "add" ? "tabpanel" : undefined}
+                  className="space-y-2"
+                >
+                  {catalogLoadState === "loading" ? (
+                    <p role="status" className="text-sm text-on-surface-variant">Loading catalog items...</p>
+                  ) : null}
 
-              <section className="space-y-2">
-                <label htmlFor="line-item-sheet-price" className="font-headline text-sm font-bold text-on-surface">
-                  Price
-                </label>
-                <input
-                  id="line-item-sheet-price"
-                  type="text"
-                  inputMode="decimal"
-                  placeholder="$ 0.00"
-                  value={priceInput}
-                  onChange={(event) => {
-                    setPriceInput(event.target.value);
-                    if (formError) {
-                      setFormError(null);
-                    }
-                  }}
-                  className="w-full rounded-lg bg-surface-container-high px-4 py-3 font-body text-sm text-on-surface placeholder:text-outline transition-all focus:bg-surface-container-lowest focus:outline-none focus:ring-2 focus:ring-primary/30"
-                />
-              </section>
+                  {catalogLoadState === "error" && catalogLoadError ? (
+                    <div className="space-y-2">
+                      <FeedbackMessage variant="error">{catalogLoadError}</FeedbackMessage>
+                      <button
+                        type="button"
+                        className="inline-flex min-h-9 items-center rounded-lg border border-outline-variant/40 px-3 text-xs font-semibold text-on-surface transition-colors hover:bg-surface-container-low"
+                        onClick={() => {
+                          setCatalogLoadState("idle");
+                          void loadCatalogItems();
+                        }}
+                      >
+                        Retry
+                      </button>
+                    </div>
+                  ) : null}
+
+                  {catalogLoadState === "loaded" && catalogItems.length === 0 ? (
+                    <p className="rounded-lg bg-surface-container-high p-4 text-sm text-on-surface-variant">
+                      No catalog items yet. Save one from the Manual tab or from another line item.
+                    </p>
+                  ) : null}
+
+                  {catalogLoadState === "loaded" && catalogItems.length > 0 ? (
+                    <ul className="max-h-56 space-y-2 overflow-y-auto pr-1">
+                      {catalogItems.map((item) => (
+                        <li
+                          key={item.id}
+                          className="rounded-lg border border-outline-variant/20 bg-surface-container-high p-3"
+                        >
+                          <div className="flex items-start justify-between gap-3">
+                            <div className="min-w-0">
+                              <p className="truncate text-sm font-semibold text-on-surface">{item.title}</p>
+                              <p className="text-xs text-on-surface-variant">{formatCatalogPrice(item.defaultPrice)}</p>
+                              {item.details ? (
+                                <p className="mt-1 text-sm text-on-surface-variant">{item.details}</p>
+                              ) : null}
+                            </div>
+                            <button
+                              type="button"
+                              className="inline-flex min-h-9 shrink-0 items-center rounded-lg border border-primary/40 px-3 text-xs font-semibold text-primary transition-colors hover:bg-primary/10"
+                              onClick={() => handleInsertCatalogItem(item)}
+                            >
+                              Insert
+                            </button>
+                          </div>
+                        </li>
+                      ))}
+                    </ul>
+                  ) : null}
+                </div>
+              )}
             </div>
           </Dialog.Content>
         </div>

--- a/frontend/src/features/quotes/components/LineItemEditSheet.tsx
+++ b/frontend/src/features/quotes/components/LineItemEditSheet.tsx
@@ -3,6 +3,7 @@ import * as Dialog from "@radix-ui/react-dialog";
 
 import type { LineItemCatalogItem } from "@/features/line-item-catalog/types/lineItemCatalog.types";
 import type { LineItemDraftWithFlags } from "@/features/quotes/types/quote.types";
+import { LineItemCatalogTabPanel } from "@/features/quotes/components/LineItemCatalogTabPanel";
 import { FeedbackMessage } from "@/shared/components/FeedbackMessage";
 import {
   LINE_ITEM_DESCRIPTION_MAX_CHARS,
@@ -19,7 +20,8 @@ interface LineItemEditSheetProps {
     title: string;
     details: string | null;
     defaultPrice: number | null;
-  }) => Promise<void>;
+  }) => Promise<LineItemCatalogItem>;
+  onDeleteFromCatalog?: (id: string) => Promise<void>;
   onLoadCatalogItems?: () => Promise<LineItemCatalogItem[]>;
   onRequestDelete?: () => void;
 }
@@ -47,13 +49,6 @@ function parsePrice(value: string): ParsedPrice {
   return { value: parsed, valid: true };
 }
 
-function formatCatalogPrice(value: number | null): string {
-  if (value === null) {
-    return "No default price";
-  }
-  return `$${value.toFixed(2)}`;
-}
-
 export function LineItemEditSheet({
   open,
   mode,
@@ -61,6 +56,7 @@ export function LineItemEditSheet({
   onClose,
   onSave,
   onSaveToCatalog,
+  onDeleteFromCatalog,
   onLoadCatalogItems,
   onRequestDelete,
 }: LineItemEditSheetProps): React.ReactElement {
@@ -75,9 +71,13 @@ export function LineItemEditSheet({
   const [catalogItems, setCatalogItems] = useState<LineItemCatalogItem[]>([]);
   const [catalogLoadState, setCatalogLoadState] = useState<CatalogLoadState>("idle");
   const [catalogLoadError, setCatalogLoadError] = useState<string | null>(null);
-  const [isSavingToCatalog, setIsSavingToCatalog] = useState(false);
+  const [savedCatalogItem, setSavedCatalogItem] = useState<LineItemCatalogItem | null>(null);
+  const [isCatalogMutationInFlight, setIsCatalogMutationInFlight] = useState(false);
   const title = mode === "edit" ? "Edit Line Item" : "Add Line Item";
   const showManualFields = mode === "edit" || activeAddTab === "manual";
+  const canSaveToCatalog = showManualFields && savedCatalogItem === null;
+  const canDeleteSavedCatalogItem = savedCatalogItem !== null;
+  const bookmarkIcon = canDeleteSavedCatalogItem ? "bookmark" : "bookmark_add";
 
   useEffect(() => {
     if (mode !== "add") {
@@ -99,7 +99,11 @@ export function LineItemEditSheet({
     setCatalogLoadError(null);
     try {
       const items = await onLoadCatalogItems();
-      setCatalogItems(items);
+      setCatalogItems((currentItems) => {
+        const loadedIds = new Set(items.map((item) => item.id));
+        const localOnlyItems = currentItems.filter((item) => !loadedIds.has(item.id));
+        return [...localOnlyItems, ...items];
+      });
       setCatalogLoadState("loaded");
     } catch (error) {
       const message = error instanceof Error ? error.message : "Unable to load catalog items";
@@ -146,7 +150,7 @@ export function LineItemEditSheet({
   }
 
   async function saveToCatalog(): Promise<void> {
-    if (!onSaveToCatalog || !showManualFields || isSavingToCatalog) {
+    if (!onSaveToCatalog || !canSaveToCatalog || isCatalogMutationInFlight) {
       return;
     }
 
@@ -155,19 +159,44 @@ export function LineItemEditSheet({
       return;
     }
 
-    setIsSavingToCatalog(true);
+    setIsCatalogMutationInFlight(true);
     try {
-      await onSaveToCatalog({
+      const createdItem = await onSaveToCatalog({
         title: parsedLineItem.description,
         details: parsedLineItem.details ?? null,
         defaultPrice: parsedLineItem.price,
       });
+      setSavedCatalogItem(createdItem);
+      setCatalogItems((currentItems) => [
+        createdItem,
+        ...currentItems.filter((item) => item.id !== createdItem.id),
+      ]);
       setFormError(null);
     } catch (error) {
       const message = error instanceof Error ? error.message : "Unable to save line item to catalog";
       setFormError(message);
     } finally {
-      setIsSavingToCatalog(false);
+      setIsCatalogMutationInFlight(false);
+    }
+  }
+
+  async function unsaveFromCatalog(): Promise<void> {
+    if (!savedCatalogItem || !onDeleteFromCatalog || isCatalogMutationInFlight) {
+      return;
+    }
+
+    setIsCatalogMutationInFlight(true);
+    try {
+      await onDeleteFromCatalog(savedCatalogItem.id);
+      setCatalogItems((currentItems) =>
+        currentItems.filter((item) => item.id !== savedCatalogItem.id));
+      setSavedCatalogItem(null);
+      setFormError(null);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Unable to remove line item from catalog";
+      setFormError(message);
+    } finally {
+      setIsCatalogMutationInFlight(false);
     }
   }
 
@@ -200,6 +229,7 @@ export function LineItemEditSheet({
         <div className="pointer-events-none fixed inset-0 z-50 flex items-end justify-center px-4 pb-4 sm:items-center sm:pb-0">
           <Dialog.Content
             className="modal-shadow pointer-events-auto w-full max-w-md rounded-[1.75rem] border border-outline-variant/20 bg-surface-container-lowest p-6"
+            aria-describedby={showManualFields ? undefined : "line-item-sheet-catalog-description"}
             onOpenAutoFocus={(event) => {
               event.preventDefault();
               if (showManualFields) {
@@ -212,18 +242,26 @@ export function LineItemEditSheet({
                 {title}
               </Dialog.Title>
               <div className="flex items-center gap-2">
-                {onSaveToCatalog ? (
+                {onSaveToCatalog && showManualFields ? (
                   <button
                     type="button"
                     aria-label="Save to catalog"
-                    className="inline-flex min-h-10 items-center gap-1 rounded-full border border-primary/30 bg-primary/5 px-3 text-xs font-bold uppercase tracking-wide text-primary transition-colors hover:bg-primary/10 disabled:cursor-not-allowed disabled:opacity-60"
-                    disabled={isSavingToCatalog || !showManualFields}
+                    className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-primary/30 bg-primary/5 text-primary transition-colors hover:bg-primary/10 disabled:cursor-not-allowed disabled:opacity-60"
+                    disabled={isCatalogMutationInFlight || (!canSaveToCatalog && !canDeleteSavedCatalogItem)}
                     onClick={() => {
+                      if (savedCatalogItem) {
+                        void unsaveFromCatalog();
+                        return;
+                      }
                       void saveToCatalog();
                     }}
                   >
-                    <span className="material-symbols-outlined text-base leading-none">bookmark_add</span>
-                    {isSavingToCatalog ? "Saving" : "Save"}
+                    <span
+                      className="material-symbols-outlined text-base leading-none"
+                      style={canDeleteSavedCatalogItem ? { fontVariationSettings: '"FILL" 1, "wght" 400, "GRAD" 0, "opsz" 24' } : undefined}
+                    >
+                      {bookmarkIcon}
+                    </span>
                   </button>
                 ) : null}
                 {mode === "edit" && onRequestDelete ? (
@@ -238,11 +276,14 @@ export function LineItemEditSheet({
                 ) : null}
               </div>
             </div>
-            <Dialog.Description className="mt-2 text-sm leading-6 text-on-surface-variant">
-              {showManualFields
-                ? "Update details now. Changes stay local until you save the review draft."
-                : "Choose a saved catalog item to insert into this draft."}
-            </Dialog.Description>
+            {!showManualFields ? (
+              <Dialog.Description
+                id="line-item-sheet-catalog-description"
+                className="mt-2 text-sm leading-6 text-on-surface-variant"
+              >
+                Pick a catalog item to insert.
+              </Dialog.Description>
+            ) : null}
 
             <div className="mt-4 space-y-4">
               {formError ? <FeedbackMessage variant="error">{formError}</FeedbackMessage> : null}
@@ -310,6 +351,9 @@ export function LineItemEditSheet({
                       value={description}
                       onChange={(event) => {
                         setDescription(event.target.value);
+                        if (savedCatalogItem) {
+                          setSavedCatalogItem(null);
+                        }
                         if (formError) {
                           setFormError(null);
                         }
@@ -332,6 +376,9 @@ export function LineItemEditSheet({
                       value={details}
                       onChange={(event) => {
                         setDetails(event.target.value);
+                        if (savedCatalogItem) {
+                          setSavedCatalogItem(null);
+                        }
                         if (formError) {
                           setFormError(null);
                         }
@@ -352,6 +399,9 @@ export function LineItemEditSheet({
                       value={priceInput}
                       onChange={(event) => {
                         setPriceInput(event.target.value);
+                        if (savedCatalogItem) {
+                          setSavedCatalogItem(null);
+                        }
                         if (formError) {
                           setFormError(null);
                         }
@@ -361,65 +411,16 @@ export function LineItemEditSheet({
                   </section>
                 </div>
               ) : (
-                <div
-                  id="line-item-tabpanel-catalog"
-                  role={mode === "add" ? "tabpanel" : undefined}
-                  className="space-y-2"
-                >
-                  {catalogLoadState === "loading" ? (
-                    <p role="status" className="text-sm text-on-surface-variant">Loading catalog items...</p>
-                  ) : null}
-
-                  {catalogLoadState === "error" && catalogLoadError ? (
-                    <div className="space-y-2">
-                      <FeedbackMessage variant="error">{catalogLoadError}</FeedbackMessage>
-                      <button
-                        type="button"
-                        className="inline-flex min-h-9 items-center rounded-lg border border-outline-variant/40 px-3 text-xs font-semibold text-on-surface transition-colors hover:bg-surface-container-low"
-                        onClick={() => {
-                          setCatalogLoadState("idle");
-                          void loadCatalogItems();
-                        }}
-                      >
-                        Retry
-                      </button>
-                    </div>
-                  ) : null}
-
-                  {catalogLoadState === "loaded" && catalogItems.length === 0 ? (
-                    <p className="rounded-lg bg-surface-container-high p-4 text-sm text-on-surface-variant">
-                      No catalog items yet. Save one from the Manual tab or from another line item.
-                    </p>
-                  ) : null}
-
-                  {catalogLoadState === "loaded" && catalogItems.length > 0 ? (
-                    <ul className="max-h-56 space-y-2 overflow-y-auto pr-1">
-                      {catalogItems.map((item) => (
-                        <li
-                          key={item.id}
-                          className="rounded-lg border border-outline-variant/20 bg-surface-container-high p-3"
-                        >
-                          <div className="flex items-start justify-between gap-3">
-                            <div className="min-w-0">
-                              <p className="truncate text-sm font-semibold text-on-surface">{item.title}</p>
-                              <p className="text-xs text-on-surface-variant">{formatCatalogPrice(item.defaultPrice)}</p>
-                              {item.details ? (
-                                <p className="mt-1 text-sm text-on-surface-variant">{item.details}</p>
-                              ) : null}
-                            </div>
-                            <button
-                              type="button"
-                              className="inline-flex min-h-9 shrink-0 items-center rounded-lg border border-primary/40 px-3 text-xs font-semibold text-primary transition-colors hover:bg-primary/10"
-                              onClick={() => handleInsertCatalogItem(item)}
-                            >
-                              Insert
-                            </button>
-                          </div>
-                        </li>
-                      ))}
-                    </ul>
-                  ) : null}
-                </div>
+                <LineItemCatalogTabPanel
+                  loadState={catalogLoadState}
+                  loadError={catalogLoadError}
+                  items={catalogItems}
+                  onRetry={() => {
+                    setCatalogLoadState("idle");
+                    void loadCatalogItems();
+                  }}
+                  onInsertItem={handleInsertCatalogItem}
+                />
               )}
             </div>
           </Dialog.Content>

--- a/frontend/src/features/quotes/components/ReviewScreen.tsx
+++ b/frontend/src/features/quotes/components/ReviewScreen.tsx
@@ -395,14 +395,8 @@ export function DocumentEditScreen(): React.ReactElement {
         setLineItemSheetState(null);
       }}
       onSaveLineItemToCatalog={async (lineItem) => {
-        try {
-          await lineItemCatalogService.createItem(lineItem);
-          setSaveError(null);
-          setToastMessage("Saved to line item catalog.");
-        } catch (error) {
-          const message = error instanceof Error ? error.message : "Unable to save line item to catalog";
-          setSaveError(message);
-        }
+        await lineItemCatalogService.createItem(lineItem);
+        setToastMessage("Saved to line item catalog.");
       }}
       onLoadLineItemCatalogItems={async () => lineItemCatalogService.listItems()}
       onRequestDeleteLineItemFromSheet={() => {

--- a/frontend/src/features/quotes/components/ReviewScreen.tsx
+++ b/frontend/src/features/quotes/components/ReviewScreen.tsx
@@ -395,9 +395,11 @@ export function DocumentEditScreen(): React.ReactElement {
         setLineItemSheetState(null);
       }}
       onSaveLineItemToCatalog={async (lineItem) => {
-        await lineItemCatalogService.createItem(lineItem);
+        const createdItem = await lineItemCatalogService.createItem(lineItem);
         setToastMessage("Saved to line item catalog.");
+        return createdItem;
       }}
+      onDeleteLineItemFromCatalog={async (itemId) => lineItemCatalogService.deleteItem(itemId)}
       onLoadLineItemCatalogItems={async () => lineItemCatalogService.listItems()}
       onRequestDeleteLineItemFromSheet={() => {
         const nextSheetState = lineItemSheetState;

--- a/frontend/src/features/quotes/components/ReviewScreen.tsx
+++ b/frontend/src/features/quotes/components/ReviewScreen.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { useBeforeUnload, useLocation, useNavigate, useParams } from "react-router-dom";
 
+import { lineItemCatalogService } from "@/features/line-item-catalog/services/lineItemCatalogService";
 import { profileService } from "@/features/profile/services/profileService";
 import { DocumentEditScreenView } from "@/features/quotes/components/DocumentEditScreenView";
 import { buildDefaultInvoiceDueDate, buildDocumentSnapshotKey, buildSaveValidationMessage, isInvoiceDocument, persistDocumentDraft } from "@/features/quotes/components/documentEditUtils";
@@ -393,6 +394,17 @@ export function DocumentEditScreen(): React.ReactElement {
         setDraft((currentDraft) => applyLineItemSheetSave(currentDraft, nextSheetState, nextLineItem));
         setLineItemSheetState(null);
       }}
+      onSaveLineItemToCatalog={async (lineItem) => {
+        try {
+          await lineItemCatalogService.createItem(lineItem);
+          setSaveError(null);
+          setToastMessage("Saved to line item catalog.");
+        } catch (error) {
+          const message = error instanceof Error ? error.message : "Unable to save line item to catalog";
+          setSaveError(message);
+        }
+      }}
+      onLoadLineItemCatalogItems={async () => lineItemCatalogService.listItems()}
       onRequestDeleteLineItemFromSheet={() => {
         const nextSheetState = lineItemSheetState;
         if (

--- a/frontend/src/features/quotes/tests/LineItemCatalogInsert.test.tsx
+++ b/frontend/src/features/quotes/tests/LineItemCatalogInsert.test.tsx
@@ -1,0 +1,270 @@
+import { useState } from "react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { lineItemCatalogService } from "@/features/line-item-catalog/services/lineItemCatalogService";
+import { DocumentEditScreen } from "@/features/quotes/components/ReviewScreen";
+import { mapQuoteToEditDraft, usePersistedReview } from "@/features/quotes/hooks/usePersistedReview";
+import { invoiceService } from "@/features/invoices/services/invoiceService";
+import { profileService } from "@/features/profile/services/profileService";
+import { quoteService } from "@/features/quotes/services/quoteService";
+import type { QuoteDetail } from "@/features/quotes/types/quote.types";
+
+const navigateMock = vi.fn();
+const useParamsMock = vi.fn(() => ({ id: "doc-1" }));
+const useLocationMock = vi.fn<() => { state: unknown }>(() => ({ state: null }));
+const useBeforeUnloadMock = vi.fn<(callback: (event: BeforeUnloadEvent) => void) => void>();
+
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual<typeof import("react-router-dom")>("react-router-dom");
+  return {
+    ...actual,
+    useNavigate: () => navigateMock,
+    useParams: () => useParamsMock(),
+    useLocation: () => useLocationMock(),
+    useBeforeUnload: (callback: (event: BeforeUnloadEvent) => void) => useBeforeUnloadMock(callback),
+  };
+});
+
+vi.mock("@/features/quotes/hooks/usePersistedReview", async () => {
+  const actual = await vi.importActual<typeof import("@/features/quotes/hooks/usePersistedReview")>(
+    "@/features/quotes/hooks/usePersistedReview",
+  );
+  return {
+    ...actual,
+    usePersistedReview: vi.fn(),
+  };
+});
+
+vi.mock("@/features/line-item-catalog/services/lineItemCatalogService", () => ({
+  lineItemCatalogService: {
+    listItems: vi.fn(),
+    createItem: vi.fn(),
+    updateItem: vi.fn(),
+    deleteItem: vi.fn(),
+  },
+}));
+
+vi.mock("@/features/quotes/services/quoteService", () => ({
+  quoteService: {
+    updateQuote: vi.fn(),
+    updateExtractionReviewMetadata: vi.fn(),
+  },
+}));
+
+vi.mock("@/features/invoices/services/invoiceService", () => ({
+  invoiceService: {
+    updateInvoice: vi.fn(),
+  },
+}));
+
+vi.mock("@/features/profile/services/profileService", () => ({
+  profileService: {
+    getProfile: vi.fn(),
+  },
+}));
+
+const mockedUsePersistedReview = vi.mocked(usePersistedReview);
+const mockedLineItemCatalogService = vi.mocked(lineItemCatalogService);
+const mockedQuoteService = vi.mocked(quoteService);
+const mockedInvoiceService = vi.mocked(invoiceService);
+const mockedProfileService = vi.mocked(profileService);
+
+function makeQuote(overrides: Partial<QuoteDetail> = {}): QuoteDetail {
+  return {
+    id: "doc-1",
+    customer_id: "cust-1",
+    doc_type: "quote",
+    extraction_tier: "primary",
+    extraction_degraded_reason_code: null,
+    customer_name: "Alice Johnson",
+    customer_email: "alice@example.com",
+    customer_phone: "+1-555-0100",
+    doc_number: "Q-001",
+    title: "Front Yard Refresh",
+    status: "draft",
+    source_type: "text",
+    transcript: "5 yards brown mulch",
+    total_amount: 120,
+    tax_rate: null,
+    discount_type: null,
+    discount_value: null,
+    deposit_amount: null,
+    notes: "Thanks for your business",
+    extraction_review_metadata: {
+      pipeline_version: "v2.5",
+      review_state: {
+        notes_pending: false,
+        pricing_pending: false,
+      },
+      seeded_fields: {
+        notes: { seeded: false, confidence: null, source: null },
+        pricing: {
+          explicit_total: { seeded: false, source: null },
+          deposit_amount: { seeded: false, source: null },
+          tax_rate: { seeded: false, source: null },
+          discount: { seeded: false, source: null },
+        },
+      },
+      hidden_details: {
+        items: [],
+      },
+      hidden_detail_state: {},
+      extraction_degraded_reason_code: null,
+    },
+    shared_at: null,
+    share_token: null,
+    has_active_share: false,
+    requires_customer_assignment: false,
+    can_reassign_customer: true,
+    linked_invoice: null,
+    pdf_artifact: {
+      status: "missing",
+      job_id: null,
+      download_url: null,
+      terminal_error: null,
+    },
+    line_items: [
+      {
+        id: "line-1",
+        description: "Brown mulch",
+        details: "5 yards",
+        price: 120,
+        sort_order: 0,
+      },
+    ],
+    created_at: "2026-03-20T00:00:00.000Z",
+    updated_at: "2026-03-20T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function renderScreen(document: QuoteDetail): void {
+  useLocationMock.mockReturnValue({ state: null });
+
+  mockedUsePersistedReview.mockImplementation(() => {
+    const [documentState] = useState<QuoteDetail | null>(document);
+    const [draftState, setDraftState] = useState(mapQuoteToEditDraft(document));
+
+    return {
+      document: documentState,
+      draft: draftState,
+      setDraft: (nextDraft) => {
+        setDraftState((currentDraft) =>
+          typeof nextDraft === "function"
+            ? nextDraft(currentDraft)
+            : nextDraft,
+        );
+      },
+      clearDraft: vi.fn(),
+      isLoadingDocument: false,
+      loadError: null,
+      refreshDocument: async () => document,
+    };
+  });
+
+  render(
+    <MemoryRouter>
+      <DocumentEditScreen />
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  mockedProfileService.getProfile.mockResolvedValue({
+    id: "user-1",
+    email: "owner@example.com",
+    first_name: "Jamie",
+    last_name: "Owner",
+    business_name: "North Star Lawn",
+    trade_type: "Landscaper",
+    timezone: "UTC",
+    default_tax_rate: null,
+    has_logo: false,
+    is_active: true,
+    is_onboarded: true,
+  });
+
+  mockedQuoteService.updateQuote.mockResolvedValue({ id: "doc-1" } as never);
+  mockedQuoteService.updateExtractionReviewMetadata.mockResolvedValue({
+    pipeline_version: "v2.5",
+    review_state: {
+      notes_pending: false,
+      pricing_pending: false,
+    },
+    seeded_fields: {
+      notes: { seeded: false, confidence: null, source: null },
+      pricing: {
+        explicit_total: { seeded: false, source: null },
+        deposit_amount: { seeded: false, source: null },
+        tax_rate: { seeded: false, source: null },
+        discount: { seeded: false, source: null },
+      },
+    },
+    hidden_details: { items: [] },
+    hidden_detail_state: {},
+    extraction_degraded_reason_code: null,
+  });
+  mockedInvoiceService.updateInvoice.mockResolvedValue({ id: "doc-1" } as never);
+
+  mockedLineItemCatalogService.createItem.mockResolvedValue({
+    id: "catalog-1",
+    title: "Brown mulch",
+    details: "5 yards",
+    defaultPrice: 120,
+    createdAt: "2026-04-20T00:00:00.000Z",
+    updatedAt: "2026-04-20T00:00:00.000Z",
+  });
+  mockedLineItemCatalogService.listItems.mockResolvedValue([
+    {
+      id: "catalog-1",
+      title: "Spring Cleanup",
+      details: "Blow out beds",
+      defaultPrice: 180,
+      createdAt: "2026-04-20T00:00:00.000Z",
+      updatedAt: "2026-04-20T00:00:00.000Z",
+    },
+  ]);
+
+  useParamsMock.mockReturnValue({ id: "doc-1" });
+  useLocationMock.mockReturnValue({ state: null });
+});
+
+describe("DocumentEditScreen line item catalog integration", () => {
+  it("saves to catalog via catalog API without quote persistence", async () => {
+    renderScreen(makeQuote());
+
+    fireEvent.click(await screen.findByRole("button", { name: /edit line item 1: brown mulch/i }));
+    const dialog = screen.getByRole("dialog", { name: /edit line item/i });
+    fireEvent.click(within(dialog).getByRole("button", { name: /save to catalog/i }));
+
+    await waitFor(() => {
+      expect(mockedLineItemCatalogService.createItem).toHaveBeenCalledWith({
+        title: "Brown mulch",
+        details: "5 yards",
+        defaultPrice: 120,
+      });
+    });
+    expect(mockedQuoteService.updateQuote).not.toHaveBeenCalled();
+  });
+
+  it("loads catalog on tab activation and inserts selected item into local draft", async () => {
+    renderScreen(makeQuote({ line_items: [] }));
+
+    expect(mockedLineItemCatalogService.listItems).not.toHaveBeenCalled();
+    fireEvent.click(await screen.findByRole("button", { name: /add line item/i }));
+    fireEvent.click(screen.getByRole("tab", { name: /catalog/i }));
+
+    await waitFor(() => {
+      expect(mockedLineItemCatalogService.listItems).toHaveBeenCalledTimes(1);
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /insert/i }));
+
+    expect(
+      await screen.findByRole("button", { name: /edit line item 1: spring cleanup/i }),
+    ).toBeInTheDocument();
+    expect(mockedQuoteService.updateQuote).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/features/quotes/tests/LineItemEditSheet.test.tsx
+++ b/frontend/src/features/quotes/tests/LineItemEditSheet.test.tsx
@@ -201,6 +201,30 @@ describe("LineItemEditSheet", () => {
     });
   });
 
+  it("shows a sheet-level error when save-to-catalog fails", async () => {
+    const user = userEvent.setup();
+    const onSaveToCatalog = vi.fn().mockRejectedValue(new Error("Unable to save line item to catalog"));
+
+    render(
+      <LineItemEditSheet
+        open
+        mode="edit"
+        initialLineItem={makeLineItem()}
+        onClose={vi.fn()}
+        onSave={vi.fn()}
+        onSaveToCatalog={onSaveToCatalog}
+        onRequestDelete={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /save to catalog/i }));
+
+    await waitFor(() => {
+      expect(onSaveToCatalog).toHaveBeenCalledTimes(1);
+    });
+    expect(screen.getByRole("alert")).toHaveTextContent("Unable to save line item to catalog");
+  });
+
   it("loads catalog tab lazily and inserts a catalog item into the add flow", async () => {
     const user = userEvent.setup();
     const onClose = vi.fn();

--- a/frontend/src/features/quotes/tests/LineItemEditSheet.test.tsx
+++ b/frontend/src/features/quotes/tests/LineItemEditSheet.test.tsx
@@ -3,6 +3,7 @@ import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 
 import { LineItemEditSheet } from "@/features/quotes/components/LineItemEditSheet";
+import type { LineItemCatalogItem } from "@/features/line-item-catalog/types/lineItemCatalog.types";
 import type { LineItemDraftWithFlags } from "@/features/quotes/types/quote.types";
 
 function makeLineItem(overrides: Partial<LineItemDraftWithFlags> = {}): LineItemDraftWithFlags {
@@ -12,6 +13,18 @@ function makeLineItem(overrides: Partial<LineItemDraftWithFlags> = {}): LineItem
     price: 120,
     flagged: true,
     flagReason: "Needs review",
+    ...overrides,
+  };
+}
+
+function makeCatalogItem(overrides: Partial<LineItemCatalogItem> = {}): LineItemCatalogItem {
+  return {
+    id: "catalog-1",
+    title: "Brown mulch",
+    details: "5 yards",
+    defaultPrice: 120,
+    createdAt: "2026-04-20T00:00:00.000Z",
+    updatedAt: "2026-04-20T00:00:00.000Z",
     ...overrides,
   };
 }
@@ -170,9 +183,106 @@ describe("LineItemEditSheet", () => {
     expect(onRequestDelete).toHaveBeenCalledTimes(1);
   });
 
-  it("saves to catalog using normalized manual values", async () => {
+  it("successful save shows filled bookmark icon and item in catalog tab list in same open", async () => {
     const user = userEvent.setup();
-    const onSaveToCatalog = vi.fn().mockResolvedValue(undefined);
+    const onSaveToCatalog = vi.fn().mockResolvedValue(
+      makeCatalogItem({
+        title: "Garden edging",
+        details: "Around driveway",
+        defaultPrice: 95.5,
+      }),
+    );
+    const onLoadCatalogItems = vi.fn().mockResolvedValue([]);
+
+    render(
+      <LineItemEditSheet
+        open
+        mode="add"
+        initialLineItem={makeLineItem()}
+        onClose={vi.fn()}
+        onSave={vi.fn()}
+        onSaveToCatalog={onSaveToCatalog}
+        onLoadCatalogItems={onLoadCatalogItems}
+      />,
+    );
+
+    const bookmarkButton = screen.getByRole("button", { name: /save to catalog/i });
+    expect(within(bookmarkButton).getByText("bookmark_add")).toBeInTheDocument();
+    expect(within(bookmarkButton).queryByText(/^save$/i)).not.toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText(/description/i), { target: { value: "  Garden edging  " } });
+    fireEvent.change(screen.getByLabelText(/details/i), { target: { value: "  Around driveway  " } });
+    fireEvent.change(screen.getByLabelText(/price/i), { target: { value: "95.5" } });
+
+    await user.click(bookmarkButton);
+
+    await waitFor(() => {
+      expect(onSaveToCatalog).toHaveBeenCalledWith({
+        title: "Garden edging",
+        details: "Around driveway",
+        defaultPrice: 95.5,
+      });
+    });
+    expect(within(bookmarkButton).getByText("bookmark")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("tab", { name: /catalog/i }));
+    await waitFor(() => {
+      expect(onLoadCatalogItems).toHaveBeenCalledTimes(1);
+    });
+    expect(await screen.findByText("Garden edging")).toBeInTheDocument();
+  });
+
+  it("clicking filled bookmark deletes saved item and resets icon/list state", async () => {
+    const user = userEvent.setup();
+    const createdItem = makeCatalogItem({
+      id: "catalog-9",
+      title: "Garden edging",
+      details: "Around driveway",
+      defaultPrice: 95.5,
+    });
+    const onSaveToCatalog = vi.fn().mockResolvedValue(createdItem);
+    const onDeleteFromCatalog = vi.fn().mockResolvedValue(undefined);
+    const onLoadCatalogItems = vi.fn().mockResolvedValue([]);
+
+    render(
+      <LineItemEditSheet
+        open
+        mode="add"
+        initialLineItem={makeLineItem()}
+        onClose={vi.fn()}
+        onSave={vi.fn()}
+        onSaveToCatalog={onSaveToCatalog}
+        onDeleteFromCatalog={onDeleteFromCatalog}
+        onLoadCatalogItems={onLoadCatalogItems}
+      />,
+    );
+
+    const bookmarkButton = screen.getByRole("button", { name: /save to catalog/i });
+    await user.click(bookmarkButton);
+    await waitFor(() => {
+      expect(onSaveToCatalog).toHaveBeenCalledTimes(1);
+    });
+    expect(within(bookmarkButton).getByText("bookmark")).toBeInTheDocument();
+
+    await user.click(bookmarkButton);
+    await waitFor(() => {
+      expect(onDeleteFromCatalog).toHaveBeenCalledWith("catalog-9");
+    });
+    expect(within(bookmarkButton).getByText("bookmark_add")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("tab", { name: /catalog/i }));
+    await waitFor(() => {
+      expect(onLoadCatalogItems).toHaveBeenCalledTimes(1);
+    });
+    expect(screen.queryByText("Garden edging")).not.toBeInTheDocument();
+  });
+
+  it("editing a field after save resets bookmark icon without deleting", async () => {
+    const user = userEvent.setup();
+    const onSaveToCatalog = vi.fn().mockResolvedValue(
+      makeCatalogItem({ id: "catalog-2", title: "Garden edging", defaultPrice: 95.5 }),
+    );
+    const onDeleteFromCatalog = vi.fn().mockResolvedValue(undefined);
 
     render(
       <LineItemEditSheet
@@ -182,23 +292,22 @@ describe("LineItemEditSheet", () => {
         onClose={vi.fn()}
         onSave={vi.fn()}
         onSaveToCatalog={onSaveToCatalog}
+        onDeleteFromCatalog={onDeleteFromCatalog}
         onRequestDelete={vi.fn()}
       />,
     );
 
-    fireEvent.change(screen.getByLabelText(/description/i), { target: { value: "  Garden edging  " } });
-    fireEvent.change(screen.getByLabelText(/details/i), { target: { value: "  Around driveway  " } });
-    fireEvent.change(screen.getByLabelText(/price/i), { target: { value: "95.5" } });
-
-    await user.click(screen.getByRole("button", { name: /save to catalog/i }));
-
+    const bookmarkButton = screen.getByRole("button", { name: /save to catalog/i });
+    await user.click(bookmarkButton);
     await waitFor(() => {
-      expect(onSaveToCatalog).toHaveBeenCalledWith({
-        title: "Garden edging",
-        details: "Around driveway",
-        defaultPrice: 95.5,
-      });
+      expect(onSaveToCatalog).toHaveBeenCalledTimes(1);
     });
+    expect(within(bookmarkButton).getByText("bookmark")).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText(/description/i), { target: { value: "Updated description" } });
+
+    expect(within(bookmarkButton).getByText("bookmark_add")).toBeInTheDocument();
+    expect(onDeleteFromCatalog).not.toHaveBeenCalled();
   });
 
   it("shows a sheet-level error when save-to-catalog fails", async () => {
@@ -247,7 +356,7 @@ describe("LineItemEditSheet", () => {
         initialLineItem={makeLineItem({ description: "", details: null, price: null })}
         onClose={onClose}
         onSave={onSave}
-        onSaveToCatalog={vi.fn().mockResolvedValue(undefined)}
+        onSaveToCatalog={vi.fn().mockResolvedValue(makeCatalogItem())}
         onLoadCatalogItems={onLoadCatalogItems}
       />,
     );
@@ -270,5 +379,27 @@ describe("LineItemEditSheet", () => {
       flagReason: null,
     });
     expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("hides save-to-catalog bookmark button on catalog tab", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <LineItemEditSheet
+        open
+        mode="add"
+        initialLineItem={makeLineItem({ description: "", details: null, price: null })}
+        onClose={vi.fn()}
+        onSave={vi.fn()}
+        onSaveToCatalog={vi.fn().mockResolvedValue(makeCatalogItem())}
+        onLoadCatalogItems={vi.fn().mockResolvedValue([])}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: /save to catalog/i })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("tab", { name: /catalog/i }));
+
+    expect(screen.queryByRole("button", { name: /save to catalog/i })).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/features/quotes/tests/LineItemEditSheet.test.tsx
+++ b/frontend/src/features/quotes/tests/LineItemEditSheet.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, within } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 
@@ -168,5 +168,83 @@ describe("LineItemEditSheet", () => {
 
     fireEvent.click(screen.getByRole("button", { name: /delete line item/i }));
     expect(onRequestDelete).toHaveBeenCalledTimes(1);
+  });
+
+  it("saves to catalog using normalized manual values", async () => {
+    const user = userEvent.setup();
+    const onSaveToCatalog = vi.fn().mockResolvedValue(undefined);
+
+    render(
+      <LineItemEditSheet
+        open
+        mode="edit"
+        initialLineItem={makeLineItem()}
+        onClose={vi.fn()}
+        onSave={vi.fn()}
+        onSaveToCatalog={onSaveToCatalog}
+        onRequestDelete={vi.fn()}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText(/description/i), { target: { value: "  Garden edging  " } });
+    fireEvent.change(screen.getByLabelText(/details/i), { target: { value: "  Around driveway  " } });
+    fireEvent.change(screen.getByLabelText(/price/i), { target: { value: "95.5" } });
+
+    await user.click(screen.getByRole("button", { name: /save to catalog/i }));
+
+    await waitFor(() => {
+      expect(onSaveToCatalog).toHaveBeenCalledWith({
+        title: "Garden edging",
+        details: "Around driveway",
+        defaultPrice: 95.5,
+      });
+    });
+  });
+
+  it("loads catalog tab lazily and inserts a catalog item into the add flow", async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    const onSave = vi.fn();
+    const onLoadCatalogItems = vi.fn().mockResolvedValue([
+      {
+        id: "catalog-1",
+        title: "Spring Cleanup",
+        details: "Blow out beds",
+        defaultPrice: 180,
+        createdAt: "2026-04-20T00:00:00.000Z",
+        updatedAt: "2026-04-20T00:00:00.000Z",
+      },
+    ]);
+
+    render(
+      <LineItemEditSheet
+        open
+        mode="add"
+        initialLineItem={makeLineItem({ description: "", details: null, price: null })}
+        onClose={onClose}
+        onSave={onSave}
+        onSaveToCatalog={vi.fn().mockResolvedValue(undefined)}
+        onLoadCatalogItems={onLoadCatalogItems}
+      />,
+    );
+
+    expect(onLoadCatalogItems).not.toHaveBeenCalled();
+
+    await user.click(screen.getByRole("tab", { name: /catalog/i }));
+    await waitFor(() => {
+      expect(onLoadCatalogItems).toHaveBeenCalledTimes(1);
+    });
+    expect(await screen.findByText("Spring Cleanup")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /insert/i }));
+
+    expect(onSave).toHaveBeenCalledWith({
+      description: "Spring Cleanup",
+      details: "Blow out beds",
+      price: 180,
+      flagged: false,
+      flagReason: null,
+    });
+    expect(onClose).toHaveBeenCalledTimes(1);
   });
 });

--- a/frontend/src/features/quotes/tests/LineItemEditSheet.test.tsx
+++ b/frontend/src/features/quotes/tests/LineItemEditSheet.test.tsx
@@ -70,7 +70,105 @@ describe("LineItemEditSheet", () => {
     expect(within(dialog).queryByRole("button", { name: /delete line item/i })).not.toBeInTheDocument();
   });
 
-  it("blocks dismiss with a validation error when description is blank", async () => {
+  it("add mode dismisses on backdrop tap with empty fields without validation", async () => {
+    const user = userEvent.setup();
+    const onSave = vi.fn();
+    const onClose = vi.fn();
+
+    render(
+      <LineItemEditSheet
+        open
+        mode="add"
+        initialLineItem={makeLineItem({ description: "", details: null, price: null })}
+        onClose={onClose}
+        onSave={onSave}
+      />,
+    );
+
+    await user.click(screen.getByTestId("line-item-edit-sheet-overlay"));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(onSave).not.toHaveBeenCalled();
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
+  it("add mode dismisses on backdrop tap with partial fields without validation", async () => {
+    const user = userEvent.setup();
+    const onSave = vi.fn();
+    const onClose = vi.fn();
+
+    render(
+      <LineItemEditSheet
+        open
+        mode="add"
+        initialLineItem={makeLineItem({ description: "", details: null, price: null })}
+        onClose={onClose}
+        onSave={onSave}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText(/description/i), { target: { value: "Mulch refresh" } });
+    await user.click(screen.getByTestId("line-item-edit-sheet-overlay"));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(onSave).not.toHaveBeenCalled();
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
+  it("add mode add button validates blank description", async () => {
+    const user = userEvent.setup();
+    const onSave = vi.fn();
+    const onClose = vi.fn();
+
+    render(
+      <LineItemEditSheet
+        open
+        mode="add"
+        initialLineItem={makeLineItem({ description: "", details: null, price: null })}
+        onClose={onClose}
+        onSave={onSave}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /add line item/i }));
+
+    expect(screen.getByRole("alert")).toHaveTextContent("Description is required.");
+    expect(onSave).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("add mode add button saves valid manual fields and closes", async () => {
+    const user = userEvent.setup();
+    const onSave = vi.fn();
+    const onClose = vi.fn();
+
+    render(
+      <LineItemEditSheet
+        open
+        mode="add"
+        initialLineItem={makeLineItem({ description: "", details: null, price: null })}
+        onClose={onClose}
+        onSave={onSave}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText(/description/i), { target: { value: "  Fresh mulch  " } });
+    fireEvent.change(screen.getByLabelText(/details/i), { target: { value: "  Front beds  " } });
+    fireEvent.change(screen.getByLabelText(/price/i), { target: { value: "95.5" } });
+
+    await user.click(screen.getByRole("button", { name: /add line item/i }));
+
+    expect(onSave).toHaveBeenCalledWith({
+      description: "Fresh mulch",
+      details: "Front beds",
+      price: 95.5,
+      flagged: true,
+      flagReason: "Needs review",
+    });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("edit mode backdrop dismiss still validates blank description", async () => {
     const user = userEvent.setup();
     const onSave = vi.fn();
     const onClose = vi.fn();

--- a/frontend/src/features/settings/components/SettingsCatalogShortcutCard.tsx
+++ b/frontend/src/features/settings/components/SettingsCatalogShortcutCard.tsx
@@ -1,0 +1,27 @@
+interface SettingsCatalogShortcutCardProps {
+  onOpenLineItemCatalog: () => void;
+}
+
+export function SettingsCatalogShortcutCard({
+  onOpenLineItemCatalog,
+}: SettingsCatalogShortcutCardProps): React.ReactElement {
+  return (
+    <section className="rounded-xl bg-surface-container-low p-4">
+      <h2 className="text-[0.6875rem] font-bold uppercase tracking-widest text-outline">
+        Catalog
+      </h2>
+      <div className="mt-3 flex items-center justify-between gap-3">
+        <p className="text-sm text-on-surface-variant">
+          Save and manage reusable line item presets.
+        </p>
+        <button
+          type="button"
+          className="inline-flex min-h-10 items-center justify-center rounded-lg border border-outline-variant/40 px-3 py-2 text-xs font-semibold text-on-surface transition-colors hover:bg-surface-container"
+          onClick={onOpenLineItemCatalog}
+        >
+          Line Item Catalog
+        </button>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/features/settings/components/SettingsScreen.tsx
+++ b/frontend/src/features/settings/components/SettingsScreen.tsx
@@ -1,8 +1,10 @@
 import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
 
 import { useAuth } from "@/features/auth/hooks/useAuth";
 import { getTimezoneOptions } from "@/features/profile/lib/timezones";
 import { profileService } from "@/features/profile/services/profileService";
+import { SettingsCatalogShortcutCard } from "@/features/settings/components/SettingsCatalogShortcutCard";
 import {
   TRADE_TYPES,
   type ProfileResponse,
@@ -28,6 +30,7 @@ const THEME_OPTIONS: ReadonlyArray<{ label: string; value: ThemePreference }> = 
 ];
 
 export function SettingsScreen(): React.ReactElement {
+  const navigate = useNavigate();
   const { logout, refreshUser } = useAuth();
   const { preference: themePreference, setPreference: setThemePreference } = useTheme();
   const logoPreviewSrc = `${import.meta.env.VITE_API_URL ?? ""}/api/profile/logo`;
@@ -372,6 +375,10 @@ export function SettingsScreen(): React.ReactElement {
                 </div>
               </div>
             </section>
+
+            <SettingsCatalogShortcutCard
+              onOpenLineItemCatalog={() => navigate("/settings/line-item-catalog")}
+            />
 
             <section className="rounded-xl bg-surface-container-low p-4">
               <h2 className="text-[0.6875rem] font-bold uppercase tracking-widest text-outline">

--- a/frontend/src/features/settings/tests/LineItemCatalogSettings.test.tsx
+++ b/frontend/src/features/settings/tests/LineItemCatalogSettings.test.tsx
@@ -1,0 +1,122 @@
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { LineItemCatalogSettingsScreen } from "@/features/line-item-catalog/components/LineItemCatalogSettingsScreen";
+import { lineItemCatalogService } from "@/features/line-item-catalog/services/lineItemCatalogService";
+
+vi.mock("@/features/line-item-catalog/services/lineItemCatalogService", () => ({
+  lineItemCatalogService: {
+    listItems: vi.fn(),
+    createItem: vi.fn(),
+    updateItem: vi.fn(),
+    deleteItem: vi.fn(),
+  },
+}));
+
+const mockedLineItemCatalogService = vi.mocked(lineItemCatalogService);
+
+function renderScreen(): void {
+  render(
+    <MemoryRouter>
+      <LineItemCatalogSettingsScreen />
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  mockedLineItemCatalogService.listItems.mockResolvedValue([
+    {
+      id: "catalog-1",
+      title: "Spring Cleanup",
+      details: "Blow out beds",
+      defaultPrice: 180,
+      createdAt: "2026-04-20T00:00:00.000Z",
+      updatedAt: "2026-04-20T00:00:00.000Z",
+    },
+  ]);
+  mockedLineItemCatalogService.createItem.mockResolvedValue({
+    id: "catalog-2",
+    title: "Mow and edge",
+    details: "Front and back yard",
+    defaultPrice: 95,
+    createdAt: "2026-04-20T01:00:00.000Z",
+    updatedAt: "2026-04-20T01:00:00.000Z",
+  });
+  mockedLineItemCatalogService.updateItem.mockResolvedValue({
+    id: "catalog-2",
+    title: "Mow, edge, and bag",
+    details: "Front and back yard",
+    defaultPrice: 105,
+    createdAt: "2026-04-20T01:00:00.000Z",
+    updatedAt: "2026-04-20T02:00:00.000Z",
+  });
+  mockedLineItemCatalogService.deleteItem.mockResolvedValue(undefined);
+});
+
+describe("LineItemCatalogSettingsScreen", () => {
+  it("validates title and supports create/edit/delete management", async () => {
+    renderScreen();
+
+    expect(await screen.findByText("Spring Cleanup")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /create item/i }));
+    expect(screen.getByRole("alert")).toHaveTextContent("Title is required.");
+    expect(mockedLineItemCatalogService.createItem).not.toHaveBeenCalled();
+
+    fireEvent.change(screen.getByLabelText(/^title$/i), {
+      target: { value: "Mow and edge" },
+    });
+    fireEvent.change(screen.getByLabelText(/details/i), {
+      target: { value: "Front and back yard" },
+    });
+    fireEvent.change(screen.getByLabelText(/default price/i), {
+      target: { value: "95" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /create item/i }));
+
+    await waitFor(() => {
+      expect(mockedLineItemCatalogService.createItem).toHaveBeenCalledWith({
+        title: "Mow and edge",
+        details: "Front and back yard",
+        defaultPrice: 95,
+      });
+    });
+    expect(await screen.findByText("Mow and edge")).toBeInTheDocument();
+
+    const createdItemCard = screen.getByText("Mow and edge").closest("article");
+    expect(createdItemCard).not.toBeNull();
+    fireEvent.click(within(createdItemCard as HTMLElement).getByRole("button", { name: /edit/i }));
+
+    fireEvent.change(screen.getByLabelText(/^title$/i), {
+      target: { value: "Mow, edge, and bag" },
+    });
+    fireEvent.change(screen.getByLabelText(/default price/i), {
+      target: { value: "105" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /update item/i }));
+
+    await waitFor(() => {
+      expect(mockedLineItemCatalogService.updateItem).toHaveBeenCalledWith("catalog-2", {
+        title: "Mow, edge, and bag",
+        details: "Front and back yard",
+        defaultPrice: 105,
+      });
+    });
+
+    const updatedCard = await screen.findByText("Mow, edge, and bag");
+    expect(updatedCard).toBeInTheDocument();
+
+    const updatedItemCard = updatedCard.closest("article");
+    expect(updatedItemCard).not.toBeNull();
+    fireEvent.click(within(updatedItemCard as HTMLElement).getByRole("button", { name: /delete/i }));
+
+    const deleteDialog = screen.getByRole("dialog", { name: /delete catalog item/i });
+    fireEvent.click(within(deleteDialog).getByRole("button", { name: /^delete$/i }));
+
+    await waitFor(() => {
+      expect(mockedLineItemCatalogService.deleteItem).toHaveBeenCalledWith("catalog-2");
+    });
+    expect(screen.queryByText("Mow, edge, and bag")).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add frontend line-item catalog client types/service and a new settings management screen (`/settings/line-item-catalog`) with create/edit/delete + title validation
- integrate review line-item sheet with `Save to catalog` and add-mode `Manual | Catalog` tabs (lazy-load catalog on tab activation)
- insert catalog selections as normal local draft line items without quote persistence side-effects
- add/expand frontend tests for sheet behavior, quote integration, and settings catalog management

## Verification
- `cd frontend && npx vitest run src/features/quotes/tests/LineItemEditSheet.test.tsx`
- `cd frontend && npx vitest run src/features/quotes/tests/LineItemCatalogInsert.test.tsx`
- `cd frontend && npx vitest run src/features/settings/tests/LineItemCatalogSettings.test.tsx`
- `cd frontend && npx eslint src/features/quotes src/features/settings src/features/line-item-catalog`
- `make frontend-verify`

Closes #468