### PR TITLE
Task #506: add shared Sheet primitive and migrate quote sheets

### DIFF
--- a/frontend/src/features/quotes/components/CaptureDetailsSheet.tsx
+++ b/frontend/src/features/quotes/components/CaptureDetailsSheet.tsx
@@ -3,6 +3,7 @@ import * as Dialog from "@radix-ui/react-dialog";
 import type { ExtractionReviewHiddenDetails, HiddenItemState } from "@/features/quotes/types/quote.types";
 import { resolveCaptureDetailsActionableItems } from "@/features/quotes/utils/captureDetails";
 import { Button } from "@/shared/components/Button";
+import { Sheet, SheetBody, SheetCloseButton, SheetFooter, SheetHeader } from "@/ui/Sheet";
 
 interface CaptureDetailsSheetProps {
   open: boolean;
@@ -27,22 +28,26 @@ export function CaptureDetailsSheet({
     .filter((item) => !hiddenDetailState?.[item.id]?.dismissed);
 
   return (
-    <Dialog.Root open={open} onOpenChange={(nextOpen) => { if (!nextOpen) onClose(); }}>
-      <Dialog.Portal>
-        <Dialog.Overlay
-          data-testid="capture-details-sheet-overlay"
-          className="modal-backdrop fixed inset-0 z-50"
-        />
-        <div className="sheet-safe-bottom pointer-events-none fixed inset-0 z-50 flex items-end justify-center px-4 sm:items-center">
-          <Dialog.Content className="modal-shadow pointer-events-auto w-full max-w-2xl rounded-[1.75rem] border border-outline-variant/20 bg-surface-container-lowest p-6">
+    <Sheet
+      open={open}
+      onOpenChange={(nextOpen) => { if (!nextOpen) onClose(); }}
+      size="lg"
+      overlayProps={{ "data-testid": "capture-details-sheet-overlay" }}
+      contentProps={{ className: "bg-surface-container-lowest" }}
+    >
+      <SheetHeader>
+        <div>
             <Dialog.Title className="font-headline text-xl font-bold tracking-tight text-on-surface">
               Capture Details
             </Dialog.Title>
             <Dialog.Description className="mt-2 text-sm leading-6 text-on-surface-variant">
               Secondary capture output for review. Main review inputs stay focused on line items, notes, and pricing.
             </Dialog.Description>
+        </div>
+        <SheetCloseButton />
+      </SheetHeader>
 
-            <div className="mt-4 max-h-[70vh] space-y-5 overflow-y-auto pr-1">
+      <SheetBody className="max-h-[70vh] space-y-5 overflow-y-auto pr-1">
               <section className="space-y-2">
                 <h3 className="text-[0.6875rem] font-bold uppercase tracking-widest text-outline">
                   Actionable Capture Details
@@ -84,21 +89,18 @@ export function CaptureDetailsSheet({
                   {transcript.trim().length > 0 ? transcript : "No transcript notes captured."}
                 </div>
               </section>
-            </div>
+      </SheetBody>
 
-            <div className="mt-6">
-              <Button
-                type="button"
-                variant="secondary"
-                className="w-full rounded-lg border border-outline-variant/30 py-3"
-                onClick={onClose}
-              >
-                Close
-              </Button>
-            </div>
-          </Dialog.Content>
-        </div>
-      </Dialog.Portal>
-    </Dialog.Root>
+      <SheetFooter>
+        <Button
+          type="button"
+          variant="secondary"
+          className="w-full rounded-lg border border-outline-variant/30 py-3"
+          onClick={onClose}
+        >
+          Close
+        </Button>
+      </SheetFooter>
+    </Sheet>
   );
 }

--- a/frontend/src/features/quotes/components/LineItemEditSheet.tsx
+++ b/frontend/src/features/quotes/components/LineItemEditSheet.tsx
@@ -10,6 +10,7 @@ import {
   LINE_ITEM_DESCRIPTION_MAX_CHARS,
   LINE_ITEM_DETAILS_MAX_CHARS,
 } from "@/shared/lib/inputLimits";
+import { Sheet } from "@/ui/Sheet";
 interface LineItemEditSheetProps {
   open: boolean;
   mode: "add" | "edit";
@@ -205,30 +206,26 @@ export function LineItemEditSheet({
     onClose();
   }
   return (
-    <Dialog.Root
+    <Sheet
       open={open}
       onOpenChange={(nextOpen) => {
         if (!nextOpen) {
           dismissWithAutosave();
         }
       }}
+      size="md"
+      overlayProps={{ "data-testid": "line-item-edit-sheet-overlay" }}
+      contentProps={{
+        "aria-describedby": showManualFields ? undefined : "line-item-sheet-catalog-description",
+        className: "bg-surface-container-lowest",
+        onOpenAutoFocus: (event) => {
+          event.preventDefault();
+          if (showManualFields) {
+            descriptionInputRef.current?.focus();
+          }
+        },
+      }}
     >
-      <Dialog.Portal>
-        <Dialog.Overlay
-          data-testid="line-item-edit-sheet-overlay"
-          className="modal-backdrop fixed inset-0 z-50"
-        />
-        <div className="sheet-safe-bottom pointer-events-none fixed inset-0 z-50 flex items-end justify-center px-4 sm:items-center">
-          <Dialog.Content
-            className="modal-shadow pointer-events-auto w-full max-w-md rounded-[1.75rem] border border-outline-variant/20 bg-surface-container-lowest p-6"
-            aria-describedby={showManualFields ? undefined : "line-item-sheet-catalog-description"}
-            onOpenAutoFocus={(event) => {
-              event.preventDefault();
-              if (showManualFields) {
-                descriptionInputRef.current?.focus();
-              }
-            }}
-          >
             <div className="flex items-start justify-between gap-4">
               <Dialog.Title className="font-headline text-xl font-bold tracking-tight text-on-surface">
                 {title}
@@ -442,9 +439,6 @@ export function LineItemEditSheet({
                 />
               )}
             </div>
-          </Dialog.Content>
-        </div>
-      </Dialog.Portal>
-    </Dialog.Root>
+    </Sheet>
   );
 }

--- a/frontend/src/features/quotes/components/QuoteCreateEntrySheet.tsx
+++ b/frontend/src/features/quotes/components/QuoteCreateEntrySheet.tsx
@@ -1,5 +1,6 @@
 import * as Dialog from "@radix-ui/react-dialog";
 import { Button } from "@/shared/components/Button";
+import { Sheet, SheetBody, SheetCloseButton, SheetHeader } from "@/ui/Sheet";
 
 interface QuoteCreateEntrySheetProps {
   open: boolean;
@@ -19,41 +20,46 @@ export function QuoteCreateEntrySheet({
   description = "Start fresh or duplicate from an existing quote.",
 }: QuoteCreateEntrySheetProps): React.ReactElement {
   return (
-    <Dialog.Root open={open} onOpenChange={(nextOpen) => { if (!nextOpen) onClose(); }}>
-      <Dialog.Portal>
-        <Dialog.Overlay className="modal-backdrop fixed inset-0 z-50" />
-        <div className="sheet-safe-bottom pointer-events-none fixed inset-0 z-50 flex items-end justify-center px-4 sm:items-center">
-          <Dialog.Content className="modal-shadow pointer-events-auto w-full max-w-md rounded-[1.75rem] border border-outline-variant/20 bg-surface-container-lowest p-6">
-            <Dialog.Title className="font-headline text-xl font-bold tracking-tight text-on-surface">
-              {title}
-            </Dialog.Title>
-            <Dialog.Description className="mt-2 text-sm leading-6 text-on-surface-variant">
-              {description}
-            </Dialog.Description>
-
-            <div className="mt-6 space-y-3">
-              <Button
-                type="button"
-                variant="primary"
-                size="md"
-                className="w-full"
-                onClick={onCreateNew}
-              >
-                Create new
-              </Button>
-              <Button
-                type="button"
-                variant="secondary"
-                size="md"
-                className="w-full"
-                onClick={onCreateFromExisting}
-              >
-                Create from existing
-              </Button>
-            </div>
-          </Dialog.Content>
+    <Sheet
+      open={open}
+      onOpenChange={(nextOpen) => { if (!nextOpen) onClose(); }}
+      size="md"
+      contentProps={{ className: "bg-surface-container-lowest" }}
+    >
+      <SheetHeader>
+        <div>
+          <Dialog.Title className="font-headline text-xl font-bold tracking-tight text-on-surface">
+            {title}
+          </Dialog.Title>
+          <Dialog.Description className="mt-2 text-sm leading-6 text-on-surface-variant">
+            {description}
+          </Dialog.Description>
         </div>
-      </Dialog.Portal>
-    </Dialog.Root>
+        <SheetCloseButton />
+      </SheetHeader>
+
+      <SheetBody>
+        <div className="mt-2 space-y-3">
+          <Button
+            type="button"
+            variant="primary"
+            size="md"
+            className="w-full"
+            onClick={onCreateNew}
+          >
+            Create new
+          </Button>
+          <Button
+            type="button"
+            variant="secondary"
+            size="md"
+            className="w-full"
+            onClick={onCreateFromExisting}
+          >
+            Create from existing
+          </Button>
+        </div>
+      </SheetBody>
+    </Sheet>
   );
 }

--- a/frontend/src/features/quotes/components/QuoteReuseChooser.tsx
+++ b/frontend/src/features/quotes/components/QuoteReuseChooser.tsx
@@ -7,6 +7,7 @@ import { Button } from "@/shared/components/Button";
 import { FeedbackMessage } from "@/shared/components/FeedbackMessage";
 import { Input } from "@/shared/components/Input";
 import { StatusPill } from "@/ui/StatusPill";
+import { Sheet, SheetBody, SheetCloseButton, SheetFooter, SheetHeader } from "@/ui/Sheet";
 import { formatCurrency, formatDate } from "@/shared/lib/formatters";
 
 interface QuoteReuseChooserProps {
@@ -146,19 +147,26 @@ export function QuoteReuseChooser({
   }
 
   return (
-    <Dialog.Root open={open} onOpenChange={(nextOpen) => { if (!nextOpen) onClose(); }}>
-      <Dialog.Portal>
-        <Dialog.Overlay className="modal-backdrop fixed inset-0 z-50" />
-        <div className="sheet-safe-bottom pointer-events-none fixed inset-0 z-50 flex items-end justify-center px-4 sm:items-center">
-          <Dialog.Content className="modal-shadow pointer-events-auto w-full max-w-2xl rounded-[1.75rem] border border-outline-variant/20 bg-surface-container-lowest p-6">
+    <Sheet
+      open={open}
+      onOpenChange={(nextOpen) => { if (!nextOpen) onClose(); }}
+      size="lg"
+      contentProps={{ className: "bg-surface-container-lowest" }}
+    >
+      <SheetHeader>
+        <div>
             <Dialog.Title className="font-headline text-xl font-bold tracking-tight text-on-surface">
               Create from existing
             </Dialog.Title>
             <Dialog.Description className="mt-2 text-sm leading-6 text-on-surface-variant">
               Pick a quote to duplicate into a new draft.
             </Dialog.Description>
+        </div>
+        <SheetCloseButton />
+      </SheetHeader>
 
-            <div className="mt-4">
+      <SheetBody>
+        <div>
               <Input
                 label="Search existing quotes"
                 id="quote-reuse-search"
@@ -278,22 +286,20 @@ export function QuoteReuseChooser({
                   ))}
                 </ul>
               ) : null}
-            </div>
-
-            <div className="mt-6">
-              <Button
-                type="button"
-                variant="secondary"
-                size="md"
-                className="w-full"
-                onClick={onClose}
-              >
-                Close
-              </Button>
-            </div>
-          </Dialog.Content>
         </div>
-      </Dialog.Portal>
-    </Dialog.Root>
+      </SheetBody>
+
+      <SheetFooter>
+        <Button
+          type="button"
+          variant="secondary"
+          size="md"
+          className="w-full"
+          onClick={onClose}
+        >
+          Close
+        </Button>
+      </SheetFooter>
+    </Sheet>
   );
 }

--- a/frontend/src/features/quotes/components/ReviewCustomerAssignmentSheet.tsx
+++ b/frontend/src/features/quotes/components/ReviewCustomerAssignmentSheet.tsx
@@ -6,6 +6,7 @@ import type { Customer, CustomerCreateRequest } from "@/features/customers/types
 import { Button } from "@/shared/components/Button";
 import { FeedbackMessage } from "@/shared/components/FeedbackMessage";
 import { Input } from "@/shared/components/Input";
+import { Sheet, SheetBody, SheetCloseButton, SheetHeader } from "@/ui/Sheet";
 
 interface ReviewCustomerAssignmentSheetProps {
   open: boolean;
@@ -137,14 +138,17 @@ export function ReviewCustomerAssignmentSheet({
   }
 
   return (
-    <Dialog.Root open={open} onOpenChange={(nextOpen) => { if (!nextOpen) onClose(); }}>
-      <Dialog.Portal>
-        <Dialog.Overlay className="modal-backdrop fixed inset-0 z-50" />
-        <div className="sheet-safe-bottom fixed inset-0 z-50 flex items-end justify-center px-4 sm:items-center">
-          <Dialog.Content
-            className="modal-shadow w-full max-w-md rounded-[1.75rem] border border-outline-variant/20 bg-surface-container-lowest p-6"
-            onOpenAutoFocus={(event) => event.preventDefault()}
-          >
+    <Sheet
+      open={open}
+      onOpenChange={(nextOpen) => { if (!nextOpen) onClose(); }}
+      size="md"
+      contentProps={{
+        className: "bg-surface-container-lowest",
+        onOpenAutoFocus: (event) => event.preventDefault(),
+      }}
+    >
+      <SheetHeader>
+        <div>
             <Dialog.Title className="font-headline text-xl font-bold tracking-tight text-on-surface">
               Assign Customer
             </Dialog.Title>
@@ -152,8 +156,11 @@ export function ReviewCustomerAssignmentSheet({
             <Dialog.Description className="mt-2 text-sm leading-6 text-on-surface-variant">
               Search existing customers or create one inline, then apply the assignment.
             </Dialog.Description>
+        </div>
+        <SheetCloseButton />
+      </SheetHeader>
 
-            <div className="mt-4 space-y-4">
+      <SheetBody className="space-y-4">
               {sheetError ? <FeedbackMessage variant="error">{sheetError}</FeedbackMessage> : null}
 
               <Input
@@ -244,10 +251,7 @@ export function ReviewCustomerAssignmentSheet({
                   </div>
                 ) : null}
               </div>
-            </div>
-          </Dialog.Content>
-        </div>
-      </Dialog.Portal>
-    </Dialog.Root>
+      </SheetBody>
+    </Sheet>
   );
 }

--- a/frontend/src/shared/components/ConfirmModal.test.tsx
+++ b/frontend/src/shared/components/ConfirmModal.test.tsx
@@ -123,7 +123,7 @@ describe("ConfirmModal", () => {
 
     expect(screen.getByTestId("confirm-modal-overlay")).toHaveClass("modal-backdrop");
     expect(screen.getByRole("dialog", { name: "Leave this screen?" })).toHaveClass(
-      "modal-shadow",
+      "ghost-shadow",
       "bg-surface-container-lowest",
       "border-outline-variant/20",
     );

--- a/frontend/src/shared/components/ConfirmModal.tsx
+++ b/frontend/src/shared/components/ConfirmModal.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from "react";
 import { useRef } from "react";
 import * as Dialog from "@radix-ui/react-dialog";
 import { Button } from "@/shared/components/Button";
+import { Sheet } from "@/ui/Sheet";
 
 interface ConfirmModalProps {
   title: string;
@@ -49,57 +50,50 @@ export function ConfirmModal({
   }
 
   return (
-    <Dialog.Root
+    <Sheet
       open
       onOpenChange={(open) => {
         if (!open) handleCancel();
       }}
+      size="md"
+      overlayProps={{ "data-testid": "confirm-modal-overlay" }}
+      contentProps={{
+        ...(!body ? { "aria-describedby": undefined } : {}),
+        className: "bg-surface-container-lowest",
+        onOpenAutoFocus: (event) => {
+          event.preventDefault();
+          cancelButtonRef.current?.focus();
+        },
+      }}
     >
-      <Dialog.Portal>
-        <Dialog.Overlay
-          data-testid="confirm-modal-overlay"
-          className="modal-backdrop fixed inset-0 z-50"
-        />
-        <div className="sheet-safe-bottom pointer-events-none fixed inset-0 z-50 flex items-end justify-center px-4 sm:items-center">
-          <Dialog.Content
-            {...(!body ? { "aria-describedby": undefined } : {})}
-            className="modal-shadow pointer-events-auto w-full max-w-md rounded-[1.75rem] border border-outline-variant/20 bg-surface-container-lowest p-6"
-            onOpenAutoFocus={(event) => {
-              event.preventDefault();
-              cancelButtonRef.current?.focus();
-            }}
-          >
-            <Dialog.Title className="font-headline text-xl font-bold tracking-tight text-on-surface">{title}</Dialog.Title>
-            {body ? (
-              <Dialog.Description className="mt-2 break-words text-sm leading-6 text-on-surface-variant">
-                {body}
-              </Dialog.Description>
-            ) : null}
-            <div className="mt-6 flex flex-col gap-3 sm:flex-row-reverse">
-              <Button
-                type="button"
-                variant={variant}
-                size="md"
-                className="flex-1"
-                onClick={handleConfirm}
-                disabled={confirmDisabled || undefined}
-              >
-                {confirmLabel}
-              </Button>
-              <Button
-                type="button"
-                ref={cancelButtonRef}
-                variant="secondary"
-                size="md"
-                className="flex-1"
-                onClick={handleCancel}
-              >
-                {cancelLabel}
-              </Button>
-            </div>
-          </Dialog.Content>
-        </div>
-      </Dialog.Portal>
-    </Dialog.Root>
+      <Dialog.Title className="font-headline text-xl font-bold tracking-tight text-on-surface">{title}</Dialog.Title>
+      {body ? (
+        <Dialog.Description asChild>
+          <div className="mt-2 break-words text-sm leading-6 text-on-surface-variant">{body}</div>
+        </Dialog.Description>
+      ) : null}
+      <div className="mt-6 flex flex-col gap-3 sm:flex-row-reverse">
+        <Button
+          type="button"
+          variant={variant}
+          size="md"
+          className="flex-1"
+          onClick={handleConfirm}
+          disabled={confirmDisabled || undefined}
+        >
+          {confirmLabel}
+        </Button>
+        <Button
+          type="button"
+          ref={cancelButtonRef}
+          variant="secondary"
+          size="md"
+          className="flex-1"
+          onClick={handleCancel}
+        >
+          {cancelLabel}
+        </Button>
+      </div>
+    </Sheet>
   );
 }

--- a/frontend/src/ui/Sheet.test.tsx
+++ b/frontend/src/ui/Sheet.test.tsx
@@ -1,0 +1,90 @@
+import { useRef, useState } from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it } from "vitest";
+import * as Dialog from "@radix-ui/react-dialog";
+
+import { Sheet, SheetBody, SheetCloseButton, SheetFooter, SheetHeader } from "@/ui/Sheet";
+
+function Harness(): React.ReactElement {
+  const [open, setOpen] = useState(false);
+  const firstActionRef = useRef<HTMLButtonElement>(null);
+
+  return (
+    <>
+      <button type="button" onClick={() => setOpen(true)}>
+        Open sheet
+      </button>
+      <Sheet
+        open={open}
+        onOpenChange={setOpen}
+        size="md"
+        overlayProps={{ "data-testid": "sheet-overlay" }}
+        contentProps={{
+          onOpenAutoFocus: (event) => {
+            event.preventDefault();
+            firstActionRef.current?.focus();
+          },
+        }}
+      >
+        <SheetHeader>
+          <div>
+            <Dialog.Title className="font-headline text-xl font-bold tracking-tight text-on-surface">
+              Test sheet
+            </Dialog.Title>
+            <Dialog.Description className="mt-2 text-sm text-on-surface-variant">
+              Sheet description
+            </Dialog.Description>
+          </div>
+          <SheetCloseButton />
+        </SheetHeader>
+        <SheetBody>
+          <button ref={firstActionRef} type="button">
+            First action
+          </button>
+          <button type="button">Second action</button>
+        </SheetBody>
+        <SheetFooter>
+          <button type="button">Footer action</button>
+        </SheetFooter>
+      </Sheet>
+    </>
+  );
+}
+
+describe("Sheet", () => {
+  it("renders dialog content when open and dismisses via overlay", async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+
+    await user.click(screen.getByRole("button", { name: "Open sheet" }));
+    expect(screen.getByRole("dialog", { name: "Test sheet" })).toBeInTheDocument();
+
+    await user.click(screen.getByTestId("sheet-overlay"));
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog", { name: "Test sheet" })).not.toBeInTheDocument();
+    });
+  });
+
+  it("traps focus while open and restores focus to opener on escape", async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+
+    const openButton = screen.getByRole("button", { name: "Open sheet" });
+    await user.click(openButton);
+
+    expect(screen.getByRole("button", { name: "First action" })).toHaveFocus();
+
+    await user.tab();
+    await user.tab();
+    await user.tab();
+    await user.tab();
+
+    expect(openButton).not.toHaveFocus();
+
+    await user.keyboard("{Escape}");
+    await waitFor(() => {
+      expect(openButton).toHaveFocus();
+    });
+  });
+});

--- a/frontend/src/ui/Sheet.tsx
+++ b/frontend/src/ui/Sheet.tsx
@@ -1,0 +1,142 @@
+import { useEffect, useRef } from "react";
+import type { ReactNode } from "react";
+import * as Dialog from "@radix-ui/react-dialog";
+
+import { Button } from "@/shared/components/Button";
+
+type SheetSize = "sm" | "md" | "lg" | "full";
+type DataAttributes = { [key in `data-${string}`]?: string | number | boolean | undefined };
+
+interface SheetProps extends Omit<Dialog.DialogProps, "children"> {
+  children: ReactNode;
+  size?: SheetSize;
+  overlayProps?: Omit<React.ComponentPropsWithoutRef<typeof Dialog.Overlay>, "className">
+    & { className?: string }
+    & DataAttributes;
+  contentProps?: Omit<React.ComponentPropsWithoutRef<typeof Dialog.Content>, "className" | "children"> & { className?: string };
+  containerClassName?: string;
+}
+
+interface SheetRegionProps {
+  children: ReactNode;
+  className?: string;
+}
+
+interface SheetCloseButtonProps {
+  className?: string;
+  label?: string;
+}
+
+const sheetSizeClasses: Record<SheetSize, string> = {
+  sm: "max-w-sm max-h-[70vh]",
+  md: "max-w-md max-h-[85vh]",
+  lg: "max-w-2xl max-h-[85vh]",
+  full: "h-[100dvh] max-w-none rounded-none md:max-w-4xl md:rounded-[var(--radius-document)]",
+};
+
+function joinClasses(...values: Array<string | null | undefined | false>): string {
+  return values.filter(Boolean).join(" ");
+}
+
+export function Sheet({
+  children,
+  size = "md",
+  overlayProps,
+  contentProps,
+  containerClassName,
+  ...dialogProps
+}: SheetProps): React.ReactElement {
+  const restoreFocusTargetRef = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    if (
+      dialogProps.open
+      && typeof document !== "undefined"
+      && document.activeElement instanceof HTMLElement
+    ) {
+      restoreFocusTargetRef.current = document.activeElement;
+    }
+  }, [dialogProps.open]);
+
+  const overlayClassName = joinClasses(
+    "modal-backdrop fixed inset-0 z-50",
+    overlayProps?.className,
+  );
+  const containerClass = joinClasses(
+    "sheet-safe-bottom pointer-events-none fixed inset-0 z-50 flex items-end justify-center px-4 md:items-center",
+    containerClassName,
+  );
+  const contentClassName = joinClasses(
+    "modal-shadow pointer-events-auto w-full border border-outline-variant/20 glass-surface ghost-shadow backdrop-blur-md rounded-[var(--radius-document)] p-6 pb-[max(env(safe-area-inset-bottom),1.25rem)] outline-none md:pb-6",
+    sheetSizeClasses[size],
+    contentProps?.className,
+  );
+  const onCloseAutoFocus: Dialog.DialogContentProps["onCloseAutoFocus"] = (event) => {
+    contentProps?.onCloseAutoFocus?.(event);
+    if (event.defaultPrevented) {
+      return;
+    }
+    if (restoreFocusTargetRef.current?.isConnected) {
+      event.preventDefault();
+      restoreFocusTargetRef.current.focus();
+    }
+  };
+
+  return (
+    <Dialog.Root {...dialogProps}>
+      <Dialog.Portal>
+        <Dialog.Overlay
+          {...overlayProps}
+          className={overlayClassName}
+        />
+        <div className={containerClass}>
+          <Dialog.Content
+            {...contentProps}
+            className={contentClassName}
+            onCloseAutoFocus={onCloseAutoFocus}
+          >
+            {children}
+          </Dialog.Content>
+        </div>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}
+
+export function SheetHeader({ children, className }: SheetRegionProps): React.ReactElement {
+  return (
+    <div className={joinClasses("flex items-start justify-between gap-4", className)}>
+      {children}
+    </div>
+  );
+}
+
+export function SheetBody({ children, className }: SheetRegionProps): React.ReactElement {
+  return <div className={joinClasses("mt-4", className)}>{children}</div>;
+}
+
+export function SheetFooter({ children, className }: SheetRegionProps): React.ReactElement {
+  return <div className={joinClasses("mt-6", className)}>{children}</div>;
+}
+
+export function SheetCloseButton({
+  className,
+  label = "Close",
+}: SheetCloseButtonProps): React.ReactElement {
+  return (
+    <Dialog.Close asChild>
+      <Button
+        type="button"
+        variant="iconButton"
+        size="xs"
+        aria-label={label}
+        className={joinClasses(
+          "shrink-0 border border-outline-variant/30 bg-surface-container-lowest text-on-surface-variant hover:bg-surface-container-low",
+          className,
+        )}
+      >
+        <span className="material-symbols-outlined text-base leading-none">close</span>
+      </Button>
+    </Dialog.Close>
+  );
+}

--- a/frontend/src/ui/Sheet.tsx
+++ b/frontend/src/ui/Sheet.tsx
@@ -63,11 +63,11 @@ export function Sheet({
     overlayProps?.className,
   );
   const containerClass = joinClasses(
-    "sheet-safe-bottom pointer-events-none fixed inset-0 z-50 flex items-end justify-center px-4 md:items-center",
+    "pointer-events-none fixed inset-0 z-50 flex items-end justify-center px-4 md:items-center",
     containerClassName,
   );
   const contentClassName = joinClasses(
-    "modal-shadow pointer-events-auto w-full border border-outline-variant/20 glass-surface ghost-shadow backdrop-blur-md rounded-[var(--radius-document)] p-6 pb-[max(env(safe-area-inset-bottom),1.25rem)] outline-none md:pb-6",
+    "pointer-events-auto w-full border border-outline-variant/20 glass-surface ghost-shadow backdrop-blur-md rounded-[var(--radius-document)] p-6 pb-[max(env(safe-area-inset-bottom),1.25rem)] outline-none md:pb-6",
     sheetSizeClasses[size],
     contentProps?.className,
   );


### PR DESCRIPTION
## Summary
- add a shared `Sheet` primitive in `frontend/src/ui/Sheet.tsx` with standardized sheet shell behavior (glass chrome, document radius, safe-area bottom padding, close affordance support, size variants)
- add `frontend/src/ui/Sheet.test.tsx` covering open/close, focus trap, and escape dismissal behavior
- migrate Task #506 targets from per-file Radix `Dialog.Root` wrappers to the shared `Sheet` shell while preserving existing copy and close handlers:
  - `ConfirmModal`
  - `CaptureDetailsSheet`
  - `QuoteCreateEntrySheet`
  - `QuoteReuseChooser`
  - `ReviewCustomerAssignmentSheet`
  - `LineItemEditSheet`

## Verification
- `cd frontend && npx vitest run src/ui/Sheet.test.tsx src/features/quotes/tests/CaptureDetailsSheet.test.tsx src/features/quotes/tests/QuoteReuseChooser.test.tsx src/features/quotes/tests/ReviewCustomerAssignmentSheet.test.tsx src/features/quotes/tests/LineItemEditSheet.test.tsx --passWithNoTests`
- `cd frontend && npx tsc --noEmit`
- `cd frontend && npx eslint src/ui/Sheet.tsx src/shared/components/ConfirmModal.tsx src/features/quotes/components/CaptureDetailsSheet.tsx src/features/quotes/components/QuoteCreateEntrySheet.tsx src/features/quotes/components/QuoteReuseChooser.tsx src/features/quotes/components/ReviewCustomerAssignmentSheet.tsx src/features/quotes/components/LineItemEditSheet.tsx src/ui/Sheet.test.tsx`
- `make frontend-verify`

Closes #506