### PR TITLE
Task #503: Safe-area and keyboard-avoid pass for shared chrome

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2,7 +2,10 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, viewport-fit=cover, interactive-widget=resizes-content"
+    />
     <meta property="og:title" content="Stima" />
     <meta
       property="og:description"

--- a/frontend/src/features/quotes/components/CaptureDetailsSheet.tsx
+++ b/frontend/src/features/quotes/components/CaptureDetailsSheet.tsx
@@ -32,7 +32,7 @@ export function CaptureDetailsSheet({
           data-testid="capture-details-sheet-overlay"
           className="modal-backdrop fixed inset-0 z-50"
         />
-        <div className="pointer-events-none fixed inset-0 z-50 flex items-end justify-center px-4 pb-4 sm:items-center sm:pb-0">
+        <div className="sheet-safe-bottom pointer-events-none fixed inset-0 z-50 flex items-end justify-center px-4 sm:items-center">
           <Dialog.Content className="modal-shadow pointer-events-auto w-full max-w-2xl rounded-[1.75rem] border border-outline-variant/20 bg-surface-container-lowest p-6">
             <Dialog.Title className="font-headline text-xl font-bold tracking-tight text-on-surface">
               Capture Details

--- a/frontend/src/features/quotes/components/LineItemEditSheet.tsx
+++ b/frontend/src/features/quotes/components/LineItemEditSheet.tsx
@@ -218,7 +218,7 @@ export function LineItemEditSheet({
           data-testid="line-item-edit-sheet-overlay"
           className="modal-backdrop fixed inset-0 z-50"
         />
-        <div className="pointer-events-none fixed inset-0 z-50 flex items-end justify-center px-4 pb-4 sm:items-center sm:pb-0">
+        <div className="sheet-safe-bottom pointer-events-none fixed inset-0 z-50 flex items-end justify-center px-4 sm:items-center">
           <Dialog.Content
             className="modal-shadow pointer-events-auto w-full max-w-md rounded-[1.75rem] border border-outline-variant/20 bg-surface-container-lowest p-6"
             aria-describedby={showManualFields ? undefined : "line-item-sheet-catalog-description"}

--- a/frontend/src/features/quotes/components/QuoteCreateEntrySheet.tsx
+++ b/frontend/src/features/quotes/components/QuoteCreateEntrySheet.tsx
@@ -21,7 +21,7 @@ export function QuoteCreateEntrySheet({
     <Dialog.Root open={open} onOpenChange={(nextOpen) => { if (!nextOpen) onClose(); }}>
       <Dialog.Portal>
         <Dialog.Overlay className="modal-backdrop fixed inset-0 z-50" />
-        <div className="pointer-events-none fixed inset-0 z-50 flex items-end justify-center px-4 pb-4 sm:items-center sm:pb-0">
+        <div className="sheet-safe-bottom pointer-events-none fixed inset-0 z-50 flex items-end justify-center px-4 sm:items-center">
           <Dialog.Content className="modal-shadow pointer-events-auto w-full max-w-md rounded-[1.75rem] border border-outline-variant/20 bg-surface-container-lowest p-6">
             <Dialog.Title className="font-headline text-xl font-bold tracking-tight text-on-surface">
               {title}

--- a/frontend/src/features/quotes/components/QuoteReuseChooser.tsx
+++ b/frontend/src/features/quotes/components/QuoteReuseChooser.tsx
@@ -148,7 +148,7 @@ export function QuoteReuseChooser({
     <Dialog.Root open={open} onOpenChange={(nextOpen) => { if (!nextOpen) onClose(); }}>
       <Dialog.Portal>
         <Dialog.Overlay className="modal-backdrop fixed inset-0 z-50" />
-        <div className="pointer-events-none fixed inset-0 z-50 flex items-end justify-center px-4 pb-4 sm:items-center sm:pb-0">
+        <div className="sheet-safe-bottom pointer-events-none fixed inset-0 z-50 flex items-end justify-center px-4 sm:items-center">
           <Dialog.Content className="modal-shadow pointer-events-auto w-full max-w-2xl rounded-[1.75rem] border border-outline-variant/20 bg-surface-container-lowest p-6">
             <Dialog.Title className="font-headline text-xl font-bold tracking-tight text-on-surface">
               Create from existing

--- a/frontend/src/features/quotes/components/ReviewCustomerAssignmentSheet.tsx
+++ b/frontend/src/features/quotes/components/ReviewCustomerAssignmentSheet.tsx
@@ -139,7 +139,7 @@ export function ReviewCustomerAssignmentSheet({
     <Dialog.Root open={open} onOpenChange={(nextOpen) => { if (!nextOpen) onClose(); }}>
       <Dialog.Portal>
         <Dialog.Overlay className="modal-backdrop fixed inset-0 z-50" />
-        <div className="fixed inset-0 z-50 flex items-end justify-center px-4 pb-4 sm:items-center sm:pb-0">
+        <div className="sheet-safe-bottom fixed inset-0 z-50 flex items-end justify-center px-4 sm:items-center">
           <Dialog.Content
             className="modal-shadow w-full max-w-md rounded-[1.75rem] border border-outline-variant/20 bg-surface-container-lowest p-6"
             onOpenAutoFocus={(event) => event.preventDefault()}
@@ -246,4 +246,3 @@ export function ReviewCustomerAssignmentSheet({
     </Dialog.Root>
   );
 }
-

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -259,6 +259,36 @@
   background-color: var(--overlay-backdrop);
 }
 
+.safe-top {
+  padding-top: max(env(safe-area-inset-top), 0px);
+}
+
+.safe-bottom {
+  padding-bottom: max(env(safe-area-inset-bottom), 0.75rem);
+}
+
+.safe-bottom-keyboard {
+  padding-bottom: max(
+    env(keyboard-inset-height, 0px),
+    env(safe-area-inset-bottom),
+    0.75rem
+  );
+}
+
+.sheet-safe-bottom {
+  padding-bottom: max(env(safe-area-inset-bottom), 1rem);
+}
+
+@media (min-width: 640px) {
+  .sheet-safe-bottom {
+    padding-bottom: 0;
+  }
+}
+
+.toast-safe-bottom {
+  bottom: calc(5rem + env(safe-area-inset-bottom));
+}
+
 .modal-shadow {
   box-shadow: var(--shadow-modal);
 }

--- a/frontend/src/shared/components/BottomNav.test.tsx
+++ b/frontend/src/shared/components/BottomNav.test.tsx
@@ -33,6 +33,7 @@ describe("BottomNav", () => {
     render(<BottomNav active="customers" />);
 
     expect(screen.getByRole("navigation")).toHaveClass(
+      "safe-bottom",
       "glass-surface-strong",
       "glass-shadow-bottom",
       "border-outline-variant/20",

--- a/frontend/src/shared/components/BottomNav.tsx
+++ b/frontend/src/shared/components/BottomNav.tsx
@@ -29,7 +29,7 @@ export function BottomNav({ active }: BottomNavProps): React.ReactElement {
   const navigate = useNavigate();
 
   return (
-    <nav className="glass-surface-strong glass-shadow-bottom fixed bottom-0 z-50 flex w-full justify-around border-t border-outline-variant/20 py-3 backdrop-blur-md">
+    <nav className="safe-bottom glass-surface-strong glass-shadow-bottom fixed bottom-0 z-50 flex w-full justify-around border-t border-outline-variant/20 py-3 backdrop-blur-md">
       {tabs.map((tab) => {
         const isActive = active === tab.key;
         return (

--- a/frontend/src/shared/components/ConfirmModal.tsx
+++ b/frontend/src/shared/components/ConfirmModal.tsx
@@ -64,7 +64,7 @@ export function ConfirmModal({
           data-testid="confirm-modal-overlay"
           className="modal-backdrop fixed inset-0 z-50"
         />
-        <div className="pointer-events-none fixed inset-0 z-50 flex items-end justify-center px-4 pb-4 sm:items-center sm:pb-0">
+        <div className="sheet-safe-bottom pointer-events-none fixed inset-0 z-50 flex items-end justify-center px-4 sm:items-center">
           <Dialog.Content
             {...(!body ? { "aria-describedby": undefined } : {})}
             className="modal-shadow pointer-events-auto w-full max-w-md rounded-[1.75rem] border border-outline-variant/20 bg-surface-container-lowest p-6"

--- a/frontend/src/shared/components/ScreenFooter.test.tsx
+++ b/frontend/src/shared/components/ScreenFooter.test.tsx
@@ -12,6 +12,7 @@ describe("ScreenFooter", () => {
     );
 
     expect(container.querySelector("footer")).toHaveClass(
+      "safe-bottom-keyboard",
       "glass-surface",
       "glass-shadow-bottom",
       "border-outline-variant/20",

--- a/frontend/src/shared/components/ScreenFooter.tsx
+++ b/frontend/src/shared/components/ScreenFooter.tsx
@@ -6,7 +6,7 @@ interface ScreenFooterProps {
 
 export function ScreenFooter({ children }: ScreenFooterProps): React.ReactElement {
   return (
-    <footer className="glass-surface glass-shadow-bottom fixed inset-x-0 bottom-0 z-40 border-t border-outline-variant/20 p-4 backdrop-blur-md">
+    <footer className="safe-bottom-keyboard glass-surface glass-shadow-bottom fixed inset-x-0 bottom-0 z-40 border-t border-outline-variant/20 p-4 backdrop-blur-md">
       {children}
     </footer>
   );

--- a/frontend/src/shared/components/ScreenHeader.test.tsx
+++ b/frontend/src/shared/components/ScreenHeader.test.tsx
@@ -10,6 +10,7 @@ describe("ScreenHeader", () => {
     expect(screen.getByRole("heading", { name: "Settings" })).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /back/i })).not.toBeInTheDocument();
     expect(container.querySelector("header")).toHaveClass(
+      "safe-top",
       "glass-surface",
       "glass-shadow-top",
       "border-outline-variant/20",

--- a/frontend/src/shared/components/ScreenHeader.tsx
+++ b/frontend/src/shared/components/ScreenHeader.tsx
@@ -22,7 +22,7 @@ export function ScreenHeader({
   const isTopLevelLayout = layout === "top-level";
 
   return (
-    <header className="glass-surface glass-shadow-top fixed top-0 z-50 h-16 w-full border-b border-outline-variant/20 backdrop-blur-md">
+    <header className="safe-top glass-surface glass-shadow-top fixed top-0 z-50 h-16 w-full border-b border-outline-variant/20 backdrop-blur-md">
       <div
         className={[
           "flex h-16 w-full items-center gap-3 px-4",

--- a/frontend/src/shared/components/Toast.test.tsx
+++ b/frontend/src/shared/components/Toast.test.tsx
@@ -23,8 +23,8 @@ describe("Toast", () => {
 
     const toast = screen.getByRole("status");
     expect(toast).toHaveClass(
+      "toast-safe-bottom",
       "fixed",
-      "bottom-20",
       "left-1/2",
       "-translate-x-1/2",
       "rounded-xl",

--- a/frontend/src/shared/components/Toast.tsx
+++ b/frontend/src/shared/components/Toast.tsx
@@ -42,7 +42,7 @@ export function Toast({
   return (
     <div
       role={isError ? "alert" : "status"}
-      className={`fixed bottom-20 left-1/2 z-50 flex w-fit max-w-[calc(100%-2rem)] -translate-x-1/2 items-center gap-3 rounded-xl px-4 py-2.5 text-sm ghost-shadow ${
+      className={`toast-safe-bottom fixed left-1/2 z-50 flex w-fit max-w-[calc(100%-2rem)] -translate-x-1/2 items-center gap-3 rounded-xl px-4 py-2.5 text-sm ghost-shadow ${
         isError
           ? "border border-error/40 bg-error-container text-error"
           : "bg-on-surface text-background"


### PR DESCRIPTION
## Summary
- add iOS-safe viewport meta with `viewport-fit=cover` and `interactive-widget=resizes-content`
- add shared safe-area utility classes in `frontend/src/index.css` for top, bottom, keyboard-aware footer padding, sheet bottom spacing, and toast bottom offset
- apply those shared classes to fixed/sticky shared chrome and quote sheet wrappers so safe-area handling stays centralized
- update shared component tests for the new class contracts

## Verification
- `cd frontend && npx tsc --noEmit`
- `cd frontend && npx eslint src/shared/components/BottomNav.tsx src/shared/components/ScreenHeader.tsx src/shared/components/WorkflowScreenHeader.tsx src/shared/components/ScreenFooter.tsx`
- `cd frontend && npx vitest run src/shared/components/BottomNav.test.tsx src/shared/components/ScreenHeader.test.tsx src/shared/components/ScreenFooter.test.tsx src/shared/components/Toast.test.tsx`
- `make frontend-verify`

Closes #503