### PR TITLE
[PR5] Capture UI adoption (design refresh)

### DIFF
--- a/frontend/src/features/quotes/components/CaptureInputPanel.tsx
+++ b/frontend/src/features/quotes/components/CaptureInputPanel.tsx
@@ -121,7 +121,7 @@ export function CaptureInputPanel({
       </section>
 
       {isRecording ? (
-        <div className="mt-auto flex flex-col items-center gap-3 pt-4 sm:pt-6">
+        <div className="mt-auto mb-2 flex flex-col items-center gap-3 pt-4 sm:pt-6">
           <div className="flex items-center gap-2">
             <span className="h-2 w-2 animate-pulse rounded-full bg-secondary" />
             <p className="text-sm font-medium text-secondary">
@@ -137,7 +137,7 @@ export function CaptureInputPanel({
           </button>
         </div>
       ) : (
-        <div className="mt-auto flex flex-col items-center gap-3 pt-4 sm:pt-6">
+        <div className="mt-auto mb-2 flex flex-col items-center gap-3 pt-4 sm:pt-6">
           <p className="text-xs uppercase tracking-widest text-outline">
             TAP TO START
           </p>

--- a/frontend/src/features/quotes/components/CaptureInputPanel.tsx
+++ b/frontend/src/features/quotes/components/CaptureInputPanel.tsx
@@ -4,6 +4,7 @@ import {
   MAX_AUDIO_CLIPS_PER_REQUEST,
   NOTE_INPUT_MAX_CHARS,
 } from "@/shared/lib/inputLimits";
+import { Eyebrow } from "@/ui/Eyebrow";
 
 interface CaptureInputPanelProps {
   clips: VoiceClip[];
@@ -38,18 +39,16 @@ export function CaptureInputPanel({
 }: CaptureInputPanelProps): React.ReactElement {
   return (
     <>
-      <section className="mb-6">
+      <section className="mb-4 rounded-[var(--radius-document)] border border-outline-variant/20 bg-surface-container-low p-4">
         <div className="mb-3 flex items-center justify-between">
-          <h2 className="font-headline text-sm font-semibold uppercase tracking-wide text-on-surface">
-            RECORDED CLIPS
-          </h2>
-          <span className="rounded-sm bg-surface-container-low px-2 py-0.5 text-[0.6875rem] font-bold uppercase tracking-widest text-outline">
+          <Eyebrow className="text-on-surface">RECORDED CLIPS</Eyebrow>
+          <span className="rounded-full bg-surface-container-lowest px-2.5 py-1 text-[0.6875rem] font-bold uppercase tracking-widest text-outline">
             {clips.length} CLIPS
           </span>
         </div>
 
         {clips.length === 0 ? (
-          <div className="flex h-28 flex-col items-center justify-center gap-2 rounded-lg border-2 border-dashed border-outline-variant/30 bg-surface-container-lowest p-4">
+          <div className="ghost-shadow flex h-28 flex-col items-center justify-center gap-2 rounded-[var(--radius-document)] border-2 border-dashed border-outline-variant/30 bg-surface-container-lowest p-4">
             <span className="material-symbols-outlined text-4xl text-outline">
               mic_off
             </span>
@@ -65,7 +64,7 @@ export function CaptureInputPanel({
               return (
                 <div
                   key={clip.id}
-                  className="flex items-center justify-between rounded-lg bg-surface-container-lowest p-3 ghost-shadow"
+                  className="ghost-shadow flex items-center justify-between rounded-[var(--radius-document)] border border-outline-variant/20 bg-surface-container-lowest p-3"
                 >
                   <div className="flex items-center gap-3">
                     <span className="material-symbols-outlined text-outline">
@@ -93,12 +92,12 @@ export function CaptureInputPanel({
         )}
       </section>
 
-      <section className="mb-4">
+      <section className="mb-4 rounded-[var(--radius-document)] border border-outline-variant/20 bg-surface-container-low p-4">
         <label
           htmlFor="capture-written-description"
-          className="mb-3 block font-headline text-sm font-semibold uppercase tracking-wide text-on-surface"
+          className="mb-3 block"
         >
-          WRITTEN DESCRIPTION
+          <Eyebrow className="text-on-surface">WRITTEN DESCRIPTION</Eyebrow>
         </label>
         <textarea
           id="capture-written-description"
@@ -107,7 +106,7 @@ export function CaptureInputPanel({
           value={notes}
           onChange={(event) => onNotesChange(event.target.value)}
           placeholder="Add any typed details here..."
-          className="w-full resize-none rounded-lg bg-surface-container-high px-4 py-3 font-body text-sm text-on-surface placeholder:text-outline transition-all focus:bg-surface-container-lowest focus:ring-2 focus:ring-primary/30 focus:outline-none"
+          className="w-full resize-none rounded-[var(--radius-document)] border border-outline-variant/25 bg-surface-container-high px-4 py-3 font-body text-sm text-on-surface placeholder:text-outline transition-all focus:border-primary/40 focus:bg-surface-container-lowest focus:ring-2 focus:ring-primary/30 focus:outline-none"
         />
         {onStartBlank ? (
           <button

--- a/frontend/src/features/quotes/components/CaptureScreen.tsx
+++ b/frontend/src/features/quotes/components/CaptureScreen.tsx
@@ -11,7 +11,6 @@ import {
 } from "@/features/quotes/components/captureScreenHelpers";
 import { CaptureInputPanel } from "@/features/quotes/components/CaptureInputPanel";
 import {
-  HOME_ROUTE,
   resolveCaptureLaunchOrigin,
 } from "@/features/quotes/utils/workflowNavigation";
 import { useVoiceCapture } from "@/features/quotes/hooks/useVoiceCapture";
@@ -287,10 +286,6 @@ export function CaptureScreen(): React.ReactElement {
     requestExit(launchOrigin);
   }
 
-  function onExitHome(): void {
-    requestExit(HOME_ROUTE);
-  }
-
   function onStartBlankClick(): void {
     if (hasUnsavedWork()) {
       setPendingExitTarget(START_BLANK_GUARD_TARGET);
@@ -310,12 +305,11 @@ export function CaptureScreen(): React.ReactElement {
         subtitle="Describe the job and we'll extract the line items"
         backLabel="Go back"
         onBack={onBack}
-        onExitHome={onExitHome}
       />
 
       <section className="mx-auto flex min-h-dvh w-full max-w-2xl flex-col px-4 pb-36 pt-20">
         {!isSupported ? (
-          <p className="mb-4 rounded-lg border border-warning-accent/40 bg-warning-container p-3 text-sm text-warning">
+          <p className="ghost-shadow mb-4 rounded-[var(--radius-document)] border-l-4 border-warning-accent bg-warning-container p-4 text-sm text-warning">
             Voice capture is not supported in this browser. You can still type
             notes and extract line items.
           </p>
@@ -345,12 +339,12 @@ export function CaptureScreen(): React.ReactElement {
       <ScreenFooter>
         <div className="mx-auto w-full max-w-2xl">
           {extractionStage ? (
-            <p className="mb-2 text-center text-sm text-on-surface-variant">
+            <p className="mb-2 text-center text-sm font-medium text-on-surface-variant">
               {extractionStage}
             </p>
           ) : null}
           {extractionStage && extractionHelperCopy ? (
-            <p className="mb-3 text-center text-xs text-on-surface-variant">
+            <p className="mb-3 text-center text-xs leading-relaxed text-on-surface-variant">
               {extractionHelperCopy}
             </p>
           ) : null}

--- a/frontend/src/features/quotes/components/CaptureScreen.tsx
+++ b/frontend/src/features/quotes/components/CaptureScreen.tsx
@@ -6,7 +6,6 @@ import {
   EXTRACTION_MAX_POLLS,
   EXTRACTION_POLL_INTERVAL_MS,
   EXTRACTION_STAGE_DELAY_MS,
-  getExtractionHelperCopy,
   getExtractionStages,
 } from "@/features/quotes/components/captureScreenHelpers";
 import { CaptureInputPanel } from "@/features/quotes/components/CaptureInputPanel";
@@ -54,7 +53,6 @@ export function CaptureScreen(): React.ReactElement {
   const isExtracting = extractionStage !== null;
   const hasClips = clips.length > 0;
   const hasNotes = notes.trim().length > 0;
-  const extractionHelperCopy = getExtractionHelperCopy(hasClips, hasNotes);
   const launchOrigin = resolveCaptureLaunchOrigin({
     customerId,
     locationState: location.state,
@@ -341,11 +339,6 @@ export function CaptureScreen(): React.ReactElement {
           {extractionStage ? (
             <p className="mb-2 text-center text-sm font-medium text-on-surface-variant">
               {extractionStage}
-            </p>
-          ) : null}
-          {extractionStage && extractionHelperCopy ? (
-            <p className="mb-3 text-center text-xs leading-relaxed text-on-surface-variant">
-              {extractionHelperCopy}
             </p>
           ) : null}
           <Button

--- a/frontend/src/features/quotes/components/DocumentEditScreenView.tsx
+++ b/frontend/src/features/quotes/components/DocumentEditScreenView.tsx
@@ -155,22 +155,17 @@ export function DocumentEditScreenView({
             type="button"
             aria-label="Capture details"
             onClick={() => setIsCaptureDetailsOpen(true)}
+            data-testid="capture-details-trigger"
             className={[
-              "inline-flex h-10 cursor-pointer items-center gap-1.5 rounded-full border px-3 text-xs font-semibold uppercase tracking-wide transition-colors",
+              "inline-flex h-10 w-10 cursor-pointer shrink-0 items-center justify-center rounded-full border transition-colors",
               hasHiddenActionableItems
                 ? "border-warning-accent/50 bg-warning-container text-warning hover:bg-warning-container/80"
-                : "border-outline-variant/30 bg-surface-container-lowest text-on-surface-variant hover:bg-surface-container-low",
+                : "border-outline-variant/30 bg-surface-container-lowest text-on-surface hover:bg-surface-container-low",
             ].join(" ")}
           >
-            {hasHiddenActionableItems ? (
-              <span
-                aria-label="Capture details need review"
-                className="material-symbols-outlined text-[1rem] leading-none"
-              >
-                error
-              </span>
-            ) : null}
-            <span>Capture Details</span>
+            <span className="material-symbols-outlined text-[1.125rem] leading-none">
+              info
+            </span>
           </button>
         ) : null}
       />

--- a/frontend/src/features/quotes/tests/CaptureScreen.test.tsx
+++ b/frontend/src/features/quotes/tests/CaptureScreen.test.tsx
@@ -404,6 +404,12 @@ describe("CaptureScreen", () => {
     ).toBeInTheDocument();
   });
 
+  it("does not render an exit-to-home button in the capture header", () => {
+    renderScreen();
+
+    expect(screen.queryByRole("button", { name: /exit to home/i })).not.toBeInTheDocument();
+  });
+
   it("shows a leave confirmation when navigating back with unsaved clips", () => {
     mockVoiceCapture({ clips: [clipFixture] });
     renderScreen();
@@ -458,18 +464,6 @@ describe("CaptureScreen", () => {
     fireEvent.click(screen.getByRole("button", { name: "Leave" }));
 
     expect(navigateMock).toHaveBeenCalledWith("/customers/cust-1", { replace: true });
-  });
-
-  it("shows the same leave confirmation when exiting home with unsaved work", () => {
-    renderScreen();
-
-    fireEvent.change(screen.getByLabelText(/written description/i), {
-      target: { value: "Install sod in backyard" },
-    });
-    fireEvent.click(screen.getByRole("button", { name: /exit to home/i }));
-
-    expect(screen.getByRole("dialog", { name: "Leave this screen?" })).toBeInTheDocument();
-    expect(navigateMock).not.toHaveBeenCalledWith(HOME_ROUTE, { replace: true });
   });
 
   it("submits extraction with customer context and routes to persisted review id", async () => {

--- a/frontend/src/features/quotes/tests/CaptureScreen.test.tsx
+++ b/frontend/src/features/quotes/tests/CaptureScreen.test.tsx
@@ -347,7 +347,7 @@ describe("CaptureScreen", () => {
     expect(screen.getByRole("button", { name: /extract line items/i })).toBeEnabled();
   });
 
-  it("shows extraction helper copy only while extraction is active", async () => {
+  it("shows extraction stage text without helper subtext while extraction is active", async () => {
     const extractDeferred = new Promise<{ type: "sync"; quoteId: string; result: ExtractionResult }>(() => {});
     mockedQuoteService.extract.mockReturnValueOnce(extractDeferred);
     renderScreen();
@@ -363,7 +363,9 @@ describe("CaptureScreen", () => {
     fireEvent.click(screen.getByRole("button", { name: /extract line items/i }));
 
     expect(await screen.findByText("Analyzing notes...")).toBeInTheDocument();
-    expect(screen.getByText(/extraction saves your notes as a draft for manual review/i)).toBeInTheDocument();
+    expect(
+      screen.queryByText(/extraction saves your notes as a draft for manual review/i),
+    ).not.toBeInTheDocument();
   });
 
   it("shows recording state with stop button and elapsed time", () => {
@@ -715,8 +717,8 @@ describe("CaptureScreen", () => {
 
     expect(screen.getByText("Analyzing notes...")).toBeInTheDocument();
     expect(
-      screen.getByText("Extraction saves your notes as a draft for manual review."),
-    ).toBeInTheDocument();
+      screen.queryByText("Extraction saves your notes as a draft for manual review."),
+    ).not.toBeInTheDocument();
 
     act(() => {
       vi.advanceTimersByTime(2500);
@@ -749,8 +751,8 @@ describe("CaptureScreen", () => {
 
     expect(screen.getByText("Uploading audio...")).toBeInTheDocument();
     expect(
-      screen.getByText("Extraction saves your recording as a draft for manual review."),
-    ).toBeInTheDocument();
+      screen.queryByText("Extraction saves your recording as a draft for manual review."),
+    ).not.toBeInTheDocument();
 
     act(() => {
       vi.advanceTimersByTime(2500);
@@ -792,8 +794,8 @@ describe("CaptureScreen", () => {
 
     expect(screen.getByText("Uploading audio...")).toBeInTheDocument();
     expect(
-      screen.getByText("Extraction saves one draft from your recording and notes for manual review."),
-    ).toBeInTheDocument();
+      screen.queryByText("Extraction saves one draft from your recording and notes for manual review."),
+    ).not.toBeInTheDocument();
 
     act(() => {
       vi.advanceTimersByTime(2500);

--- a/frontend/src/features/quotes/tests/ReviewScreen.test.tsx
+++ b/frontend/src/features/quotes/tests/ReviewScreen.test.tsx
@@ -635,7 +635,7 @@ describe("DocumentEditScreen", () => {
     });
   });
 
-  it("does not show the capture-details alert icon for transcript-only details", async () => {
+  it("uses neutral styling for capture-details trigger when there are no actionable items", async () => {
     renderScreen({
       document: makeQuote({
         extraction_review_metadata: {
@@ -646,8 +646,9 @@ describe("DocumentEditScreen", () => {
         },
       }),
     });
-    expect(await screen.findByRole("button", { name: /capture details/i })).toBeInTheDocument();
-    expect(screen.queryByLabelText("Capture details need review")).not.toBeInTheDocument();
+    const trigger = await screen.findByRole("button", { name: /capture details/i });
+    expect(trigger).toHaveClass("bg-surface-container-lowest", "text-on-surface");
+    expect(trigger).not.toHaveClass("bg-warning-container", "text-warning");
   });
 
   it("renders capture details only in the header trailing area", async () => {
@@ -677,7 +678,7 @@ describe("DocumentEditScreen", () => {
     expect(screen.queryByRole("button", { name: /capture details/i })).not.toBeInTheDocument();
   });
 
-  it("shows the capture-details alert icon when hidden actionable items exist", async () => {
+  it("uses amber styling for capture-details trigger when hidden actionable items exist", async () => {
     renderScreen({
       document: makeQuote({
         extraction_review_metadata: {
@@ -696,7 +697,8 @@ describe("DocumentEditScreen", () => {
         },
       }),
     });
-    expect(await screen.findByLabelText("Capture details need review")).toBeInTheDocument();
+    const trigger = await screen.findByRole("button", { name: /capture details/i });
+    expect(trigger).toHaveClass("bg-warning-container", "text-warning");
   });
 
   it("hides the capture-details trigger when only non-overflow unresolved reasons exist", async () => {


### PR DESCRIPTION
## Summary
- refresh Capture screen visual hierarchy with document-radius card treatment for recorded clips and written description sections
- keep recorder/start-stop, extraction flow, routes, and unsaved-work behavior intact while removing the header exit `X` action per latest direction
- raise recorder controls slightly to avoid footer overlap and remove extraction helper subtext to reduce sticky footer height

## Verification
- `cd frontend && npx vitest run src/features/quotes/tests/CaptureScreen.test.tsx src/shared/components/WorkflowScreenHeader.test.tsx`
- `cd frontend && npx tsc --noEmit`
- `cd frontend && npx eslint src/features/quotes/components/CaptureScreen.tsx src/features/quotes/components/CaptureInputPanel.tsx src/features/quotes/tests/CaptureScreen.test.tsx src/shared/components/WorkflowScreenHeader.tsx src/shared/components/ScreenFooter.tsx src/shared/components/Button.tsx src/ui/Banner.tsx src/ui/Card.tsx src/ui/Eyebrow.tsx`
- `make frontend-verify`

Closes #494