### PR TITLE
Task #482: Move Capture Details trigger to review header

### DIFF
--- a/frontend/src/features/quotes/components/DocumentEditScreenView.tsx
+++ b/frontend/src/features/quotes/components/DocumentEditScreenView.tsx
@@ -1,3 +1,6 @@
+import { useMemo, useState } from "react";
+
+import { CaptureDetailsSheet } from "@/features/quotes/components/CaptureDetailsSheet";
 import { DocumentEditOverlays } from "@/features/quotes/components/DocumentEditOverlays";
 import { ReviewActionFooter } from "@/features/quotes/components/ReviewActionFooter";
 import { ReviewFormContent } from "@/features/quotes/components/ReviewFormContent";
@@ -5,6 +8,7 @@ import { isInvoiceDocument } from "@/features/quotes/components/documentEditUtil
 import type { ReviewLineItemSheetState } from "@/features/quotes/components/reviewLineItemSheetState";
 import { type DocumentEditDraft, type PersistedEditableDocument } from "@/features/quotes/hooks/usePersistedReview";
 import type { ExtractionReviewHiddenDetails, ExtractionTier, HiddenItemState, LineItemDraftWithFlags } from "@/features/quotes/types/quote.types";
+import { hasUndismissedCaptureDetailsItems, resolveCaptureDetailsActionableItems } from "@/features/quotes/utils/captureDetails";
 import type { LineItemCatalogItem } from "@/features/line-item-catalog/types/lineItemCatalog.types";
 import { WorkflowScreenHeader } from "@/shared/components/WorkflowScreenHeader";
 
