### PR TITLE
PR-C: Adopt onboarding and auth shell radius tokens

### DIFF
--- a/frontend/src/features/auth/components/ForgotPasswordPage.tsx
+++ b/frontend/src/features/auth/components/ForgotPasswordPage.tsx
@@ -40,7 +40,7 @@ export function ForgotPasswordPage(): React.ReactElement {
   return (
     <main className="screen-radial-backdrop flex min-h-screen flex-col items-center justify-center px-4 py-8">
       <h1 className="mb-8 font-headline text-3xl font-bold text-primary">Stima</h1>
-      <section className="w-full max-w-sm rounded-xl bg-surface-container-lowest p-6 ghost-shadow">
+      <section className="w-full max-w-sm rounded-[var(--radius-document)] bg-surface-container-lowest p-6 ghost-shadow">
         <h2 className="mb-2 font-headline text-2xl font-bold text-on-surface">Forgot password?</h2>
         <p className="mb-6 text-sm text-on-surface-variant">
           Enter your email and we&apos;ll send a reset link if your account exists.
@@ -57,7 +57,10 @@ export function ForgotPasswordPage(): React.ReactElement {
           />
 
           {error ? (
-            <div role="alert" className="rounded-lg border-l-4 border-error bg-error-container p-4">
+            <div
+              role="alert"
+              className="rounded-[var(--radius-document)] border-l-4 border-error bg-error-container p-4"
+            >
               <p className="text-sm font-medium text-error">{error}</p>
             </div>
           ) : null}

--- a/frontend/src/features/auth/components/LoginForm.tsx
+++ b/frontend/src/features/auth/components/LoginForm.tsx
@@ -54,7 +54,7 @@ export function LoginForm(): React.ReactElement {
   return (
     <main className="screen-radial-backdrop flex min-h-screen flex-col items-center justify-center px-4 py-8">
       <h1 className="mb-8 font-headline text-3xl font-bold text-primary">Stima</h1>
-      <section className="w-full max-w-sm rounded-xl bg-surface-container-lowest p-6 ghost-shadow">
+      <section className="w-full max-w-sm rounded-[var(--radius-document)] bg-surface-container-lowest p-6 ghost-shadow">
         <h2 className="mb-6 font-headline text-2xl font-bold text-on-surface">Welcome Back</h2>
         <form className="flex flex-col gap-4" onSubmit={onSubmit}>
           <Input
@@ -81,7 +81,10 @@ export function LoginForm(): React.ReactElement {
           </p>
 
           {error ? (
-            <div role="alert" className="rounded-lg border-l-4 border-error bg-error-container p-4">
+            <div
+              role="alert"
+              className="rounded-[var(--radius-document)] border-l-4 border-error bg-error-container p-4"
+            >
               <p className="text-sm font-medium text-error">{error}</p>
             </div>
           ) : null}

--- a/frontend/src/features/auth/components/RegisterForm.tsx
+++ b/frontend/src/features/auth/components/RegisterForm.tsx
@@ -39,7 +39,7 @@ export function RegisterForm(): React.ReactElement {
   return (
     <main className="screen-radial-backdrop flex min-h-screen flex-col items-center justify-center px-4 py-8">
       <h1 className="mb-8 font-headline text-3xl font-bold text-primary">Stima</h1>
-      <section className="w-full max-w-sm rounded-xl bg-surface-container-lowest p-6 ghost-shadow">
+      <section className="w-full max-w-sm rounded-[var(--radius-document)] bg-surface-container-lowest p-6 ghost-shadow">
         <h2 className="mb-6 font-headline text-2xl font-bold text-on-surface">Create your account</h2>
         <form className="flex flex-col gap-4" onSubmit={onSubmit}>
           <Input
@@ -72,7 +72,10 @@ export function RegisterForm(): React.ReactElement {
           />
 
           {error ? (
-            <div role="alert" className="rounded-lg border-l-4 border-error bg-error-container p-4">
+            <div
+              role="alert"
+              className="rounded-[var(--radius-document)] border-l-4 border-error bg-error-container p-4"
+            >
               <p className="text-sm font-medium text-error">{error}</p>
             </div>
           ) : null}

--- a/frontend/src/features/auth/components/ResetPasswordPage.tsx
+++ b/frontend/src/features/auth/components/ResetPasswordPage.tsx
@@ -71,12 +71,15 @@ export function ResetPasswordPage(): React.ReactElement {
   return (
     <main className="screen-radial-backdrop flex min-h-screen flex-col items-center justify-center px-4 py-8">
       <h1 className="mb-8 font-headline text-3xl font-bold text-primary">Stima</h1>
-      <section className="w-full max-w-sm rounded-xl bg-surface-container-lowest p-6 ghost-shadow">
+      <section className="w-full max-w-sm rounded-[var(--radius-document)] bg-surface-container-lowest p-6 ghost-shadow">
         <h2 className="mb-6 font-headline text-2xl font-bold text-on-surface">Reset password</h2>
 
         {shouldShowBadTokenState ? (
           <div className="space-y-4">
-            <div role="alert" className="rounded-lg border-l-4 border-error bg-error-container p-4">
+            <div
+              role="alert"
+              className="rounded-[var(--radius-document)] border-l-4 border-error bg-error-container p-4"
+            >
               <p className="text-sm font-medium text-error">{BAD_TOKEN_MESSAGE}</p>
             </div>
             <p className="text-sm text-on-surface-variant">
@@ -107,7 +110,10 @@ export function ResetPasswordPage(): React.ReactElement {
             />
 
             {error ? (
-              <div role="alert" className="rounded-lg border-l-4 border-error bg-error-container p-4">
+              <div
+                role="alert"
+                className="rounded-[var(--radius-document)] border-l-4 border-error bg-error-container p-4"
+              >
                 <p className="text-sm font-medium text-error">{error}</p>
               </div>
             ) : null}

--- a/frontend/src/features/profile/components/OnboardingForm.tsx
+++ b/frontend/src/features/profile/components/OnboardingForm.tsx
@@ -49,13 +49,16 @@ export function OnboardingForm(): React.ReactElement {
   return (
     <main className="screen-radial-backdrop flex min-h-screen flex-col items-center justify-center px-4 py-8">
       <h1 className="mb-8 font-headline text-3xl font-bold text-primary">Stima</h1>
-      <section className="w-full max-w-sm rounded-xl bg-surface-container-lowest p-6 ghost-shadow">
+      <section className="w-full max-w-sm rounded-[var(--radius-document)] bg-surface-container-lowest p-6 ghost-shadow">
         <h2 className="font-headline text-2xl font-bold text-on-surface">Set up your business</h2>
         <p className="mb-6 mt-2 text-sm text-on-surface-variant">
           Tell us a bit about your work so we can tailor your quotes.
         </p>
         {error ? (
-          <div role="alert" className="mb-4 rounded-lg border-l-4 border-error bg-error-container p-4">
+          <div
+            role="alert"
+            className="mb-4 rounded-[var(--radius-document)] border-l-4 border-error bg-error-container p-4"
+          >
             <p className="text-sm font-medium text-error">{error}</p>
           </div>
         ) : null}


### PR DESCRIPTION
## Summary
- update onboarding and auth shell containers to use `rounded-[var(--radius-document)]`
- align inline auth/onboarding error rails to the document radius token while preserving existing error semantics and copy
- keep routes, handlers, API flows, and user-facing text unchanged

## Verification
- `cd frontend && npx vitest run src/features/profile/tests/OnboardingForm.test.tsx src/features/auth/tests/`
- `cd frontend && npx tsc --noEmit`
- `cd frontend && npx eslint src/features/profile/components/OnboardingForm.tsx src/features/auth/components/LoginForm.tsx src/features/auth/components/RegisterForm.tsx src/features/auth/components/ResetPasswordPage.tsx src/features/auth/components/ForgotPasswordPage.tsx`
- `make frontend-verify`

Closes #511