### PR TITLE
Task 481: line-item review badge + edit-sheet explanation

### DIFF
--- a/frontend/src/features/quotes/components/LineItemCard.tsx
+++ b/frontend/src/features/quotes/components/LineItemCard.tsx
@@ -1,7 +1,5 @@
 import type { PointerEvent as ReactPointerEvent } from "react";
 
-import { resolveLineItemFlagMessage } from "@/features/quotes/utils/lineItemFlags";
-
 interface LineItemCardProps {
   description: string;
   details: string | null;
@@ -23,7 +21,6 @@ export function LineItemCard({
   details,
   price,
   flagged = false,
-  flagReason,
   disabled = false,
   isDragging = false,
   isDropSettling = false,
@@ -35,7 +32,6 @@ export function LineItemCard({
 }: LineItemCardProps): React.ReactElement {
   const lineItemLabel = description.trim() || "Untitled line item";
   const priceLabel = price !== null ? `$${price.toFixed(2)}` : "—";
-  const flagMessage = flagged ? resolveLineItemFlagMessage(flagReason) : null;
   const showDragHandle = isReorderMode;
   const canEditRow = !disabled && !isReorderMode;
 
@@ -88,15 +84,6 @@ export function LineItemCard({
             ) : null}
           </div>
           {details ? <p className="mt-0.5 text-sm text-on-surface-variant">{details}</p> : null}
-          {flagMessage ? (
-            <p
-              title={flagMessage}
-              className="mt-1 inline-flex max-w-full items-center gap-1 text-xs text-warning"
-            >
-              <span className="material-symbols-outlined text-[0.95rem] leading-none">info</span>
-              <span className="truncate">{flagMessage}</span>
-            </p>
-          ) : null}
         </div>
 
         <div className="mt-0.5 flex shrink-0 items-center">

--- a/frontend/src/features/quotes/components/LineItemEditSheet.tsx
+++ b/frontend/src/features/quotes/components/LineItemEditSheet.tsx
@@ -1,15 +1,14 @@
 import { useEffect, useRef, useState } from "react";
 import * as Dialog from "@radix-ui/react-dialog";
-
 import type { LineItemCatalogItem } from "@/features/line-item-catalog/types/lineItemCatalog.types";
 import type { LineItemDraftWithFlags } from "@/features/quotes/types/quote.types";
 import { LineItemCatalogTabPanel } from "@/features/quotes/components/LineItemCatalogTabPanel";
+import { resolveLineItemReviewExplanation } from "@/features/quotes/utils/lineItemFlags";
 import { FeedbackMessage } from "@/shared/components/FeedbackMessage";
 import {
   LINE_ITEM_DESCRIPTION_MAX_CHARS,
   LINE_ITEM_DETAILS_MAX_CHARS,
 } from "@/shared/lib/inputLimits";
-
 interface LineItemEditSheetProps {
   open: boolean;
   mode: "add" | "edit";
@@ -30,9 +29,7 @@ interface ParsedPrice {
   value: number | null;
   valid: boolean;
 }
-
 type AddLineItemTab = "manual" | "catalog";
-
 type CatalogLoadState = "idle" | "loading" | "loaded" | "error";
 
 function parsePrice(value: string): ParsedPrice {
@@ -40,12 +37,10 @@ function parsePrice(value: string): ParsedPrice {
   if (trimmed.length === 0) {
     return { value: null, valid: true };
   }
-
   const parsed = Number(trimmed);
   if (!Number.isFinite(parsed)) {
     return { value: null, valid: false };
   }
-
   return { value: parsed, valid: true };
 }
 
@@ -78,6 +73,9 @@ export function LineItemEditSheet({
   const canSaveToCatalog = showManualFields && savedCatalogItem === null;
   const canDeleteSavedCatalogItem = savedCatalogItem !== null;
   const bookmarkIcon = canDeleteSavedCatalogItem ? "bookmark" : "bookmark_add";
+  const reviewExplanation = mode === "edit" && initialLineItem.flagged
+    ? resolveLineItemReviewExplanation(initialLineItem.flagReason)
+    : null;
 
   useEffect(() => {
     if (mode !== "add") {
@@ -301,10 +299,14 @@ export function LineItemEditSheet({
                 Pick a catalog item to insert.
               </Dialog.Description>
             ) : null}
-
             <div className="mt-4 space-y-4">
               {formError ? <FeedbackMessage variant="error">{formError}</FeedbackMessage> : null}
-
+              {reviewExplanation ? (
+                <div className="rounded-lg border-l-4 border-warning-accent bg-warning-container/50 p-4">
+                  <p className="text-xs font-bold uppercase tracking-wide text-warning">Review needed</p>
+                  <p className="mt-1 text-sm leading-6 text-warning">{reviewExplanation}</p>
+                </div>
+              ) : null}
               {mode === "add" ? (
                 <div
                   role="tablist"
@@ -350,7 +352,6 @@ export function LineItemEditSheet({
                   </button>
                 </div>
               ) : null}
-
               {showManualFields ? (
                 <div id="line-item-tabpanel-manual" role={mode === "add" ? "tabpanel" : undefined} className="space-y-4">
                   <section className="space-y-2">
@@ -378,7 +379,6 @@ export function LineItemEditSheet({
                       className="w-full rounded-lg bg-surface-container-high px-4 py-3 font-body text-sm text-on-surface placeholder:text-outline transition-all focus:bg-surface-container-lowest focus:outline-none focus:ring-2 focus:ring-primary/30"
                     />
                   </section>
-
                   <section className="space-y-2">
                     <div className="flex items-end justify-between">
                       <label htmlFor="line-item-sheet-details" className="font-headline text-sm font-bold text-on-surface">
@@ -403,7 +403,6 @@ export function LineItemEditSheet({
                       className="w-full rounded-lg border border-outline-variant/30 bg-surface-container-high p-4 text-sm text-on-surface placeholder:text-outline/70 outline-none transition-all focus:border-primary focus:bg-surface-container-lowest focus:ring-2 focus:ring-primary/20"
                     />
                   </section>
-
                   <section className="space-y-2">
                     <label htmlFor="line-item-sheet-price" className="font-headline text-sm font-bold text-on-surface">
                       Price

--- a/frontend/src/features/quotes/tests/LineItemCard.test.tsx
+++ b/frontend/src/features/quotes/tests/LineItemCard.test.tsx
@@ -32,9 +32,7 @@ describe("LineItemCard", () => {
     );
 
     expect(screen.getByText("REVIEW")).toBeInTheDocument();
-    expect(
-      screen.getByText("Spoken amount was interpreted as dollars instead of cents."),
-    ).toBeInTheDocument();
+    expect(screen.queryByText("Spoken amount was interpreted as dollars instead of cents.")).not.toBeInTheDocument();
   });
 
   it("renders em dash when price is blank", () => {

--- a/frontend/src/features/quotes/tests/LineItemEditSheet.test.tsx
+++ b/frontend/src/features/quotes/tests/LineItemEditSheet.test.tsx
@@ -51,6 +51,39 @@ describe("LineItemEditSheet", () => {
     expect(within(dialog).getByRole("button", { name: /delete line item/i })).toBeInTheDocument();
   });
 
+  it("shows spoken-money review explanation for flagged edit items", () => {
+    render(
+      <LineItemEditSheet
+        open
+        mode="edit"
+        initialLineItem={makeLineItem({ flagReason: "spoken_money_correction" })}
+        onClose={vi.fn()}
+        onSave={vi.fn()}
+        onRequestDelete={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Review needed")).toBeInTheDocument();
+    expect(
+      screen.getByText("Voice capture may have interpreted cents as dollars. Confirm the amount and update the price if needed."),
+    ).toBeInTheDocument();
+  });
+
+  it("does not show review explanation for unflagged items", () => {
+    render(
+      <LineItemEditSheet
+        open
+        mode="edit"
+        initialLineItem={makeLineItem({ flagged: false, flagReason: null })}
+        onClose={vi.fn()}
+        onSave={vi.fn()}
+        onRequestDelete={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByText("Review needed")).not.toBeInTheDocument();
+  });
+
   it("renders add mode without sheet trash", () => {
     render(
       <LineItemEditSheet

--- a/frontend/src/features/quotes/utils/lineItemFlags.ts
+++ b/frontend/src/features/quotes/utils/lineItemFlags.ts
@@ -1,11 +1,24 @@
 export const SPOKEN_MONEY_CORRECTION_FLAG_REASON = "spoken_money_correction";
+const DEFAULT_FLAG_MESSAGE = "This item may need review";
+const DEFAULT_REVIEW_EXPLANATION = "Review this line item before continuing.";
 
 export function resolveLineItemFlagMessage(flagReason: string | null | undefined): string {
   const normalizedReason = flagReason?.trim();
   if (normalizedReason === SPOKEN_MONEY_CORRECTION_FLAG_REASON) {
     return "Spoken amount was interpreted as dollars instead of cents.";
   }
-  return normalizedReason || "This item may need review";
+  return normalizedReason || DEFAULT_FLAG_MESSAGE;
+}
+
+export function resolveLineItemReviewExplanation(flagReason: string | null | undefined): string {
+  const normalizedReason = flagReason?.trim();
+  if (normalizedReason === SPOKEN_MONEY_CORRECTION_FLAG_REASON) {
+    return "Voice capture may have interpreted cents as dollars. Confirm the amount and update the price if needed.";
+  }
+  if (normalizedReason) {
+    return normalizedReason.endsWith(".") ? normalizedReason : `${normalizedReason}.`;
+  }
+  return DEFAULT_REVIEW_EXPLANATION;
 }
 
 export function shouldClearSpokenMoneyFlagOnPriceEdit(params: {


### PR DESCRIPTION
## Summary
- keep flagged line-item cards badge-only by removing inline warning sentence from row UI
- add a review explanation block inside the line-item edit sheet for flagged items using per-flag copy
- preserve existing spoken-money auto-clear behavior and cover updated behavior with focused tests

## Verification
- `cd frontend && npx vitest run src/features/quotes/tests/LineItemCard.test.tsx`
- `cd frontend && npx vitest run src/features/quotes/tests/LineItemEditSheet.test.tsx`
- `cd frontend && npx vitest run src/features/quotes/tests/ReviewScreen.test.tsx`
- `make frontend-verify`

Closes #481