### PR TITLE
Task #512: Adopt settings + catalog settings design system surfaces

### DIFF
--- a/frontend/src/features/line-item-catalog/components/LineItemCatalogSettingsScreen.tsx
+++ b/frontend/src/features/line-item-catalog/components/LineItemCatalogSettingsScreen.tsx
@@ -11,6 +11,8 @@ import { ScreenHeader } from "@/shared/components/ScreenHeader";
 import { Input } from "@/shared/components/Input";
 import { NumericField } from "@/ui/NumericField";
 import { useToast } from "@/ui/Toast";
+import { Card } from "@/ui/Card";
+import { Eyebrow } from "@/ui/Eyebrow";
 
 interface ParsedPriceInput {
   value: number | null;
@@ -216,10 +218,8 @@ export function LineItemCatalogSettingsScreen(): React.ReactElement {
 
         {!isLoading && !loadError ? (
           <>
-            <section className="ghost-shadow rounded-xl bg-surface-container-lowest p-6">
-              <h2 className="text-[0.6875rem] font-bold uppercase tracking-widest text-outline">
-                {isEditMode ? "Edit Catalog Item" : "Add Catalog Item"}
-              </h2>
+            <Card className="p-6">
+              <Eyebrow>{isEditMode ? "Edit Catalog Item" : "Add Catalog Item"}</Eyebrow>
 
               <form className="mt-4 space-y-3" onSubmit={(event) => void handleSubmit(event)}>
                 {formError ? <FeedbackMessage variant="error">{formError}</FeedbackMessage> : null}
@@ -240,7 +240,7 @@ export function LineItemCatalogSettingsScreen(): React.ReactElement {
                     rows={3}
                     value={details}
                     onChange={(event) => setDetails(event.target.value)}
-                    className="w-full rounded-lg border border-outline-variant/30 bg-surface-container-high p-4 text-sm text-on-surface outline-none transition-all focus:border-primary focus:bg-surface-container-lowest focus:ring-2 focus:ring-primary/20"
+                    className="w-full rounded-[var(--radius-document)] border border-outline-variant/30 bg-surface-container-high p-4 text-sm text-on-surface outline-none transition-all focus:border-primary focus:bg-surface-container-lowest focus:ring-2 focus:ring-primary/20"
                   />
                 </div>
 
@@ -276,12 +276,10 @@ export function LineItemCatalogSettingsScreen(): React.ReactElement {
                   ) : null}
                 </div>
               </form>
-            </section>
+            </Card>
 
-            <section className="rounded-xl bg-surface-container-low p-4">
-              <h2 className="text-[0.6875rem] font-bold uppercase tracking-widest text-outline">
-                Saved Items
-              </h2>
+            <Card className="bg-surface-container-low p-4">
+              <Eyebrow>Saved Items</Eyebrow>
               {sortedItems.length === 0 ? (
                 <p className="mt-3 text-sm text-on-surface-variant">
                   No catalog items yet. Create one to reuse it in quote line items.
@@ -291,7 +289,7 @@ export function LineItemCatalogSettingsScreen(): React.ReactElement {
                   {sortedItems.map((item) => (
                     <article
                       key={item.id}
-                      className="rounded-lg border border-outline-variant/20 bg-surface-container-lowest p-3"
+                      className="rounded-[var(--radius-document)] border border-outline-variant/20 bg-surface-container-lowest p-3"
                     >
                       <div className="flex items-start justify-between gap-3">
                         <div className="min-w-0 space-y-1">
@@ -326,7 +324,7 @@ export function LineItemCatalogSettingsScreen(): React.ReactElement {
                   ))}
                 </div>
               )}
-            </section>
+            </Card>
           </>
         ) : null}
       </section>

--- a/frontend/src/features/settings/components/SettingsCatalogShortcutCard.tsx
+++ b/frontend/src/features/settings/components/SettingsCatalogShortcutCard.tsx
@@ -20,7 +20,7 @@ export function SettingsCatalogShortcutCard({
           type="button"
           variant="secondary"
           size="sm"
-          className="px-3 py-2 text-xs"
+          className="shrink-0 whitespace-nowrap px-3 py-2 text-xs"
           onClick={onOpenLineItemCatalog}
         >
           Line Item Catalog

--- a/frontend/src/features/settings/components/SettingsCatalogShortcutCard.tsx
+++ b/frontend/src/features/settings/components/SettingsCatalogShortcutCard.tsx
@@ -1,4 +1,6 @@
 import { Button } from "@/shared/components/Button";
+import { Card } from "@/ui/Card";
+import { Eyebrow } from "@/ui/Eyebrow";
 
 interface SettingsCatalogShortcutCardProps {
   onOpenLineItemCatalog: () => void;
@@ -8,10 +10,8 @@ export function SettingsCatalogShortcutCard({
   onOpenLineItemCatalog,
 }: SettingsCatalogShortcutCardProps): React.ReactElement {
   return (
-    <section className="rounded-xl bg-surface-container-low p-4">
-      <h2 className="text-[0.6875rem] font-bold uppercase tracking-widest text-outline">
-        Catalog
-      </h2>
+    <Card className="bg-surface-container-low p-4">
+      <Eyebrow>Catalog</Eyebrow>
       <div className="mt-3 flex items-center justify-between gap-3">
         <p className="text-sm text-on-surface-variant">
           Save and manage reusable line item presets.
@@ -26,6 +26,6 @@ export function SettingsCatalogShortcutCard({
           Line Item Catalog
         </Button>
       </div>
-    </section>
+    </Card>
   );
 }

--- a/frontend/src/features/settings/components/SettingsScreen.tsx
+++ b/frontend/src/features/settings/components/SettingsScreen.tsx
@@ -24,6 +24,8 @@ import type { ThemePreference } from "@/shared/lib/theme";
 import { NumericField } from "@/ui/NumericField";
 import { Select } from "@/ui/Select";
 import { useToast } from "@/ui/Toast";
+import { Card } from "@/ui/Card";
+import { Eyebrow } from "@/ui/Eyebrow";
 
 const THEME_OPTIONS: ReadonlyArray<{ label: string; value: ThemePreference }> = [
   { label: "System default", value: "system" },
@@ -197,27 +199,23 @@ export function SettingsScreen(): React.ReactElement {
               <FeedbackMessage variant="error">{saveError}</FeedbackMessage>
             ) : null}
 
-            <section className="ghost-shadow rounded-xl bg-surface-container-lowest p-6">
-              <h2 className="mb-4 text-[0.6875rem] font-bold uppercase tracking-widest text-outline">
-                Business Profile
-              </h2>
+            <Card className="p-6">
+              <Eyebrow className="mb-4">Business Profile</Eyebrow>
 
               <div className="mt-4 flex flex-col gap-4">
                 <div
                   data-testid="settings-logo-block"
-                  className="rounded-xl bg-surface-container-low p-4"
+                  className="rounded-[var(--radius-document)] bg-surface-container-low p-4"
                 >
                   <div className="flex flex-col gap-3">
-                    <p className="text-[0.6875rem] font-bold uppercase tracking-widest text-outline">
-                      Logo
-                    </p>
+                    <Eyebrow>Logo</Eyebrow>
                     <div
                       data-testid="settings-logo-content-row"
                       className="flex flex-col gap-3 min-[360px]:grid min-[360px]:grid-cols-[128px_minmax(0,1fr)] min-[360px]:items-start min-[360px]:gap-4"
                     >
                       <div
                         data-testid="settings-logo-preview-tile"
-                        className="flex h-[128px] w-[128px] rounded-xl bg-surface-container-lowest p-2"
+                        className="flex h-[128px] w-[128px] rounded-[var(--radius-document)] bg-surface-container-lowest p-2"
                       >
                         <div className="flex h-full w-full items-center justify-center rounded-lg bg-surface-container p-2">
                           {hasLogo ? (
@@ -245,7 +243,7 @@ export function SettingsScreen(): React.ReactElement {
                             type="button"
                             variant="ghost"
                             size="sm"
-                            className="min-h-10 rounded-lg border border-outline-variant/30 px-3 text-xs text-on-surface"
+                            className="min-h-10 border border-outline-variant/30 px-3 text-xs text-on-surface"
                             disabled={isLogoSubmitting}
                             onClick={() => logoUploadInputRef.current?.click()}
                           >
@@ -266,7 +264,7 @@ export function SettingsScreen(): React.ReactElement {
                               type="button"
                               variant="destructive"
                               size="sm"
-                              className="min-h-10 rounded-lg px-3 text-xs"
+                              className="min-h-10 px-3 text-xs"
                               disabled={isLogoSubmitting}
                               onClick={() => setIsRemoveLogoOpen(true)}
                             >
@@ -360,21 +358,17 @@ export function SettingsScreen(): React.ReactElement {
                   ))}
                 </Select>
               </div>
-            </section>
+            </Card>
 
             <SettingsCatalogShortcutCard
               onOpenLineItemCatalog={() => navigate("/settings/line-item-catalog")}
             />
 
-            <section className="rounded-xl bg-surface-container-low p-4">
-              <h2 className="text-[0.6875rem] font-bold uppercase tracking-widest text-outline">
-                Account
-              </h2>
+            <Card className="bg-surface-container-low p-4">
+              <Eyebrow>Account</Eyebrow>
               <div className="mt-3 flex items-center justify-between gap-3">
                 <div className="min-w-0 flex-1">
-                  <p className="text-[0.6875rem] font-bold uppercase tracking-widest text-outline">
-                    Email
-                  </p>
+                  <Eyebrow>Email</Eyebrow>
                   <p className="truncate text-sm text-on-surface">{email}</p>
                 </div>
 
@@ -382,13 +376,13 @@ export function SettingsScreen(): React.ReactElement {
                   type="button"
                   variant="ghost"
                   size="sm"
-                  className="shrink-0 rounded-lg border border-outline-variant/30 px-4 text-sm text-on-surface"
+                  className="shrink-0 border border-outline-variant/30 px-4 text-sm text-on-surface"
                   onClick={() => setIsSignOutConfirmOpen(true)}
                 >
                   Sign Out
                 </Button>
               </div>
-            </section>
+            </Card>
 
             <div className="pt-2">
               <Button

--- a/frontend/src/features/settings/components/SettingsScreen.tsx
+++ b/frontend/src/features/settings/components/SettingsScreen.tsx
@@ -374,9 +374,9 @@ export function SettingsScreen(): React.ReactElement {
 
                 <Button
                   type="button"
-                  variant="ghost"
+                  variant="destructive"
                   size="sm"
-                  className="shrink-0 border border-outline-variant/30 px-4 text-sm text-on-surface"
+                  className="shrink-0 px-4"
                   onClick={() => setIsSignOutConfirmOpen(true)}
                 >
                   Sign Out

--- a/frontend/src/features/settings/tests/SettingsScreen.test.tsx
+++ b/frontend/src/features/settings/tests/SettingsScreen.test.tsx
@@ -408,8 +408,8 @@ describe("SettingsScreen", () => {
     renderScreen();
 
     const signOutButton = await screen.findByRole("button", { name: /sign out/i });
-    expect(signOutButton).toHaveClass("border", "border-outline-variant/30", "text-on-surface");
-    expect(signOutButton).not.toHaveClass("bg-secondary");
+    expect(signOutButton).toHaveClass("border", "border-secondary", "text-secondary");
+    expect(signOutButton).not.toHaveClass("text-on-surface");
 
     fireEvent.click(signOutButton);
 

--- a/frontend/src/features/settings/tests/SettingsScreen.test.tsx
+++ b/frontend/src/features/settings/tests/SettingsScreen.test.tsx
@@ -135,7 +135,7 @@ describe("SettingsScreen", () => {
       "text-[0.6875rem]",
       "font-bold",
       "uppercase",
-      "tracking-widest",
+      "tracking-[0.12em]",
       "text-outline",
     );
     expect(screen.getByText("Stima")).toBeInTheDocument();
@@ -156,7 +156,7 @@ describe("SettingsScreen", () => {
     );
     expect(screen.getByLabelText(/upload logo/i)).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /save changes/i }).closest("footer")).toBeNull();
-    expect(screen.getByText("Account").closest("section")).toHaveClass("bg-surface-container-low");
+    expect(screen.getByText("Account").closest("div")).toHaveClass("bg-surface-container-low");
     expect(screen.queryByText("Session")).not.toBeInTheDocument();
     expect(screen.queryByLabelText(/^email$/i)).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /back/i })).not.toBeInTheDocument();
@@ -437,7 +437,7 @@ describe("SettingsScreen", () => {
 
     expect(await screen.findByText("Business Profile")).toBeInTheDocument();
     expect(screen.getByTestId("settings-logo-block")).toHaveClass(
-      "rounded-xl",
+      "rounded-[var(--radius-document)]",
       "bg-surface-container-low",
       "p-4",
     );
@@ -460,7 +460,7 @@ describe("SettingsScreen", () => {
     expect(previewTile).toHaveClass(
       "h-[128px]",
       "w-[128px]",
-      "rounded-xl",
+      "rounded-[var(--radius-document)]",
       "bg-surface-container-lowest",
     );
     expect(
@@ -483,7 +483,7 @@ describe("SettingsScreen", () => {
 
     expect(await screen.findByText("Business Profile")).toBeInTheDocument();
     expect(screen.getByTestId("settings-logo-block")).toHaveClass(
-      "rounded-xl",
+      "rounded-[var(--radius-document)]",
       "bg-surface-container-low",
       "p-4",
     );
@@ -506,7 +506,7 @@ describe("SettingsScreen", () => {
     expect(previewTile).toHaveClass(
       "h-[128px]",
       "w-[128px]",
-      "rounded-xl",
+      "rounded-[var(--radius-document)]",
       "bg-surface-container-lowest",
     );
     expect(
@@ -620,7 +620,7 @@ describe("SettingsScreen", () => {
       expect(screen.getByTestId("settings-logo-preview-tile")).toHaveClass(
         "h-[128px]",
         "w-[128px]",
-        "rounded-xl",
+        "rounded-[var(--radius-document)]",
         "bg-surface-container-lowest",
       );
       expect(screen.getByText("No logo")).toBeInTheDocument();


### PR DESCRIPTION
## Summary
- adopt `Eyebrow` and `Card` in Settings and Line Item Catalog settings screens for consistent section framing
- replace touched `rounded-xl`/`rounded-lg` settings surfaces with `rounded-[var(--radius-document)]` while preserving existing behavior and copy
- update targeted Settings screen tests for intentional class-level UI changes

## Verification
- cd frontend && npx vitest run src/features/settings/tests/SettingsScreen.test.tsx
- cd frontend && npx vitest run src/features/settings/tests/LineItemCatalogSettings.test.tsx
- cd frontend && npx tsc --noEmit
- cd frontend && npx eslint src/features/settings/components/ src/features/line-item-catalog/components/LineItemCatalogSettingsScreen.tsx
- make frontend-verify

Closes #512