### PR TITLE
Follow-up: button pointer + Save Draft variant polish

### DIFF
--- a/frontend/src/features/invoices/components/InvoiceDetailScreen.tsx
+++ b/frontend/src/features/invoices/components/InvoiceDetailScreen.tsx
@@ -247,6 +247,7 @@ export function InvoiceDetailScreen(): React.ReactElement {
                     <Button
                       type="button"
                       variant="secondary"
+                      size="lg"
                       className={documentActionUtilityButtonClassName}
                       disabled={!hasCustomerEmail || isBusy}
                       isLoading={isSendingEmail}
@@ -260,6 +261,7 @@ export function InvoiceDetailScreen(): React.ReactElement {
                   <Button
                     type="button"
                     variant="secondary"
+                    size="lg"
                     className={documentActionUtilityButtonClassName}
                     disabled={isBusy}
                     leadingIcon={(

--- a/frontend/src/features/invoices/components/InvoiceDetailScreen.tsx
+++ b/frontend/src/features/invoices/components/InvoiceDetailScreen.tsx
@@ -246,7 +246,7 @@ export function InvoiceDetailScreen(): React.ReactElement {
                   {emailActionLabel ? (
                     <Button
                       type="button"
-                      variant="secondary"
+                      variant="ghost"
                       size="lg"
                       className={documentActionUtilityButtonClassName}
                       disabled={!hasCustomerEmail || isBusy}
@@ -260,7 +260,7 @@ export function InvoiceDetailScreen(): React.ReactElement {
 
                   <Button
                     type="button"
-                    variant="secondary"
+                    variant="ghost"
                     size="lg"
                     className={documentActionUtilityButtonClassName}
                     disabled={isBusy}

--- a/frontend/src/features/invoices/components/InvoiceDetailScreen.tsx
+++ b/frontend/src/features/invoices/components/InvoiceDetailScreen.tsx
@@ -220,7 +220,7 @@ export function InvoiceDetailScreen(): React.ReactElement {
                   rel="noopener noreferrer"
                   className={documentActionPrimaryLinkClassName}
                 >
-                  <span className="material-symbols-outlined text-base">open_in_new</span>
+                  <span className="material-symbols-outlined text-base leading-none">open_in_new</span>
                   Open PDF
                 </a>
               ) : (
@@ -232,6 +232,11 @@ export function InvoiceDetailScreen(): React.ReactElement {
                     void onGeneratePdf();
                   }}
                   isLoading={isPdfBusy}
+                  leadingIcon={(
+                    <span className="material-symbols-outlined text-base leading-none">
+                      picture_as_pdf
+                    </span>
+                  )}
                 >
                   Generate PDF
                 </Button>
@@ -239,28 +244,35 @@ export function InvoiceDetailScreen(): React.ReactElement {
               utilityActions={(
                 <>
                   {emailActionLabel ? (
-                    <button
+                    <Button
                       type="button"
+                      variant="secondary"
                       className={documentActionUtilityButtonClassName}
                       disabled={!hasCustomerEmail || isBusy}
+                      isLoading={isSendingEmail}
+                      leadingIcon={<span className="material-symbols-outlined text-base leading-none">mail</span>}
                       onClick={() => onRequestSendEmail({ emailActionLabel, hasCustomerEmail, isPdfBusy })}
                     >
-                      <span className="material-symbols-outlined text-base">mail</span>
-                      {isSendingEmail ? "Sending..." : emailActionLabel}
-                    </button>
+                      {emailActionLabel}
+                    </Button>
                   ) : null}
 
-                  <button
+                  <Button
                     type="button"
+                    variant="secondary"
                     className={documentActionUtilityButtonClassName}
                     disabled={isBusy}
+                    leadingIcon={(
+                      <span className="material-symbols-outlined text-base leading-none">
+                        content_copy
+                      </span>
+                    )}
                     onClick={() => {
                       void onCopyLink();
                     }}
                   >
-                    <span className="material-symbols-outlined text-base">content_copy</span>
                     Copy Link
-                  </button>
+                  </Button>
                 </>
               )}
               utilityLabel="Invoice utilities"

--- a/frontend/src/features/invoices/tests/InvoiceDetailScreen.test.tsx
+++ b/frontend/src/features/invoices/tests/InvoiceDetailScreen.test.tsx
@@ -652,11 +652,11 @@ describe("InvoiceDetailScreen", () => {
     renderScreen();
 
     fireEvent.click(await screen.findByRole("button", { name: /send email/i }));
-    fireEvent.click(screen.getByRole("button", { name: /^Send Email$/i }));
+    fireEvent.click(screen.getByRole("button", { name: /^(send|resend) email$/i }));
 
-    expect(
-      await screen.findByRole("button", { name: /sending/i }),
-    ).toBeDisabled();
+    const sendingButton = await screen.findByRole("button", { name: /send email/i });
+    expect(sendingButton).toBeDisabled();
+    expect(within(sendingButton).getByTestId("button-spinner")).toBeInTheDocument();
     expect(screen.queryByText(/alice@example\.com/i)).not.toBeInTheDocument();
 
     resolveSend(
@@ -696,7 +696,7 @@ describe("InvoiceDetailScreen", () => {
     renderScreen();
 
     fireEvent.click(await screen.findByRole("button", { name: /send email/i }));
-    fireEvent.click(screen.getByRole("button", { name: /^Send Email$/i }));
+    fireEvent.click(screen.getByRole("button", { name: /^(send|resend) email$/i }));
 
     expect(await screen.findByText("Email delivery failed. Please try again.")).toBeInTheDocument();
     expect(screen.queryByText(/alice@example\.com/i)).not.toBeInTheDocument();

--- a/frontend/src/features/profile/tests/OnboardingForm.test.tsx
+++ b/frontend/src/features/profile/tests/OnboardingForm.test.tsx
@@ -176,8 +176,9 @@ describe("OnboardingForm", () => {
     });
     fireEvent.click(screen.getByRole("button", { name: /continue/i }));
 
-    const submitButton = screen.getByRole("button", { name: /loading/i });
+    const submitButton = screen.getByRole("button", { name: /continue/i });
     expect(submitButton).toBeDisabled();
+    expect(submitButton.querySelector("[data-testid='button-spinner']")).toBeInTheDocument();
 
     resolveUpdate?.(profileResponse());
     await waitFor(() => expect(screen.getByRole("button", { name: /continue/i })).toBeEnabled());

--- a/frontend/src/features/quotes/components/CaptureDetailsSheet.tsx
+++ b/frontend/src/features/quotes/components/CaptureDetailsSheet.tsx
@@ -2,6 +2,7 @@ import * as Dialog from "@radix-ui/react-dialog";
 
 import type { ExtractionReviewHiddenDetails, HiddenItemState } from "@/features/quotes/types/quote.types";
 import { resolveCaptureDetailsActionableItems } from "@/features/quotes/utils/captureDetails";
+import { Button } from "@/shared/components/Button";
 
 interface CaptureDetailsSheetProps {
   open: boolean;
@@ -56,14 +57,16 @@ export function CaptureDetailsSheet({
                         <p className="font-semibold">{item.label}</p>
                         <p className="mt-1 whitespace-pre-wrap text-on-surface-variant">{item.text}</p>
                         <div className="mt-3">
-                          <button
+                          <Button
                             type="button"
-                            className="rounded-md border border-outline-variant/40 px-2 py-1 text-[0.6875rem] font-semibold uppercase tracking-wide text-on-surface-variant transition-colors hover:bg-surface-container-lowest disabled:cursor-not-allowed disabled:opacity-60"
+                            variant="ghost"
+                            size="sm"
+                            className="rounded-md border border-outline-variant/40 px-2 py-1 text-[0.6875rem] uppercase tracking-wide"
                             disabled={isMutating || !onDismissHiddenItem}
                             onClick={() => { void onDismissHiddenItem?.(item.id); }}
                           >
                             Dismiss
-                          </button>
+                          </Button>
                         </div>
                       </li>
                     ))}
@@ -84,13 +87,14 @@ export function CaptureDetailsSheet({
             </div>
 
             <div className="mt-6">
-              <button
+              <Button
                 type="button"
-                className="inline-flex min-h-12 w-full cursor-pointer items-center justify-center rounded-lg border border-outline-variant/30 bg-surface-container-low px-4 py-3 text-sm font-semibold text-on-surface transition-colors hover:bg-surface-container-lowest"
+                variant="secondary"
+                className="w-full rounded-lg border border-outline-variant/30 py-3"
                 onClick={onClose}
               >
                 Close
-              </button>
+              </Button>
             </div>
           </Dialog.Content>
         </div>

--- a/frontend/src/features/quotes/components/QuotePreviewActions.tsx
+++ b/frontend/src/features/quotes/components/QuotePreviewActions.tsx
@@ -119,7 +119,7 @@ export function QuotePreviewActions({
           {showEmailAction ? (
             <Button
               type="button"
-              variant="secondary"
+              variant="ghost"
               size="lg"
               className={documentActionUtilityButtonClassName}
               disabled={
@@ -141,7 +141,7 @@ export function QuotePreviewActions({
 
           <Button
             type="button"
-            variant="secondary"
+            variant="ghost"
             size="lg"
             className={documentActionUtilityButtonClassName}
             disabled={

--- a/frontend/src/features/quotes/components/QuotePreviewActions.tsx
+++ b/frontend/src/features/quotes/components/QuotePreviewActions.tsx
@@ -120,6 +120,7 @@ export function QuotePreviewActions({
             <Button
               type="button"
               variant="secondary"
+              size="lg"
               className={documentActionUtilityButtonClassName}
               disabled={
                 disabled
@@ -141,6 +142,7 @@ export function QuotePreviewActions({
           <Button
             type="button"
             variant="secondary"
+            size="lg"
             className={documentActionUtilityButtonClassName}
             disabled={
               disabled

--- a/frontend/src/features/quotes/components/QuotePreviewActions.tsx
+++ b/frontend/src/features/quotes/components/QuotePreviewActions.tsx
@@ -78,7 +78,7 @@ export function QuotePreviewActions({
           rel="noopener noreferrer"
           className={documentActionPrimaryLinkClassName}
         >
-          <span className="material-symbols-outlined text-base">open_in_new</span>
+          <span className="material-symbols-outlined text-base leading-none">open_in_new</span>
           Open PDF
         </a>
       );
@@ -99,8 +99,12 @@ export function QuotePreviewActions({
         onClick={() => {
           void onGeneratePdf();
         }}
+        leadingIcon={(
+          <span className="material-symbols-outlined text-base leading-none">
+            picture_as_pdf
+          </span>
+        )}
       >
-        <span className="material-symbols-outlined text-base">picture_as_pdf</span>
         Generate PDF
       </Button>
     );
@@ -127,7 +131,7 @@ export function QuotePreviewActions({
                 || isMarkingLost
               }
               isLoading={isSendingEmail}
-              leadingIcon={<span className="material-symbols-outlined text-base">mail</span>}
+              leadingIcon={<span className="material-symbols-outlined text-base leading-none">mail</span>}
               onClick={onRequestSendEmail}
             >
               {emailActionLabel}
@@ -146,7 +150,7 @@ export function QuotePreviewActions({
               || isMarkingWon
               || isMarkingLost
             }
-            leadingIcon={<span className="material-symbols-outlined text-base">content_copy</span>}
+            leadingIcon={<span className="material-symbols-outlined text-base leading-none">content_copy</span>}
             onClick={() => {
               void onCopyLink();
             }}

--- a/frontend/src/features/quotes/components/QuotePreviewActions.tsx
+++ b/frontend/src/features/quotes/components/QuotePreviewActions.tsx
@@ -113,8 +113,9 @@ export function QuotePreviewActions({
       utilityActions={showUtilities ? (
         <>
           {showEmailAction ? (
-            <button
+            <Button
               type="button"
+              variant="secondary"
               className={documentActionUtilityButtonClassName}
               disabled={
                 disabled
@@ -125,15 +126,17 @@ export function QuotePreviewActions({
                 || isMarkingWon
                 || isMarkingLost
               }
+              isLoading={isSendingEmail}
+              leadingIcon={<span className="material-symbols-outlined text-base">mail</span>}
               onClick={onRequestSendEmail}
             >
-              <span className="material-symbols-outlined text-base">mail</span>
-              {isSendingEmail ? "Sending..." : emailActionLabel}
-            </button>
+              {emailActionLabel}
+            </Button>
           ) : null}
 
-          <button
+          <Button
             type="button"
+            variant="secondary"
             className={documentActionUtilityButtonClassName}
             disabled={
               disabled
@@ -143,13 +146,13 @@ export function QuotePreviewActions({
               || isMarkingWon
               || isMarkingLost
             }
+            leadingIcon={<span className="material-symbols-outlined text-base">content_copy</span>}
             onClick={() => {
               void onCopyLink();
             }}
           >
-            <span className="material-symbols-outlined text-base">content_copy</span>
             Copy Link
-          </button>
+          </Button>
         </>
       ) : null}
       utilityLabel={showUtilities ? "Quote utilities" : undefined}

--- a/frontend/src/features/quotes/components/ReviewActionFooter.tsx
+++ b/frontend/src/features/quotes/components/ReviewActionFooter.tsx
@@ -36,14 +36,16 @@ export function ReviewActionFooter({
           >
             {primaryActionLabel}
           </Button>
-          <button
+          <Button
             type="button"
-            className="w-full cursor-pointer rounded-[var(--radius-document)] border border-outline-variant/30 bg-surface-container-low px-4 py-3 font-semibold text-on-surface transition-colors hover:bg-surface-container-lowest disabled:cursor-not-allowed disabled:opacity-60 sm:flex-1"
+            variant="tonal"
+            className="w-full sm:flex-1"
             disabled={isInteractionLocked || isSavingDraft}
+            isLoading={isSavingDraft}
             onClick={onSaveDraft}
           >
-            {isSavingDraft ? "Loading..." : "Save Draft"}
-          </button>
+            Save Draft
+          </Button>
         </div>
         {requiresCustomerAssignment ? (
           <p className="text-center text-xs text-warning">

--- a/frontend/src/features/quotes/components/ReviewActionFooter.tsx
+++ b/frontend/src/features/quotes/components/ReviewActionFooter.tsx
@@ -38,7 +38,7 @@ export function ReviewActionFooter({
           </Button>
           <Button
             type="button"
-            variant="tonal"
+            variant="secondary"
             className="w-full sm:flex-1"
             disabled={isInteractionLocked || isSavingDraft}
             isLoading={isSavingDraft}

--- a/frontend/src/features/settings/components/SettingsScreen.tsx
+++ b/frontend/src/features/settings/components/SettingsScreen.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 
 import { useAuth } from "@/features/auth/hooks/useAuth";
@@ -35,7 +35,6 @@ export function SettingsScreen(): React.ReactElement {
   const { preference: themePreference, setPreference: setThemePreference } = useTheme();
   const logoPreviewSrc = `${import.meta.env.VITE_API_URL ?? ""}/api/profile/logo`;
   const logoSizeLimitLabel = formatByteLimit(MAX_LOGO_SIZE_BYTES);
-
   const [businessName, setBusinessName] = useState("");
   const [firstName, setFirstName] = useState("");
   const [lastName, setLastName] = useState("");
@@ -54,7 +53,7 @@ export function SettingsScreen(): React.ReactElement {
   const [isRemoveLogoOpen, setIsRemoveLogoOpen] = useState(false);
   const [isSignOutConfirmOpen, setIsSignOutConfirmOpen] = useState(false);
   const [logoPreviewVersion, setLogoPreviewVersion] = useState(0);
-
+  const logoUploadInputRef = useRef<HTMLInputElement>(null);
   function applyProfile(profile: ProfileResponse): void {
     setBusinessName(profile.business_name ?? "");
     setFirstName(profile.first_name ?? "");
@@ -68,11 +67,9 @@ export function SettingsScreen(): React.ReactElement {
 
   useEffect(() => {
     let isActive = true;
-
     async function loadProfile(): Promise<void> {
       setIsLoadingProfile(true);
       setLoadError(null);
-
       try {
         const profile = await profileService.getProfile();
         if (isActive) {
@@ -89,9 +86,7 @@ export function SettingsScreen(): React.ReactElement {
         }
       }
     }
-
     void loadProfile();
-
     return () => {
       isActive = false;
     };
@@ -103,15 +98,12 @@ export function SettingsScreen(): React.ReactElement {
     if (!file) {
       return;
     }
-
     if (file.size > MAX_LOGO_SIZE_BYTES) {
       setLogoError(`Logo must be ${logoSizeLimitLabel} or smaller.`);
       return;
     }
-
     setLogoError(null);
     setIsLogoSubmitting(true);
-
     try {
       const profile = await profileService.uploadLogo(file);
       applyProfile(profile);
@@ -128,10 +120,8 @@ export function SettingsScreen(): React.ReactElement {
     if (isLogoSubmitting) {
       return;
     }
-
     setLogoError(null);
     setIsLogoSubmitting(true);
-
     try {
       await profileService.deleteLogo();
       setHasLogo(false);
@@ -155,7 +145,6 @@ export function SettingsScreen(): React.ReactElement {
     setSaveError(null);
     setSaveSuccess(null);
     setIsSubmitting(true);
-
     try {
       await profileService.updateProfile({
         business_name: businessName,
@@ -182,18 +171,15 @@ export function SettingsScreen(): React.ReactElement {
   return (
     <main className="min-h-screen bg-background pb-24 pt-16">
       <ScreenHeader title="Settings" layout="top-level" />
-
       <section className="mx-auto w-full max-w-3xl space-y-4 px-4 pt-4">
         {isLoadingProfile ? (
           <p role="status" className="text-sm text-on-surface-variant">
             Loading settings...
           </p>
         ) : null}
-
         {!isLoadingProfile && loadError ? (
           <FeedbackMessage variant="error">{loadError}</FeedbackMessage>
         ) : null}
-
         {!isLoadingProfile && !loadError ? (
           <form className="space-y-4 pb-8" onSubmit={onSubmit}>
             {saveError ? (
@@ -244,14 +230,20 @@ export function SettingsScreen(): React.ReactElement {
                           {`JPEG or PNG, up to ${logoSizeLimitLabel}. Appears on quote PDFs.`}
                         </p>
                         <div className="flex flex-col items-start gap-2">
-                          <label
-                            htmlFor="settings-logo-upload"
-                            className="inline-flex min-h-10 cursor-pointer items-center justify-center rounded-lg border border-outline-variant/30 bg-surface-container-lowest px-3 py-2 text-xs font-semibold text-on-surface transition-colors hover:bg-surface-container"
+                          <Button
+                            type="button"
+                            variant="ghost"
+                            size="sm"
+                            className="min-h-10 rounded-lg border border-outline-variant/30 px-3 text-xs text-on-surface"
+                            disabled={isLogoSubmitting}
+                            onClick={() => logoUploadInputRef.current?.click()}
                           >
                             Upload Logo
-                          </label>
+                          </Button>
                           <input
+                            ref={logoUploadInputRef}
                             id="settings-logo-upload"
+                            aria-label="Upload logo"
                             type="file"
                             accept="image/jpeg,image/png"
                             className="sr-only"
@@ -259,14 +251,16 @@ export function SettingsScreen(): React.ReactElement {
                             onChange={onLogoUpload}
                           />
                           {hasLogo ? (
-                            <button
+                            <Button
                               type="button"
-                              className="inline-flex min-h-10 cursor-pointer items-center justify-center rounded-lg border border-secondary px-3 py-2 text-xs font-semibold text-secondary transition-all active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-60"
+                              variant="destructive"
+                              size="sm"
+                              className="min-h-10 rounded-lg px-3 text-xs"
                               disabled={isLogoSubmitting}
                               onClick={() => setIsRemoveLogoOpen(true)}
                             >
                               Remove
-                            </button>
+                            </Button>
                           ) : null}
                         </div>
                         {logoError ? <FeedbackMessage variant="error">{logoError}</FeedbackMessage> : null}
@@ -392,14 +386,15 @@ export function SettingsScreen(): React.ReactElement {
                   <p className="truncate text-sm text-on-surface">{email}</p>
                 </div>
 
-                {/* Sign out is a compact filled terracotta button per Stitch, not the shared outlined destructive variant. */}
-                <button
+                <Button
                   type="button"
-                  className="shrink-0 cursor-pointer rounded-lg bg-secondary px-4 py-2 text-sm font-semibold text-on-secondary transition-all active:scale-[0.98]"
+                  variant="ghost"
+                  size="sm"
+                  className="shrink-0 rounded-lg border border-outline-variant/30 px-4 text-sm text-on-surface"
                   onClick={() => setIsSignOutConfirmOpen(true)}
                 >
                   Sign Out
-                </button>
+                </Button>
               </div>
             </section>
 

--- a/frontend/src/features/settings/tests/SettingsScreen.test.tsx
+++ b/frontend/src/features/settings/tests/SettingsScreen.test.tsx
@@ -375,8 +375,9 @@ describe("SettingsScreen", () => {
     await screen.findByLabelText(/business name/i);
     fireEvent.click(screen.getByRole("button", { name: /save changes/i }));
 
-    const submitButton = screen.getByRole("button", { name: /loading/i });
+    const submitButton = screen.getByRole("button", { name: /save changes/i });
     expect(submitButton).toBeDisabled();
+    expect(within(submitButton).getByTestId("button-spinner")).toHaveClass("animate-spin");
 
     resolveUpdate?.(makeProfileResponse());
     await waitFor(() => expect(screen.getByRole("button", { name: /save changes/i })).toBeEnabled());
@@ -404,8 +405,8 @@ describe("SettingsScreen", () => {
     renderScreen();
 
     const signOutButton = await screen.findByRole("button", { name: /sign out/i });
-    expect(signOutButton).toHaveClass("bg-secondary", "text-on-secondary");
-    expect(signOutButton).not.toHaveClass("border");
+    expect(signOutButton).toHaveClass("border", "border-outline-variant/30", "text-on-surface");
+    expect(signOutButton).not.toHaveClass("bg-secondary");
 
     fireEvent.click(signOutButton);
 

--- a/frontend/src/shared/components/Button.test.tsx
+++ b/frontend/src/shared/components/Button.test.tsx
@@ -59,7 +59,21 @@ describe("Button", () => {
 
     expect(button).toBeDisabled();
     expect(screen.getByTestId("button-spinner")).toHaveClass("animate-spin");
+    const movingDots = screen.getByTestId("button-spinner").querySelectorAll("span");
+    expect(movingDots).toHaveLength(2);
+    expect(movingDots[0]).toHaveClass("bg-current", "rounded-full");
+    expect(movingDots[1]).toHaveClass("bg-current", "rounded-full", "opacity-[0.65]");
     expect(onClick).not.toHaveBeenCalled();
+  });
+
+  it("applies variant-aware spinner contrast colors", () => {
+    render(
+      <Button variant="destructive" isLoading>
+        Delete
+      </Button>,
+    );
+
+    expect(screen.getByTestId("button-spinner").parentElement).toHaveClass("text-secondary");
   });
 
   it("throws if iconButton is rendered without an aria-label", () => {

--- a/frontend/src/shared/components/Button.test.tsx
+++ b/frontend/src/shared/components/Button.test.tsx
@@ -11,19 +11,42 @@ describe("Button", () => {
     expect(button).toHaveClass("forest-gradient", "text-on-primary", "rounded-[var(--radius-document)]", "w-full");
   });
 
-  it("renders destructive variant styles", () => {
-    render(<Button variant="destructive">Delete</Button>);
+  it("renders all variants with tokenized classes", () => {
+    render(
+      <>
+        <Button variant="secondary">Secondary</Button>
+        <Button variant="tonal">Tonal</Button>
+        <Button variant="destructive">Delete</Button>
+        <Button variant="ghost">Back</Button>
+        <Button variant="iconButton" aria-label="Close dialog">
+          <span className="material-symbols-outlined">close</span>
+        </Button>
+      </>,
+    );
 
+    expect(screen.getByRole("button", { name: "Secondary" })).toHaveClass("bg-surface-container-high");
+    expect(screen.getByRole("button", { name: "Tonal" })).toHaveClass("bg-primary/15");
     expect(screen.getByRole("button", { name: "Delete" })).toHaveClass("border-secondary", "text-secondary");
+    expect(screen.getByRole("button", { name: "Back" })).toHaveClass("text-on-surface-variant");
+    expect(screen.getByRole("button", { name: "Close dialog" })).toHaveClass("rounded-full", "min-h-12");
   });
 
-  it("renders ghost variant styles", () => {
-    render(<Button variant="ghost">Back</Button>);
+  it("renders leading and trailing icon slots", () => {
+    render(
+      <Button
+        leadingIcon={<span data-testid="leading-icon">left</span>}
+        trailingIcon={<span data-testid="trailing-icon">right</span>}
+      >
+        Continue
+      </Button>,
+    );
 
-    expect(screen.getByRole("button", { name: "Back" })).toHaveClass("p-2", "rounded-full");
+    expect(screen.getByRole("button", { name: "Continue" })).toBeInTheDocument();
+    expect(screen.getByTestId("leading-icon")).toBeInTheDocument();
+    expect(screen.getByTestId("trailing-icon")).toBeInTheDocument();
   });
 
-  it("shows loading label and disables button when loading", () => {
+  it("shows an animated spinner and disables button when loading", () => {
     const onClick = vi.fn();
     render(
       <Button isLoading onClick={onClick}>
@@ -31,10 +54,22 @@ describe("Button", () => {
       </Button>,
     );
 
-    const button = screen.getByRole("button", { name: "Loading..." });
+    const button = screen.getByRole("button", { name: "Submit Loading" });
     fireEvent.click(button);
 
     expect(button).toBeDisabled();
+    expect(screen.getByTestId("button-spinner")).toHaveClass("animate-spin");
     expect(onClick).not.toHaveBeenCalled();
+  });
+
+  it("throws if iconButton is rendered without an aria-label", () => {
+    expect(() =>
+      render(
+        // @ts-expect-error: this intentionally exercises runtime guardrails for missing aria-label.
+        <Button variant="iconButton">
+          <span className="material-symbols-outlined">close</span>
+        </Button>,
+      ),
+    ).toThrow("requires an aria-label");
   });
 });

--- a/frontend/src/shared/components/Button.tsx
+++ b/frontend/src/shared/components/Button.tsx
@@ -51,10 +51,34 @@ const iconButtonSizeClasses: Record<ButtonSize, string> = {
   lg: "h-14 w-14 min-h-14 min-w-14 p-0",
 };
 
-const spinnerSizeClasses: Record<ButtonSize, string> = {
+const spinnerContainerSizeClasses: Record<ButtonSize, string> = {
   sm: "h-4 w-4",
   md: "h-5 w-5",
   lg: "h-6 w-6",
+};
+
+const spinnerDotClasses: Record<ButtonSize, { top: string; bottom: string }> = {
+  sm: {
+    top: "top-0 h-1.5 w-1.5",
+    bottom: "bottom-0 h-1 w-1",
+  },
+  md: {
+    top: "top-0 h-2 w-2",
+    bottom: "bottom-0 h-1.5 w-1.5",
+  },
+  lg: {
+    top: "top-0 h-2.5 w-2.5",
+    bottom: "bottom-0 h-2 w-2",
+  },
+};
+
+const spinnerToneClasses: Record<ButtonVariant, string> = {
+  primary: "text-on-primary",
+  secondary: "text-on-surface",
+  tonal: "text-primary",
+  destructive: "text-secondary",
+  ghost: "text-on-surface-variant",
+  iconButton: "text-on-surface-variant",
 };
 
 const contentGapClasses: Record<ButtonSize, string> = {
@@ -121,27 +145,19 @@ export function Button({
       </span>
       {isLoading ? (
         <span className="pointer-events-none absolute inset-0 inline-flex items-center justify-center">
-          <svg
-            data-testid="button-spinner"
-            className={`animate-spin ${spinnerSizeClasses[size]}`}
-            viewBox="0 0 24 24"
+          <span
             aria-hidden="true"
+            className={`relative inline-flex items-center justify-center ${spinnerContainerSizeClasses[size]} ${spinnerToneClasses[variant]}`}
           >
-            <circle
-              className="opacity-25"
-              cx="12"
-              cy="12"
-              r="10"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="4"
-            />
-            <path
-              className="opacity-90"
-              fill="currentColor"
-              d="M4 12a8 8 0 0 1 8-8v4a4 4 0 0 0-4 4z"
-            />
-          </svg>
+            <span data-testid="button-spinner" className="absolute inset-0 animate-spin [animation-duration:1.1s]">
+              <span
+                className={`absolute left-1/2 -translate-x-1/2 rounded-full bg-current ${spinnerDotClasses[size].top}`}
+              />
+              <span
+                className={`absolute bottom-0 left-1/2 -translate-x-1/2 rounded-full bg-current opacity-[0.65] ${spinnerDotClasses[size].bottom}`}
+              />
+            </span>
+          </span>
           <span className="sr-only">Loading</span>
         </span>
       ) : null}

--- a/frontend/src/shared/components/Button.tsx
+++ b/frontend/src/shared/components/Button.tsx
@@ -106,7 +106,7 @@ export function Button({
   const isIconButton = variant === "iconButton";
 
   const buttonClassName = [
-    "relative inline-flex items-center justify-center font-semibold transition-all active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-60",
+    "relative inline-flex cursor-pointer items-center justify-center font-semibold transition-all active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-60",
     variantClasses[variant],
     isIconButton ? iconButtonSizeClasses[size] : `${sizeClasses[size]} min-w-[6ch]`,
     className,

--- a/frontend/src/shared/components/Button.tsx
+++ b/frontend/src/shared/components/Button.tsx
@@ -1,37 +1,84 @@
-import type { ReactNode } from "react";
+import type { ButtonHTMLAttributes, ReactNode } from "react";
 
-interface ButtonProps {
-  children: ReactNode;
-  variant?: "primary" | "destructive" | "ghost";
+type ButtonVariant = "primary" | "secondary" | "tonal" | "destructive" | "ghost" | "iconButton";
+type ButtonSize = "sm" | "md" | "lg";
+
+interface BaseButtonProps extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, "children"> {
   className?: string;
-  type?: "button" | "submit";
-  form?: string;
-  disabled?: boolean;
+  size?: ButtonSize;
   isLoading?: boolean;
-  onClick?: () => void;
+  leadingIcon?: ReactNode;
+  trailingIcon?: ReactNode;
 }
 
-const variantClasses = {
+type RegularButtonProps = BaseButtonProps & {
+  variant?: Exclude<ButtonVariant, "iconButton">;
+  children: ReactNode;
+};
+
+type IconButtonProps = BaseButtonProps & {
+  variant: "iconButton";
+  children?: ReactNode;
+  "aria-label": string;
+};
+
+type ButtonProps = RegularButtonProps | IconButtonProps;
+
+const variantClasses: Record<ButtonVariant, string> = {
   primary:
-    "forest-gradient text-on-primary font-semibold py-4 rounded-[var(--radius-document)] active:scale-[0.98] transition-all",
+    "forest-gradient rounded-[var(--radius-document)] text-on-primary hover:brightness-105",
+  secondary:
+    "rounded-[var(--radius-document)] bg-surface-container-high text-on-surface hover:bg-surface-container",
+  tonal:
+    "rounded-[var(--radius-document)] bg-primary/15 text-primary hover:bg-primary/20",
   destructive:
-    "border border-secondary text-secondary font-semibold py-4 rounded-[var(--radius-document)] active:scale-[0.98] transition-all",
-  ghost: "p-2 rounded-full hover:bg-surface-container-low active:scale-95 transition-all",
-} as const;
+    "rounded-[var(--radius-document)] border border-secondary text-secondary hover:bg-secondary/10",
+  ghost:
+    "rounded-[var(--radius-document)] bg-transparent text-on-surface-variant hover:bg-surface-container-low",
+  iconButton:
+    "rounded-full bg-transparent text-on-surface-variant hover:bg-surface-container-low",
+};
+
+const sizeClasses: Record<ButtonSize, string> = {
+  sm: "min-h-11 gap-1.5 px-3 py-2 text-sm",
+  md: "min-h-12 gap-2 px-4 py-4 text-sm",
+  lg: "min-h-14 gap-2.5 px-5 py-5 text-base",
+};
+
+const iconButtonSizeClasses: Record<ButtonSize, string> = {
+  sm: "h-11 w-11 min-h-11 min-w-11 p-0",
+  md: "h-12 w-12 min-h-12 min-w-12 p-0",
+  lg: "h-14 w-14 min-h-14 min-w-14 p-0",
+};
+
+const spinnerSizeClasses: Record<ButtonSize, string> = {
+  sm: "h-4 w-4",
+  md: "h-5 w-5",
+  lg: "h-6 w-6",
+};
 
 export function Button({
   children,
   variant = "primary",
   className,
+  size = "md",
   type = "button",
-  form,
   disabled = false,
   isLoading = false,
-  onClick,
+  leadingIcon,
+  trailingIcon,
+  ...rest
 }: ButtonProps): React.ReactElement {
+  if (variant === "iconButton" && !rest["aria-label"]) {
+    throw new Error("Button variant `iconButton` requires an aria-label.");
+  }
+
+  const isIconButton = variant === "iconButton";
+
   const buttonClassName = [
-    "inline-flex cursor-pointer items-center justify-center disabled:cursor-not-allowed disabled:opacity-60",
+    "relative inline-flex items-center justify-center font-semibold transition-all active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-60",
     variantClasses[variant],
+    isIconButton ? iconButtonSizeClasses[size] : `${sizeClasses[size]} min-w-[6ch]`,
     className,
   ]
     .filter(Boolean)
@@ -39,13 +86,49 @@ export function Button({
 
   return (
     <button
+      {...rest}
       type={type}
-      form={form}
-      onClick={onClick}
       disabled={disabled || isLoading}
+      aria-busy={isLoading || undefined}
       className={buttonClassName}
     >
-      {isLoading ? "Loading..." : children}
+      <span className={`inline-flex items-center ${isLoading ? "opacity-0" : "opacity-100"}`}>
+        {isIconButton ? (
+          children
+        ) : (
+          <>
+            {leadingIcon ? <span aria-hidden="true">{leadingIcon}</span> : null}
+            <span>{children}</span>
+            {trailingIcon ? <span aria-hidden="true">{trailingIcon}</span> : null}
+          </>
+        )}
+      </span>
+      {isLoading ? (
+        <span className="pointer-events-none absolute inset-0 inline-flex items-center justify-center">
+          <svg
+            data-testid="button-spinner"
+            className={`animate-spin ${spinnerSizeClasses[size]}`}
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
+            <circle
+              className="opacity-25"
+              cx="12"
+              cy="12"
+              r="10"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="4"
+            />
+            <path
+              className="opacity-90"
+              fill="currentColor"
+              d="M4 12a8 8 0 0 1 8-8v4a4 4 0 0 0-4 4z"
+            />
+          </svg>
+          <span className="sr-only">Loading</span>
+        </span>
+      ) : null}
     </button>
   );
 }

--- a/frontend/src/shared/components/Button.tsx
+++ b/frontend/src/shared/components/Button.tsx
@@ -40,9 +40,9 @@ const variantClasses: Record<ButtonVariant, string> = {
 };
 
 const sizeClasses: Record<ButtonSize, string> = {
-  sm: "min-h-11 gap-1.5 px-3 py-2 text-sm",
-  md: "min-h-12 gap-2 px-4 py-4 text-sm",
-  lg: "min-h-14 gap-2.5 px-5 py-5 text-base",
+  sm: "min-h-11 px-3 py-2 text-sm",
+  md: "min-h-12 px-4 py-4 text-sm",
+  lg: "min-h-14 px-5 py-5 text-base",
 };
 
 const iconButtonSizeClasses: Record<ButtonSize, string> = {
@@ -55,6 +55,12 @@ const spinnerSizeClasses: Record<ButtonSize, string> = {
   sm: "h-4 w-4",
   md: "h-5 w-5",
   lg: "h-6 w-6",
+};
+
+const contentGapClasses: Record<ButtonSize, string> = {
+  sm: "gap-1.5",
+  md: "gap-2",
+  lg: "gap-2.5",
 };
 
 export function Button({
@@ -92,14 +98,24 @@ export function Button({
       aria-busy={isLoading || undefined}
       className={buttonClassName}
     >
-      <span className={`inline-flex items-center ${isLoading ? "opacity-0" : "opacity-100"}`}>
+      <span
+        className={`inline-flex items-center justify-center whitespace-nowrap ${isIconButton ? "leading-none" : contentGapClasses[size]} ${isLoading ? "opacity-0" : "opacity-100"}`}
+      >
         {isIconButton ? (
           children
         ) : (
           <>
-            {leadingIcon ? <span aria-hidden="true">{leadingIcon}</span> : null}
-            <span>{children}</span>
-            {trailingIcon ? <span aria-hidden="true">{trailingIcon}</span> : null}
+            {leadingIcon ? (
+              <span aria-hidden="true" className="inline-flex items-center justify-center leading-none">
+                {leadingIcon}
+              </span>
+            ) : null}
+            <span className="leading-none">{children}</span>
+            {trailingIcon ? (
+              <span aria-hidden="true" className="inline-flex items-center justify-center leading-none">
+                {trailingIcon}
+              </span>
+            ) : null}
           </>
         )}
       </span>

--- a/frontend/src/shared/components/DocumentActionSurface.tsx
+++ b/frontend/src/shared/components/DocumentActionSurface.tsx
@@ -9,7 +9,7 @@ const utilityGridClassNames = {
 
 export const documentActionPrimaryButtonClassName = "min-h-14 w-full gap-2 text-center";
 export const documentActionPrimaryLinkClassName = "forest-gradient inline-flex min-h-14 w-full cursor-pointer items-center justify-center gap-2 rounded-[var(--radius-document)] px-4 py-4 text-center font-semibold text-on-primary transition-all active:scale-[0.98]";
-export const documentActionUtilityButtonClassName = "w-full border border-outline text-center";
+export const documentActionUtilityButtonClassName = "w-full border border-outline text-center text-on-surface";
 
 interface DocumentActionSurfaceProps {
   sectionLabel: string;

--- a/frontend/src/shared/components/DocumentActionSurface.tsx
+++ b/frontend/src/shared/components/DocumentActionSurface.tsx
@@ -9,7 +9,7 @@ const utilityGridClassNames = {
 
 export const documentActionPrimaryButtonClassName = "min-h-14 w-full gap-2 text-center";
 export const documentActionPrimaryLinkClassName = "forest-gradient inline-flex min-h-14 w-full cursor-pointer items-center justify-center gap-2 rounded-[var(--radius-document)] px-4 py-4 text-center font-semibold text-on-primary transition-all active:scale-[0.98]";
-export const documentActionUtilityButtonClassName = "inline-flex min-h-14 w-full cursor-pointer items-center justify-center gap-2 rounded-[var(--radius-document)] border border-outline px-4 py-4 text-center text-sm font-semibold text-on-surface transition-all active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-40";
+export const documentActionUtilityButtonClassName = "w-full border border-outline text-center";
 
 interface DocumentActionSurfaceProps {
   sectionLabel: string;


### PR DESCRIPTION
## Summary
- add `cursor-pointer` to shared `Button` base class for enabled controls
- switch Review footer secondary action (`Save Draft`) to `variant="secondary"` per follow-up tweak

## Verification
- `cd frontend && npx eslint src/shared/components/Button.tsx src/features/quotes/components/ReviewActionFooter.tsx`
- `cd frontend && npx tsc --noEmit`
- `cd frontend && npx vitest run src/shared/components/Button.test.tsx`

Follow-up after merged PR #524.