### PR TITLE
Task #480: Remove grouped review-state banners from quote review

### DIFF
--- a/frontend/src/features/quotes/components/DocumentEditScreenView.tsx
+++ b/frontend/src/features/quotes/components/DocumentEditScreenView.tsx
@@ -19,8 +19,6 @@ interface DocumentEditScreenViewProps {
   requiresCustomerAssignment: boolean;
   canReassignCustomer: boolean;
   isInteractionLocked: boolean;
-  notesReviewPending: boolean;
-  pricingReviewPending: boolean;
   extractionTier: ExtractionTier | null;
   extractionDegradedReasonCode: string | null;
   hiddenDetails?: ExtractionReviewHiddenDetails;
@@ -85,8 +83,6 @@ export function DocumentEditScreenView({
   requiresCustomerAssignment,
   canReassignCustomer,
   isInteractionLocked,
-  notesReviewPending,
-  pricingReviewPending,
   extractionTier,
   extractionDegradedReasonCode,
   hiddenDetails,
@@ -156,8 +152,6 @@ export function DocumentEditScreenView({
         requiresCustomerAssignment={requiresCustomerAssignment}
         canReassignCustomer={canReassignCustomer}
         isInteractionLocked={isInteractionLocked}
-        notesReviewPending={notesReviewPending}
-        pricingReviewPending={pricingReviewPending}
         extractionTier={extractionTier}
         extractionDegradedReasonCode={extractionDegradedReasonCode}
         hiddenDetails={hiddenDetails}

--- a/frontend/src/features/quotes/components/ReviewFormContent.tsx
+++ b/frontend/src/features/quotes/components/ReviewFormContent.tsx
@@ -43,8 +43,6 @@ interface ReviewFormContentProps {
   requiresCustomerAssignment: boolean;
   canReassignCustomer: boolean;
   isInteractionLocked: boolean;
-  notesReviewPending: boolean;
-  pricingReviewPending: boolean;
   extractionTier: ExtractionTier | null;
   extractionDegradedReasonCode: string | null;
   hiddenDetails?: ExtractionReviewHiddenDetails;
@@ -80,8 +78,6 @@ export function ReviewFormContent({
   requiresCustomerAssignment,
   canReassignCustomer,
   isInteractionLocked,
-  notesReviewPending,
-  pricingReviewPending,
   extractionTier,
   extractionDegradedReasonCode,
   hiddenDetails,
@@ -220,20 +216,6 @@ export function ReviewFormContent({
             </div>
           </button>
         </section>
-      ) : null}
-
-      {pricingReviewPending ? (
-        <Banner
-          title="Pricing Pending Review"
-          message="Pricing fields were seeded from capture details. Review totals, tax, discount, and deposit."
-        />
-      ) : null}
-
-      {notesReviewPending ? (
-        <Banner
-          title="Notes Pending Review"
-          message="Notes were seeded from capture details. Review and adjust before continuing."
-        />
       ) : null}
 
       <ReviewLineItemsSection

--- a/frontend/src/features/quotes/components/ReviewScreen.tsx
+++ b/frontend/src/features/quotes/components/ReviewScreen.tsx
@@ -212,10 +212,6 @@ export function DocumentEditScreen(): React.ReactElement {
     lineItemsForSubmit,
     lineItemSum,
   } = buildLineItemSubmitState(activeDraft.lineItems);
-  const notesReviewPending = activeDraft.docType === "quote"
-    && Boolean(extractionReviewMetadata?.review_state.notes_pending);
-  const pricingReviewPending = activeDraft.docType === "quote"
-    && Boolean(extractionReviewMetadata?.review_state.pricing_pending);
 
   const isInteractionLocked = submitAction !== null || isAssigningCustomer;
   const lineItemSheetInitialItem = lineItemSheetState
@@ -293,8 +289,6 @@ export function DocumentEditScreen(): React.ReactElement {
       requiresCustomerAssignment={requiresCustomerAssignment}
       canReassignCustomer={canReassignCustomer}
       isInteractionLocked={isInteractionLocked}
-      notesReviewPending={notesReviewPending}
-      pricingReviewPending={pricingReviewPending}
       extractionTier={!isInvoiceDocument(activeDocument) ? activeDocument.extraction_tier : null}
       extractionDegradedReasonCode={!isInvoiceDocument(activeDocument) ? activeDocument.extraction_degraded_reason_code : null}
       hiddenDetails={extractionReviewMetadata?.hidden_details}

--- a/frontend/src/features/quotes/tests/ReviewScreen.test.tsx
+++ b/frontend/src/features/quotes/tests/ReviewScreen.test.tsx
@@ -419,7 +419,7 @@ describe("DocumentEditScreen", () => {
     expect(screen.queryByRole("button", { name: /continue to preview/i })).not.toBeInTheDocument();
   });
 
-  it("shows grouped review markers from sidecar review_state", async () => {
+  it("does not show grouped review markers from sidecar review_state", async () => {
     renderScreen({
       document: makeQuote({
         extraction_review_metadata: {
@@ -432,8 +432,9 @@ describe("DocumentEditScreen", () => {
       }),
     });
 
-    expect(await screen.findByText("Pricing Pending Review")).toBeInTheDocument();
-    expect(screen.getByText("Notes Pending Review")).toBeInTheDocument();
+    expect(await screen.findByRole("button", { name: /continue to preview/i })).toBeInTheDocument();
+    expect(screen.queryByText("Pricing Pending Review")).not.toBeInTheDocument();
+    expect(screen.queryByText("Notes Pending Review")).not.toBeInTheDocument();
   });
 
   it("shows the high-severity review marker when extraction is degraded with no line items", async () => {


### PR DESCRIPTION
## Summary
- remove grouped `notes/pricing` review-state banner rendering from quote review form
- remove now-unused `notesReviewPending` and `pricingReviewPending` props/wiring from review screen view chain
- update review screen test to assert grouped review-state banners are not shown even when metadata flags are true

## Verification
- cd frontend && npx vitest run src/features/quotes/tests/ReviewScreen.test.tsx
- make frontend-verify

Closes #480