### PR TITLE
Follow-up: button pointer and save draft variant tweak

### DIFF
--- a/frontend/src/features/quotes/components/ReviewActionFooter.tsx
+++ b/frontend/src/features/quotes/components/ReviewActionFooter.tsx
@@ -38,7 +38,7 @@ export function ReviewActionFooter({
           </Button>
           <Button
             type="button"
-            variant="tonal"
+            variant="secondary"
             className="w-full sm:flex-1"
             disabled={isInteractionLocked || isSavingDraft}
             isLoading={isSavingDraft}

--- a/frontend/src/shared/components/Button.tsx
+++ b/frontend/src/shared/components/Button.tsx
@@ -106,7 +106,7 @@ export function Button({
   const isIconButton = variant === "iconButton";
 
   const buttonClassName = [
-    "relative inline-flex items-center justify-center font-semibold transition-all active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-60",
+    "relative inline-flex cursor-pointer items-center justify-center font-semibold transition-all active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-60",
     variantClasses[variant],
     isIconButton ? iconButtonSizeClasses[size] : `${sizeClasses[size]} min-w-[6ch]`,
     className,


### PR DESCRIPTION
Summary
- add cursor-pointer to shared Button base classes for enabled controls
- switch ReviewActionFooter Save Draft button to secondary variant

Verification
- cd frontend && npx eslint src/shared/components/Button.tsx src/features/quotes/components/ReviewActionFooter.tsx
- cd frontend && npx tsc --noEmit
- cd frontend && npx vitest run src/shared/components/Button.test.tsx

Follow-up after merged PR #524.