@@ -131,6 +135,14 @@ export function DocumentEditScreenView({
   onLeaveConfirm,
   onLeaveCancel,
 }: DocumentEditScreenViewProps): React.ReactElement {
+  const [isCaptureDetailsOpen, setIsCaptureDetailsOpen] = useState(false);
+  const hasTranscript = activeDraft.transcript.trim().length > 0;
+  const hasHiddenActionableItems = useMemo(() => hasUndismissedCaptureDetailsItems(
+    resolveCaptureDetailsActionableItems(hiddenDetails),
+    hiddenDetailState,
+  ), [hiddenDetails, hiddenDetailState]);
+  const showCaptureDetailsTrigger = !isInvoiceDocument(document) && (hasTranscript || hasHiddenActionableItems);
+
   return (
     <main className="min-h-screen bg-background pb-28">
       <WorkflowScreenHeader
@@ -138,6 +150,29 @@ export function DocumentEditScreenView({
         subtitle="Confirm line items and pricing"
         backLabel={backLabel}
         onBack={() => onRequestNavigation({ to: backTarget, replace: true })}
+        trailing={showCaptureDetailsTrigger ? (
+          <button
+            type="button"
+            aria-label="Capture details"
+            onClick={() => setIsCaptureDetailsOpen(true)}
+            className={[
+              "inline-flex h-10 cursor-pointer items-center gap-1.5 rounded-full border px-3 text-xs font-semibold uppercase tracking-wide transition-colors",
+              hasHiddenActionableItems
+                ? "border-warning-accent/50 bg-warning-container text-warning hover:bg-warning-container/80"
+                : "border-outline-variant/30 bg-surface-container-lowest text-on-surface-variant hover:bg-surface-container-low",
+            ].join(" ")}
+          >
+            {hasHiddenActionableItems ? (
+              <span
+                aria-label="Capture details need review"
+                className="material-symbols-outlined text-[1rem] leading-none"
+              >
+                error
+              </span>
+            ) : null}
+            <span>Capture Details</span>
+          </button>
+        ) : null}
       />
 
       <ReviewFormContent
@@ -154,11 +189,8 @@ export function DocumentEditScreenView({
         isInteractionLocked={isInteractionLocked}
         extractionTier={extractionTier}
         extractionDegradedReasonCode={extractionDegradedReasonCode}
-        hiddenDetails={hiddenDetails}
-        hiddenDetailState={hiddenDetailState}
         lineItemSum={lineItemSum}
         suggestedTaxRate={suggestedTaxRate}
-        isMutatingHiddenItems={isMutatingHiddenItems}
         onDocumentTypeChange={onDocumentTypeChange}
         onDueDateChange={onDueDateChange}
         onRequestAssignment={onOpenAssignment}
@@ -172,8 +204,19 @@ export function DocumentEditScreenView({
         onDiscountValueChange={onDiscountValueChange}
         onDepositAmountChange={onDepositAmountChange}
         onNotesChange={onNotesChange}
-        onDismissHiddenItem={onDismissHiddenItem}
       />
+
+      {!isInvoiceDocument(document) ? (
+        <CaptureDetailsSheet
+          open={isCaptureDetailsOpen}
+          onClose={() => setIsCaptureDetailsOpen(false)}
+          transcript={activeDraft.transcript}
+          hiddenDetails={hiddenDetails}
+          hiddenDetailState={hiddenDetailState}
+          onDismissHiddenItem={onDismissHiddenItem}
+          isMutating={isMutatingHiddenItems}
+        />
+      ) : null}
 
       <ReviewActionFooter
         requiresCustomerAssignment={requiresCustomerAssignment}

--- a/frontend/src/features/quotes/components/ReviewFormContent.tsx
+++ b/frontend/src/features/quotes/components/ReviewFormContent.tsx
@@ -1,12 +1,8 @@
-import { useState } from "react";
-
-import { CaptureDetailsSheet } from "@/features/quotes/components/CaptureDetailsSheet";
 import { ReviewCustomerRow } from "@/features/quotes/components/ReviewCustomerRow";
 import { ReviewDocumentTypeSelector, type ReviewDocumentType } from "@/features/quotes/components/ReviewDocumentTypeSelector";
 import { ReviewLineItemsSection } from "@/features/quotes/components/ReviewLineItemsSection";
 import { TotalAmountSection } from "@/features/quotes/components/TotalAmountSection";
-import type { ExtractionReviewHiddenDetails, ExtractionTier, HiddenItemState } from "@/features/quotes/types/quote.types";
-import { hasUndismissedCaptureDetailsItems, resolveCaptureDetailsActionableItems } from "@/features/quotes/utils/captureDetails";
+import type { ExtractionTier } from "@/features/quotes/types/quote.types";
 import { FeedbackMessage } from "@/shared/components/FeedbackMessage";
 import {
   DOCUMENT_NOTES_MAX_CHARS,
@@ -45,11 +41,8 @@ interface ReviewFormContentProps {
   isInteractionLocked: boolean;
   extractionTier: ExtractionTier | null;
   extractionDegradedReasonCode: string | null;
-  hiddenDetails?: ExtractionReviewHiddenDetails;
-  hiddenDetailState?: Record<string, HiddenItemState>;
   lineItemSum: number;
   suggestedTaxRate: number | null;
-  isMutatingHiddenItems: boolean;
   onDocumentTypeChange: (nextType: ReviewDocumentType) => void;
   onDueDateChange: (nextDueDate: string) => void;
   onRequestAssignment: () => void;
@@ -63,7 +56,6 @@ interface ReviewFormContentProps {
   onDiscountValueChange: (nextDiscountValue: number | null) => void;
   onDepositAmountChange: (nextDepositAmount: number | null) => void;
   onNotesChange: (nextNotes: string) => void;
-  onDismissHiddenItem: (itemId: string) => Promise<void>;
 }
 
 export function ReviewFormContent({
@@ -80,11 +72,8 @@ export function ReviewFormContent({
   isInteractionLocked,
   extractionTier,
   extractionDegradedReasonCode,
-  hiddenDetails,
-  hiddenDetailState,
   lineItemSum,
   suggestedTaxRate,
-  isMutatingHiddenItems,
   onDocumentTypeChange,
   onDueDateChange,
   onRequestAssignment,
@@ -98,17 +87,10 @@ export function ReviewFormContent({
   onDiscountValueChange,
   onDepositAmountChange,
   onNotesChange,
-  onDismissHiddenItem,
 }: ReviewFormContentProps): React.ReactElement {
-  const [isCaptureDetailsOpen, setIsCaptureDetailsOpen] = useState(false);
   const showDueDateField = documentType === "invoice";
-  const showQuoteOnlySections = documentType === "quote";
   const showSevereDegradedMarker = extractionTier === "degraded"
     && draft.lineItems.length === 0;
-  const hasHiddenActionableItems = hasUndismissedCaptureDetailsItems(
-    resolveCaptureDetailsActionableItems(hiddenDetails),
-    hiddenDetailState,
-  );
 
   return (
     <form
@@ -188,36 +170,6 @@ export function ReviewFormContent({
         </section>
       ) : null}
 
-      {showQuoteOnlySections ? (
-        <section className="space-y-2">
-          <button
-            type="button"
-            className="inline-flex w-full cursor-pointer items-center justify-between rounded-[var(--radius-document)] border border-outline-variant/30 bg-surface-container-high px-4 py-3 text-left transition-colors hover:bg-surface-container-lowest"
-            onClick={() => {
-              setIsCaptureDetailsOpen(true);
-            }}
-          >
-            <div>
-              <Eyebrow>Capture Details</Eyebrow>
-              <p className="text-sm text-on-surface-variant">
-                Actionable items and transcript.
-              </p>
-            </div>
-            <div className="inline-flex items-center gap-1.5">
-              {hasHiddenActionableItems ? (
-                <span
-                  aria-label="Capture details need review"
-                  className="material-symbols-outlined text-[1.125rem] leading-none text-warning"
-                >
-                  error
-                </span>
-              ) : null}
-              <span className="material-symbols-outlined text-[1rem] leading-none text-outline">chevron_right</span>
-            </div>
-          </button>
-        </section>
-      ) : null}
-
       <ReviewLineItemsSection
         lineItems={draft.lineItems}
         isInteractionLocked={isInteractionLocked}
@@ -257,18 +209,6 @@ export function ReviewFormContent({
           placeholder="Any notes to include for the customer."
         />
       </section>
-
-      {showQuoteOnlySections ? (
-        <CaptureDetailsSheet
-          open={isCaptureDetailsOpen}
-          onClose={() => setIsCaptureDetailsOpen(false)}
-          transcript={draft.transcript ?? ""}
-          hiddenDetails={hiddenDetails}
-          hiddenDetailState={hiddenDetailState}
-          onDismissHiddenItem={onDismissHiddenItem}
-          isMutating={isMutatingHiddenItems}
-        />
-      ) : null}
     </form>
   );
 }

--- a/frontend/src/features/quotes/tests/ReviewScreen.test.tsx
+++ b/frontend/src/features/quotes/tests/ReviewScreen.test.tsx
@@ -650,6 +650,33 @@ describe("DocumentEditScreen", () => {
     expect(screen.queryByLabelText("Capture details need review")).not.toBeInTheDocument();
   });
 
+  it("renders capture details only in the header trailing area", async () => {
+    renderScreen();
+
+    const header = await screen.findByRole("banner");
+    const reviewForm = document.getElementById("quote-review-form");
+    expect(reviewForm).not.toBeNull();
+    expect(within(header).getByRole("button", { name: /capture details/i })).toBeInTheDocument();
+    expect(within(reviewForm as HTMLElement).queryByRole("button", { name: /capture details/i })).not.toBeInTheDocument();
+  });
+
+  it("hides the capture-details trigger when transcript and hidden details are both empty", async () => {
+    renderScreen({
+      document: makeQuote({
+        transcript: "",
+        extraction_review_metadata: {
+          ...makeQuote().extraction_review_metadata!,
+          hidden_details: {
+            items: [],
+          },
+        },
+      }),
+    });
+
+    await screen.findByRole("button", { name: /continue to preview/i });
+    expect(screen.queryByRole("button", { name: /capture details/i })).not.toBeInTheDocument();
+  });
+
   it("shows the capture-details alert icon when hidden actionable items exist", async () => {
     renderScreen({
       document: makeQuote({


### PR DESCRIPTION
## Summary
- move the Capture Details trigger from the review form body to the review header trailing area
- lift Capture Details sheet mount/open handling into the review screen view so the header trigger controls it directly
- apply trigger visibility + semantics from Task #482: hide when no transcript and no undismissed hidden items, keep transcript-only neutral, and show warning emphasis when undismissed hidden items exist
- add review screen tests for header placement and hidden-when-empty visibility

## Verification
- `cd frontend && npx vitest run src/features/quotes/tests/ReviewScreen.test.tsx`
- `make frontend-verify`

Closes #482