### PR TITLE
Task #490: PR3 Quote Preview UI adoption (design refresh)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,4 +31,6 @@ venv/
 infra/terraform/envs/*.tfvars
 plans/archived
 plans/*
-!plans/2026-04-17
+!plans/2026-04-19
+!plans/2026-04-20
+!plans/2026-04-21

--- a/frontend/src/features/invoices/components/InvoiceDetailScreen.tsx
+++ b/frontend/src/features/invoices/components/InvoiceDetailScreen.tsx
@@ -24,7 +24,8 @@ import {
 import { FeedbackMessage } from "@/shared/components/FeedbackMessage";
 import { OverflowMenu } from "@/shared/components/OverflowMenu";
 import { ScreenHeader } from "@/shared/components/ScreenHeader";
-import { StatusBadge } from "@/shared/components/StatusBadge";
+import { Eyebrow } from "@/ui/Eyebrow";
+import { StatusPill } from "@/ui/StatusPill";
 import { formatDate } from "@/shared/lib/formatters";
 import { canNavigateBack } from "@/shared/lib/navigation";
 
@@ -122,12 +123,12 @@ export function InvoiceDetailScreen(): React.ReactElement {
 
   const outcomeBanner = invoice?.status === "paid"
     ? {
-      className: "mx-4 mt-4 rounded-lg border border-success/30 bg-success-container p-4 text-sm text-success",
+      className: "mx-4 mt-4 rounded-[var(--radius-document)] border border-success/30 bg-success-container p-4 text-sm text-success",
       message: "This invoice is marked as paid.",
     }
     : invoice?.status === "void"
       ? {
-        className: "mx-4 mt-4 rounded-lg border border-outline/40 bg-surface-container-low p-4 text-sm text-on-surface-variant",
+        className: "mx-4 mt-4 rounded-[var(--radius-document)] border border-outline/40 bg-surface-container-low p-4 text-sm text-on-surface-variant",
         message: "This invoice is marked as void.",
       }
       : null;
@@ -140,7 +141,7 @@ export function InvoiceDetailScreen(): React.ReactElement {
         onBack={handleBack}
         trailing={invoice ? (
           <div className="flex items-center gap-2">
-            <StatusBadge variant={invoice.status} />
+            <StatusPill variant={invoice.status} />
             {canEdit ? (
               <button
                 type="button"
@@ -189,13 +190,11 @@ export function InvoiceDetailScreen(): React.ReactElement {
               clientContact={clientContact}
             />
 
-            <section className="mt-4 px-4">
-              <div className="ghost-shadow rounded-lg border border-outline/40 bg-surface-container-lowest p-4">
-                <div className="flex items-start justify-between gap-3">
+            <section className="mt-3 px-4">
+              <div className="ghost-shadow rounded-[var(--radius-document)] border border-outline-variant/30 bg-surface-container-lowest p-4">
+                <div className="flex items-start justify-between gap-4">
                   <div>
-                    <p className="text-[0.6875rem] font-bold uppercase tracking-widest text-outline">
-                      Invoice Status
-                    </p>
+                    <Eyebrow>Invoice Status</Eyebrow>
                     <p className="mt-2 text-sm text-on-surface-variant">
                       {hasSourceQuote
                         ? `Created from quote ${invoice.source_quote_number} on ${formatDate(invoice.created_at)}`
@@ -213,28 +212,21 @@ export function InvoiceDetailScreen(): React.ReactElement {
                       </button>
                     ) : null}
                   </div>
+                  <div className="shrink-0 text-right">
+                    <Eyebrow>Due Date</Eyebrow>
+                    <p className="mt-2 text-sm text-on-surface">
+                      {invoice.due_date ? formatDate(`${invoice.due_date}T00:00:00.000Z`) : "No due date"}
+                    </p>
+                  </div>
                 </div>
               </div>
             </section>
             <QuoteLineItemsSection lineItems={invoice.line_items} />
 
-            <section className="px-4 pb-2">
-              <div className="rounded-lg bg-surface-container-low p-4">
-                <p className="text-[0.6875rem] font-bold uppercase tracking-widest text-outline">
-                  Due Date
-                </p>
-                <p className="mt-3 text-sm text-on-surface">
-                  {invoice.due_date ? formatDate(`${invoice.due_date}T00:00:00.000Z`) : "No due date"}
-                </p>
-              </div>
-            </section>
-
             {shouldRenderNotes ? (
-              <section className="px-4 pb-2">
-                <div className="rounded-lg bg-surface-container-low p-4">
-                  <p className="text-[0.6875rem] font-bold uppercase tracking-widest text-outline">
-                    Customer Notes
-                  </p>
+              <section className="mt-3 px-4">
+                <div className="ghost-shadow rounded-[var(--radius-document)] border border-outline-variant/30 bg-surface-container-lowest p-4">
+                  <Eyebrow>Customer Notes</Eyebrow>
                   <p className="mt-3 whitespace-pre-wrap text-sm text-on-surface-variant">
                     {invoice.notes}
                   </p>

--- a/frontend/src/features/quotes/components/LinkedInvoiceCard.tsx
+++ b/frontend/src/features/quotes/components/LinkedInvoiceCard.tsx
@@ -1,5 +1,6 @@
 import type { LinkedInvoiceSummary } from "@/features/quotes/types/quote.types";
-import { StatusBadge } from "@/shared/components/StatusBadge";
+import { Eyebrow } from "@/ui/Eyebrow";
+import { StatusPill } from "@/ui/StatusPill";
 import { formatCurrency, formatDate } from "@/shared/lib/formatters";
 
 interface LinkedInvoiceCardProps {
@@ -27,12 +28,10 @@ export function LinkedInvoiceCard({
         type="button"
         onClick={() => onOpenInvoice(linkedInvoice.id)}
         aria-label={`Open linked invoice ${linkedInvoice.doc_number}`}
-        className="ghost-shadow flex w-full cursor-pointer items-center justify-between gap-3 rounded-lg border border-outline-variant/30 bg-surface-container-lowest px-4 py-3 text-left transition-all hover:bg-surface-container-low active:scale-[0.99]"
+        className="ghost-shadow flex w-full cursor-pointer items-center justify-between gap-3 rounded-[var(--radius-document)] border border-outline-variant/30 bg-surface-container-lowest px-4 py-3 text-left transition-all hover:bg-surface-container-low active:scale-[0.99]"
       >
         <div className="min-w-0">
-          <p className="text-[0.6875rem] font-bold uppercase tracking-widest text-outline">
-            Linked Invoice
-          </p>
+          <Eyebrow>Linked Invoice</Eyebrow>
           <p className="mt-1.5 font-semibold text-on-surface">
             {linkedInvoice.doc_number}
           </p>
@@ -41,7 +40,7 @@ export function LinkedInvoiceCard({
           </p>
         </div>
         <div className="flex items-center gap-2 pl-2">
-          <StatusBadge variant={linkedInvoice.status} />
+          <StatusPill variant={linkedInvoice.status} />
           <span className="material-symbols-outlined text-on-surface-variant">arrow_forward</span>
         </div>
       </button>

--- a/frontend/src/features/quotes/components/QuoteDetailsCard.tsx
+++ b/frontend/src/features/quotes/components/QuoteDetailsCard.tsx
@@ -1,3 +1,4 @@
+import { Eyebrow } from "@/ui/Eyebrow";
 import { PricingRow } from "@/shared/components/PricingRow";
 import { formatCurrency } from "@/shared/lib/formatters";
 import { calculatePricingFromPersisted, resolveLineItemSum, type DiscountType } from "@/shared/lib/pricing";
@@ -38,10 +39,10 @@ export function QuoteDetailsCard({
 
   return (
     <div className="mt-4 px-4 pb-6">
-      <section className="ghost-shadow rounded-lg border-l-4 border-primary bg-surface-container-lowest p-4">
+      <section className="ghost-shadow rounded-[var(--radius-document)] border-l-4 border-primary bg-surface-container-lowest p-4">
         <div className="grid grid-cols-[minmax(0,1fr)_auto] gap-x-4 gap-y-3">
           <div className="min-w-0">
-            <h2 className="text-[0.6875rem] font-bold uppercase tracking-widest text-outline">CLIENT</h2>
+            <Eyebrow>CLIENT</Eyebrow>
           </div>
 
           <div className="justify-self-end text-right">
@@ -56,9 +57,9 @@ export function QuoteDetailsCard({
           </div>
 
           <div className="self-end justify-self-end text-right">
-            <h2 className="text-[0.6875rem] font-bold uppercase tracking-widest text-outline">
+            <Eyebrow>
               {pricingBreakdown.hasPricingBreakdown ? "TOTAL" : "TOTAL AMOUNT"}
-            </h2>
+            </Eyebrow>
             <p className="mt-1 font-headline text-2xl font-bold text-primary">
               {formatCurrency(totalAmount)}
             </p>

--- a/frontend/src/features/quotes/components/QuoteLineItemsSection.tsx
+++ b/frontend/src/features/quotes/components/QuoteLineItemsSection.tsx
@@ -24,7 +24,7 @@ export function QuoteLineItemsSection({
               className="ghost-shadow flex items-start justify-between rounded-[var(--radius-document)] bg-surface-container-lowest p-3"
             >
               <div className="min-w-0 flex-1">
-                <p className="font-medium text-on-surface break-words [overflow-wrap:anywhere]">
+                <p className="font-bold text-on-surface break-words [overflow-wrap:anywhere]">
                   {item.description}
                 </p>
                 {item.details ? (
@@ -33,7 +33,7 @@ export function QuoteLineItemsSection({
                   </p>
                 ) : null}
               </div>
-              <p className="ml-4 shrink-0 font-bold text-on-surface">
+              <p className="ml-4 shrink-0 font-bold text-primary">
                 {item.price !== null ? formatCurrency(item.price) : "—"}
               </p>
             </li>

--- a/frontend/src/features/quotes/components/QuoteLineItemsSection.tsx
+++ b/frontend/src/features/quotes/components/QuoteLineItemsSection.tsx
@@ -1,3 +1,4 @@
+import { Eyebrow } from "@/ui/Eyebrow";
 import { formatCurrency } from "@/shared/lib/formatters";
 
 import type { LineItem } from "@/features/quotes/types/quote.types";
@@ -12,19 +13,15 @@ export function QuoteLineItemsSection({
   return (
     <section className="mx-4 mt-4">
       <div className="mb-2 flex items-center justify-between">
-        <h2 className="text-[0.6875rem] font-bold uppercase tracking-widest text-outline">
-          LINE ITEMS
-        </h2>
-        <span className="text-[0.6875rem] font-bold uppercase tracking-widest text-outline">
-          {lineItems.length} ITEMS
-        </span>
+        <Eyebrow>LINE ITEMS</Eyebrow>
+        <Eyebrow>{lineItems.length} ITEMS</Eyebrow>
       </div>
       <ul className="space-y-2">
         {lineItems.map((item) => {
           return (
             <li
               key={item.id}
-              className="ghost-shadow flex items-start justify-between rounded-lg bg-surface-container-lowest p-3"
+              className="ghost-shadow flex items-start justify-between rounded-[var(--radius-document)] bg-surface-container-lowest p-3"
             >
               <div className="min-w-0 flex-1">
                 <p className="font-medium text-on-surface break-words [overflow-wrap:anywhere]">

--- a/frontend/src/features/quotes/components/QuotePreview.tsx
+++ b/frontend/src/features/quotes/components/QuotePreview.tsx
@@ -196,7 +196,7 @@ export function QuotePreview(): React.ReactElement {
         {!isLoadingQuote && !loadError ? (
           <>
             {quote && extractionDegradedCopy ? (
-              <div className="mx-4 mt-4 rounded-lg border border-warning-accent/40 bg-warning-container p-4 text-sm text-warning">
+              <div className="mx-4 mt-4 rounded-[var(--radius-document)] border border-warning-accent/40 bg-warning-container p-4 text-sm text-warning">
                 {extractionDegradedCopy}
               </div>
             ) : null}

--- a/frontend/src/features/quotes/components/QuotePreviewHeaderActions.tsx
+++ b/frontend/src/features/quotes/components/QuotePreviewHeaderActions.tsx
@@ -1,6 +1,6 @@
 import type { OverflowMenuItem } from "@/shared/components/OverflowMenu";
 import { OverflowMenu } from "@/shared/components/OverflowMenu";
-import { StatusBadge } from "@/shared/components/StatusBadge";
+import { StatusPill } from "@/ui/StatusPill";
 
 import type { QuoteStatus } from "@/features/quotes/types/quote.types";
 
@@ -19,7 +19,7 @@ export function QuotePreviewHeaderActions({
 }: QuotePreviewHeaderActionsProps): React.ReactElement {
   return (
     <div className="flex items-center gap-2">
-      <StatusBadge variant={status} />
+      <StatusPill variant={status} />
       {canEdit ? (
         <button
           type="button"

--- a/frontend/src/features/quotes/tests/QuotePreview.test.tsx
+++ b/frontend/src/features/quotes/tests/QuotePreview.test.tsx
@@ -815,7 +815,7 @@ describe("QuotePreview", () => {
 
     renderScreen();
 
-    expect(await screen.findByRole("heading", { name: "LINE ITEMS" })).toBeInTheDocument();
+    expect(await screen.findByText("LINE ITEMS")).toBeInTheDocument();
     expect(screen.getByText("2 ITEMS")).toBeInTheDocument();
     expect(screen.getByText("Brown mulch")).toBeInTheDocument();
     expect(screen.getByText("5 yards")).toBeInTheDocument();
@@ -857,7 +857,7 @@ describe("QuotePreview", () => {
     await screen.findByRole("heading", { name: "Test Customer" });
 
     const detailsHeading = screen.getByText("CLIENT");
-    const lineItemsHeading = screen.getByRole("heading", { name: "LINE ITEMS" });
+    const lineItemsHeading = screen.getByText("LINE ITEMS");
     const primaryAction = screen.getByRole("button", { name: /generate pdf/i });
 
     expect(detailsHeading.compareDocumentPosition(primaryAction) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();

--- a/frontend/src/shared/components/DocumentActionSurface.tsx
+++ b/frontend/src/shared/components/DocumentActionSurface.tsx
@@ -47,7 +47,7 @@ export function DocumentActionSurface({
   return (
     <>
       <section className="mt-4 px-4" aria-label={sectionLabel}>
-        <div className="ghost-shadow rounded-xl border border-outline-variant/30 bg-surface-container-lowest p-4">
+        <div className="ghost-shadow rounded-[var(--radius-document)] border border-outline-variant/30 bg-surface-container-lowest p-4">
           {primaryAction}
 
           {shouldRenderUtilities ? (

--- a/frontend/src/shared/components/DocumentActionSurface.tsx
+++ b/frontend/src/shared/components/DocumentActionSurface.tsx
@@ -8,8 +8,8 @@ const utilityGridClassNames = {
 } as const;
 
 export const documentActionPrimaryButtonClassName = "min-h-14 w-full gap-2 text-center";
-export const documentActionPrimaryLinkClassName = "forest-gradient inline-flex min-h-14 w-full cursor-pointer items-center justify-center gap-2 rounded-lg px-4 py-4 text-center font-semibold text-on-primary transition-all active:scale-[0.98]";
-export const documentActionUtilityButtonClassName = "inline-flex min-h-14 w-full cursor-pointer items-center justify-center gap-2 rounded-lg border border-outline px-4 py-4 text-center text-sm font-semibold text-on-surface transition-all active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-40";
+export const documentActionPrimaryLinkClassName = "forest-gradient inline-flex min-h-14 w-full cursor-pointer items-center justify-center gap-2 rounded-[var(--radius-document)] px-4 py-4 text-center font-semibold text-on-primary transition-all active:scale-[0.98]";
+export const documentActionUtilityButtonClassName = "inline-flex min-h-14 w-full cursor-pointer items-center justify-center gap-2 rounded-[var(--radius-document)] border border-outline px-4 py-4 text-center text-sm font-semibold text-on-surface transition-all active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-40";
 
 interface DocumentActionSurfaceProps {
   sectionLabel: string;

--- a/plans/2026-04-21/design-ui-adoption/pr4-document-hero-card.md
+++ b/plans/2026-04-21/design-ui-adoption/pr4-document-hero-card.md
@@ -1,0 +1,119 @@
+# PR4 — Document Hero Card Redesign
+
+## Status
+
+**Planning — ready to scope as a Task.** Follow-up to PR3 (Quote Preview UI adoption, PR #491). Redesigns the hero information card on both `/quotes/:id/preview` and `/invoices/:id` into a single consistent `DocumentHeroCard` component.
+
+---
+
+## Motivation
+
+After PR3 landed the design refresh on Quote Preview, the Invoice Detail screen was also updated for consistency. Both screens currently use `QuoteDetailsCard` (client + document type + total) as the hero, with a separate card below it for invoice-specific metadata (status, source, due date). In conversation review this was identified as:
+
+- Two cards where one would read better
+- Redundant `StatusPill` in the header (proposed: move to hero card, clean up header)
+- `LinkedInvoiceCard` on Quote Preview using a different interaction pattern than "Open Quote →" on Invoice Detail
+- Header titles using dynamic document data (customer name / title) rather than a stable screen label
+
+---
+
+## Proposed Design
+
+### Hero Card — two-column layout
+
+One card replaces `QuoteDetailsCard` + the Invoice Status / Linked Invoice card.
+
+**Left column**
+
+| Slot | Quote Preview | Invoice Detail |
+|------|--------------|----------------|
+| Eyebrow | `CLIENT` | `CLIENT` |
+| Primary | client name (bold) | client name (bold) |
+| Secondary | client contact (sm, variant) | client contact (sm, variant) |
+| *(conditional)* | `LINKED INVOICE` eyebrow + `Open Invoice →` button (if linked invoice exists) | `INVOICE STATUS` eyebrow + `Created on [date]` (sm, variant) + `Open Quote →` button (if source quote exists) |
+
+**Right column**
+
+| Slot | Quote Preview | Invoice Detail |
+|------|--------------|----------------|
+| Document stamp | `QUOTE` (font-headline, large) | `INVOICE` (font-headline, large) |
+| Eyebrow | `TOTAL AMOUNT` | `TOTAL AMOUNT` |
+| Amount | total value (font-headline, primary green) | total value (font-headline, primary green) |
+| *(conditional)* | — | `DUE DATE` eyebrow + date value (sm) |
+| Pill | `StatusPill` | `StatusPill` |
+
+**Pricing breakdown** (tax / discount / deposit) renders below the two-column grid, inside the same card, when those fields are set — identical to current `QuoteDetailsCard` behaviour.
+
+### "Open Quote →" / "Open Invoice →" buttons
+
+Both use the same inline button style: `text-sm font-semibold text-primary` + `arrow_forward` icon. Currently the Quote Preview uses a dedicated `LinkedInvoiceCard` component; after this change both screens use the same inline link inside the hero card.
+
+### Header changes (both screens)
+
+| | Before | After |
+|---|---|---|
+| `title` | dynamic (customer name / doc title / fallback) | `"Quote Preview"` or `"Invoice Preview"` (fixed) |
+| `subtitle` | doc number when title/customer present | `"Q-001"` or `"Q-001 · Spring Cleanup"` (number + optional title, `·` separator) |
+| Trailing | StatusPill + edit + overflow | edit + overflow only (pill moves to hero card) |
+
+---
+
+## Scope
+
+### In
+
+- `frontend/src/ui/DocumentHeroCard.tsx` — new shared primitive (replaces `QuoteDetailsCard` at both call-sites)
+- `frontend/src/features/quotes/components/QuotePreview.tsx` — header convention + swap to `DocumentHeroCard`
+- `frontend/src/features/invoices/components/InvoiceDetailScreen.tsx` — header convention + swap to `DocumentHeroCard`
+- `frontend/src/features/quotes/components/QuoteDetailsCard.tsx` — **delete** (no remaining call-sites after migration)
+- `frontend/src/features/quotes/components/LinkedInvoiceCard.tsx` — **delete** (folded into `DocumentHeroCard`)
+- `frontend/src/features/quotes/components/QuotePreviewHeaderActions.tsx` — remove `StatusPill`; keep edit + overflow
+
+### Out
+
+- Review / Edit, Capture, Quote List
+- New API calls or data fields (due date already exists on `InvoiceDetail`)
+- Copy changes to action buttons, overflow labels, dialogs
+- Pricing / tax / discount logic (carry over unchanged from `QuoteDetailsCard`)
+
+---
+
+## Copy decisions locked in planning
+
+- Invoice Status line: `Created on [date]` — no "from Quote Q-001" prefix, regardless of source. Source quote link renders separately below.
+- Header title strings: `"Quote Preview"` and `"Invoice Preview"` (literal, not dynamic).
+- Subtitle format: `"I-002"` or `"I-002 · Spring Cleanup"` when title exists.
+
+---
+
+## Acceptance criteria
+
+- [ ] Both screens show the unified two-column hero card with client info, document type, total, and status pill
+- [ ] StatusPill removed from both screen headers; header shows edit + overflow only
+- [ ] Header title is `"Quote Preview"` / `"Invoice Preview"`; subtitle is `doc_number` or `doc_number · title`
+- [ ] "Open Invoice →" on Quote Preview and "Open Quote →" on Invoice Detail use identical button style
+- [ ] Pricing breakdown (tax / discount / deposit) still renders correctly when fields are set
+- [ ] `requiresCustomerAssignment` redirect on Quote Preview unchanged
+- [ ] All existing test assertions pass or are updated for intentional DOM changes
+- [ ] `make frontend-verify` passes
+
+---
+
+## Files touched (estimate)
+
+| Path | Change |
+|------|--------|
+| `frontend/src/ui/DocumentHeroCard.tsx` | New |
+| `frontend/src/features/quotes/components/QuotePreview.tsx` | Header + hero card swap |
+| `frontend/src/features/quotes/components/QuotePreviewHeaderActions.tsx` | Remove StatusPill |
+| `frontend/src/features/quotes/components/QuoteDetailsCard.tsx` | Delete |
+| `frontend/src/features/quotes/components/LinkedInvoiceCard.tsx` | Delete |
+| `frontend/src/features/invoices/components/InvoiceDetailScreen.tsx` | Header + hero card swap |
+| `frontend/src/features/quotes/tests/QuotePreview.test.tsx` | Update header + hero assertions |
+| `frontend/src/features/invoices/tests/InvoiceDetailScreen.test.tsx` | Update header + hero assertions |
+
+---
+
+## Parent
+
+Design adoption Spec #485 — PR4 closes the hero card consistency gap identified during PR3 review.


### PR DESCRIPTION
## Summary

- `StatusBadge` → `StatusPill` in `QuotePreviewHeaderActions` and `LinkedInvoiceCard` (D2)
- `rounded-lg` → `rounded-[var(--radius-document)]` on degraded-extraction strip (`QuotePreview`), hero card (`QuoteDetailsCard`), linked-invoice row (`LinkedInvoiceCard`), and read-only line-item rows (`QuoteLineItemsSection`)
- `rounded-xl` → `rounded-[var(--radius-document)]` on `DocumentActionSurface` inner container (D3 — note: in this project `--radius-xl: 0.5rem` vs `--radius-document: 0.75rem`, so this is a small visible radius increase, not the zero-change assumed in spec; design intent is correct)
- `Eyebrow` primitive used for section labels: CLIENT/TOTAL in `QuoteDetailsCard`, "Linked Invoice" in `LinkedInvoiceCard`, LINE ITEMS / count in `QuoteLineItemsSection`
- Test assertions updated: `getByRole("heading", { name: "LINE ITEMS" })` → `getByText("LINE ITEMS")` (intentional DOM change — Eyebrow renders `<p>` not `<h2>`)

**No behavior changes.** All actions, copy, navigation, hooks, and overflow items unchanged.

## Regression surface

`DocumentActionSurface` is shared with `InvoiceDetailScreen` — radius increase applies there too (visual-only, no behavior change). `QuoteDetailsCard` and `QuoteLineItemsSection` also used in `InvoiceDetailScreen` — same visual-only changes. `InvoiceDetailScreen.test.tsx` passes in Tier 3.

## Test plan

- [x] `npx vitest run QuotePreview.test.tsx QuotePreviewActions.test.tsx DocumentActionSurface.test.tsx` — 79 pass
- [x] `npx tsc --noEmit` — clean
- [x] `make frontend-verify` — all pass (pre-existing file-size/act warnings in unrelated files)
- [x] Manual Tier 4: Draft quote PDF/email/share flow; degraded extraction banner; linked invoice row; invoice detail action surface regression

Closes #490