### PR TITLE
Task #488: PR2 Review/Edit UI adoption and refinement

### DIFF
--- a/frontend/src/features/quotes/components/DocumentEditScreenView.tsx
+++ b/frontend/src/features/quotes/components/DocumentEditScreenView.tsx
@@ -146,10 +146,8 @@ export function DocumentEditScreenView({
   return (
     <main className="min-h-screen bg-background pb-28">
       <WorkflowScreenHeader
-        title={activeDraft.title.trim().length > 0
-          ? activeDraft.title.trim()
-          : document.doc_number ?? (activeDraft.docType === "invoice" ? "Edit Invoice" : "Review Quote")}
-        subtitle={document.doc_number}
+        title="Review & Edit"
+        subtitle="Confirm line items and pricing"
         backLabel={backLabel}
         onBack={() => onRequestNavigation({ to: backTarget, replace: true })}
       />

--- a/frontend/src/features/quotes/components/LineItemCard.tsx
+++ b/frontend/src/features/quotes/components/LineItemCard.tsx
@@ -73,7 +73,9 @@ export function LineItemCard({
         disabled={!canEditRow}
         className={`flex min-w-0 flex-1 items-start justify-between gap-3 rounded-[var(--radius-document)] p-1 text-left transition-colors ${
           canEditRow ? "cursor-pointer hover:bg-surface-container-low/70" : "cursor-default"
-        } disabled:opacity-60`}
+        } ${
+          !canEditRow && !isDragging ? "opacity-60" : ""
+        }`}
         onClick={onEdit}
       >
         <div className="min-w-0 flex-1">

--- a/frontend/src/features/quotes/components/LineItemCard.tsx
+++ b/frontend/src/features/quotes/components/LineItemCard.tsx
@@ -41,8 +41,8 @@ export function LineItemCard({
 
   return (
     <div
-      className={`flex w-full items-start gap-3 rounded-xl bg-surface-container-lowest p-3 ghost-shadow ${
-        flagged ? "border border-warning-accent/20" : ""
+      className={`flex w-full items-start gap-3 rounded-[var(--radius-document)] bg-surface-container-lowest p-3 ghost-shadow ${
+        flagged ? "border-l-4 border-warning-accent" : ""
       } ${
         isReorderMode
           ? "transition-[transform,box-shadow,background-color] duration-150 ease-out"
@@ -71,7 +71,7 @@ export function LineItemCard({
         type="button"
         aria-label={ariaLabel}
         disabled={!canEditRow}
-        className={`flex min-w-0 flex-1 items-start justify-between gap-3 rounded-lg p-1 text-left transition-colors ${
+        className={`flex min-w-0 flex-1 items-start justify-between gap-3 rounded-[var(--radius-document)] p-1 text-left transition-colors ${
           canEditRow ? "cursor-pointer hover:bg-surface-container-low/70" : "cursor-default"
         } disabled:opacity-60`}
         onClick={onEdit}
@@ -80,7 +80,7 @@ export function LineItemCard({
           <div className="flex items-center gap-2">
             <p className="truncate font-bold text-on-surface">{description}</p>
             {flagged ? (
-              <span className="rounded bg-warning-container px-2 py-0.5 text-[0.6875rem] font-bold uppercase tracking-wide text-warning">
+              <span className="rounded-full bg-warning-container px-2.5 py-1 text-[0.6875rem] font-bold uppercase tracking-wide text-warning">
                 REVIEW
               </span>
             ) : null}
@@ -98,7 +98,7 @@ export function LineItemCard({
         </div>
 
         <div className="mt-0.5 flex shrink-0 items-center">
-          <p className="font-bold text-on-surface">{priceLabel}</p>
+          <p className="font-bold text-primary">{priceLabel}</p>
         </div>
       </button>
     </div>

--- a/frontend/src/features/quotes/components/ReviewActionFooter.tsx
+++ b/frontend/src/features/quotes/components/ReviewActionFooter.tsx
@@ -29,7 +29,7 @@ export function ReviewActionFooter({
           <Button
             type="button"
             variant="primary"
-            className="w-full sm:flex-1"
+            className="w-full !rounded-[var(--radius-document)] sm:flex-1"
             disabled={isContinueDisabled}
             isLoading={isContinuing}
             onClick={onPrimaryAction}
@@ -38,7 +38,7 @@ export function ReviewActionFooter({
           </Button>
           <button
             type="button"
-            className="w-full cursor-pointer rounded-lg border border-outline-variant/30 bg-surface-container-low px-4 py-3 font-semibold text-on-surface transition-colors hover:bg-surface-container-lowest disabled:cursor-not-allowed disabled:opacity-60 sm:flex-1"
+            className="w-full cursor-pointer rounded-[var(--radius-document)] border border-outline-variant/30 bg-surface-container-low px-4 py-3 font-semibold text-on-surface transition-colors hover:bg-surface-container-lowest disabled:cursor-not-allowed disabled:opacity-60 sm:flex-1"
             disabled={isInteractionLocked || isSavingDraft}
             onClick={onSaveDraft}
           >

--- a/frontend/src/features/quotes/components/ReviewActionFooter.tsx
+++ b/frontend/src/features/quotes/components/ReviewActionFooter.tsx
@@ -29,7 +29,7 @@ export function ReviewActionFooter({
           <Button
             type="button"
             variant="primary"
-            className="w-full !rounded-[var(--radius-document)] sm:flex-1"
+            className="w-full sm:flex-1"
             disabled={isContinueDisabled}
             isLoading={isContinuing}
             onClick={onPrimaryAction}

--- a/frontend/src/features/quotes/components/ReviewCustomerRow.tsx
+++ b/frontend/src/features/quotes/components/ReviewCustomerRow.tsx
@@ -1,3 +1,5 @@
+import { Eyebrow } from "@/ui/Eyebrow";
+
 interface ReviewCustomerRowProps {
   customerName: string | null;
   requiresCustomerAssignment: boolean;
@@ -19,9 +21,9 @@ export function ReviewCustomerRow({
   return (
     <section className="space-y-2">
       <div className="flex items-center justify-between gap-3">
-        <p className="text-[0.6875rem] font-bold uppercase tracking-widest text-outline">Customer</p>
+        <Eyebrow>Customer</Eyebrow>
         {requiresCustomerAssignment ? (
-          <span className="rounded-lg bg-warning-container px-2.5 py-1 text-[0.6875rem] font-bold uppercase tracking-wide text-warning">
+          <span className="rounded-full bg-warning-container px-2.5 py-1 text-[0.6875rem] font-bold uppercase tracking-wide text-warning">
             Needs customer
           </span>
         ) : null}
@@ -29,7 +31,7 @@ export function ReviewCustomerRow({
 
       <button
         type="button"
-        className={`flex w-full cursor-pointer items-center justify-between rounded-lg border border-outline-variant/30 bg-surface-container-high px-4 py-3 text-left transition-all hover:bg-surface-container-lowest disabled:cursor-not-allowed disabled:opacity-70 ${
+        className={`flex w-full cursor-pointer items-center justify-between rounded-[var(--radius-document)] border border-outline-variant/30 bg-surface-container-high px-4 py-3 text-left transition-all hover:bg-surface-container-lowest disabled:cursor-not-allowed disabled:opacity-70 ${
           requiresCustomerAssignment
             ? "ring-2 ring-warning-accent/60 animate-pulse [animation-iteration-count:3]"
             : ""

--- a/frontend/src/features/quotes/components/ReviewDocumentTypeSelector.tsx
+++ b/frontend/src/features/quotes/components/ReviewDocumentTypeSelector.tsx
@@ -1,3 +1,5 @@
+import { Eyebrow } from "@/ui/Eyebrow";
+
 export type ReviewDocumentType = "quote" | "invoice";
 
 interface ReviewDocumentTypeSelectorProps {
@@ -30,9 +32,7 @@ export function ReviewDocumentTypeSelector({
   return (
     <section className="space-y-2">
       <div>
-        <p className="text-[0.6875rem] font-bold uppercase tracking-widest text-outline">
-          Document Type
-        </p>
+        <Eyebrow>Document Type</Eyebrow>
       </div>
 
       <div role="radiogroup" aria-label="Document type" className="flex flex-row gap-3">
@@ -48,11 +48,11 @@ export function ReviewDocumentTypeSelector({
               aria-checked={isSelected}
               disabled={isOptionDisabled}
               className={[
-                "w-full cursor-pointer rounded-xl py-3 text-center font-headline text-lg font-bold tracking-tight transition-all",
+                "w-full cursor-pointer py-3 text-center font-headline text-lg font-bold tracking-tight transition-all",
                 "disabled:cursor-not-allowed disabled:opacity-60",
                 isSelected
-                  ? "ghost-shadow bg-surface-container-lowest ring-2 ring-primary/30 text-on-surface"
-                  : "bg-surface-container-low text-on-surface hover:bg-surface-container-lowest",
+                  ? "ghost-shadow rounded-[var(--radius-document)] bg-surface-container-lowest ring-2 ring-primary/30 text-on-surface"
+                  : "rounded-[var(--radius-document)] bg-surface-container-low text-on-surface hover:bg-surface-container-lowest",
               ].join(" ")}
               onClick={() => onChange(option.value)}
             >

--- a/frontend/src/features/quotes/components/ReviewFormContent.tsx
+++ b/frontend/src/features/quotes/components/ReviewFormContent.tsx
@@ -11,25 +11,8 @@ import { FeedbackMessage } from "@/shared/components/FeedbackMessage";
 import {
   DOCUMENT_NOTES_MAX_CHARS,
 } from "@/shared/lib/inputLimits";
-
-interface ReviewPendingMarkerProps {
-  title: string;
-  message: string;
-}
-
-function ReviewPendingMarker({ title, message }: ReviewPendingMarkerProps): React.ReactElement {
-  return (
-    <section className="ghost-shadow rounded-lg border-l-4 border-warning-accent bg-warning-container p-4">
-      <div className="flex items-start gap-3">
-        <span className="material-symbols-outlined text-warning">error</span>
-        <div>
-          <p className="text-[0.6875rem] font-bold uppercase tracking-wider text-warning">{title}</p>
-          <p className="text-sm font-medium leading-snug text-warning">{message}</p>
-        </div>
-      </div>
-    </section>
-  );
-}
+import { Banner } from "@/ui/Banner";
+import { Eyebrow } from "@/ui/Eyebrow";
 
 interface ReviewFormContentProps {
   customerName: string | null;
@@ -140,7 +123,7 @@ export function ReviewFormContent({
       onSubmit={(event) => event.preventDefault()}
     >
       {locationNotice ? (
-        <section className="rounded-lg border border-warning-accent/40 bg-warning-container p-4 text-sm text-warning">
+        <section className="rounded-[var(--radius-document)] border border-warning-accent/40 bg-warning-container p-4 text-sm text-warning">
           {locationNotice}
         </section>
       ) : null}
@@ -154,7 +137,7 @@ export function ReviewFormContent({
       ) : null}
 
       {showSevereDegradedMarker ? (
-        <ReviewPendingMarker
+        <Banner
           title="Review Required"
           message={extractionDegradedReasonCode
             ? "Extraction degraded and no line items were found. Review capture details before continuing."
@@ -163,11 +146,10 @@ export function ReviewFormContent({
       ) : null}
 
       <section className="space-y-2">
-        <label
-          htmlFor="quote-review-title"
-          className="text-[0.6875rem] font-bold uppercase tracking-widest text-outline"
-        >
+        <label htmlFor="quote-review-title">
+          <Eyebrow>
           {documentType === "invoice" ? "INVOICE TITLE" : "QUOTE TITLE"}
+          </Eyebrow>
         </label>
         <input
           id="quote-review-title"
@@ -176,7 +158,7 @@ export function ReviewFormContent({
           maxLength={120}
           disabled={isInteractionLocked}
           onChange={(event) => onTitleChange(event.target.value)}
-          className="w-full rounded-lg bg-surface-container-high px-4 py-3 font-body text-sm text-on-surface placeholder:text-outline transition-all focus:bg-surface-container-lowest focus:outline-none focus:ring-2 focus:ring-primary/30"
+          className="w-full rounded-[var(--radius-document)] bg-surface-container-high px-4 py-3 font-body text-sm text-on-surface placeholder:text-outline transition-all focus:bg-surface-container-lowest focus:outline-none focus:ring-2 focus:ring-primary/30"
           placeholder="Front yard refresh (optional)"
         />
       </section>
@@ -198,11 +180,8 @@ export function ReviewFormContent({
 
       {showDueDateField ? (
         <section className="space-y-2">
-          <label
-            htmlFor="document-review-due-date"
-            className="text-[0.6875rem] font-bold uppercase tracking-widest text-outline"
-          >
-            INVOICE DUE DATE
+          <label htmlFor="document-review-due-date">
+            <Eyebrow>INVOICE DUE DATE</Eyebrow>
           </label>
           <input
             id="document-review-due-date"
@@ -210,7 +189,7 @@ export function ReviewFormContent({
             value={draft.dueDate ?? ""}
             disabled={isInteractionLocked}
             onChange={(event) => onDueDateChange(event.target.value)}
-            className="w-full rounded-lg bg-surface-container-high px-4 py-3 font-body text-sm text-on-surface placeholder:text-outline transition-all focus:bg-surface-container-lowest focus:outline-none focus:ring-2 focus:ring-primary/30"
+            className="w-full rounded-[var(--radius-document)] bg-surface-container-high px-4 py-3 font-body text-sm text-on-surface placeholder:text-outline transition-all focus:bg-surface-container-lowest focus:outline-none focus:ring-2 focus:ring-primary/30"
           />
         </section>
       ) : null}
@@ -219,14 +198,14 @@ export function ReviewFormContent({
         <section className="space-y-2">
           <button
             type="button"
-            className="inline-flex w-full cursor-pointer items-center justify-between rounded-lg border border-outline-variant/30 bg-surface-container-high px-4 py-3 text-left transition-colors hover:bg-surface-container-lowest"
+            className="inline-flex w-full cursor-pointer items-center justify-between rounded-[var(--radius-document)] border border-outline-variant/30 bg-surface-container-high px-4 py-3 text-left transition-colors hover:bg-surface-container-lowest"
             onClick={() => {
               onCaptureDetailsOpen();
               setIsCaptureDetailsOpen(true);
             }}
           >
             <div>
-              <p className="text-[0.6875rem] font-bold uppercase tracking-widest text-outline">Capture Details</p>
+              <Eyebrow>Capture Details</Eyebrow>
               <p className="text-sm text-on-surface-variant">
                 Actionable items and transcript.
               </p>
@@ -247,14 +226,14 @@ export function ReviewFormContent({
       ) : null}
 
       {pricingReviewPending ? (
-        <ReviewPendingMarker
+        <Banner
           title="Pricing Pending Review"
           message="Pricing fields were seeded from capture details. Review totals, tax, discount, and deposit."
         />
       ) : null}
 
       {notesReviewPending ? (
-        <ReviewPendingMarker
+        <Banner
           title="Notes Pending Review"
           message="Notes were seeded from capture details. Review and adjust before continuing."
         />
@@ -285,11 +264,8 @@ export function ReviewFormContent({
       />
 
       <section className="space-y-2">
-        <label
-          htmlFor="quote-review-notes"
-          className="text-xs font-bold uppercase tracking-wider text-outline-variant"
-        >
-          CUSTOMER NOTES
+        <label htmlFor="quote-review-notes">
+          <Eyebrow className="text-outline-variant">CUSTOMER NOTES</Eyebrow>
         </label>
         <textarea
           id="quote-review-notes"
@@ -298,7 +274,7 @@ export function ReviewFormContent({
           value={draft.notes}
           disabled={isInteractionLocked}
           onChange={(event) => onNotesChange(event.target.value)}
-          className="w-full rounded-lg border border-outline-variant/30 bg-surface-container-high p-4 text-sm text-on-surface placeholder:text-outline/70 outline-none transition-all focus:border-primary focus:bg-surface-container-lowest focus:ring-2 focus:ring-primary/20"
+          className="w-full rounded-[var(--radius-document)] border border-outline-variant/30 bg-surface-container-high p-4 text-sm text-on-surface placeholder:text-outline/70 outline-none transition-all focus:border-primary focus:bg-surface-container-lowest focus:ring-2 focus:ring-primary/20"
           placeholder="Any notes to include for the customer."
         />
       </section>

--- a/frontend/src/features/quotes/components/ReviewFormContent.tsx
+++ b/frontend/src/features/quotes/components/ReviewFormContent.tsx
@@ -123,7 +123,7 @@ export function ReviewFormContent({
       onSubmit={(event) => event.preventDefault()}
     >
       {locationNotice ? (
-        <section className="rounded-[var(--radius-document)] border border-warning-accent/40 bg-warning-container p-4 text-sm text-warning">
+        <section className="ghost-shadow rounded-[var(--radius-document)] border-l-4 border-warning-accent bg-warning-container p-4 text-sm text-warning backdrop-blur-md">
           {locationNotice}
         </section>
       ) : null}
@@ -265,7 +265,7 @@ export function ReviewFormContent({
 
       <section className="space-y-2">
         <label htmlFor="quote-review-notes">
-          <Eyebrow className="text-outline-variant">CUSTOMER NOTES</Eyebrow>
+          <Eyebrow>CUSTOMER NOTES</Eyebrow>
         </label>
         <textarea
           id="quote-review-notes"

--- a/frontend/src/features/quotes/components/ReviewLineItemsSection.tsx
+++ b/frontend/src/features/quotes/components/ReviewLineItemsSection.tsx
@@ -124,10 +124,10 @@ export function ReviewLineItemsSection({
         <button
           type="button"
           disabled={isInteractionLocked || (!isReorderModeActive && lineItems.length < 2)}
-          className={`inline-flex min-h-9 items-center rounded-full border px-3 py-1 text-xs font-bold uppercase tracking-wide transition-colors ${
+          className={`inline-flex min-h-9 items-center rounded-full border px-3 py-1.5 text-xs font-semibold transition-all ${
             isReorderModeActive
-              ? "border-primary/40 bg-primary/10 text-primary hover:bg-primary/15"
-              : "border-outline-variant/40 bg-surface-container-lowest text-on-surface hover:bg-surface-container-low"
+              ? "border-primary/30 bg-primary/15 text-primary ghost-shadow"
+              : "border-outline-variant/35 bg-surface-container-high/80 text-on-surface-variant hover:border-outline-variant/50 hover:bg-surface-container-high"
           } disabled:cursor-not-allowed disabled:opacity-60`}
           onClick={() => {
             clearDragState();

--- a/frontend/src/features/quotes/components/ReviewLineItemsSection.tsx
+++ b/frontend/src/features/quotes/components/ReviewLineItemsSection.tsx
@@ -177,7 +177,7 @@ export function ReviewLineItemsSection({
             );
           })
         ) : (
-          <p className="rounded-lg bg-surface-container-lowest p-4 text-sm text-outline">
+          <p className="rounded-[var(--radius-document)] bg-surface-container-lowest p-4 text-sm text-outline">
             No line items on this quote yet.
           </p>
         )}
@@ -186,7 +186,7 @@ export function ReviewLineItemsSection({
       <div className="grid gap-3 sm:grid-cols-1">
         <button
           type="button"
-          className="flex w-full cursor-pointer items-center justify-center gap-2 rounded-lg border-2 border-dashed border-outline-variant/30 py-3 text-sm text-on-surface-variant transition-colors hover:bg-surface-container-low disabled:cursor-not-allowed disabled:opacity-60"
+          className="flex w-full cursor-pointer items-center justify-center gap-2 rounded-[var(--radius-document)] border-2 border-dashed border-outline-variant/30 py-3 text-sm text-on-surface-variant transition-colors hover:bg-surface-container-low disabled:cursor-not-allowed disabled:opacity-60"
           disabled={isInteractionLocked || hasReachedLineItemLimit || isReorderModeActive}
           onClick={onAddLineItem}
         >

--- a/frontend/src/features/quotes/components/TotalAmountSection.test.tsx
+++ b/frontend/src/features/quotes/components/TotalAmountSection.test.tsx
@@ -51,7 +51,7 @@ describe("TotalAmountSection", () => {
     renderSection();
 
     expect(screen.getByRole("spinbutton", { name: /total amount/i })).toHaveClass(
-      "bg-surface-container-lowest",
+      "bg-surface-container-high",
     );
   });
 

--- a/frontend/src/features/quotes/components/TotalAmountSection.tsx
+++ b/frontend/src/features/quotes/components/TotalAmountSection.tsx
@@ -154,7 +154,7 @@ export function TotalAmountSection({
                     onDiscountValueChange(null);
                   }}
                 />
-                <span className="relative inline-flex h-5 w-9 shrink-0 rounded-full bg-outline-variant/40 transition-colors peer-checked:bg-primary peer-disabled:opacity-50 after:absolute after:left-0.5 after:top-0.5 after:h-4 after:w-4 after:rounded-full after:bg-surface-container-lowest after:shadow-sm after:transition-transform peer-checked:after:translate-x-4" />
+                <span className="relative inline-flex h-5 w-9 shrink-0 rounded-full bg-outline-variant/40 transition-colors peer-checked:bg-primary peer-focus-visible:ring-2 peer-focus-visible:ring-primary/40 peer-disabled:opacity-50 after:absolute after:left-0.5 after:top-0.5 after:h-4 after:w-4 after:rounded-full after:bg-surface-container-lowest after:shadow-sm after:transition-transform peer-checked:after:translate-x-4" />
                 <span className="font-semibold">Discount</span>
               </label>
               {isDiscountEnabled ? (
@@ -206,7 +206,7 @@ export function TotalAmountSection({
                     onTaxRateChange(null);
                   }}
                 />
-                <span className="relative inline-flex h-5 w-9 shrink-0 rounded-full bg-outline-variant/40 transition-colors peer-checked:bg-primary peer-disabled:opacity-50 after:absolute after:left-0.5 after:top-0.5 after:h-4 after:w-4 after:rounded-full after:bg-surface-container-lowest after:shadow-sm after:transition-transform peer-checked:after:translate-x-4" />
+                <span className="relative inline-flex h-5 w-9 shrink-0 rounded-full bg-outline-variant/40 transition-colors peer-checked:bg-primary peer-focus-visible:ring-2 peer-focus-visible:ring-primary/40 peer-disabled:opacity-50 after:absolute after:left-0.5 after:top-0.5 after:h-4 after:w-4 after:rounded-full after:bg-surface-container-lowest after:shadow-sm after:transition-transform peer-checked:after:translate-x-4" />
                 <span className="font-semibold">Tax</span>
               </label>
               {isTaxEnabled ? (
@@ -247,7 +247,7 @@ export function TotalAmountSection({
                     onDepositAmountChange(null);
                   }}
                 />
-                <span className="relative inline-flex h-5 w-9 shrink-0 rounded-full bg-outline-variant/40 transition-colors peer-checked:bg-primary peer-disabled:opacity-50 after:absolute after:left-0.5 after:top-0.5 after:h-4 after:w-4 after:rounded-full after:bg-surface-container-lowest after:shadow-sm after:transition-transform peer-checked:after:translate-x-4" />
+                <span className="relative inline-flex h-5 w-9 shrink-0 rounded-full bg-outline-variant/40 transition-colors peer-checked:bg-primary peer-focus-visible:ring-2 peer-focus-visible:ring-primary/40 peer-disabled:opacity-50 after:absolute after:left-0.5 after:top-0.5 after:h-4 after:w-4 after:rounded-full after:bg-surface-container-lowest after:shadow-sm after:transition-transform peer-checked:after:translate-x-4" />
                 <span className="font-semibold">Deposit</span>
               </label>
               {isDepositEnabled ? (

--- a/frontend/src/features/quotes/components/TotalAmountSection.tsx
+++ b/frontend/src/features/quotes/components/TotalAmountSection.tsx
@@ -90,7 +90,7 @@ export function TotalAmountSection({
               const parsedValue = Number(rawValue);
               onTotalChange(Number.isFinite(parsedValue) ? parsedValue : null);
             }}
-            className="w-full rounded-[var(--radius-document)] border-2 border-primary bg-surface-container-high py-3 pl-10 pr-12 font-headline text-3xl font-bold tracking-tight text-on-surface outline-none transition-all focus:ring-2 focus:ring-primary/20"
+            className="w-full rounded-[var(--radius-document)] border-2 border-primary bg-surface-container-high py-3 pl-10 pr-12 font-headline text-3xl font-bold tracking-tight text-primary outline-none transition-all focus:ring-2 focus:ring-primary/20"
           />
         </div>
       </div>
@@ -123,7 +123,7 @@ export function TotalAmountSection({
               </p>
             </div>
             <span className="material-symbols-outlined text-on-surface-variant">
-              {isOptionalPricingOpen ? "expand_more" : "chevron_right"}
+              {isOptionalPricingOpen ? "expand_less" : "expand_more"}
             </span>
           </button>
         )}
@@ -131,12 +131,13 @@ export function TotalAmountSection({
         {shouldShowOptionalPricingPanel ? (
           <div
             id="optional-pricing-panel"
-            className="mt-4 space-y-3 rounded-[var(--radius-document)] border border-outline-variant/20 bg-surface-container-lowest/60 p-3 shadow-[inset_0_1px_0_rgba(255,255,255,0.03)]"
+            className="mt-4 space-y-3 rounded-[var(--radius-document)] bg-surface-container-lowest/60 p-3 shadow-[inset_0_1px_0_rgba(255,255,255,0.03)]"
           >
             <section className="rounded-[var(--radius-document)] border border-outline-variant/20 bg-surface-container-high/60 p-3">
-              <label className="flex items-center gap-3 text-sm text-on-surface">
+              <label className={`flex select-none items-center gap-3 text-sm text-on-surface ${disabled ? "cursor-not-allowed" : "cursor-pointer"}`}>
                 <input
                   type="checkbox"
+                  className="peer sr-only"
                   checked={isDiscountEnabled}
                   disabled={disabled}
                   onChange={(event) => {
@@ -153,6 +154,7 @@ export function TotalAmountSection({
                     onDiscountValueChange(null);
                   }}
                 />
+                <span className="relative inline-flex h-5 w-9 shrink-0 rounded-full bg-outline-variant/40 transition-colors peer-checked:bg-primary peer-disabled:opacity-50 after:absolute after:left-0.5 after:top-0.5 after:h-4 after:w-4 after:rounded-full after:bg-surface-container-lowest after:shadow-sm after:transition-transform peer-checked:after:translate-x-4" />
                 <span className="font-semibold">Discount</span>
               </label>
               {isDiscountEnabled ? (
@@ -188,9 +190,10 @@ export function TotalAmountSection({
             </section>
 
             <section className="rounded-[var(--radius-document)] border border-outline-variant/20 bg-surface-container-high/60 p-3">
-              <label className="flex items-center gap-3 text-sm text-on-surface">
+              <label className={`flex select-none items-center gap-3 text-sm text-on-surface ${disabled ? "cursor-not-allowed" : "cursor-pointer"}`}>
                 <input
                   type="checkbox"
+                  className="peer sr-only"
                   checked={isTaxEnabled}
                   disabled={disabled}
                   onChange={(event) => {
@@ -203,6 +206,7 @@ export function TotalAmountSection({
                     onTaxRateChange(null);
                   }}
                 />
+                <span className="relative inline-flex h-5 w-9 shrink-0 rounded-full bg-outline-variant/40 transition-colors peer-checked:bg-primary peer-disabled:opacity-50 after:absolute after:left-0.5 after:top-0.5 after:h-4 after:w-4 after:rounded-full after:bg-surface-container-lowest after:shadow-sm after:transition-transform peer-checked:after:translate-x-4" />
                 <span className="font-semibold">Tax</span>
               </label>
               {isTaxEnabled ? (
@@ -225,9 +229,10 @@ export function TotalAmountSection({
             </section>
 
             <section className="rounded-[var(--radius-document)] border border-outline-variant/20 bg-surface-container-high/60 p-3">
-              <label className="flex items-center gap-3 text-sm text-on-surface">
+              <label className={`flex select-none items-center gap-3 text-sm text-on-surface ${disabled ? "cursor-not-allowed" : "cursor-pointer"}`}>
                 <input
                   type="checkbox"
+                  className="peer sr-only"
                   checked={isDepositEnabled}
                   disabled={disabled}
                   onChange={(event) => {
@@ -242,6 +247,7 @@ export function TotalAmountSection({
                     onDepositAmountChange(null);
                   }}
                 />
+                <span className="relative inline-flex h-5 w-9 shrink-0 rounded-full bg-outline-variant/40 transition-colors peer-checked:bg-primary peer-disabled:opacity-50 after:absolute after:left-0.5 after:top-0.5 after:h-4 after:w-4 after:rounded-full after:bg-surface-container-lowest after:shadow-sm after:transition-transform peer-checked:after:translate-x-4" />
                 <span className="font-semibold">Deposit</span>
               </label>
               {isDepositEnabled ? (

--- a/frontend/src/features/quotes/components/TotalAmountSection.tsx
+++ b/frontend/src/features/quotes/components/TotalAmountSection.tsx
@@ -3,6 +3,7 @@ import { useState } from "react";
 import { PricingRow } from "@/shared/components/PricingRow";
 import { formatCurrency } from "@/shared/lib/formatters";
 import { calculatePricingFromSubtotal, parseTaxPercentInput, toTaxPercentDisplay, type DiscountType } from "@/shared/lib/pricing";
+import { Eyebrow } from "@/ui/Eyebrow";
 
 interface TotalAmountSectionProps {
   lineItemSum: number;
@@ -57,21 +58,21 @@ export function TotalAmountSection({
   const shouldShowOptionalPricingPanel = hasActiveOptionalPricing || isOptionalPricingOpen;
 
   return (
-    <section className="rounded-lg bg-surface-container-low p-4">
+    <section className="rounded-[var(--radius-document)] bg-surface-container-low p-4">
       <div className="flex items-center justify-between text-sm text-outline">
         <span>Line Item Sum</span>
         <span>{formatCurrency(lineItemSum)}</span>
       </div>
       <div className="mt-4 border-t border-outline-variant/30 pt-4">
-        <label
-          htmlFor="quote-total"
-          className="block text-xs font-bold uppercase tracking-widest text-on-surface"
-        >
-          {hasPricingBreakdown ? "SUBTOTAL" : "TOTAL AMOUNT"}
+        <label htmlFor="quote-total" className="block">
+          <Eyebrow className="text-on-surface">{hasPricingBreakdown ? "SUBTOTAL" : "TOTAL AMOUNT"}</Eyebrow>
         </label>
         <div className="relative mt-2">
           <span className="absolute left-4 top-1/2 -translate-y-1/2 text-2xl font-bold text-primary">
             $
+          </span>
+          <span className="pointer-events-none absolute right-4 top-1/2 -translate-y-1/2 text-base leading-none text-on-surface-variant">
+            <span className="material-symbols-outlined text-base">edit</span>
           </span>
           <input
             id="quote-total"
@@ -89,18 +90,16 @@ export function TotalAmountSection({
               const parsedValue = Number(rawValue);
               onTotalChange(Number.isFinite(parsedValue) ? parsedValue : null);
             }}
-            className="w-full rounded-lg border-2 border-primary bg-surface-container-lowest py-3 pl-10 pr-4 font-headline text-3xl font-bold tracking-tight text-primary outline-none transition-all focus:ring-2 focus:ring-primary/20"
+            className="w-full rounded-[var(--radius-document)] border-2 border-primary bg-surface-container-high py-3 pl-10 pr-12 font-headline text-3xl font-bold tracking-tight text-on-surface outline-none transition-all focus:ring-2 focus:ring-primary/20"
           />
         </div>
       </div>
 
       <div className="mt-4 border-t border-outline-variant/30 pt-4">
         {hasActiveOptionalPricing ? (
-          <div className="flex items-center justify-between gap-4 rounded-lg bg-surface-container-lowest px-4 py-3">
+          <div className="flex items-center justify-between gap-4 rounded-[var(--radius-document)] bg-surface-container-lowest px-4 py-3">
             <div>
-              <p className="text-xs font-bold uppercase tracking-widest text-on-surface">
-                Optional Pricing
-              </p>
+              <Eyebrow className="text-on-surface">Optional Pricing</Eyebrow>
               <p className="mt-1 text-sm text-outline">
                 Tax, discount, and deposit
               </p>
@@ -114,13 +113,11 @@ export function TotalAmountSection({
             type="button"
             aria-expanded={isOptionalPricingOpen}
             aria-controls="optional-pricing-panel"
-            className="flex w-full cursor-pointer items-center justify-between gap-4 rounded-lg bg-surface-container-lowest px-4 py-3 text-left transition-colors hover:bg-surface-container"
+            className="flex w-full cursor-pointer items-center justify-between gap-4 rounded-[var(--radius-document)] bg-surface-container-lowest px-4 py-3 text-left transition-colors hover:bg-surface-container"
             onClick={() => setIsOptionalPricingOpen((current) => !current)}
           >
             <div>
-              <p className="text-xs font-bold uppercase tracking-widest text-on-surface">
-                Optional Pricing
-              </p>
+              <Eyebrow className="text-on-surface">Optional Pricing</Eyebrow>
               <p className="mt-1 text-sm text-outline">
                 Tax, discount, and deposit
               </p>
@@ -160,7 +157,7 @@ export function TotalAmountSection({
                   value={discountType ?? "fixed"}
                   disabled={disabled}
                   onChange={(event) => onDiscountTypeChange(event.target.value as DiscountType)}
-                  className="w-full rounded-lg bg-surface-container-high px-4 py-3 text-sm text-on-surface transition-all focus:bg-surface-container-lowest focus:outline-none focus:ring-2 focus:ring-primary/30"
+                  className="w-full rounded-[var(--radius-document)] bg-surface-container-high px-4 py-3 text-sm text-on-surface transition-all focus:bg-surface-container-lowest focus:outline-none focus:ring-2 focus:ring-primary/30"
                 >
                   <option value="fixed">Fixed $</option>
                   <option value="percent">Percent %</option>
@@ -174,7 +171,7 @@ export function TotalAmountSection({
                     const nextValue = event.target.value.trim();
                     onDiscountValueChange(nextValue.length > 0 ? Number(nextValue) : null);
                   }}
-                  className="w-full rounded-lg bg-surface-container-high px-4 py-3 text-sm text-on-surface transition-all focus:bg-surface-container-lowest focus:outline-none focus:ring-2 focus:ring-primary/30"
+                  className="w-full rounded-[var(--radius-document)] bg-surface-container-high px-4 py-3 text-sm text-on-surface transition-all focus:bg-surface-container-lowest focus:outline-none focus:ring-2 focus:ring-primary/30"
                   placeholder={discountType === "percent" ? "10" : "25"}
                 />
               </div>
@@ -206,7 +203,7 @@ export function TotalAmountSection({
                   disabled={disabled}
                   value={toTaxPercentDisplay(taxRate)}
                   onChange={(event) => onTaxRateChange(parseTaxPercentInput(event.target.value))}
-                  className="w-full rounded-lg bg-surface-container-high px-4 py-3 pr-10 text-sm text-on-surface transition-all focus:bg-surface-container-lowest focus:outline-none focus:ring-2 focus:ring-primary/30"
+                  className="w-full rounded-[var(--radius-document)] bg-surface-container-high px-4 py-3 pr-10 text-sm text-on-surface transition-all focus:bg-surface-container-lowest focus:outline-none focus:ring-2 focus:ring-primary/30"
                   placeholder="8.25"
                 />
                 <span className="pointer-events-none absolute right-4 top-1/2 -translate-y-1/2 text-sm text-outline">
@@ -244,7 +241,7 @@ export function TotalAmountSection({
                   const nextValue = event.target.value.trim();
                   onDepositAmountChange(nextValue.length > 0 ? Number(nextValue) : null);
                 }}
-                className="w-full rounded-lg bg-surface-container-high px-4 py-3 text-sm text-on-surface transition-all focus:bg-surface-container-lowest focus:outline-none focus:ring-2 focus:ring-primary/30"
+                className="w-full rounded-[var(--radius-document)] bg-surface-container-high px-4 py-3 text-sm text-on-surface transition-all focus:bg-surface-container-lowest focus:outline-none focus:ring-2 focus:ring-primary/30"
                 placeholder="50"
               />
             ) : null}

--- a/frontend/src/features/quotes/components/TotalAmountSection.tsx
+++ b/frontend/src/features/quotes/components/TotalAmountSection.tsx
@@ -97,14 +97,14 @@ export function TotalAmountSection({
 
       <div className="mt-4 border-t border-outline-variant/30 pt-4">
         {hasActiveOptionalPricing ? (
-          <div className="flex items-center justify-between gap-4 rounded-[var(--radius-document)] bg-surface-container-lowest px-4 py-3">
+          <div className="flex items-center justify-between gap-4 rounded-[var(--radius-document)] border border-outline-variant/25 bg-surface-container-high/80 px-4 py-3 shadow-[inset_0_1px_0_rgba(255,255,255,0.03)]">
             <div>
               <Eyebrow className="text-on-surface">Optional Pricing</Eyebrow>
-              <p className="mt-1 text-sm text-outline">
+              <p className="mt-1 text-sm text-on-surface-variant">
                 Tax, discount, and deposit
               </p>
             </div>
-            <span className="material-symbols-outlined text-outline">
+            <span className="material-symbols-outlined text-on-surface-variant">
               expand_more
             </span>
           </div>
@@ -113,138 +113,152 @@ export function TotalAmountSection({
             type="button"
             aria-expanded={isOptionalPricingOpen}
             aria-controls="optional-pricing-panel"
-            className="flex w-full cursor-pointer items-center justify-between gap-4 rounded-[var(--radius-document)] bg-surface-container-lowest px-4 py-3 text-left transition-colors hover:bg-surface-container"
+            className="flex w-full cursor-pointer items-center justify-between gap-4 rounded-[var(--radius-document)] border border-outline-variant/25 bg-surface-container-high/80 px-4 py-3 text-left shadow-[inset_0_1px_0_rgba(255,255,255,0.03)] transition-all hover:border-outline-variant/40 hover:bg-surface-container-high"
             onClick={() => setIsOptionalPricingOpen((current) => !current)}
           >
             <div>
               <Eyebrow className="text-on-surface">Optional Pricing</Eyebrow>
-              <p className="mt-1 text-sm text-outline">
+              <p className="mt-1 text-sm text-on-surface-variant">
                 Tax, discount, and deposit
               </p>
             </div>
-            <span className="material-symbols-outlined text-outline">
+            <span className="material-symbols-outlined text-on-surface-variant">
               {isOptionalPricingOpen ? "expand_more" : "chevron_right"}
             </span>
           </button>
         )}
 
         {shouldShowOptionalPricingPanel ? (
-          <div id="optional-pricing-panel" className="mt-4 space-y-3">
-            <label className="flex items-center gap-3 text-sm text-on-surface">
-              <input
-                type="checkbox"
-                checked={isDiscountEnabled}
-                disabled={disabled}
-                onChange={(event) => {
-                  if (event.target.checked) {
-                    setDiscountToggleOverride(true);
-                    onDiscountTypeChange(discountType ?? "fixed");
-                    if (discountValue === 0) {
-                      onDiscountValueChange(null);
-                    }
-                    return;
-                  }
-                  setDiscountToggleOverride(false);
-                  onDiscountTypeChange(null);
-                  onDiscountValueChange(null);
-                }}
-              />
-              Discount
-            </label>
-            {isDiscountEnabled ? (
-              <div className="grid gap-3 md:grid-cols-[minmax(0,140px)_1fr]">
-                <select
-                  value={discountType ?? "fixed"}
+          <div
+            id="optional-pricing-panel"
+            className="mt-4 space-y-3 rounded-[var(--radius-document)] border border-outline-variant/20 bg-surface-container-lowest/60 p-3 shadow-[inset_0_1px_0_rgba(255,255,255,0.03)]"
+          >
+            <section className="rounded-[var(--radius-document)] border border-outline-variant/20 bg-surface-container-high/60 p-3">
+              <label className="flex items-center gap-3 text-sm text-on-surface">
+                <input
+                  type="checkbox"
+                  checked={isDiscountEnabled}
                   disabled={disabled}
-                  onChange={(event) => onDiscountTypeChange(event.target.value as DiscountType)}
-                  className="w-full rounded-[var(--radius-document)] bg-surface-container-high px-4 py-3 text-sm text-on-surface transition-all focus:bg-surface-container-lowest focus:outline-none focus:ring-2 focus:ring-primary/30"
-                >
-                  <option value="fixed">Fixed $</option>
-                  <option value="percent">Percent %</option>
-                </select>
+                  onChange={(event) => {
+                    if (event.target.checked) {
+                      setDiscountToggleOverride(true);
+                      onDiscountTypeChange(discountType ?? "fixed");
+                      if (discountValue === 0) {
+                        onDiscountValueChange(null);
+                      }
+                      return;
+                    }
+                    setDiscountToggleOverride(false);
+                    onDiscountTypeChange(null);
+                    onDiscountValueChange(null);
+                  }}
+                />
+                <span className="font-semibold">Discount</span>
+              </label>
+              {isDiscountEnabled ? (
+                <div className="mt-3 grid gap-3 md:grid-cols-[minmax(0,140px)_1fr]">
+                  <div className="relative">
+                    <select
+                      value={discountType ?? "fixed"}
+                      disabled={disabled}
+                      onChange={(event) => onDiscountTypeChange(event.target.value as DiscountType)}
+                      className="w-full appearance-none rounded-[var(--radius-document)] border border-outline-variant/30 bg-surface-container-high px-4 py-3 pr-12 text-sm text-on-surface transition-all focus:border-primary/40 focus:bg-surface-container-lowest focus:outline-none focus:ring-2 focus:ring-primary/25"
+                    >
+                      <option value="fixed">Fixed $</option>
+                      <option value="percent">Percent %</option>
+                    </select>
+                    <span className="pointer-events-none absolute inset-y-0 right-3 inline-flex items-center text-sm text-outline">
+                      <span className="material-symbols-outlined block text-sm leading-none">expand_more</span>
+                    </span>
+                  </div>
+                  <input
+                    type="number"
+                    step="0.01"
+                    disabled={disabled}
+                    value={discountValue ?? ""}
+                    onChange={(event) => {
+                      const nextValue = event.target.value.trim();
+                      onDiscountValueChange(nextValue.length > 0 ? Number(nextValue) : null);
+                    }}
+                    className="w-full rounded-[var(--radius-document)] border border-outline-variant/30 bg-surface-container-high px-4 py-3 text-sm text-on-surface transition-all focus:border-primary/40 focus:bg-surface-container-lowest focus:outline-none focus:ring-2 focus:ring-primary/25"
+                    placeholder={discountType === "percent" ? "10" : "25"}
+                  />
+                </div>
+              ) : null}
+            </section>
+
+            <section className="rounded-[var(--radius-document)] border border-outline-variant/20 bg-surface-container-high/60 p-3">
+              <label className="flex items-center gap-3 text-sm text-on-surface">
+                <input
+                  type="checkbox"
+                  checked={isTaxEnabled}
+                  disabled={disabled}
+                  onChange={(event) => {
+                    if (event.target.checked) {
+                      setTaxToggleOverride(true);
+                      onTaxRateChange(taxRate ?? suggestedTaxRate ?? null);
+                      return;
+                    }
+                    setTaxToggleOverride(false);
+                    onTaxRateChange(null);
+                  }}
+                />
+                <span className="font-semibold">Tax</span>
+              </label>
+              {isTaxEnabled ? (
+                <div className="relative mt-3">
+                  <input
+                    type="number"
+                    step="0.01"
+                    aria-label="Tax rate (%)"
+                    disabled={disabled}
+                    value={toTaxPercentDisplay(taxRate)}
+                    onChange={(event) => onTaxRateChange(parseTaxPercentInput(event.target.value))}
+                    className="w-full rounded-[var(--radius-document)] border border-outline-variant/30 bg-surface-container-high px-4 py-3 pr-10 text-sm text-on-surface transition-all focus:border-primary/40 focus:bg-surface-container-lowest focus:outline-none focus:ring-2 focus:ring-primary/25"
+                    placeholder="8.25"
+                  />
+                  <span className="pointer-events-none absolute right-4 top-1/2 -translate-y-1/2 text-sm text-outline">
+                    %
+                  </span>
+                </div>
+              ) : null}
+            </section>
+
+            <section className="rounded-[var(--radius-document)] border border-outline-variant/20 bg-surface-container-high/60 p-3">
+              <label className="flex items-center gap-3 text-sm text-on-surface">
+                <input
+                  type="checkbox"
+                  checked={isDepositEnabled}
+                  disabled={disabled}
+                  onChange={(event) => {
+                    if (event.target.checked) {
+                      setDepositToggleOverride(true);
+                      if (depositAmount === 0) {
+                        onDepositAmountChange(null);
+                      }
+                      return;
+                    }
+                    setDepositToggleOverride(false);
+                    onDepositAmountChange(null);
+                  }}
+                />
+                <span className="font-semibold">Deposit</span>
+              </label>
+              {isDepositEnabled ? (
                 <input
                   type="number"
                   step="0.01"
                   disabled={disabled}
-                  value={discountValue ?? ""}
+                  value={depositAmount ?? ""}
                   onChange={(event) => {
                     const nextValue = event.target.value.trim();
-                    onDiscountValueChange(nextValue.length > 0 ? Number(nextValue) : null);
+                    onDepositAmountChange(nextValue.length > 0 ? Number(nextValue) : null);
                   }}
-                  className="w-full rounded-[var(--radius-document)] bg-surface-container-high px-4 py-3 text-sm text-on-surface transition-all focus:bg-surface-container-lowest focus:outline-none focus:ring-2 focus:ring-primary/30"
-                  placeholder={discountType === "percent" ? "10" : "25"}
+                  className="mt-3 w-full rounded-[var(--radius-document)] border border-outline-variant/30 bg-surface-container-high px-4 py-3 text-sm text-on-surface transition-all focus:border-primary/40 focus:bg-surface-container-lowest focus:outline-none focus:ring-2 focus:ring-primary/25"
+                  placeholder="50"
                 />
-              </div>
-            ) : null}
-
-            <label className="flex items-center gap-3 text-sm text-on-surface">
-              <input
-                type="checkbox"
-                checked={isTaxEnabled}
-                disabled={disabled}
-                onChange={(event) => {
-                  if (event.target.checked) {
-                    setTaxToggleOverride(true);
-                    onTaxRateChange(taxRate ?? suggestedTaxRate ?? null);
-                    return;
-                  }
-                  setTaxToggleOverride(false);
-                  onTaxRateChange(null);
-                }}
-              />
-              Tax
-            </label>
-            {isTaxEnabled ? (
-              <div className="relative">
-                <input
-                  type="number"
-                  step="0.01"
-                  aria-label="Tax rate (%)"
-                  disabled={disabled}
-                  value={toTaxPercentDisplay(taxRate)}
-                  onChange={(event) => onTaxRateChange(parseTaxPercentInput(event.target.value))}
-                  className="w-full rounded-[var(--radius-document)] bg-surface-container-high px-4 py-3 pr-10 text-sm text-on-surface transition-all focus:bg-surface-container-lowest focus:outline-none focus:ring-2 focus:ring-primary/30"
-                  placeholder="8.25"
-                />
-                <span className="pointer-events-none absolute right-4 top-1/2 -translate-y-1/2 text-sm text-outline">
-                  %
-                </span>
-              </div>
-            ) : null}
-
-            <label className="flex items-center gap-3 text-sm text-on-surface">
-              <input
-                type="checkbox"
-                checked={isDepositEnabled}
-                disabled={disabled}
-                onChange={(event) => {
-                  if (event.target.checked) {
-                    setDepositToggleOverride(true);
-                    if (depositAmount === 0) {
-                      onDepositAmountChange(null);
-                    }
-                    return;
-                  }
-                  setDepositToggleOverride(false);
-                  onDepositAmountChange(null);
-                }}
-              />
-              Deposit
-            </label>
-            {isDepositEnabled ? (
-              <input
-                type="number"
-                step="0.01"
-                disabled={disabled}
-                value={depositAmount ?? ""}
-                onChange={(event) => {
-                  const nextValue = event.target.value.trim();
-                  onDepositAmountChange(nextValue.length > 0 ? Number(nextValue) : null);
-                }}
-                className="w-full rounded-[var(--radius-document)] bg-surface-container-high px-4 py-3 text-sm text-on-surface transition-all focus:bg-surface-container-lowest focus:outline-none focus:ring-2 focus:ring-primary/30"
-                placeholder="50"
-              />
-            ) : null}
+              ) : null}
+            </section>
           </div>
         ) : null}
       </div>

--- a/frontend/src/shared/components/AIConfidenceBanner.tsx
+++ b/frontend/src/shared/components/AIConfidenceBanner.tsx
@@ -1,3 +1,5 @@
+import { Banner } from "@/ui/Banner";
+
 interface AIConfidenceBannerProps {
   message: string;
   onDismiss?: () => void;
@@ -10,23 +12,12 @@ export function AIConfidenceBanner({
   dismissLabel = "Dismiss confidence note",
 }: AIConfidenceBannerProps): React.ReactElement {
   return (
-    <div className="ghost-shadow rounded-lg border-l-4 border-warning-accent bg-warning-container p-4 backdrop-blur-md">
-      <div className="flex items-start gap-3">
-        <div className="flex-1">
-          <p className="text-[0.6875rem] font-bold uppercase tracking-wider text-warning">AI Confidence Note</p>
-          <p className="text-sm font-medium leading-snug text-warning">{message}</p>
-        </div>
-        {onDismiss ? (
-          <button
-            type="button"
-            aria-label={dismissLabel}
-            className="inline-flex h-8 w-8 cursor-pointer items-center justify-center rounded-full text-warning transition-colors hover:bg-warning/10"
-            onClick={onDismiss}
-          >
-            <span className="material-symbols-outlined text-base">close</span>
-          </button>
-        ) : null}
-      </div>
-    </div>
+    <Banner
+      kind="warn"
+      title="AI Confidence Note"
+      message={message}
+      onDismiss={onDismiss}
+      dismissLabel={dismissLabel}
+    />
   );
 }

--- a/frontend/src/shared/components/Button.test.tsx
+++ b/frontend/src/shared/components/Button.test.tsx
@@ -8,7 +8,7 @@ describe("Button", () => {
     render(<Button className="w-full">Create quote</Button>);
 
     const button = screen.getByRole("button", { name: "Create quote" });
-    expect(button).toHaveClass("forest-gradient", "text-on-primary", "rounded-lg", "w-full");
+    expect(button).toHaveClass("forest-gradient", "text-on-primary", "rounded-[var(--radius-document)]", "w-full");
   });
 
   it("renders destructive variant styles", () => {

--- a/frontend/src/shared/components/Button.tsx
+++ b/frontend/src/shared/components/Button.tsx
@@ -13,9 +13,9 @@ interface ButtonProps {
 
 const variantClasses = {
   primary:
-    "forest-gradient text-on-primary font-semibold py-4 rounded-lg active:scale-[0.98] transition-all",
+    "forest-gradient text-on-primary font-semibold py-4 rounded-[var(--radius-document)] active:scale-[0.98] transition-all",
   destructive:
-    "border border-secondary text-secondary font-semibold py-4 rounded-lg active:scale-[0.98] transition-all",
+    "border border-secondary text-secondary font-semibold py-4 rounded-[var(--radius-document)] active:scale-[0.98] transition-all",
   ghost: "p-2 rounded-full hover:bg-surface-container-low active:scale-95 transition-all",
 } as const;
 

--- a/frontend/src/ui/Banner.tsx
+++ b/frontend/src/ui/Banner.tsx
@@ -1,0 +1,80 @@
+import { Eyebrow } from "@/ui/Eyebrow";
+
+type BannerKind = "warn" | "info" | "success" | "error";
+
+interface BannerProps {
+  title: string;
+  message: string;
+  kind?: BannerKind;
+  onDismiss?: () => void;
+  dismissLabel?: string;
+}
+
+const kindStyles: Record<BannerKind, {
+  container: string;
+  title: string;
+  body: string;
+  icon: string;
+}> = {
+  warn: {
+    container: "border-l-4 border-warning-accent bg-warning-container",
+    title: "text-warning",
+    body: "text-warning",
+    icon: "error",
+  },
+  info: {
+    container: "border-l-4 border-info bg-info-container",
+    title: "text-info",
+    body: "text-info",
+    icon: "info",
+  },
+  success: {
+    container: "border-l-4 border-success bg-success-container",
+    title: "text-success",
+    body: "text-success",
+    icon: "check_circle",
+  },
+  error: {
+    container: "border-l-4 border-error bg-error-container",
+    title: "text-error",
+    body: "text-error",
+    icon: "error",
+  },
+};
+
+export function Banner({
+  title,
+  message,
+  kind = "warn",
+  onDismiss,
+  dismissLabel = "Dismiss message",
+}: BannerProps): React.ReactElement {
+  const style = kindStyles[kind];
+
+  return (
+    <section
+      className={[
+        "ghost-shadow rounded-[var(--radius-document)] p-4 backdrop-blur-md",
+        style.container,
+      ].join(" ")}
+    >
+      <div className="flex items-start gap-3">
+        <span className={["material-symbols-outlined", style.body].join(" ")}>{style.icon}</span>
+        <div className="min-w-0 flex-1">
+          <Eyebrow className={style.title}>{title}</Eyebrow>
+          <p className={["text-sm font-medium leading-snug", style.body].join(" ")}>{message}</p>
+        </div>
+        {onDismiss ? (
+          <button
+            type="button"
+            aria-label={dismissLabel}
+            className={["inline-flex h-8 w-8 cursor-pointer items-center justify-center rounded-full transition-colors", style.body].join(" ")}
+            onClick={onDismiss}
+          >
+            <span className="material-symbols-outlined text-base">close</span>
+          </button>
+        ) : null}
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/ui/Banner.tsx
+++ b/frontend/src/ui/Banner.tsx
@@ -68,7 +68,7 @@ export function Banner({
           <button
             type="button"
             aria-label={dismissLabel}
-            className={["inline-flex h-8 w-8 cursor-pointer items-center justify-center rounded-full transition-colors", style.body].join(" ")}
+            className={["inline-flex h-8 w-8 cursor-pointer items-center justify-center rounded-full transition-colors hover:bg-current/10", style.body].join(" ")}
             onClick={onDismiss}
           >
             <span className="material-symbols-outlined text-base">close</span>


### PR DESCRIPTION
## Summary
Implements Task #488 for PR2 Review/Edit design adoption on `/documents/:id/edit`, plus follow-up visual refinements requested during implementation.

## What Changed
- Added reusable `Banner` primitive and consolidated Review pending/warning surfaces.
- Updated Review/Edit layout styling for design-system consistency (`--radius-document`, pill treatment, improved hierarchy).
- Refined line-item card presentation (flag rail treatment, pricing emphasis, drag-state polish).
- Refined Optional Pricing editor styling and reorder utility control styling.
- Updated Review/Edit header copy per design direction.
- Normalized footer button radius via shared `Button` variant styling.
- Improved dismiss affordance hover feedback on `Banner` dismiss button.

## Scope Guardrails
- Styling/layout refinement only.
- No pricing logic/math changes.
- No routing/flow/CTA behavior changes.
- No API/state-machine changes.

## Verification
- Targeted vitest suites for Review/LineItems/TotalAmount and related components passed during implementation.
- `cd frontend && npx tsc --noEmit` equivalent checks passed.
- `make frontend-verify` was run successfully during the implementation pass.

Closes #488