### PR TITLE
Task #525: complete Button migration sweep and API hardening

### DIFF
--- a/frontend/src/features/customers/components/CustomerDetailScreen.tsx
+++ b/frontend/src/features/customers/components/CustomerDetailScreen.tsx
@@ -19,7 +19,6 @@ import { Button } from "@/shared/components/Button";
 import { FeedbackMessage } from "@/shared/components/FeedbackMessage";
 import { ScreenHeader } from "@/shared/components/ScreenHeader";
 import { Toast } from "@/shared/components/Toast";
-
 type HistoryMode = "quotes" | "invoices";
 
 function getCustomerDraftValues(nextCustomer: Customer): {
@@ -39,7 +38,6 @@ export function CustomerDetailScreen(): React.ReactElement {
   const navigate = useNavigate();
   const { id } = useParams<{ id: string }>();
   const { user } = useAuth();
-
   const [customer, setCustomer] = useState<Customer | null>(null);
   const [customerQuotes, setCustomerQuotes] = useState<QuoteListItem[]>([]);
   const [customerInvoices, setCustomerInvoices] = useState<InvoiceListItem[]>([]);
@@ -338,20 +336,22 @@ export function CustomerDetailScreen(): React.ReactElement {
                     >
                       Create Document
                     </Button>
-                    <button
+                    <Button
                       type="button"
+                      variant="secondary"
+                      size="md"
                       onClick={openEditMode}
-                      className="cursor-pointer rounded-lg border border-outline/20 px-4 py-4 text-sm font-semibold text-on-surface transition-all hover:bg-surface-container-low active:scale-[0.98]"
                     >
                       Edit
-                    </button>
-                    <button
+                    </Button>
+                    <Button
                       type="button"
+                      variant="destructive"
+                      size="md"
                       onClick={openDeleteConfirmation}
-                      className="cursor-pointer rounded-lg border border-error/40 px-4 py-4 text-sm font-semibold text-error transition-all hover:bg-error/10 active:scale-[0.98]"
                     >
                       Delete Customer
-                    </button>
+                    </Button>
                   </div>
                 </div>
               </section>

--- a/frontend/src/features/customers/components/CustomerInfoForm.tsx
+++ b/frontend/src/features/customers/components/CustomerInfoForm.tsx
@@ -73,14 +73,16 @@ export function CustomerInfoForm({
 
         <div className="mt-2 flex flex-col-reverse gap-3 sm:flex-row sm:justify-end">
           {onCancel ? (
-            <button
+            <Button
               type="button"
+              variant="secondary"
+              size="md"
               onClick={onCancel}
               disabled={isSaving}
-              className="w-full cursor-pointer rounded-lg border border-outline/20 px-4 py-3 text-sm font-semibold text-on-surface transition-all hover:bg-surface-container-low disabled:cursor-not-allowed disabled:opacity-60 sm:w-auto"
+              className="w-full sm:w-auto"
             >
               Cancel
-            </button>
+            </Button>
           ) : null}
 
           <Button type="submit" variant="primary" className="w-full px-6 sm:w-auto" isLoading={isSaving}>

--- a/frontend/src/features/customers/components/CustomerInlineCreateForm.tsx
+++ b/frontend/src/features/customers/components/CustomerInlineCreateForm.tsx
@@ -70,13 +70,15 @@ export function CustomerInlineCreateForm({
         <Button type="submit" variant="primary" className="mt-2 w-full" isLoading={isCreating}>
           Create {"&"} Continue {">"}
         </Button>
-        <button
+        <Button
           type="button"
-          className="cursor-pointer text-sm font-semibold text-on-surface-variant transition-colors hover:text-on-surface"
+          variant="ghost"
+          size="sm"
+          className="justify-start px-0"
           onClick={onCancel}
         >
           Back to search
-        </button>
+        </Button>
       </form>
     </section>
   );

--- a/frontend/src/features/invoices/components/InvoiceDetailScreen.tsx
+++ b/frontend/src/features/invoices/components/InvoiceDetailScreen.tsx
@@ -16,9 +16,7 @@ import {
   DocumentActionStatus,
   DocumentActionSuccessMessage,
   DocumentActionSurface,
-  documentActionPrimaryButtonClassName,
   documentActionPrimaryLinkClassName,
-  documentActionUtilityButtonClassName,
 } from "@/shared/components/DocumentActionSurface";
 import { FeedbackMessage } from "@/shared/components/FeedbackMessage";
 import { OverflowMenu } from "@/shared/components/OverflowMenu";
@@ -143,14 +141,15 @@ export function InvoiceDetailScreen(): React.ReactElement {
         trailing={invoice ? (
           <div className="flex items-center gap-2">
             {canEdit ? (
-              <button
-                type="button"
+              <Button
+                variant="iconButton"
+                size="sm"
                 onClick={() => navigate(`/documents/${invoice.id}/edit`)}
                 aria-label="Edit invoice"
-                className="inline-flex h-10 w-10 cursor-pointer shrink-0 items-center justify-center rounded-full border border-outline-variant/30 bg-surface-container-lowest text-on-surface ghost-shadow transition-all hover:bg-surface-container-low active:scale-95"
+                className="border border-outline-variant/30 bg-surface-container-lowest text-on-surface ghost-shadow"
               >
                 <span className="material-symbols-outlined block text-[1.125rem] leading-none">edit</span>
-              </button>
+              </Button>
             ) : null}
             <OverflowMenu items={overflowItems} />
           </div>
@@ -226,7 +225,9 @@ export function InvoiceDetailScreen(): React.ReactElement {
               ) : (
                 <Button
                   type="button"
-                  className={documentActionPrimaryButtonClassName}
+                  variant="primary"
+                  size="lg"
+                  className="w-full"
                   disabled={isBusy}
                   onClick={() => {
                     void onGeneratePdf();
@@ -246,9 +247,9 @@ export function InvoiceDetailScreen(): React.ReactElement {
                   {emailActionLabel ? (
                     <Button
                       type="button"
-                      variant="ghost"
+                      variant="secondary"
                       size="lg"
-                      className={documentActionUtilityButtonClassName}
+                      className="w-full"
                       disabled={!hasCustomerEmail || isBusy}
                       isLoading={isSendingEmail}
                       leadingIcon={<span className="material-symbols-outlined text-base leading-none">mail</span>}
@@ -260,9 +261,9 @@ export function InvoiceDetailScreen(): React.ReactElement {
 
                   <Button
                     type="button"
-                    variant="ghost"
+                    variant="secondary"
                     size="lg"
-                    className={documentActionUtilityButtonClassName}
+                    className="w-full"
                     disabled={isBusy}
                     leadingIcon={(
                       <span className="material-symbols-outlined text-base leading-none">

--- a/frontend/src/features/line-item-catalog/components/LineItemCatalogSettingsScreen.tsx
+++ b/frontend/src/features/line-item-catalog/components/LineItemCatalogSettingsScreen.tsx
@@ -263,13 +263,14 @@ export function LineItemCatalogSettingsScreen(): React.ReactElement {
                     {isEditMode ? "Update Item" : "Create Item"}
                   </Button>
                   {isEditMode ? (
-                    <button
+                    <Button
                       type="button"
-                      className="inline-flex min-h-10 items-center justify-center rounded-lg border border-outline-variant/40 px-4 py-2 text-sm font-semibold text-on-surface transition-colors hover:bg-surface-container-low"
+                      variant="secondary"
+                      size="sm"
                       onClick={resetForm}
                     >
                       Cancel
-                    </button>
+                    </Button>
                   ) : null}
                 </div>
               </form>
@@ -299,20 +300,24 @@ export function LineItemCatalogSettingsScreen(): React.ReactElement {
                           ) : null}
                         </div>
                         <div className="flex gap-2">
-                          <button
+                          <Button
                             type="button"
-                            className="inline-flex min-h-9 items-center justify-center rounded-lg border border-outline-variant/40 px-3 text-xs font-semibold text-on-surface transition-colors hover:bg-surface-container-low"
+                            variant="secondary"
+                            size="sm"
+                            className="min-h-9 px-3 text-xs"
                             onClick={() => startEdit(item)}
                           >
                             Edit
-                          </button>
-                          <button
+                          </Button>
+                          <Button
                             type="button"
-                            className="inline-flex min-h-9 items-center justify-center rounded-lg border border-error/30 px-3 text-xs font-semibold text-error transition-colors hover:bg-error-container/40"
+                            variant="destructive"
+                            size="sm"
+                            className="min-h-9 px-3 text-xs"
                             onClick={() => setItemPendingDelete(item)}
                           >
                             Delete
-                          </button>
+                          </Button>
                         </div>
                       </div>
                     </article>

--- a/frontend/src/features/quotes/components/CaptureInputPanel.tsx
+++ b/frontend/src/features/quotes/components/CaptureInputPanel.tsx
@@ -4,6 +4,7 @@ import {
   MAX_AUDIO_CLIPS_PER_REQUEST,
   NOTE_INPUT_MAX_CHARS,
 } from "@/shared/lib/inputLimits";
+import { Button } from "@/shared/components/Button";
 import { Eyebrow } from "@/ui/Eyebrow";
 
 interface CaptureInputPanelProps {
@@ -74,17 +75,19 @@ export function CaptureInputPanel({
                       Clip {clipNumber} · {clip.durationSeconds}s
                     </p>
                   </div>
-                  <button
+                  <Button
                     type="button"
+                    variant="iconButton"
+                    size="xs"
                     aria-label={`Delete clip ${clipNumber}`}
-                    className="cursor-pointer rounded-full p-1 text-outline transition-colors hover:bg-surface-container-low active:scale-95 disabled:cursor-not-allowed disabled:opacity-60"
+                    className="text-outline hover:bg-surface-container-low"
                     onClick={() => removeClip(clip.id)}
                     disabled={isExtracting}
                   >
                     <span className="material-symbols-outlined text-base">
                       close
                     </span>
-                  </button>
+                  </Button>
                 </div>
               );
             })}

--- a/frontend/src/features/quotes/components/DocumentEditScreenView.tsx
+++ b/frontend/src/features/quotes/components/DocumentEditScreenView.tsx
@@ -10,6 +10,7 @@ import { type DocumentEditDraft, type PersistedEditableDocument } from "@/featur
 import type { ExtractionReviewHiddenDetails, ExtractionTier, HiddenItemState, LineItemDraftWithFlags } from "@/features/quotes/types/quote.types";
 import { hasUndismissedCaptureDetailsItems, resolveCaptureDetailsActionableItems } from "@/features/quotes/utils/captureDetails";
 import type { LineItemCatalogItem } from "@/features/line-item-catalog/types/lineItemCatalog.types";
+import { Button } from "@/shared/components/Button";
 import { WorkflowScreenHeader } from "@/shared/components/WorkflowScreenHeader";
 
 interface DocumentEditScreenViewProps {
@@ -151,13 +152,15 @@ export function DocumentEditScreenView({
         backLabel={backLabel}
         onBack={() => onRequestNavigation({ to: backTarget, replace: true })}
         trailing={showCaptureDetailsTrigger ? (
-          <button
+          <Button
             type="button"
+            variant="iconButton"
+            size="sm"
             aria-label="Capture details"
             onClick={() => setIsCaptureDetailsOpen(true)}
             data-testid="capture-details-trigger"
             className={[
-              "inline-flex h-10 w-10 cursor-pointer shrink-0 items-center justify-center rounded-full border transition-colors",
+              "shrink-0 border transition-colors",
               hasHiddenActionableItems
                 ? "border-warning-accent/50 bg-warning-container text-warning hover:bg-warning-container/80"
                 : "border-outline-variant/30 bg-surface-container-lowest text-on-surface hover:bg-surface-container-low",
@@ -166,7 +169,7 @@ export function DocumentEditScreenView({
             <span className="material-symbols-outlined text-[1.125rem] leading-none">
               info
             </span>
-          </button>
+          </Button>
         ) : null}
       />
 

--- a/frontend/src/features/quotes/components/LineItemCatalogTabPanel.tsx
+++ b/frontend/src/features/quotes/components/LineItemCatalogTabPanel.tsx
@@ -1,4 +1,5 @@
 import type { LineItemCatalogItem } from "@/features/line-item-catalog/types/lineItemCatalog.types";
+import { Button } from "@/shared/components/Button";
 import { FeedbackMessage } from "@/shared/components/FeedbackMessage";
 
 interface LineItemCatalogTabPanelProps {
@@ -32,13 +33,15 @@ export function LineItemCatalogTabPanel({
       {loadState === "error" && loadError ? (
         <div className="space-y-2">
           <FeedbackMessage variant="error">{loadError}</FeedbackMessage>
-          <button
+          <Button
             type="button"
-            className="inline-flex min-h-9 items-center rounded-lg border border-outline-variant/40 px-3 text-xs font-semibold text-on-surface transition-colors hover:bg-surface-container-low"
+            variant="secondary"
+            size="sm"
+            className="min-h-9 px-3 text-xs"
             onClick={onRetry}
           >
             Retry
-          </button>
+          </Button>
         </div>
       ) : null}
 

--- a/frontend/src/features/quotes/components/LineItemEditSheet.tsx
+++ b/frontend/src/features/quotes/components/LineItemEditSheet.tsx
@@ -4,6 +4,7 @@ import type { LineItemCatalogItem } from "@/features/line-item-catalog/types/lin
 import type { LineItemDraftWithFlags } from "@/features/quotes/types/quote.types";
 import { LineItemCatalogTabPanel } from "@/features/quotes/components/LineItemCatalogTabPanel";
 import { resolveLineItemReviewExplanation } from "@/features/quotes/utils/lineItemFlags";
+import { Button } from "@/shared/components/Button";
 import { FeedbackMessage } from "@/shared/components/FeedbackMessage";
 import {
   LINE_ITEM_DESCRIPTION_MAX_CHARS,
@@ -24,7 +25,6 @@ interface LineItemEditSheetProps {
   onLoadCatalogItems?: () => Promise<LineItemCatalogItem[]>;
   onRequestDelete?: () => void;
 }
-
 interface ParsedPrice {
   value: number | null;
   valid: boolean;
@@ -235,10 +235,12 @@ export function LineItemEditSheet({
               </Dialog.Title>
               <div className="flex items-center gap-2">
                 {onSaveToCatalog && showManualFields ? (
-                  <button
+                  <Button
                     type="button"
+                    variant="iconButton"
+                    size="sm"
                     aria-label="Save to catalog"
-                    className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-primary/30 bg-primary/5 text-primary transition-colors hover:bg-primary/10 disabled:cursor-not-allowed disabled:opacity-60"
+                    className="border border-primary/30 bg-primary/5 text-primary hover:bg-primary/10"
                     disabled={isCatalogMutationInFlight || (!canSaveToCatalog && !canDeleteSavedCatalogItem)}
                     onClick={() => {
                       if (savedCatalogItem) {
@@ -254,27 +256,31 @@ export function LineItemEditSheet({
                     >
                       {bookmarkIcon}
                     </span>
-                  </button>
+                  </Button>
                 ) : null}
                 {mode === "add" && showManualFields ? (
-                  <button
+                  <Button
                     type="button"
+                    variant="iconButton"
+                    size="sm"
                     aria-label="Add line item"
-                    className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-primary/30 bg-primary/5 text-primary transition-colors hover:bg-primary/10"
+                    className="border border-primary/30 bg-primary/5 text-primary hover:bg-primary/10"
                     onClick={addLineItemAndClose}
                   >
                     <span className="material-symbols-outlined text-base leading-none">check</span>
-                  </button>
+                  </Button>
                 ) : null}
                 {mode === "edit" && onRequestDelete ? (
-                  <button
+                  <Button
                     type="button"
+                    variant="iconButton"
+                    size="sm"
                     aria-label="Delete line item"
-                    className="inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-full border border-error/30 bg-error-container/40 text-error transition-colors hover:bg-error-container/60"
+                    className="shrink-0 border border-error/30 bg-error-container/40 text-error hover:bg-error-container/60"
                     onClick={onRequestDelete}
                   >
                     <span className="material-symbols-outlined text-[1.125rem] leading-none">delete</span>
-                  </button>
+                  </Button>
                 ) : null}
               </div>
             </div>

--- a/frontend/src/features/quotes/components/LineItemRow.tsx
+++ b/frontend/src/features/quotes/components/LineItemRow.tsx
@@ -1,4 +1,5 @@
 import type { LineItemDraftWithFlags } from "@/features/quotes/types/quote.types";
+import { Button } from "@/shared/components/Button";
 import { resolveLineItemFlagMessage } from "@/features/quotes/utils/lineItemFlags";
 
 interface LineItemRowProps {
@@ -87,13 +88,14 @@ export function LineItemRow({
           />
         </div>
 
-        <button
+        <Button
           type="button"
+          variant="destructive"
+          size="sm"
           onClick={onDelete}
-          className="cursor-pointer rounded-md border border-outline-variant px-3 py-2 text-sm font-medium text-on-surface transition hover:bg-surface-container-low"
         >
           Delete
-        </button>
+        </Button>
       </div>
     </div>
   );

--- a/frontend/src/features/quotes/components/QuoteCreateEntrySheet.tsx
+++ b/frontend/src/features/quotes/components/QuoteCreateEntrySheet.tsx
@@ -1,4 +1,5 @@
 import * as Dialog from "@radix-ui/react-dialog";
+import { Button } from "@/shared/components/Button";
 
 interface QuoteCreateEntrySheetProps {
   open: boolean;
@@ -31,20 +32,24 @@ export function QuoteCreateEntrySheet({
             </Dialog.Description>
 
             <div className="mt-6 space-y-3">
-              <button
+              <Button
                 type="button"
-                className="inline-flex min-h-12 w-full cursor-pointer items-center justify-center rounded-lg forest-gradient px-4 py-3 text-sm font-semibold text-on-primary transition-all active:scale-[0.98]"
+                variant="primary"
+                size="md"
+                className="w-full"
                 onClick={onCreateNew}
               >
                 Create new
-              </button>
-              <button
+              </Button>
+              <Button
                 type="button"
-                className="inline-flex min-h-12 w-full cursor-pointer items-center justify-center rounded-lg border border-outline-variant/30 bg-surface-container-low px-4 py-3 text-sm font-semibold text-on-surface transition-colors hover:bg-surface-container-lowest"
+                variant="secondary"
+                size="md"
+                className="w-full"
                 onClick={onCreateFromExisting}
               >
                 Create from existing
-              </button>
+              </Button>
             </div>
           </Dialog.Content>
         </div>

--- a/frontend/src/features/quotes/components/QuoteList.tsx
+++ b/frontend/src/features/quotes/components/QuoteList.tsx
@@ -7,6 +7,7 @@ import { useQuoteCreateFlow } from "@/features/quotes/hooks/useQuoteCreateFlow";
 import { quoteService } from "@/features/quotes/services/quoteService";
 import type { QuoteListItem } from "@/features/quotes/types/quote.types";
 import { BottomNav } from "@/shared/components/BottomNav";
+import { Button } from "@/shared/components/Button";
 import { DocumentCardSkeleton } from "@/shared/components/DocumentCardSkeleton";
 import { FeedbackMessage } from "@/shared/components/FeedbackMessage";
 import { Input } from "@/shared/components/Input";
@@ -40,8 +41,6 @@ interface DocumentRowsSectionProps {
   rows: DocumentRow[];
   onRowClick: (row: DocumentRow) => void;
 }
-
-const headerIconButtonClasses = "inline-flex h-10 w-10 cursor-pointer shrink-0 items-center justify-center rounded-full border border-outline-variant/30 bg-surface-container-lowest text-on-surface ghost-shadow transition-all hover:bg-surface-container-low active:scale-95";
 
 function DocumentRowsSection({ label, rows, onRowClick }: DocumentRowsSectionProps): React.ReactElement {
   return (
@@ -281,14 +280,16 @@ export function QuoteList(): React.ReactElement {
               </button>
             </div>
             {!isSearchOpen ? (
-              <button
+              <Button
                 type="button"
+                variant="iconButton"
+                size="sm"
                 aria-label="Open search"
-                className={headerIconButtonClasses}
+                className="border border-outline-variant/30 bg-surface-container-lowest text-on-surface ghost-shadow"
                 onClick={() => setIsSearchOpen(true)}
               >
                 <span className="material-symbols-outlined block text-[1.125rem] leading-none">search</span>
-              </button>
+              </Button>
             ) : null}
           </div>
           {isSearchOpen ? (
@@ -302,17 +303,19 @@ export function QuoteList(): React.ReactElement {
                 onChange={(event) => setSearchQuery(event.target.value)}
                 className="pr-14"
               />
-              <button
+              <Button
                 type="button"
+                variant="iconButton"
+                size="xs"
                 aria-label="Close search"
-                className="absolute right-3 top-1/2 inline-flex h-6 w-6 -translate-y-1/2 cursor-pointer items-center justify-center rounded-full text-outline transition-all hover:bg-surface-container-low active:scale-95"
+                className="absolute right-3 top-1/2 -translate-y-1/2 text-outline"
                 onClick={() => {
                   setSearchQuery("");
                   setIsSearchOpen(false);
                 }}
               >
                 <span className="material-symbols-outlined block text-base leading-none">close</span>
-              </button>
+              </Button>
             </div>
           ) : null}
         </div>

--- a/frontend/src/features/quotes/components/QuotePreviewActions.tsx
+++ b/frontend/src/features/quotes/components/QuotePreviewActions.tsx
@@ -6,9 +6,7 @@ import {
   DocumentActionStatus,
   DocumentActionSuccessMessage,
   DocumentActionSurface,
-  documentActionPrimaryButtonClassName,
   documentActionPrimaryLinkClassName,
-  documentActionUtilityButtonClassName,
 } from "@/shared/components/DocumentActionSurface";
 
 interface QuotePreviewActionsProps {
@@ -87,7 +85,9 @@ export function QuotePreviewActions({
     return (
       <Button
         type="button"
-        className={documentActionPrimaryButtonClassName}
+        variant="primary"
+        size="lg"
+        className="w-full"
         disabled={
           disabled
           || isGeneratingPdf
@@ -119,9 +119,9 @@ export function QuotePreviewActions({
           {showEmailAction ? (
             <Button
               type="button"
-              variant="ghost"
+              variant="secondary"
               size="lg"
-              className={documentActionUtilityButtonClassName}
+              className="w-full"
               disabled={
                 disabled
                 || !hasCustomerEmail
@@ -141,9 +141,9 @@ export function QuotePreviewActions({
 
           <Button
             type="button"
-            variant="ghost"
+            variant="secondary"
             size="lg"
-            className={documentActionUtilityButtonClassName}
+            className="w-full"
             disabled={
               disabled
               || isGeneratingPdf

--- a/frontend/src/features/quotes/components/QuotePreviewHeaderActions.tsx
+++ b/frontend/src/features/quotes/components/QuotePreviewHeaderActions.tsx
@@ -1,4 +1,5 @@
 import type { OverflowMenuItem } from "@/shared/components/OverflowMenu";
+import { Button } from "@/shared/components/Button";
 import { OverflowMenu } from "@/shared/components/OverflowMenu";
 
 interface QuotePreviewHeaderActionsProps {
@@ -15,14 +16,16 @@ export function QuotePreviewHeaderActions({
   return (
     <div className="flex items-center gap-2">
       {canEdit ? (
-        <button
+        <Button
           type="button"
+          variant="iconButton"
+          size="sm"
           onClick={onEdit}
           aria-label="Edit quote"
-          className="inline-flex h-10 w-10 cursor-pointer shrink-0 items-center justify-center rounded-full border border-outline-variant/30 bg-surface-container-lowest text-on-surface ghost-shadow transition-all hover:bg-surface-container-low active:scale-95"
+          className="border border-outline-variant/30 bg-surface-container-lowest text-on-surface ghost-shadow"
         >
           <span className="material-symbols-outlined block text-[1.125rem] leading-none">edit</span>
-        </button>
+        </Button>
       ) : null}
       <OverflowMenu items={overflowItems} />
     </div>

--- a/frontend/src/features/quotes/components/QuoteReuseChooser.tsx
+++ b/frontend/src/features/quotes/components/QuoteReuseChooser.tsx
@@ -3,6 +3,7 @@ import * as Dialog from "@radix-ui/react-dialog";
 
 import { quoteService } from "@/features/quotes/services/quoteService";
 import type { QuoteReuseCandidate } from "@/features/quotes/types/quote.types";
+import { Button } from "@/shared/components/Button";
 import { FeedbackMessage } from "@/shared/components/FeedbackMessage";
 import { Input } from "@/shared/components/Input";
 import { StatusPill } from "@/ui/StatusPill";
@@ -280,13 +281,15 @@ export function QuoteReuseChooser({
             </div>
 
             <div className="mt-6">
-              <button
+              <Button
                 type="button"
-                className="inline-flex min-h-12 w-full cursor-pointer items-center justify-center rounded-lg border border-outline-variant/30 bg-surface-container-low px-4 py-3 text-sm font-semibold text-on-surface transition-colors hover:bg-surface-container-lowest"
+                variant="secondary"
+                size="md"
+                className="w-full"
                 onClick={onClose}
               >
                 Close
-              </button>
+              </Button>
             </div>
           </Dialog.Content>
         </div>

--- a/frontend/src/features/quotes/components/ReviewCustomerAssignmentSheet.tsx
+++ b/frontend/src/features/quotes/components/ReviewCustomerAssignmentSheet.tsx
@@ -3,6 +3,7 @@ import * as Dialog from "@radix-ui/react-dialog";
 
 import { customerService } from "@/features/customers/services/customerService";
 import type { Customer, CustomerCreateRequest } from "@/features/customers/types/customer.types";
+import { Button } from "@/shared/components/Button";
 import { FeedbackMessage } from "@/shared/components/FeedbackMessage";
 import { Input } from "@/shared/components/Input";
 
@@ -197,15 +198,17 @@ export function ReviewCustomerAssignmentSheet({
               )}
 
               <div className="rounded-lg bg-surface-container-low p-4">
-                <button
+                <Button
                   type="button"
-                  className="inline-flex cursor-pointer items-center gap-2 text-sm font-semibold text-primary"
+                  variant="ghost"
+                  size="sm"
+                  className="items-center gap-2 px-0"
                   disabled={isSubmitting}
                   onClick={() => setIsCreateExpanded((isExpanded) => !isExpanded)}
                 >
                   <span className="material-symbols-outlined text-base">person_add</span>
                   {isCreateExpanded ? "Hide New Customer Form" : "Create New Customer"}
-                </button>
+                </Button>
 
                 {isCreateExpanded ? (
                   <div className="mt-3 space-y-3">
@@ -228,14 +231,16 @@ export function ReviewCustomerAssignmentSheet({
                       value={newCustomerEmail}
                       onChange={(event) => setNewCustomerEmail(event.target.value)}
                     />
-                    <button
+                    <Button
                       type="button"
-                      className="w-full cursor-pointer rounded-lg forest-gradient px-4 py-3 text-sm font-semibold text-on-primary disabled:cursor-not-allowed disabled:opacity-60"
+                      variant="primary"
+                      size="md"
+                      className="w-full"
                       disabled={isSubmitting}
                       onClick={() => void createAndAssignCustomer()}
                     >
                       Create and Assign
-                    </button>
+                    </Button>
                   </div>
                 ) : null}
               </div>

--- a/frontend/src/features/settings/components/SettingsCatalogShortcutCard.tsx
+++ b/frontend/src/features/settings/components/SettingsCatalogShortcutCard.tsx
@@ -1,3 +1,5 @@
+import { Button } from "@/shared/components/Button";
+
 interface SettingsCatalogShortcutCardProps {
   onOpenLineItemCatalog: () => void;
 }
@@ -14,13 +16,15 @@ export function SettingsCatalogShortcutCard({
         <p className="text-sm text-on-surface-variant">
           Save and manage reusable line item presets.
         </p>
-        <button
+        <Button
           type="button"
-          className="inline-flex min-h-10 items-center justify-center rounded-lg border border-outline-variant/40 px-3 py-2 text-xs font-semibold text-on-surface transition-colors hover:bg-surface-container"
+          variant="secondary"
+          size="sm"
+          className="px-3 py-2 text-xs"
           onClick={onOpenLineItemCatalog}
         >
           Line Item Catalog
-        </button>
+        </Button>
       </div>
     </section>
   );

--- a/frontend/src/shared/components/Button.test.tsx
+++ b/frontend/src/shared/components/Button.test.tsx
@@ -1,3 +1,4 @@
+import { createRef } from "react";
 import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
@@ -29,6 +30,24 @@ describe("Button", () => {
     expect(screen.getByRole("button", { name: "Delete" })).toHaveClass("border-secondary", "text-secondary");
     expect(screen.getByRole("button", { name: "Back" })).toHaveClass("text-on-surface-variant");
     expect(screen.getByRole("button", { name: "Close dialog" })).toHaveClass("rounded-full", "min-h-12");
+  });
+
+  it("attaches forwarded refs to the native button element", () => {
+    const ref = createRef<HTMLButtonElement>();
+    render(<Button ref={ref}>Open</Button>);
+
+    expect(ref.current).toBeInstanceOf(HTMLButtonElement);
+    expect(ref.current).toBe(screen.getByRole("button", { name: "Open" }));
+  });
+
+  it("supports xs iconButton size for inline dismiss affordances", () => {
+    render(
+      <Button variant="iconButton" size="xs" aria-label="Dismiss banner">
+        <span className="material-symbols-outlined">close</span>
+      </Button>,
+    );
+
+    expect(screen.getByRole("button", { name: "Dismiss banner" })).toHaveClass("h-8", "w-8", "min-h-8", "min-w-8");
   });
 
   it("renders leading and trailing icon slots", () => {

--- a/frontend/src/shared/components/Button.tsx
+++ b/frontend/src/shared/components/Button.tsx
@@ -1,11 +1,12 @@
+import { forwardRef } from "react";
 import type { ButtonHTMLAttributes, ReactNode } from "react";
 
 type ButtonVariant = "primary" | "secondary" | "tonal" | "destructive" | "ghost" | "iconButton";
-type ButtonSize = "sm" | "md" | "lg";
+type RegularButtonSize = "sm" | "md" | "lg";
+type IconButtonSize = RegularButtonSize | "xs";
 
 interface BaseButtonProps extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, "children"> {
   className?: string;
-  size?: ButtonSize;
   isLoading?: boolean;
   leadingIcon?: ReactNode;
   trailingIcon?: ReactNode;
@@ -13,11 +14,13 @@ interface BaseButtonProps extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, 
 
 type RegularButtonProps = BaseButtonProps & {
   variant?: Exclude<ButtonVariant, "iconButton">;
+  size?: RegularButtonSize;
   children: ReactNode;
 };
 
 type IconButtonProps = BaseButtonProps & {
   variant: "iconButton";
+  size?: IconButtonSize;
   children?: ReactNode;
   "aria-label": string;
 };
@@ -39,25 +42,35 @@ const variantClasses: Record<ButtonVariant, string> = {
     "rounded-full bg-transparent text-on-surface-variant hover:bg-surface-container-low",
 };
 
-const sizeClasses: Record<ButtonSize, string> = {
+const sizeClasses: Record<RegularButtonSize, string> = {
   sm: "min-h-11 px-3 py-2 text-sm",
   md: "min-h-12 px-4 py-4 text-sm",
   lg: "min-h-14 px-5 py-5 text-base",
 };
 
-const iconButtonSizeClasses: Record<ButtonSize, string> = {
+/**
+ * `xs` intentionally breaks the 44px tap-target floor and is reserved for close/dismiss controls
+ * inside larger tappable containers (for example banners and toasts).
+ */
+const iconButtonSizeClasses: Record<IconButtonSize, string> = {
+  xs: "h-8 w-8 min-h-8 min-w-8 p-0",
   sm: "h-11 w-11 min-h-11 min-w-11 p-0",
   md: "h-12 w-12 min-h-12 min-w-12 p-0",
   lg: "h-14 w-14 min-h-14 min-w-14 p-0",
 };
 
-const spinnerContainerSizeClasses: Record<ButtonSize, string> = {
+const spinnerContainerSizeClasses: Record<IconButtonSize, string> = {
+  xs: "h-4 w-4",
   sm: "h-4 w-4",
   md: "h-5 w-5",
   lg: "h-6 w-6",
 };
 
-const spinnerDotClasses: Record<ButtonSize, { top: string; bottom: string }> = {
+const spinnerDotClasses: Record<IconButtonSize, { top: string; bottom: string }> = {
+  xs: {
+    top: "top-0 h-1.5 w-1.5",
+    bottom: "bottom-0 h-1 w-1",
+  },
   sm: {
     top: "top-0 h-1.5 w-1.5",
     bottom: "bottom-0 h-1 w-1",
@@ -81,34 +94,38 @@ const spinnerToneClasses: Record<ButtonVariant, string> = {
   iconButton: "text-on-surface-variant",
 };
 
-const contentGapClasses: Record<ButtonSize, string> = {
+const contentGapClasses: Record<RegularButtonSize, string> = {
   sm: "gap-1.5",
   md: "gap-2",
   lg: "gap-2.5",
 };
 
-export function Button({
-  children,
-  variant = "primary",
-  className,
-  size = "md",
-  type = "button",
-  disabled = false,
-  isLoading = false,
-  leadingIcon,
-  trailingIcon,
-  ...rest
-}: ButtonProps): React.ReactElement {
+export const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button(
+  {
+    children,
+    variant = "primary",
+    className,
+    size = "md",
+    type = "button",
+    disabled = false,
+    isLoading = false,
+    leadingIcon,
+    trailingIcon,
+    ...rest
+  }: ButtonProps,
+  ref,
+): React.ReactElement {
   if (variant === "iconButton" && !rest["aria-label"]) {
     throw new Error("Button variant `iconButton` requires an aria-label.");
   }
 
   const isIconButton = variant === "iconButton";
+  const regularSize: RegularButtonSize = size === "xs" ? "sm" : size;
 
   const buttonClassName = [
     "relative inline-flex cursor-pointer items-center justify-center font-semibold transition-all active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-60",
     variantClasses[variant],
-    isIconButton ? iconButtonSizeClasses[size] : `${sizeClasses[size]} min-w-[6ch]`,
+    isIconButton ? iconButtonSizeClasses[size] : `${sizeClasses[regularSize]} min-w-[6ch]`,
     className,
   ]
     .filter(Boolean)
@@ -117,13 +134,14 @@ export function Button({
   return (
     <button
       {...rest}
+      ref={ref}
       type={type}
       disabled={disabled || isLoading}
       aria-busy={isLoading || undefined}
       className={buttonClassName}
     >
       <span
-        className={`inline-flex items-center justify-center whitespace-nowrap ${isIconButton ? "leading-none" : contentGapClasses[size]} ${isLoading ? "opacity-0" : "opacity-100"}`}
+        className={`inline-flex items-center justify-center whitespace-nowrap ${isIconButton ? "leading-none" : contentGapClasses[regularSize]} ${isLoading ? "opacity-0" : "opacity-100"}`}
       >
         {isIconButton ? (
           children
@@ -163,4 +181,6 @@ export function Button({
       ) : null}
     </button>
   );
-}
+});
+
+Button.displayName = "Button";

--- a/frontend/src/shared/components/ConfirmModal.test.tsx
+++ b/frontend/src/shared/components/ConfirmModal.test.tsx
@@ -93,7 +93,7 @@ describe("ConfirmModal", () => {
       />,
     );
 
-    expect(screen.getByRole("button", { name: "Delete" })).toHaveClass("bg-secondary", "text-on-secondary");
+    expect(screen.getByRole("button", { name: "Delete" })).toHaveClass("border-secondary", "text-secondary");
   });
 
   it("renders primary confirm styling by default", () => {

--- a/frontend/src/shared/components/ConfirmModal.tsx
+++ b/frontend/src/shared/components/ConfirmModal.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from "react";
 import { useRef } from "react";
 import * as Dialog from "@radix-ui/react-dialog";
+import { Button } from "@/shared/components/Button";
 
 interface ConfirmModalProps {
   title: string;
@@ -12,11 +13,6 @@ interface ConfirmModalProps {
   confirmDisabled?: boolean;
   variant?: "primary" | "destructive";
 }
-
-const confirmButtonClasses = {
-  primary: "forest-gradient text-on-primary",
-  destructive: "bg-secondary text-on-secondary",
-} as const;
 
 export function ConfirmModal({
   title,
@@ -80,22 +76,26 @@ export function ConfirmModal({
               </Dialog.Description>
             ) : null}
             <div className="mt-6 flex flex-col gap-3 sm:flex-row-reverse">
-              <button
+              <Button
                 type="button"
-                className={`inline-flex min-h-12 flex-1 items-center justify-center rounded-lg px-4 py-3 text-sm font-semibold transition-all ${confirmDisabled ? "cursor-not-allowed opacity-60" : "cursor-pointer active:scale-[0.98]"} ${confirmButtonClasses[variant]}`}
+                variant={variant}
+                size="md"
+                className="flex-1"
                 onClick={handleConfirm}
-                disabled={confirmDisabled}
+                disabled={confirmDisabled || undefined}
               >
                 {confirmLabel}
-              </button>
-              <button
+              </Button>
+              <Button
                 type="button"
                 ref={cancelButtonRef}
-                className="inline-flex min-h-12 cursor-pointer flex-1 items-center justify-center rounded-lg border border-outline-variant/30 bg-surface-container-low px-4 py-3 text-sm font-semibold text-on-surface transition-colors hover:bg-surface-container-lowest"
+                variant="secondary"
+                size="md"
+                className="flex-1"
                 onClick={handleCancel}
               >
                 {cancelLabel}
-              </button>
+              </Button>
             </div>
           </Dialog.Content>
         </div>

--- a/frontend/src/shared/components/DocumentActionSurface.tsx
+++ b/frontend/src/shared/components/DocumentActionSurface.tsx
@@ -7,9 +7,7 @@ const utilityGridClassNames = {
   2: "grid grid-cols-2 items-stretch gap-2",
 } as const;
 
-export const documentActionPrimaryButtonClassName = "min-h-14 w-full gap-2 text-center";
 export const documentActionPrimaryLinkClassName = "forest-gradient inline-flex min-h-14 w-full cursor-pointer items-center justify-center gap-2 rounded-[var(--radius-document)] px-4 py-4 text-center font-semibold text-on-primary transition-all active:scale-[0.98]";
-export const documentActionUtilityButtonClassName = "w-full border border-outline text-center text-on-surface";
 
 interface DocumentActionSurfaceProps {
   sectionLabel: string;

--- a/frontend/src/shared/components/OptionalPricingBanner.tsx
+++ b/frontend/src/shared/components/OptionalPricingBanner.tsx
@@ -1,3 +1,5 @@
+import { Button } from "@/shared/components/Button";
+
 interface OptionalPricingBannerProps {
   message: string;
   onDismiss: () => void;
@@ -12,14 +14,16 @@ export function OptionalPricingBanner({
   return (
     <div className="flex items-start justify-between gap-3 rounded-lg border border-warning/20 bg-warning-container px-3 py-2 text-xs text-warning">
       <p>{message}</p>
-      <button
+      <Button
         type="button"
+        variant="iconButton"
+        size="xs"
         aria-label={dismissLabel}
         onClick={onDismiss}
-        className="inline-flex h-6 w-6 shrink-0 cursor-pointer items-center justify-center rounded-full text-warning transition-colors hover:bg-warning/10"
+        className="shrink-0 text-warning hover:bg-warning/10"
       >
         <span className="material-symbols-outlined text-base">close</span>
-      </button>
+      </Button>
     </div>
   );
 }

--- a/frontend/src/shared/components/OverflowMenu.tsx
+++ b/frontend/src/shared/components/OverflowMenu.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useId, useRef, useState } from "react";
+import { Button } from "@/shared/components/Button";
 
 export interface OverflowMenuItem {
   label: string;
@@ -132,11 +133,13 @@ export function OverflowMenu({
             }
 
             return (
-              <button
+              <Button
                 key={item.label}
                 type="button"
+                variant="ghost"
+                size="sm"
                 role="menuitem"
-                className={`${itemClassName} cursor-pointer ${toneClassName}`}
+                className={`${itemClassName} ${toneClassName}`}
                 disabled={item.disabled}
                 onClick={() => {
                   setIsOpen(false);
@@ -146,7 +149,7 @@ export function OverflowMenu({
               >
                 <span className="material-symbols-outlined text-[1.125rem]">{item.icon}</span>
                 <span>{item.label}</span>
-              </button>
+              </Button>
             );
           })}
         </div>

--- a/frontend/src/shared/components/ScreenHeader.tsx
+++ b/frontend/src/shared/components/ScreenHeader.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from "react";
+import { Button } from "@/shared/components/Button";
 
 interface ScreenHeaderProps {
   title: string;
@@ -30,14 +31,16 @@ export function ScreenHeader({
         ].join(" ")}
       >
         {onBack ? (
-          <button
+          <Button
             type="button"
+            variant="iconButton"
+            size="sm"
             onClick={onBack}
             aria-label={backLabel}
-            className="inline-flex h-10 w-10 cursor-pointer items-center justify-center rounded-full text-primary transition-all hover:bg-surface-container-low active:scale-95"
+            className="text-primary"
           >
             <span className="material-symbols-outlined block text-[1.125rem] leading-none">arrow_back</span>
-          </button>
+          </Button>
         ) : null}
         {isTopLevelLayout ? (
           <p className="shrink-0 font-headline text-[2rem] font-bold leading-none text-primary">Stima</p>

--- a/frontend/src/shared/components/WorkflowScreenHeader.tsx
+++ b/frontend/src/shared/components/WorkflowScreenHeader.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from "react";
 
+import { Button } from "@/shared/components/Button";
 import { ScreenHeader } from "@/shared/components/ScreenHeader";
 
 interface WorkflowScreenHeaderProps {
@@ -26,14 +27,16 @@ export function WorkflowScreenHeader({
   const trailingContent = onExitHome ? (
     <div className="flex items-center gap-2">
       {trailing}
-      <button
+      <Button
         type="button"
+        variant="iconButton"
+        size="sm"
         onClick={onExitHome}
         aria-label={exitHomeLabel}
-        className="inline-flex h-10 w-10 cursor-pointer shrink-0 items-center justify-center rounded-full border border-outline-variant/30 bg-surface-container-lowest text-on-surface ghost-shadow transition-all hover:bg-surface-container-low active:scale-95"
+        className="border border-outline-variant/30 bg-surface-container-lowest text-on-surface ghost-shadow"
       >
         <span className="material-symbols-outlined block text-[1.125rem] leading-none">close</span>
-      </button>
+      </Button>
     </div>
   ) : trailing;
 

--- a/frontend/src/ui/Banner.tsx
+++ b/frontend/src/ui/Banner.tsx
@@ -1,3 +1,4 @@
+import { Button } from "@/shared/components/Button";
 import { Eyebrow } from "@/ui/Eyebrow";
 
 type BannerKind = "warn" | "info" | "success" | "error";
@@ -65,14 +66,16 @@ export function Banner({
           <p className={["text-sm font-medium leading-snug", style.body].join(" ")}>{message}</p>
         </div>
         {onDismiss ? (
-          <button
+          <Button
             type="button"
+            variant="iconButton"
+            size="xs"
             aria-label={dismissLabel}
-            className={["inline-flex h-8 w-8 cursor-pointer items-center justify-center rounded-full transition-colors hover:bg-current/10", style.body].join(" ")}
+            className={["shrink-0 hover:bg-current/10", style.body].join(" ")}
             onClick={onDismiss}
           >
             <span className="material-symbols-outlined text-base">close</span>
-          </button>
+          </Button>
         ) : null}
       </div>
     </section>

--- a/frontend/src/ui/RAW_BUTTON_WHITELIST.md
+++ b/frontend/src/ui/RAW_BUTTON_WHITELIST.md
@@ -1,0 +1,28 @@
+# Raw Button Whitelist
+
+This file documents production `<button>` usages that intentionally stay raw and should not be auto-migrated to `Button`.
+
+## Allowed Raw Patterns
+
+- FABs:
+  - `frontend/src/features/quotes/components/QuoteList.tsx` (`New quote` floating action button)
+  - `frontend/src/features/customers/components/CustomerListScreen.tsx` (`New customer` floating action button)
+  - Reason: fixed positioning, circular geometry, and custom elevation pattern are purpose-built and do not map cleanly to current `Button` variants.
+
+- Tab and segmented toggles (`role="tab"`, `role="radio"`, `aria-pressed` segmented controls):
+  - `ReviewDocumentTypeSelector`, `TradeTypeSelector`, `BottomNav`
+  - segmented filters such as document/history mode switches
+  - Reason: these are structural navigation controls, not action buttons.
+
+- Full-row list/card triggers:
+  - `LineItemCard`, `ReviewCustomerRow`, `ReviewLineItemsSection` and similar row-sized click targets
+  - Reason: these controls are card/list surfaces with row-level interaction semantics.
+
+- Purpose-specific structural controls:
+  - drag handles
+  - recording controls
+  - accordion-like triggers
+  - Reason: custom interaction behaviors and geometry are tighter than the shared button abstraction.
+
+- Test-only `<button>` elements:
+  - Test files may continue to use raw `<button>` markup for focused behavior fixtures.


### PR DESCRIPTION
## Summary
- add `Button` `forwardRef` support and `iconButton` `xs` size with tests
- retire legacy document action button class exports and migrate action surfaces to Button variants
- migrate scoped secondary/destructive/ghost/iconButton call sites across quote/customer/invoice/settings flows
- add `frontend/src/ui/RAW_BUTTON_WHITELIST.md` for intentional raw button patterns

## Verification
- `cd frontend && npx vitest run src/shared/components/Button.test.tsx src/shared/components/ConfirmModal.test.tsx src/shared/components/OverflowMenu.test.tsx src/features/quotes/tests/QuotePreviewActions.test.tsx`
- `cd frontend && npx tsc --noEmit`
- `cd frontend && npx eslint src/shared/components/Button.tsx src/shared/components/DocumentActionSurface.tsx src/shared/components/ConfirmModal.tsx src/shared/components/OverflowMenu.tsx src/shared/components/ScreenHeader.tsx src/shared/components/WorkflowScreenHeader.tsx src/features/quotes/components/QuotePreviewActions.tsx src/features/quotes/components/QuotePreviewHeaderActions.tsx src/features/quotes/components/QuoteCreateEntrySheet.tsx src/features/quotes/components/QuoteReuseChooser.tsx src/features/quotes/components/ReviewCustomerAssignmentSheet.tsx src/features/quotes/components/LineItemCatalogTabPanel.tsx src/features/quotes/components/LineItemRow.tsx src/features/quotes/components/LineItemEditSheet.tsx src/features/quotes/components/CaptureInputPanel.tsx src/features/quotes/components/DocumentEditScreenView.tsx src/features/quotes/components/QuoteList.tsx src/features/line-item-catalog/components/LineItemCatalogSettingsScreen.tsx src/features/settings/components/SettingsCatalogShortcutCard.tsx src/features/invoices/components/InvoiceDetailScreen.tsx src/features/customers/components/CustomerDetailScreen.tsx src/features/customers/components/CustomerInfoForm.tsx src/features/customers/components/CustomerInlineCreateForm.tsx src/ui/Banner.tsx`
- `make frontend-verify`

Closes #525