### PR TITLE
Task #505: Upgrade Input primitive and migrate field call sites

### DIFF
--- a/frontend/src/features/auth/components/LoginForm.tsx
+++ b/frontend/src/features/auth/components/LoginForm.tsx
@@ -6,6 +6,7 @@ import { useAuth } from "@/features/auth/hooks/useAuth";
 import { Button } from "@/shared/components/Button";
 import { Input } from "@/shared/components/Input";
 import { Toast } from "@/shared/components/Toast";
+import { PasswordField } from "@/ui/PasswordField";
 
 interface LoginLocationState {
   from?: Location;
@@ -18,7 +19,6 @@ export function LoginForm(): React.ReactElement {
   const location = useLocation();
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
-  const [isPasswordVisible, setIsPasswordVisible] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [flashMessage, setFlashMessage] = useState(
@@ -56,35 +56,14 @@ export function LoginForm(): React.ReactElement {
             value={email}
             onChange={(event) => setEmail(event.target.value)}
           />
-          <div className="flex flex-col gap-1">
-            <label htmlFor="password" className="text-sm font-medium text-on-surface">
-              Password
-            </label>
-            <div className="relative">
-              <input
-                id="password"
-                type={isPasswordVisible ? "text" : "password"}
-                autoComplete="current-password"
-                required
-                aria-required="true"
-                value={password}
-                onChange={(event) => setPassword(event.target.value)}
-                className={[
-                  "w-full bg-surface-container-high rounded-lg px-4 py-3 pr-20 font-body text-sm text-on-surface",
-                  "placeholder:text-outline focus:outline-none focus:ring-2 focus:ring-primary/30 focus:bg-surface-container-lowest transition-all",
-                ].join(" ")}
-              />
-              <button
-                type="button"
-                className="absolute inset-y-0 right-3 cursor-pointer text-xs font-semibold text-primary"
-                aria-label={isPasswordVisible ? "Hide password" : "Show password"}
-                aria-pressed={isPasswordVisible}
-                onClick={() => setIsPasswordVisible((visible) => !visible)}
-              >
-                {isPasswordVisible ? "Hide" : "Show"}
-              </button>
-            </div>
-          </div>
+          <PasswordField
+            id="password"
+            label="Password"
+            autoComplete="current-password"
+            required
+            value={password}
+            onChange={(event) => setPassword(event.target.value)}
+          />
 
           <p className="-mt-1 text-right text-sm text-on-surface-variant">
             <Link to="/forgot-password" className="font-semibold text-primary">

--- a/frontend/src/features/auth/components/RegisterForm.tsx
+++ b/frontend/src/features/auth/components/RegisterForm.tsx
@@ -4,6 +4,7 @@ import { Link, useNavigate } from "react-router-dom";
 import { useAuth } from "@/features/auth/hooks/useAuth";
 import { Button } from "@/shared/components/Button";
 import { Input } from "@/shared/components/Input";
+import { PasswordField } from "@/ui/PasswordField";
 
 export function RegisterForm(): React.ReactElement {
   const { register } = useAuth();
@@ -11,8 +12,6 @@ export function RegisterForm(): React.ReactElement {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [confirmPassword, setConfirmPassword] = useState("");
-  const [isPasswordVisible, setIsPasswordVisible] = useState(false);
-  const [isConfirmPasswordVisible, setIsConfirmPasswordVisible] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const passwordsMatch = password === confirmPassword;
@@ -51,71 +50,26 @@ export function RegisterForm(): React.ReactElement {
             value={email}
             onChange={(event) => setEmail(event.target.value)}
           />
-          <div className="flex flex-col gap-1">
-            <label htmlFor="password" className="text-sm font-medium text-on-surface">
-              Password
-            </label>
-            <div className="relative">
-              <input
-                id="password"
-                type={isPasswordVisible ? "text" : "password"}
-                autoComplete="new-password"
-                required
-                aria-required="true"
-                value={password}
-                onChange={(event) => setPassword(event.target.value)}
-                className={[
-                  "w-full bg-surface-container-high rounded-lg px-4 py-3 pr-20 font-body text-sm text-on-surface",
-                  "placeholder:text-outline focus:outline-none focus:ring-2 focus:ring-primary/30 focus:bg-surface-container-lowest transition-all",
-                ].join(" ")}
-              />
-              <button
-                type="button"
-                className="absolute inset-y-0 right-3 cursor-pointer text-xs font-semibold text-primary"
-                aria-label={isPasswordVisible ? "Hide password" : "Show password"}
-                aria-pressed={isPasswordVisible}
-                onClick={() => setIsPasswordVisible((visible) => !visible)}
-              >
-                {isPasswordVisible ? "Hide" : "Show"}
-              </button>
-            </div>
-          </div>
-          <div className="flex flex-col gap-1">
-            <label htmlFor="confirm-password" className="text-sm font-medium text-on-surface">
-              Confirm Password
-            </label>
-            <div className="relative">
-              <input
-                id="confirm-password"
-                type={isConfirmPasswordVisible ? "text" : "password"}
-                autoComplete="new-password"
-                required
-                aria-required="true"
-                value={confirmPassword}
-                onChange={(event) => setConfirmPassword(event.target.value)}
-                aria-invalid={showPasswordMismatch}
-                aria-describedby={showPasswordMismatch ? "confirm-password-error" : undefined}
-                className={[
-                  "w-full bg-surface-container-high rounded-lg px-4 py-3 pr-28 font-body text-sm text-on-surface",
-                  "placeholder:text-outline focus:outline-none focus:ring-2 focus:ring-primary/30 focus:bg-surface-container-lowest transition-all",
-                ].join(" ")}
-              />
-              <button
-                type="button"
-                className="absolute inset-y-0 right-3 cursor-pointer text-xs font-semibold text-primary"
-                aria-label={isConfirmPasswordVisible ? "Hide confirm password" : "Show confirm password"}
-                aria-pressed={isConfirmPasswordVisible}
-                onClick={() => setIsConfirmPasswordVisible((visible) => !visible)}
-              >
-                {isConfirmPasswordVisible ? "Hide" : "Show"}
-              </button>
-            </div>
-            {showPasswordMismatch ? (
-              <p id="confirm-password-error" className="text-xs text-error">
-                Passwords do not match.
-              </p>
-            ) : null}
-          </div>
+          <PasswordField
+            id="password"
+            label="Password"
+            autoComplete="new-password"
+            required
+            value={password}
+            onChange={(event) => setPassword(event.target.value)}
+          />
+          <PasswordField
+            id="confirm-password"
+            label="Confirm Password"
+            autoComplete="new-password"
+            required
+            value={confirmPassword}
+            onChange={(event) => setConfirmPassword(event.target.value)}
+            invalid={showPasswordMismatch}
+            error={showPasswordMismatch ? "Passwords do not match." : undefined}
+            showToggleLabel="Show confirm password"
+            hideToggleLabel="Hide confirm password"
+          />
 
           {error ? (
             <div role="alert" className="rounded-lg border-l-4 border-error bg-error-container p-4">

--- a/frontend/src/features/auth/components/ResetPasswordPage.tsx
+++ b/frontend/src/features/auth/components/ResetPasswordPage.tsx
@@ -3,8 +3,8 @@ import { Link, useNavigate, useSearchParams } from "react-router-dom";
 
 import { authService } from "@/features/auth/services/authService";
 import { Button } from "@/shared/components/Button";
-import { Input } from "@/shared/components/Input";
 import { isHttpRequestError } from "@/shared/lib/http";
+import { PasswordField } from "@/ui/PasswordField";
 
 const RESET_PASSWORD_SUCCESS_MESSAGE = "Password reset successful. Please sign in.";
 const BAD_TOKEN_MESSAGE = "This reset link is invalid or expired. Request a new reset link.";
@@ -87,21 +87,23 @@ export function ResetPasswordPage(): React.ReactElement {
           </div>
         ) : (
           <form className="flex flex-col gap-4" onSubmit={onSubmit}>
-            <Input
+            <PasswordField
               id="new-password"
               label="New Password"
-              type="password"
               required
               value={newPassword}
               onChange={(event) => setNewPassword(event.target.value)}
+              autoComplete="new-password"
             />
-            <Input
+            <PasswordField
               id="confirm-password"
               label="Confirm Password"
-              type="password"
               required
               value={confirmPassword}
               onChange={(event) => setConfirmPassword(event.target.value)}
+              autoComplete="new-password"
+              showToggleLabel="Show password confirmation"
+              hideToggleLabel="Hide password confirmation"
             />
 
             {error ? (

--- a/frontend/src/features/line-item-catalog/components/LineItemCatalogSettingsScreen.tsx
+++ b/frontend/src/features/line-item-catalog/components/LineItemCatalogSettingsScreen.tsx
@@ -9,6 +9,8 @@ import { ConfirmModal } from "@/shared/components/ConfirmModal";
 import { FeedbackMessage } from "@/shared/components/FeedbackMessage";
 import { ScreenHeader } from "@/shared/components/ScreenHeader";
 import { Toast } from "@/shared/components/Toast";
+import { Input } from "@/shared/components/Input";
+import { NumericField } from "@/ui/NumericField";
 
 interface ParsedPriceInput {
   value: number | null;
@@ -16,7 +18,7 @@ interface ParsedPriceInput {
 }
 
 function parsePriceInput(priceInput: string): ParsedPriceInput {
-  const trimmed = priceInput.trim();
+  const trimmed = priceInput.replaceAll(",", "").trim();
   if (trimmed.length === 0) {
     return { value: null, error: null };
   }
@@ -213,18 +215,12 @@ export function LineItemCatalogSettingsScreen(): React.ReactElement {
               <form className="mt-4 space-y-3" onSubmit={(event) => void handleSubmit(event)}>
                 {formError ? <FeedbackMessage variant="error">{formError}</FeedbackMessage> : null}
 
-                <div className="space-y-1">
-                  <label htmlFor="line-item-catalog-title" className="text-sm font-medium text-on-surface">
-                    Title
-                  </label>
-                  <input
-                    id="line-item-catalog-title"
-                    type="text"
-                    value={title}
-                    onChange={(event) => setTitle(event.target.value)}
-                    className="w-full rounded-lg bg-surface-container-high px-4 py-3 font-body text-sm text-on-surface transition-all focus:bg-surface-container-lowest focus:outline-none focus:ring-2 focus:ring-primary/30"
-                  />
-                </div>
+                <Input
+                  id="line-item-catalog-title"
+                  label="Title"
+                  value={title}
+                  onChange={(event) => setTitle(event.target.value)}
+                />
 
                 <div className="space-y-1">
                   <label htmlFor="line-item-catalog-details" className="text-sm font-medium text-on-surface">
@@ -239,20 +235,17 @@ export function LineItemCatalogSettingsScreen(): React.ReactElement {
                   />
                 </div>
 
-                <div className="space-y-1">
-                  <label htmlFor="line-item-catalog-default-price" className="text-sm font-medium text-on-surface">
-                    Default price (optional)
-                  </label>
-                  <input
-                    id="line-item-catalog-default-price"
-                    type="text"
-                    inputMode="decimal"
-                    value={defaultPriceInput}
-                    onChange={(event) => setDefaultPriceInput(event.target.value)}
-                    placeholder="0.00"
-                    className="w-full rounded-lg bg-surface-container-high px-4 py-3 font-body text-sm text-on-surface transition-all focus:bg-surface-container-lowest focus:outline-none focus:ring-2 focus:ring-primary/30"
-                  />
-                </div>
+                <NumericField
+                  id="line-item-catalog-default-price"
+                  label="Default price (optional)"
+                  value={defaultPriceInput}
+                  onChange={setDefaultPriceInput}
+                  placeholder="0.00"
+                  currencySymbol="$"
+                  step={0.01}
+                  formatOnBlur
+                  showStepControls
+                />
 
                 <div className="flex flex-wrap gap-2 pt-1">
                   <Button

--- a/frontend/src/features/quotes/components/LineItemRow.tsx
+++ b/frontend/src/features/quotes/components/LineItemRow.tsx
@@ -1,6 +1,8 @@
 import type { LineItemDraftWithFlags } from "@/features/quotes/types/quote.types";
 import { Button } from "@/shared/components/Button";
+import { Input } from "@/shared/components/Input";
 import { resolveLineItemFlagMessage } from "@/features/quotes/utils/lineItemFlags";
+import { NumericField } from "@/ui/NumericField";
 
 interface LineItemRowProps {
   rowId: string;
@@ -20,8 +22,6 @@ export function LineItemRow({
   const descriptionInputId = `${rowId}-description`;
   const detailsInputId = `${rowId}-details`;
   const priceInputId = `${rowId}-price`;
-  const inputClassName =
-    "rounded-md border border-outline-variant px-3 py-2 text-sm text-on-surface outline-none focus:border-primary focus:ring-2 focus:ring-primary/30";
 
   return (
     <div className="rounded-md border border-outline-variant p-4">
@@ -31,27 +31,20 @@ export function LineItemRow({
         </p>
       ) : null}
       <div className="grid gap-3 md:grid-cols-[1.3fr_1.3fr_0.8fr_auto] md:items-end">
-        <div className="flex flex-col gap-1">
-          <label className="text-sm font-medium text-on-surface" htmlFor={descriptionInputId}>
-            Description
-          </label>
-          <input
+        <div>
+          <Input
             id={descriptionInputId}
-            type="text"
+            label="Description"
             value={item.description}
             onChange={(event) => onChange({ ...item, description: event.target.value })}
-            className={inputClassName}
+            error={descriptionError ?? undefined}
           />
-          {descriptionError ? <p className="text-xs text-error">{descriptionError}</p> : null}
         </div>
 
-        <div className="flex flex-col gap-1">
-          <label className="text-sm font-medium text-on-surface" htmlFor={detailsInputId}>
-            Details
-          </label>
-          <input
+        <div>
+          <Input
             id={detailsInputId}
-            type="text"
+            label="Details"
             value={item.details ?? ""}
             onChange={(event) =>
               onChange({
@@ -59,32 +52,31 @@ export function LineItemRow({
                 details: event.target.value.trim().length > 0 ? event.target.value : null,
               })
             }
-            className={inputClassName}
           />
         </div>
 
-        <div className="flex flex-col gap-1">
-          <label className="text-sm font-medium text-on-surface" htmlFor={priceInputId}>
-            Price
-          </label>
-          <input
+        <div>
+          <NumericField
             id={priceInputId}
-            type="number"
-            step="0.01"
-            value={item.price ?? ""}
-            onChange={(event) => {
-              const rawValue = event.target.value.trim();
-              if (rawValue === "") {
+            label="Price"
+            step={0.01}
+            value={item.price === null ? "" : item.price.toString()}
+            currencySymbol="$"
+            onChange={(rawPriceValue) => {
+              const normalizedValue = rawPriceValue.replaceAll(",", "").trim();
+              if (normalizedValue === "") {
                 onChange({ ...item, price: null });
                 return;
               }
-              const parsedValue = Number(rawValue);
+              const parsedValue = Number(normalizedValue);
               onChange({
                 ...item,
                 price: Number.isFinite(parsedValue) ? parsedValue : null,
               });
             }}
-            className={inputClassName}
+            showStepControls
+            formatOnBlur
+            hint="USD"
           />
         </div>
 

--- a/frontend/src/features/quotes/components/ReviewFormContent.tsx
+++ b/frontend/src/features/quotes/components/ReviewFormContent.tsx
@@ -4,6 +4,7 @@ import { ReviewLineItemsSection } from "@/features/quotes/components/ReviewLineI
 import { TotalAmountSection } from "@/features/quotes/components/TotalAmountSection";
 import type { ExtractionTier } from "@/features/quotes/types/quote.types";
 import { FeedbackMessage } from "@/shared/components/FeedbackMessage";
+import { Input } from "@/shared/components/Input";
 import {
   DOCUMENT_NOTES_MAX_CHARS,
 } from "@/shared/lib/inputLimits";
@@ -122,19 +123,15 @@ export function ReviewFormContent({
       ) : null}
 
       <section className="space-y-2">
-        <label htmlFor="quote-review-title">
-          <Eyebrow>
-          {documentType === "invoice" ? "INVOICE TITLE" : "QUOTE TITLE"}
-          </Eyebrow>
-        </label>
-        <input
+        <Eyebrow>{documentType === "invoice" ? "INVOICE TITLE" : "QUOTE TITLE"}</Eyebrow>
+        <Input
           id="quote-review-title"
-          type="text"
+          label={documentType === "invoice" ? "Invoice title" : "Quote title"}
+          hideLabel
           value={draft.title}
           maxLength={120}
           disabled={isInteractionLocked}
           onChange={(event) => onTitleChange(event.target.value)}
-          className="w-full rounded-[var(--radius-document)] bg-surface-container-high px-4 py-3 font-body text-sm text-on-surface placeholder:text-outline transition-all focus:bg-surface-container-lowest focus:outline-none focus:ring-2 focus:ring-primary/30"
           placeholder="Front yard refresh (optional)"
         />
       </section>
@@ -156,16 +153,15 @@ export function ReviewFormContent({
 
       {showDueDateField ? (
         <section className="space-y-2">
-          <label htmlFor="document-review-due-date">
-            <Eyebrow>INVOICE DUE DATE</Eyebrow>
-          </label>
-          <input
+          <Eyebrow>INVOICE DUE DATE</Eyebrow>
+          <Input
             id="document-review-due-date"
             type="date"
+            label="Invoice due date"
+            hideLabel
             value={draft.dueDate ?? ""}
             disabled={isInteractionLocked}
             onChange={(event) => onDueDateChange(event.target.value)}
-            className="w-full rounded-[var(--radius-document)] bg-surface-container-high px-4 py-3 font-body text-sm text-on-surface placeholder:text-outline transition-all focus:bg-surface-container-lowest focus:outline-none focus:ring-2 focus:ring-primary/30"
           />
         </section>
       ) : null}

--- a/frontend/src/features/settings/components/SettingsScreen.tsx
+++ b/frontend/src/features/settings/components/SettingsScreen.tsx
@@ -22,6 +22,8 @@ import { formatByteLimit } from "@/shared/lib/formatters";
 import { MAX_LOGO_SIZE_BYTES } from "@/shared/lib/inputLimits";
 import { parseTaxPercentInput, toTaxPercentDisplay } from "@/shared/lib/pricing";
 import type { ThemePreference } from "@/shared/lib/theme";
+import { NumericField } from "@/ui/NumericField";
+import { Select } from "@/ui/Select";
 
 const THEME_OPTIONS: ReadonlyArray<{ label: string; value: ThemePreference }> = [
   { label: "System default", value: "system" },
@@ -298,75 +300,56 @@ export function SettingsScreen(): React.ReactElement {
                   data-testid="settings-profile-meta-row"
                   className="grid grid-cols-1 gap-4 min-[360px]:grid-cols-2"
                 >
-                  <div className="flex flex-col gap-1">
-                    <label htmlFor="settings-trade-type" className="text-sm font-medium text-on-surface">
-                      Trade type
-                    </label>
-                    <select
-                      id="settings-trade-type"
-                      value={tradeType}
-                      onChange={(event) => setTradeType(event.target.value as TradeType)}
-                      className="w-full rounded-lg bg-surface-container-high px-4 py-3 font-body text-sm text-on-surface transition-all focus:bg-surface-container-lowest focus:outline-none focus:ring-2 focus:ring-primary/30"
-                    >
-                      {TRADE_TYPES.map((tradeTypeOption) => (
-                        <option key={tradeTypeOption} value={tradeTypeOption}>
-                          {tradeTypeOption}
-                        </option>
-                      ))}
-                    </select>
-                  </div>
-
-                  <div className="flex flex-col gap-1">
-                    <label htmlFor="settings-default-tax-rate" className="text-sm font-medium text-on-surface">
-                      Tax rate (%)
-                    </label>
-                    <input
-                      id="settings-default-tax-rate"
-                      type="number"
-                      step="0.01"
-                      value={defaultTaxRate}
-                      onChange={(event) => setDefaultTaxRate(event.target.value)}
-                      className="w-full rounded-lg bg-surface-container-high px-4 py-3 font-body text-sm text-on-surface transition-all focus:bg-surface-container-lowest focus:outline-none focus:ring-2 focus:ring-primary/30"
-                      placeholder="8.25"
-                    />
-                  </div>
-                </div>
-
-                <div className="flex flex-col gap-1">
-                  <label htmlFor="settings-timezone" className="text-sm font-medium text-on-surface">
-                    Timezone
-                  </label>
-                  <select
-                    id="settings-timezone"
-                    value={timezone}
-                    onChange={(event) => setTimezone(event.target.value)}
-                    className="w-full rounded-lg bg-surface-container-high px-4 py-3 font-body text-sm text-on-surface transition-all focus:bg-surface-container-lowest focus:outline-none focus:ring-2 focus:ring-primary/30"
+                  <Select
+                    id="settings-trade-type"
+                    label="Trade type"
+                    value={tradeType}
+                    onChange={(event) => setTradeType(event.target.value as TradeType)}
                   >
-                    {getTimezoneOptions(timezone).map((timezoneOption) => (
-                      <option key={timezoneOption} value={timezoneOption}>
-                        {timezoneOption}
+                    {TRADE_TYPES.map((tradeTypeOption) => (
+                      <option key={tradeTypeOption} value={tradeTypeOption}>
+                        {tradeTypeOption}
                       </option>
                     ))}
-                  </select>
+                  </Select>
+
+                  <NumericField
+                    id="settings-default-tax-rate"
+                    label="Tax rate (%)"
+                    step={0.01}
+                    value={defaultTaxRate}
+                    onChange={setDefaultTaxRate}
+                    placeholder="8.25"
+                    showStepControls={false}
+                    formatOnBlur={false}
+                  />
                 </div>
 
-                <div className="flex flex-col gap-1">
-                  <label htmlFor="settings-theme" className="text-sm font-medium text-on-surface">
-                    Theme
-                  </label>
-                  <select
-                    id="settings-theme"
-                    value={themePreference}
-                    onChange={(event) => setThemePreference(event.target.value as ThemePreference)}
-                    className="w-full rounded-lg bg-surface-container-high px-4 py-3 font-body text-sm text-on-surface transition-all focus:bg-surface-container-lowest focus:outline-none focus:ring-2 focus:ring-primary/30"
-                  >
-                    {THEME_OPTIONS.map((option) => (
-                      <option key={option.value} value={option.value}>
-                        {option.label}
-                      </option>
-                    ))}
-                  </select>
-                </div>
+                <Select
+                  id="settings-timezone"
+                  label="Timezone"
+                  value={timezone}
+                  onChange={(event) => setTimezone(event.target.value)}
+                >
+                  {getTimezoneOptions(timezone).map((timezoneOption) => (
+                    <option key={timezoneOption} value={timezoneOption}>
+                      {timezoneOption}
+                    </option>
+                  ))}
+                </Select>
+
+                <Select
+                  id="settings-theme"
+                  label="Theme"
+                  value={themePreference}
+                  onChange={(event) => setThemePreference(event.target.value as ThemePreference)}
+                >
+                  {THEME_OPTIONS.map((option) => (
+                    <option key={option.value} value={option.value}>
+                      {option.label}
+                    </option>
+                  ))}
+                </Select>
               </div>
             </section>
 

--- a/frontend/src/shared/components/Input.test.tsx
+++ b/frontend/src/shared/components/Input.test.tsx
@@ -9,7 +9,8 @@ describe("Input", () => {
 
     const input = screen.getByLabelText("Email");
     expect(input).toHaveAttribute("id", "email");
-    expect(input).toHaveClass("bg-surface-container-high", "focus:ring-primary/30");
+    expect(input).toHaveClass("bg-transparent");
+    expect(input.closest("div")).toHaveClass("rounded-[var(--radius-document)]");
   });
 
   it("renders input without label and id when omitted", () => {
@@ -40,5 +41,44 @@ describe("Input", () => {
     expect(input).toHaveClass("custom-input");
     expect(onChange).toHaveBeenCalled();
     expect(screen.getByText("Name is required")).toBeInTheDocument();
+    expect(input).toHaveAttribute("aria-invalid", "true");
+  });
+
+  it("renders hint text, adornments, and aria-describedby wiring", () => {
+    render(
+      <Input
+        id="amount"
+        label="Amount"
+        value="100"
+        onChange={vi.fn()}
+        hint="USD only"
+        startAdornment="$"
+        endAdornment="per hour"
+      />,
+    );
+
+    const input = screen.getByLabelText("Amount");
+    expect(input).toHaveAttribute("aria-describedby", "amount-hint");
+    expect(screen.getByText("USD only")).toHaveAttribute("id", "amount-hint");
+    expect(screen.getByText("$")).toBeInTheDocument();
+    expect(screen.getByText("per hour")).toBeInTheDocument();
+  });
+
+  it("supports invalid visuals without error text", () => {
+    render(
+      <Input
+        id="zip-code"
+        label="Zip code"
+        value="12"
+        onChange={vi.fn()}
+        hint="Use five digits"
+        invalid
+      />,
+    );
+
+    const input = screen.getByLabelText("Zip code");
+    expect(input).toHaveAttribute("aria-invalid", "true");
+    expect(screen.getByText("Zip code")).toHaveClass("text-error");
+    expect(screen.getByText("Use five digits")).toHaveClass("text-error");
   });
 });

--- a/frontend/src/shared/components/Input.tsx
+++ b/frontend/src/shared/components/Input.tsx
@@ -1,6 +1,6 @@
-import type { ChangeEvent } from "react";
+import { useId, type ChangeEvent, type FocusEvent, type ReactNode } from "react";
 
-interface InputProps {
+export interface InputProps {
   label?: string;
   id?: string;
   placeholder?: string;
@@ -8,11 +8,20 @@ interface InputProps {
   type?: string;
   autoComplete?: string;
   required?: boolean;
+  disabled?: boolean;
   hideLabel?: boolean;
   maxLength?: number;
   value: string;
   onChange: (event: ChangeEvent<HTMLInputElement>) => void;
   error?: string;
+  hint?: string;
+  startAdornment?: ReactNode;
+  endAdornment?: ReactNode;
+  invalid?: boolean;
+  size?: "sm" | "md";
+  inputMode?: "text" | "decimal" | "numeric" | "email" | "tel";
+  onBlur?: (event: FocusEvent<HTMLInputElement>) => void;
+  onFocus?: (event: FocusEvent<HTMLInputElement>) => void;
 }
 
 export function Input({
@@ -23,15 +32,40 @@ export function Input({
   type = "text",
   autoComplete,
   required = false,
+  disabled = false,
   hideLabel = false,
   maxLength,
   value,
   onChange,
   error,
+  hint,
+  startAdornment,
+  endAdornment,
+  invalid = false,
+  size = "md",
+  inputMode,
+  onBlur,
+  onFocus,
 }: InputProps): React.ReactElement {
+  const generatedId = useId();
+  const accessibilityBaseId = id ?? `input-${generatedId.replaceAll(":", "")}`;
+  const hintId = hint ? `${accessibilityBaseId}-hint` : undefined;
+  const errorId = error ? `${accessibilityBaseId}-error` : undefined;
+  const describedBy = [hintId, errorId].filter(Boolean).join(" ") || undefined;
+  const hasError = invalid || Boolean(error);
+
+  const fieldClassName = [
+    "flex items-center gap-2 rounded-[var(--radius-document)] bg-surface-container-high px-4 font-body text-sm text-on-surface transition-all",
+    "focus-within:bg-surface-container-lowest focus-within:ring-2 focus-within:ring-primary/30",
+    size === "md" ? "min-h-[var(--tap-target-min)] py-2" : "min-h-9 py-1.5",
+    hasError ? "border border-error" : "border border-transparent",
+    disabled ? "cursor-not-allowed opacity-70" : "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+
   const inputClassName = [
-    "w-full bg-surface-container-high rounded-lg px-4 py-3 font-body text-sm text-on-surface",
-    "placeholder:text-outline focus:outline-none focus:ring-2 focus:ring-primary/30 focus:bg-surface-container-lowest transition-all",
+    "w-full bg-transparent text-sm text-on-surface placeholder:text-outline focus:outline-none",
     className,
   ]
     .filter(Boolean)
@@ -42,24 +76,54 @@ export function Input({
       {label ? (
         <label
           htmlFor={id}
-          className={hideLabel ? "sr-only" : "text-sm font-medium text-on-surface"}
+          className={[
+            hideLabel ? "sr-only" : "text-sm font-medium",
+            hasError ? "text-error" : "text-on-surface",
+          ].join(" ")}
         >
           {label}
         </label>
       ) : null}
-      <input
-        id={id}
-        type={type}
-        autoComplete={autoComplete}
-        value={value}
-        onChange={onChange}
-        required={required}
-        aria-required={required}
-        maxLength={maxLength}
-        placeholder={placeholder}
-        className={inputClassName}
-      />
-      {error ? <p className="text-xs text-error">{error}</p> : null}
+      <div className={fieldClassName}>
+        {startAdornment ? (
+          <span className="flex shrink-0 items-center text-sm text-on-surface-variant">
+            {startAdornment}
+          </span>
+        ) : null}
+        <input
+          id={id}
+          type={type}
+          autoComplete={autoComplete}
+          value={value}
+          onChange={onChange}
+          required={required}
+          disabled={disabled}
+          aria-required={required}
+          aria-invalid={hasError}
+          aria-describedby={describedBy}
+          maxLength={maxLength}
+          placeholder={placeholder}
+          inputMode={inputMode}
+          onBlur={onBlur}
+          onFocus={onFocus}
+          className={inputClassName}
+        />
+        {endAdornment ? (
+          <span className="flex shrink-0 items-center text-sm text-on-surface-variant">
+            {endAdornment}
+          </span>
+        ) : null}
+      </div>
+      {hint ? (
+        <p id={hintId} className={hasError ? "text-xs text-error" : "text-xs text-on-surface-variant"}>
+          {hint}
+        </p>
+      ) : null}
+      {error ? (
+        <p id={errorId} className="text-xs text-error">
+          {error}
+        </p>
+      ) : null}
     </div>
   );
 }

--- a/frontend/src/ui/NumericField.test.tsx
+++ b/frontend/src/ui/NumericField.test.tsx
@@ -1,0 +1,43 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { NumericField } from "@/ui/NumericField";
+
+describe("NumericField", () => {
+  it("formats with locale separators on blur for money fields", () => {
+    const onChange = vi.fn();
+    render(
+      <NumericField
+        id="price"
+        label="Price"
+        value="1234.5"
+        onChange={onChange}
+        step={0.01}
+        currencySymbol="$"
+      />,
+    );
+
+    fireEvent.blur(screen.getByLabelText("Price"));
+
+    expect(onChange).toHaveBeenCalledWith("1,234.50");
+  });
+
+  it("supports step controls", () => {
+    const onChange = vi.fn();
+    render(
+      <NumericField
+        id="amount"
+        label="Amount"
+        value="10"
+        onChange={onChange}
+        step={0.5}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /increase value/i }));
+    fireEvent.click(screen.getByRole("button", { name: /decrease value/i }));
+
+    expect(onChange).toHaveBeenNthCalledWith(1, "10.5");
+    expect(onChange).toHaveBeenNthCalledWith(2, "9.5");
+  });
+});

--- a/frontend/src/ui/NumericField.tsx
+++ b/frontend/src/ui/NumericField.tsx
@@ -1,0 +1,127 @@
+import { Input, type InputProps } from "@/shared/components/Input";
+
+interface NumericFieldProps extends Omit<InputProps, "type" | "value" | "onChange" | "inputMode" | "startAdornment" | "endAdornment"> {
+  value: string;
+  onChange: (nextValue: string) => void;
+  step?: number;
+  min?: number;
+  max?: number;
+  locale?: string;
+  formatOnBlur?: boolean;
+  showStepControls?: boolean;
+  currencySymbol?: string;
+}
+
+function parseNumericValue(value: string): number | null {
+  const normalizedValue = value.replaceAll(",", "").trim();
+  if (normalizedValue.length === 0) {
+    return null;
+  }
+
+  const parsedValue = Number(normalizedValue);
+  if (!Number.isFinite(parsedValue)) {
+    return null;
+  }
+
+  return parsedValue;
+}
+
+function roundToStepPrecision(value: number, step: number): number {
+  const stepParts = step.toString().split(".");
+  const precision = stepParts[1]?.length ?? 0;
+  return Number(value.toFixed(precision));
+}
+
+function formatWithLocale(value: number, locale: string, step: number): string {
+  const stepParts = step.toString().split(".");
+  const precision = stepParts[1]?.length ?? 0;
+
+  return new Intl.NumberFormat(locale, {
+    minimumFractionDigits: precision,
+    maximumFractionDigits: precision,
+  }).format(value);
+}
+
+export function NumericField({
+  value,
+  onChange,
+  step = 0.01,
+  min,
+  max,
+  locale = "en-US",
+  formatOnBlur = true,
+  showStepControls = true,
+  currencySymbol,
+  ...props
+}: NumericFieldProps): React.ReactElement {
+  const applyStep = (direction: "up" | "down") => {
+    const currentValue = parseNumericValue(value) ?? 0;
+    const delta = direction === "up" ? step : -step;
+    let nextValue = roundToStepPrecision(currentValue + delta, step);
+
+    if (typeof min === "number") {
+      nextValue = Math.max(min, nextValue);
+    }
+    if (typeof max === "number") {
+      nextValue = Math.min(max, nextValue);
+    }
+
+    onChange(nextValue.toString());
+  };
+
+  return (
+    <Input
+      {...props}
+      type="text"
+      value={value}
+      onChange={(event) => onChange(event.target.value)}
+      onBlur={(event) => {
+        if (!formatOnBlur) {
+          props.onBlur?.(event);
+          return;
+        }
+
+        const parsedValue = parseNumericValue(value);
+        if (parsedValue === null) {
+          onChange("");
+          props.onBlur?.(event);
+          return;
+        }
+
+        onChange(formatWithLocale(parsedValue, locale, step));
+        props.onBlur?.(event);
+      }}
+      onFocus={(event) => {
+        if (formatOnBlur) {
+          const parsedValue = parseNumericValue(value);
+          if (parsedValue !== null) {
+            onChange(roundToStepPrecision(parsedValue, step).toString());
+          }
+        }
+        props.onFocus?.(event);
+      }}
+      inputMode="decimal"
+      startAdornment={currencySymbol ? <span aria-hidden="true">{currencySymbol}</span> : undefined}
+      endAdornment={showStepControls ? (
+        <div className="flex items-center gap-1">
+          <button
+            type="button"
+            aria-label="Decrease value"
+            className="flex h-6 w-6 items-center justify-center rounded-[var(--radius-document)] border border-outline-variant/40 text-xs text-on-surface-variant"
+            onClick={() => applyStep("down")}
+          >
+            -
+          </button>
+          <button
+            type="button"
+            aria-label="Increase value"
+            className="flex h-6 w-6 items-center justify-center rounded-[var(--radius-document)] border border-outline-variant/40 text-xs text-on-surface-variant"
+            onClick={() => applyStep("up")}
+          >
+            +
+          </button>
+        </div>
+      ) : undefined}
+    />
+  );
+}

--- a/frontend/src/ui/PasswordField.test.tsx
+++ b/frontend/src/ui/PasswordField.test.tsx
@@ -1,0 +1,31 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { PasswordField } from "@/ui/PasswordField";
+
+describe("PasswordField", () => {
+  it("toggles visibility and aria-pressed state", () => {
+    render(
+      <PasswordField
+        id="password"
+        label="Password"
+        value="secret"
+        onChange={vi.fn()}
+      />,
+    );
+
+    const input = screen.getByLabelText("Password");
+    const toggle = screen.getByRole("button", { name: /show password/i });
+
+    expect(input).toHaveAttribute("type", "password");
+    expect(toggle).toHaveAttribute("aria-pressed", "false");
+
+    fireEvent.click(toggle);
+
+    expect(input).toHaveAttribute("type", "text");
+    expect(screen.getByRole("button", { name: /hide password/i })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+  });
+});

--- a/frontend/src/ui/PasswordField.tsx
+++ b/frontend/src/ui/PasswordField.tsx
@@ -1,0 +1,36 @@
+import { useState } from "react";
+
+import { Input, type InputProps } from "@/shared/components/Input";
+
+interface PasswordFieldProps extends Omit<InputProps, "type" | "endAdornment"> {
+  showToggleLabel?: string;
+  hideToggleLabel?: string;
+}
+
+export function PasswordField({
+  showToggleLabel = "Show password",
+  hideToggleLabel = "Hide password",
+  autoComplete = "current-password",
+  ...props
+}: PasswordFieldProps): React.ReactElement {
+  const [isVisible, setIsVisible] = useState(false);
+
+  return (
+    <Input
+      {...props}
+      type={isVisible ? "text" : "password"}
+      autoComplete={autoComplete}
+      endAdornment={(
+        <button
+          type="button"
+          className="cursor-pointer text-xs font-semibold text-primary"
+          aria-label={isVisible ? hideToggleLabel : showToggleLabel}
+          aria-pressed={isVisible}
+          onClick={() => setIsVisible((visible) => !visible)}
+        >
+          {isVisible ? "Hide" : "Show"}
+        </button>
+      )}
+    />
+  );
+}

--- a/frontend/src/ui/Select.test.tsx
+++ b/frontend/src/ui/Select.test.tsx
@@ -1,0 +1,36 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { Select } from "@/ui/Select";
+
+describe("Select", () => {
+  it("renders label, hint, and selected value", () => {
+    render(
+      <Select id="theme" label="Theme" value="light" onChange={vi.fn()} hint="Choose your app theme">
+        <option value="light">Light</option>
+        <option value="dark">Dark</option>
+      </Select>,
+    );
+
+    const select = screen.getByLabelText("Theme");
+    expect(select).toHaveValue("light");
+    expect(select).toHaveAttribute("aria-describedby", "theme-hint");
+    expect(screen.getByText("Choose your app theme")).toHaveAttribute("id", "theme-hint");
+  });
+
+  it("supports invalid visuals and onChange", () => {
+    const onChange = vi.fn();
+    render(
+      <Select id="trade" label="Trade" value="builder" onChange={onChange} error="Required" invalid>
+        <option value="builder">Builder</option>
+        <option value="plumber">Plumber</option>
+      </Select>,
+    );
+
+    fireEvent.change(screen.getByLabelText("Trade"), { target: { value: "plumber" } });
+
+    expect(onChange).toHaveBeenCalled();
+    expect(screen.getByLabelText("Trade")).toHaveAttribute("aria-invalid", "true");
+    expect(screen.getByText("Required")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/ui/Select.tsx
+++ b/frontend/src/ui/Select.tsx
@@ -1,0 +1,100 @@
+import { useId, type ChangeEvent, type ReactNode } from "react";
+
+interface SelectProps {
+  label?: string;
+  id?: string;
+  value: string;
+  onChange: (event: ChangeEvent<HTMLSelectElement>) => void;
+  className?: string;
+  required?: boolean;
+  hideLabel?: boolean;
+  error?: string;
+  hint?: string;
+  invalid?: boolean;
+  size?: "sm" | "md";
+  children: ReactNode;
+}
+
+export function Select({
+  label,
+  id,
+  value,
+  onChange,
+  className,
+  required = false,
+  hideLabel = false,
+  error,
+  hint,
+  invalid = false,
+  size = "md",
+  children,
+}: SelectProps): React.ReactElement {
+  const generatedId = useId();
+  const accessibilityBaseId = id ?? `select-${generatedId.replaceAll(":", "")}`;
+  const hintId = hint ? `${accessibilityBaseId}-hint` : undefined;
+  const errorId = error ? `${accessibilityBaseId}-error` : undefined;
+  const describedBy = [hintId, errorId].filter(Boolean).join(" ") || undefined;
+  const hasError = invalid || Boolean(error);
+
+  const fieldClassName = [
+    "relative rounded-[var(--radius-document)] bg-surface-container-high px-4 font-body text-sm text-on-surface transition-all",
+    "focus-within:bg-surface-container-lowest focus-within:ring-2 focus-within:ring-primary/30",
+    size === "md" ? "min-h-[var(--tap-target-min)]" : "min-h-9",
+    hasError ? "border border-error" : "border border-transparent",
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  return (
+    <div className="flex flex-col gap-1">
+      {label ? (
+        <label
+          htmlFor={id}
+          className={[
+            hideLabel ? "sr-only" : "text-sm font-medium",
+            hasError ? "text-error" : "text-on-surface",
+          ].join(" ")}
+        >
+          {label}
+        </label>
+      ) : null}
+
+      <div className={fieldClassName}>
+        <select
+          id={id}
+          value={value}
+          onChange={onChange}
+          required={required}
+          aria-required={required}
+          aria-invalid={hasError}
+          aria-describedby={describedBy}
+          className={[
+            "h-full w-full appearance-none bg-transparent py-2 pr-6 text-sm text-on-surface outline-none",
+            className,
+          ]
+            .filter(Boolean)
+            .join(" ")}
+        >
+          {children}
+        </select>
+        <span
+          aria-hidden="true"
+          className="pointer-events-none absolute inset-y-0 right-3 flex items-center text-on-surface-variant"
+        >
+          ▾
+        </span>
+      </div>
+
+      {hint ? (
+        <p id={hintId} className={hasError ? "text-xs text-error" : "text-xs text-on-surface-variant"}>
+          {hint}
+        </p>
+      ) : null}
+      {error ? (
+        <p id={errorId} className="text-xs text-error">
+          {error}
+        </p>
+      ) : null}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- upgraded `Input` with additive slot API (`hint`, adornments, invalid state, input mode, size) and adoption-token styling (`--radius-document`, tap-target minimum)
- added shared wrappers `PasswordField`, `NumericField`, and `Select` under `frontend/src/ui` with matching label/hint/error slot shape
- migrated Task #505 call sites in auth, quotes, settings, and line-item catalog to use the shared primitives
- added wrapper tests and expanded `Input` tests for adornments, invalid state, and `aria-describedby` wiring

## Verification
- `cd frontend && npx vitest run src/shared/components/Input.test.tsx src/ui/ src/features/auth/tests/ src/features/settings/tests/ src/features/quotes/tests/LineItemRow.test.tsx --passWithNoTests`
- `cd frontend && npx tsc --noEmit`
- `cd frontend && npx eslint src/shared/components/Input.tsx src/ui/NumericField.tsx src/ui/Select.tsx src/ui/PasswordField.tsx src/features/auth/components/ src/features/quotes/components/LineItemRow.tsx src/features/quotes/components/ReviewFormContent.tsx src/features/settings/components/SettingsScreen.tsx src/features/line-item-catalog/components/LineItemCatalogSettingsScreen.tsx`
- `make frontend-verify`
- `cd frontend/src && rg -n "<input " features/` (no matches)

Closes #505