### PR TITLE
Task #483: Narrow Capture Details to transcript + true overflow

### DIFF
--- a/frontend/src/features/quotes/components/CaptureDetailsSheet.tsx
+++ b/frontend/src/features/quotes/components/CaptureDetailsSheet.tsx
@@ -13,40 +13,6 @@ interface CaptureDetailsSheetProps {
   isMutating?: boolean;
 }
 
-function formatPricingField(
-  pricingField: "explicit_total" | "deposit_amount" | "tax_rate" | "discount" | null | undefined,
-): string | null {
-  if (!pricingField) {
-    return null;
-  }
-
-  if (pricingField === "explicit_total") {
-    return "total";
-  }
-  if (pricingField === "deposit_amount") {
-    return "deposit";
-  }
-  if (pricingField === "tax_rate") {
-    return "tax";
-  }
-  return "discount";
-}
-
-function buildActionableLabel(item: {
-  kind: "unresolved_segment";
-  field: "notes" | "explicit_total" | "deposit_amount" | "tax_rate" | "discount" | null;
-  reason: string | null;
-}): string {
-  const pricingField = formatPricingField(item.field === "notes" ? null : item.field);
-  if (item.field === "notes") {
-    return "Unresolved note";
-  }
-  if (pricingField) {
-    return `Unresolved ${pricingField}`;
-  }
-  return (item.reason ?? "leftover_classification").replaceAll("_", " ");
-}
-
 export function CaptureDetailsSheet({
   open,
   onClose,
@@ -87,7 +53,7 @@ export function CaptureDetailsSheet({
                         key={item.id}
                         className="rounded-lg border border-outline-variant/30 bg-surface-container-high p-3 text-sm text-on-surface"
                       >
-                        <p className="font-semibold">{buildActionableLabel(item)}</p>
+                        <p className="font-semibold">{item.label}</p>
                         <p className="mt-1 whitespace-pre-wrap text-on-surface-variant">{item.text}</p>
                         <div className="mt-3">
                           <button

--- a/frontend/src/features/quotes/tests/ReviewScreen.test.tsx
+++ b/frontend/src/features/quotes/tests/ReviewScreen.test.tsx
@@ -699,6 +699,31 @@ describe("DocumentEditScreen", () => {
     expect(await screen.findByLabelText("Capture details need review")).toBeInTheDocument();
   });
 
+  it("hides the capture-details trigger when only non-overflow unresolved reasons exist", async () => {
+    renderScreen({
+      document: makeQuote({
+        transcript: "",
+        extraction_review_metadata: {
+          ...makeQuote().extraction_review_metadata!,
+          hidden_details: {
+            items: [
+              {
+                id: "unresolved-1",
+                kind: "unresolved_segment",
+                field: "notes",
+                reason: "typed_conflict",
+                text: "customer said maybe cedar mulch",
+              },
+            ],
+          },
+        },
+      }),
+    });
+
+    await screen.findByRole("button", { name: /continue to preview/i });
+    expect(screen.queryByRole("button", { name: /capture details/i })).not.toBeInTheDocument();
+  });
+
   it("renders one unified actionable feed plus transcript with dismiss-only actions", async () => {
     renderScreen({
       document: makeQuote({
@@ -710,15 +735,29 @@ describe("DocumentEditScreen", () => {
                 id: "unresolved-1",
                 kind: "unresolved_segment",
                 field: null,
-                reason: "typed_conflict",
-                text: "discount 25",
+                reason: "leftover_classification",
+                text: "trim rose bed maybe",
               },
               {
                 id: "unresolved-2",
                 kind: "unresolved_segment",
+                field: "notes",
+                reason: "leftover_classification",
+                text: "ask for back gate access",
+              },
+              {
+                id: "unresolved-3",
+                kind: "unresolved_segment",
+                field: "explicit_total",
+                reason: "leftover_classification",
+                text: "total could be 390",
+              },
+              {
+                id: "unresolved-4",
+                kind: "unresolved_segment",
                 field: null,
                 reason: "typed_conflict",
-                text: "trim rose bed maybe",
+                text: "conflicting typed note should not surface",
               },
             ],
           },
@@ -736,6 +775,12 @@ describe("DocumentEditScreen", () => {
     expect(screen.queryByText("Unresolved Capture Details")).not.toBeInTheDocument();
     expect(screen.queryByText("AI Review Notes")).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /mark reviewed/i })).not.toBeInTheDocument();
+    expect(screen.getByText("Unplaced capture detail")).toBeInTheDocument();
+    expect(screen.getByText("Unresolved note")).toBeInTheDocument();
+    expect(screen.getByText("Unresolved pricing detail")).toBeInTheDocument();
+    expect(screen.queryByText("leftover classification")).not.toBeInTheDocument();
+    expect(screen.queryByText("typed conflict")).not.toBeInTheDocument();
+    expect(screen.queryByText("conflicting typed note should not surface")).not.toBeInTheDocument();
     expect(screen.getAllByRole("button", { name: /^dismiss$/i }).length).toBeGreaterThan(0);
     expect(screen.getByText("Original capture transcript text.")).toBeInTheDocument();
     const transcriptSection = transcriptHeading.closest("section");

--- a/frontend/src/features/quotes/utils/captureDetails.ts
+++ b/frontend/src/features/quotes/utils/captureDetails.ts
@@ -1,11 +1,45 @@
 import type { ExtractionReviewHiddenDetails, HiddenItemState } from "@/features/quotes/types/quote.types";
 
+const PRICING_FIELDS = new Set(["explicit_total", "deposit_amount", "tax_rate", "discount"] as const);
+const TRUE_OVERFLOW_REASON = "leftover_classification";
+
+type CaptureDetailsDisplayBucket =
+  | "unplaced_capture_detail"
+  | "unresolved_note"
+  | "unresolved_pricing_detail";
+
+const DISPLAY_BUCKET_LABELS: Record<CaptureDetailsDisplayBucket, string> = {
+  unplaced_capture_detail: "Unplaced capture detail",
+  unresolved_note: "Unresolved note",
+  unresolved_pricing_detail: "Unresolved pricing detail",
+};
+
 export interface CaptureDetailsActionableItem {
   id: string;
   kind: "unresolved_segment";
   field: "notes" | "explicit_total" | "deposit_amount" | "tax_rate" | "discount" | null;
-  reason: string | null;
+  label: string;
   text: string;
+}
+
+function resolveDisplayBucket(item: {
+  field: "notes" | "explicit_total" | "deposit_amount" | "tax_rate" | "discount" | null;
+  reason: string | null;
+}): CaptureDetailsDisplayBucket | null {
+  // "True overflow" items come from leftover classification; other reasons are transcript/model conflicts.
+  if (item.reason !== null && item.reason !== TRUE_OVERFLOW_REASON) {
+    return null;
+  }
+
+  if (item.field === "notes") {
+    return "unresolved_note";
+  }
+
+  if (item.field !== null && PRICING_FIELDS.has(item.field)) {
+    return "unresolved_pricing_detail";
+  }
+
+  return "unplaced_capture_detail";
 }
 
 export function resolveCaptureDetailsActionableItems(
@@ -15,13 +49,27 @@ export function resolveCaptureDetailsActionableItems(
     return [];
   }
 
-  return hiddenDetails.items.map((item) => ({
-    id: item.id,
-    kind: item.kind,
-    field: item.field ?? null,
-    reason: item.reason ?? null,
-    text: item.text,
-  }));
+  return hiddenDetails.items.flatMap((item) => {
+    const normalizedItem = {
+      id: item.id,
+      kind: item.kind,
+      field: item.field ?? null,
+      reason: item.reason ?? null,
+      text: item.text,
+    } as const;
+    const displayBucket = resolveDisplayBucket(normalizedItem);
+    if (!displayBucket) {
+      return [];
+    }
+
+    return [{
+      id: normalizedItem.id,
+      kind: normalizedItem.kind,
+      field: normalizedItem.field,
+      label: DISPLAY_BUCKET_LABELS[displayBucket],
+      text: normalizedItem.text,
+    }];
+  });
 }
 
 export function hasUndismissedCaptureDetailsItems(


### PR DESCRIPTION
## Summary
- narrow Capture Details actionable items to true overflow only (`reason=leftover_classification` or legacy `null`)
- map unresolved segment display buckets using product labels only
- keep sheet content focused on actionable overflow + transcript (no internal reason strings exposed)
- add/adjust review tests for filtering and labels

## Unresolved segment mapping (documented before coding)
- `field=notes` + true overflow reason -> **Unresolved note**
- `field` in `explicit_total|deposit_amount|tax_rate|discount` + true overflow reason -> **Unresolved pricing detail**
- all other true overflow rows -> **Unplaced capture detail**
- non-overflow reasons (for example `typed_conflict`) are filtered out at display time

## Verification
- `cd frontend && npx vitest run src/features/quotes/tests/ReviewScreen.test.tsx`
- `make frontend-verify`

Closes #483