### PR TITLE
Task #498: Add line-item review dismiss action in edit sheet

### DIFF
--- a/frontend/src/features/quotes/components/LineItemEditSheet.tsx
+++ b/frontend/src/features/quotes/components/LineItemEditSheet.tsx
@@ -31,7 +31,6 @@ interface ParsedPrice {
 }
 type AddLineItemTab = "manual" | "catalog";
 type CatalogLoadState = "idle" | "loading" | "loaded" | "error";
-
 function parsePrice(value: string): ParsedPrice {
   const trimmed = value.trim();
   if (trimmed.length === 0) {
@@ -61,6 +60,8 @@ export function LineItemEditSheet({
   const [priceInput, setPriceInput] = useState(
     initialLineItem.price == null ? "" : initialLineItem.price.toString(),
   );
+  const [lineItemFlagged, setLineItemFlagged] = useState(Boolean(initialLineItem.flagged));
+  const [lineItemFlagReason, setLineItemFlagReason] = useState(initialLineItem.flagReason ?? null);
   const [formError, setFormError] = useState<string | null>(null);
   const [activeAddTab, setActiveAddTab] = useState<AddLineItemTab>("manual");
   const [catalogItems, setCatalogItems] = useState<LineItemCatalogItem[]>([]);
@@ -73,10 +74,9 @@ export function LineItemEditSheet({
   const canSaveToCatalog = showManualFields && savedCatalogItem === null;
   const canDeleteSavedCatalogItem = savedCatalogItem !== null;
   const bookmarkIcon = canDeleteSavedCatalogItem ? "bookmark" : "bookmark_add";
-  const reviewExplanation = mode === "edit" && initialLineItem.flagged
-    ? resolveLineItemReviewExplanation(initialLineItem.flagReason)
+  const reviewExplanation = mode === "edit" && lineItemFlagged
+    ? resolveLineItemReviewExplanation(lineItemFlagReason)
     : null;
-
   useEffect(() => {
     if (mode !== "add") {
       return;
@@ -92,7 +92,6 @@ export function LineItemEditSheet({
     ) {
       return;
     }
-
     setCatalogLoadState("loading");
     setCatalogLoadError(null);
     try {
@@ -109,61 +108,53 @@ export function LineItemEditSheet({
       setCatalogLoadState("error");
     }
   }
-
   function parseManualLineItem(): LineItemDraftWithFlags | null {
     const trimmedDescription = description.trim();
     if (trimmedDescription.length === 0) {
       setFormError("Description is required.");
       return null;
     }
-
     const parsedPrice = parsePrice(priceInput);
     if (!parsedPrice.valid) {
       setFormError("Enter a valid number for price.");
       return null;
     }
-
     setFormError(null);
     return {
       ...initialLineItem,
       description: trimmedDescription,
       details: details.trim().length > 0 ? details.trim() : null,
       price: parsedPrice.value,
+      flagged: lineItemFlagged,
+      flagReason: lineItemFlagReason,
     };
   }
-
   function dismissWithAutosave(): void {
     if (mode === "add") {
       onClose();
       return;
     }
-
     const parsedLineItem = parseManualLineItem();
     if (!parsedLineItem) {
       return;
     }
-
     onSave(parsedLineItem);
     onClose();
   }
-
   function addLineItemAndClose(): void {
     const parsedLineItem = parseManualLineItem();
     if (!parsedLineItem) return;
     onSave(parsedLineItem);
     onClose();
   }
-
   async function saveToCatalog(): Promise<void> {
     if (!onSaveToCatalog || !canSaveToCatalog || isCatalogMutationInFlight) {
       return;
     }
-
     const parsedLineItem = parseManualLineItem();
     if (!parsedLineItem) {
       return;
     }
-
     setIsCatalogMutationInFlight(true);
     try {
       const createdItem = await onSaveToCatalog({
@@ -184,12 +175,10 @@ export function LineItemEditSheet({
       setIsCatalogMutationInFlight(false);
     }
   }
-
   async function unsaveFromCatalog(): Promise<void> {
     if (!savedCatalogItem || !onDeleteFromCatalog || isCatalogMutationInFlight) {
       return;
     }
-
     setIsCatalogMutationInFlight(true);
     try {
       await onDeleteFromCatalog(savedCatalogItem.id);
@@ -204,7 +193,6 @@ export function LineItemEditSheet({
       setIsCatalogMutationInFlight(false);
     }
   }
-
   function handleInsertCatalogItem(item: LineItemCatalogItem): void {
     setFormError(null);
     onSave({
@@ -216,7 +204,6 @@ export function LineItemEditSheet({
     });
     onClose();
   }
-
   return (
     <Dialog.Root
       open={open}
@@ -305,6 +292,16 @@ export function LineItemEditSheet({
                 <div className="rounded-lg border-l-4 border-warning-accent bg-warning-container/50 p-4">
                   <p className="text-xs font-bold uppercase tracking-wide text-warning">Review needed</p>
                   <p className="mt-1 text-sm leading-6 text-warning">{reviewExplanation}</p>
+                  <button
+                    type="button"
+                    className="mt-3 inline-flex items-center justify-center rounded-md border border-warning-accent/50 bg-warning-container px-2.5 py-1.5 text-xs font-bold uppercase tracking-wide text-warning transition-colors hover:bg-warning-container/80"
+                    onClick={() => {
+                      setLineItemFlagged(false);
+                      setLineItemFlagReason(null);
+                    }}
+                  >
+                    Dismiss
+                  </button>
                 </div>
               ) : null}
               {mode === "add" ? (

--- a/frontend/src/features/quotes/tests/LineItemEditSheet.test.tsx
+++ b/frontend/src/features/quotes/tests/LineItemEditSheet.test.tsx
@@ -84,6 +84,71 @@ describe("LineItemEditSheet", () => {
     expect(screen.queryByText("Review needed")).not.toBeInTheDocument();
   });
 
+  it("dismisses the review banner and clears flag fields on save", async () => {
+    const user = userEvent.setup();
+    const onSave = vi.fn();
+    const onClose = vi.fn();
+
+    render(
+      <LineItemEditSheet
+        open
+        mode="edit"
+        initialLineItem={makeLineItem({ flagReason: "spoken_money_correction" })}
+        onClose={onClose}
+        onSave={onSave}
+        onRequestDelete={vi.fn()}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText(/details/i), { target: { value: " 6 yards " } });
+    await user.click(screen.getByRole("button", { name: /^dismiss$/i }));
+    await user.click(screen.getByTestId("line-item-edit-sheet-overlay"));
+
+    expect(onSave).toHaveBeenCalledWith({
+      description: "Brown mulch",
+      details: "6 yards",
+      price: 120,
+      flagged: false,
+      flagReason: null,
+    });
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(screen.queryByText("Review needed")).not.toBeInTheDocument();
+  });
+
+  it("keeps a dismissed review state after validation errors until save succeeds", async () => {
+    const user = userEvent.setup();
+    const onSave = vi.fn();
+    const onClose = vi.fn();
+
+    render(
+      <LineItemEditSheet
+        open
+        mode="edit"
+        initialLineItem={makeLineItem({ flagReason: "spoken_money_correction" })}
+        onClose={onClose}
+        onSave={onSave}
+        onRequestDelete={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /^dismiss$/i }));
+    fireEvent.change(screen.getByLabelText(/description/i), { target: { value: "   " } });
+    await user.click(screen.getByTestId("line-item-edit-sheet-overlay"));
+
+    expect(screen.getByRole("alert")).toHaveTextContent("Description is required.");
+    expect(onSave).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+
+    fireEvent.change(screen.getByLabelText(/description/i), { target: { value: "Brown mulch" } });
+    await user.click(screen.getByTestId("line-item-edit-sheet-overlay"));
+
+    expect(onSave).toHaveBeenCalledWith(expect.objectContaining({
+      flagged: false,
+      flagReason: null,
+    }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
   it("renders add mode without sheet trash", () => {
     render(
       <LineItemEditSheet

--- a/frontend/src/features/quotes/tests/ReviewScreen.test.tsx
+++ b/frontend/src/features/quotes/tests/ReviewScreen.test.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -581,6 +582,57 @@ describe("DocumentEditScreen", () => {
     expect(document.querySelectorAll("[data-line-item-index]").length).toBe(1);
     expect(screen.getByText("Cleanup labor")).toBeInTheDocument();
     expect(screen.queryByText("No line items on this quote yet.")).not.toBeInTheDocument();
+  });
+
+  it("persists line-item review dismiss from the edit sheet", async () => {
+    const user = userEvent.setup();
+
+    renderScreen({
+      document: makeQuote({
+        line_items: [
+          {
+            id: "line-1",
+            description: "Brown mulch",
+            details: "5 yards",
+            price: 120,
+            flagged: true,
+            flag_reason: "spoken_money_correction",
+            sort_order: 0,
+          },
+        ],
+      }),
+    });
+
+    const editLineItemButton = await screen.findByRole("button", { name: /edit line item 1: brown mulch/i });
+    const lineItemRow = editLineItemButton.closest("[data-line-item-index]");
+    expect(lineItemRow).not.toBeNull();
+    expect(within(lineItemRow as HTMLElement).getByText("REVIEW")).toBeInTheDocument();
+
+    await user.click(editLineItemButton);
+    const editSheet = screen.getByRole("dialog", { name: /edit line item/i });
+    await user.click(within(editSheet).getByRole("button", { name: /^dismiss$/i }));
+    await user.click(screen.getByTestId("line-item-edit-sheet-overlay"));
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog", { name: /edit line item/i })).not.toBeInTheDocument();
+    });
+
+    const updatedLineItemButton = await screen.findByRole("button", { name: /edit line item 1: brown mulch/i });
+    const updatedLineItemRow = updatedLineItemButton.closest("[data-line-item-index]");
+    expect(updatedLineItemRow).not.toBeNull();
+    expect(within(updatedLineItemRow as HTMLElement).queryByText("REVIEW")).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /continue to preview/i }));
+    await waitFor(() => {
+      expect(mockedQuoteService.updateQuote).toHaveBeenCalledWith("doc-1", expect.objectContaining({
+        line_items: expect.arrayContaining([
+          expect.objectContaining({
+            description: "Brown mulch",
+            flagged: false,
+            flag_reason: null,
+          }),
+        ]),
+      }));
+    });
   });
 
   it("does not show the capture-details alert icon for transcript-only details", async () => {

--- a/frontend/src/features/quotes/tests/reviewLineItemSheetState.test.ts
+++ b/frontend/src/features/quotes/tests/reviewLineItemSheetState.test.ts
@@ -65,6 +65,37 @@ describe("reviewLineItemSheetState", () => {
     });
   });
 
+  it("keeps a manually dismissed review flag cleared when price is unchanged", () => {
+    const nextDraft = applyLineItemSheetSave(
+      {
+        lineItems: [
+          {
+            description: "Mulch",
+            details: "front beds",
+            price: 450,
+            flagged: true,
+            flagReason: "spoken_money_correction",
+          },
+        ],
+        total: 450,
+      },
+      { mode: "edit", index: 0 },
+      {
+        description: "Mulch",
+        details: "front beds",
+        price: 450,
+        flagged: false,
+        flagReason: null,
+      },
+    );
+
+    expect(nextDraft.lineItems[0]).toMatchObject({
+      price: 450,
+      flagged: false,
+      flagReason: null,
+    });
+  });
+
   it("reorders line items in local draft order", () => {
     const nextDraft = applyLineItemReorder(
       {


### PR DESCRIPTION
## Summary
- add a banner-local Dismiss action in LineItemEditSheet for flagged edit-mode line items
- persist dismiss intent in sheet-local line-item state so the next save clears flagged/flagReason
- keep existing spoken-money auto-clear path intact and covered with regression tests

## Verification
- cd frontend && npx vitest run src/features/quotes/tests/LineItemEditSheet.test.tsx
- cd frontend && npx vitest run src/features/quotes/tests/reviewLineItemSheetState.test.ts
- cd frontend && npx vitest run src/features/quotes/tests/ReviewScreen.test.tsx
- make frontend-verify

Closes #498