### PR TITLE
Task #514: Customer surfaces UI adoption

### DIFF
--- a/frontend/src/features/customers/components/CustomerCreateScreen.tsx
+++ b/frontend/src/features/customers/components/CustomerCreateScreen.tsx
@@ -60,7 +60,7 @@ export function CustomerCreateScreen(): React.ReactElement {
       />
 
       <section className="mx-auto w-full max-w-3xl px-4 pt-20">
-        <section className="rounded-xl bg-surface-container-lowest p-6 ghost-shadow">
+        <section className="rounded-[var(--radius-document)] bg-surface-container-lowest p-6 ghost-shadow">
           {createError ? (
             <div className="mb-4">
               <FeedbackMessage variant="error">{createError}</FeedbackMessage>

--- a/frontend/src/features/customers/components/CustomerDetailLoadingSkeleton.tsx
+++ b/frontend/src/features/customers/components/CustomerDetailLoadingSkeleton.tsx
@@ -3,14 +3,14 @@ import { SkeletonBlock } from "@/shared/components/SkeletonBlock";
 export function CustomerDetailLoadingSkeleton(): React.ReactElement {
   return (
     <>
-      <section className="rounded-xl bg-surface-container-lowest p-4 ghost-shadow">
+      <section className="rounded-[var(--radius-document)] bg-surface-container-lowest p-4 ghost-shadow">
         <div className="space-y-3">
           <SkeletonBlock width="45%" height="1rem" />
           <SkeletonBlock width="72%" height="1rem" />
           <SkeletonBlock width="68%" height="1rem" />
         </div>
       </section>
-      <section className="rounded-xl bg-surface-container-low p-3">
+      <section className="rounded-[var(--radius-document)] bg-surface-container-low p-3">
         <div className="mb-3 flex items-center justify-between gap-3">
           <SkeletonBlock width="48%" height="2.25rem" borderRadius="9999px" />
           <SkeletonBlock width="20%" height="0.875rem" />

--- a/frontend/src/features/customers/components/CustomerDetailScreen.tsx
+++ b/frontend/src/features/customers/components/CustomerDetailScreen.tsx
@@ -294,7 +294,7 @@ export function CustomerDetailScreen(): React.ReactElement {
         {!isLoading && !loadError && customer ? (
           <>
             {!isEditing ? (
-              <section className="rounded-xl bg-surface-container-lowest p-4 ghost-shadow">
+              <section className="rounded-[var(--radius-document)] bg-surface-container-lowest p-4 ghost-shadow">
                 <div className="flex flex-col gap-3">
                   <dl className="flex flex-col gap-1.5">
                     <div className="flex items-center gap-3">

--- a/frontend/src/features/customers/components/CustomerInfoForm.tsx
+++ b/frontend/src/features/customers/components/CustomerInfoForm.tsx
@@ -4,6 +4,7 @@ import { Button } from "@/shared/components/Button";
 import { FeedbackMessage } from "@/shared/components/FeedbackMessage";
 import { Input } from "@/shared/components/Input";
 import { CUSTOMER_ADDRESS_MAX_CHARS } from "@/shared/lib/inputLimits";
+import { Eyebrow } from "@/ui/Eyebrow";
 
 interface CustomerInfoFormProps {
   name: string;
@@ -35,10 +36,8 @@ export function CustomerInfoForm({
   saveError,
 }: CustomerInfoFormProps): React.ReactElement {
   return (
-    <section className="rounded-xl bg-surface-container-lowest p-6 ghost-shadow">
-      <h2 className="mb-4 text-[0.6875rem] font-bold uppercase tracking-widest text-outline">
-        Customer Info
-      </h2>
+    <section className="rounded-[var(--radius-document)] bg-surface-container-lowest p-6 ghost-shadow">
+      <Eyebrow className="mb-4">Customer Info</Eyebrow>
 
       {saveError ? (
         <div className="mb-4">

--- a/frontend/src/features/customers/components/CustomerInlineCreateForm.tsx
+++ b/frontend/src/features/customers/components/CustomerInlineCreateForm.tsx
@@ -35,7 +35,7 @@ export function CustomerInlineCreateForm({
   error,
 }: CustomerInlineCreateFormProps): React.ReactElement {
   return (
-    <section className="rounded-xl bg-surface-container-lowest p-6 ghost-shadow">
+    <section className="rounded-[var(--radius-document)] bg-surface-container-lowest p-6 ghost-shadow">
       {error ? (
         <div className="mb-4">
           <FeedbackMessage variant="error">{error}</FeedbackMessage>

--- a/frontend/src/features/customers/components/InvoiceHistoryList.tsx
+++ b/frontend/src/features/customers/components/InvoiceHistoryList.tsx
@@ -2,6 +2,7 @@ import type { InvoiceListItem } from "@/features/invoices/types/invoice.types";
 import { FeedbackMessage } from "@/shared/components/FeedbackMessage";
 import { SkeletonBlock } from "@/shared/components/SkeletonBlock";
 import { formatCurrency, formatDate } from "@/shared/lib/formatters";
+import { Eyebrow } from "@/ui/Eyebrow";
 import { StatusPill } from "@/ui/StatusPill";
 
 interface InvoiceHistoryListProps {
@@ -27,19 +28,22 @@ export function InvoiceHistoryList({
     <section>
       {showHeader ? (
         <div className="mb-2 flex items-center justify-between">
-          <p className="text-[0.6875rem] font-bold uppercase tracking-widest text-outline">
-            Invoice History
-          </p>
-          <p className="text-[0.6875rem] font-bold uppercase tracking-widest text-outline">
-            {invoiceCountLabel}
-          </p>
+          <Eyebrow>Invoice History</Eyebrow>
+          <Eyebrow>{invoiceCountLabel}</Eyebrow>
         </div>
       ) : null}
 
       {isLoading ? (
-        <div role="status" aria-label="Loading invoices" className="space-y-3 rounded-xl bg-surface-container-low p-3">
+        <div
+          role="status"
+          aria-label="Loading invoices"
+          className="space-y-3 rounded-[var(--radius-document)] bg-surface-container-low p-3"
+        >
           {Array.from({ length: 3 }).map((_, index) => (
-            <div key={`invoice-history-skeleton-${index}`} className="rounded-xl bg-surface-container-lowest p-4 ghost-shadow">
+            <div
+              key={`invoice-history-skeleton-${index}`}
+              className="rounded-[var(--radius-document)] bg-surface-container-lowest p-4 ghost-shadow"
+            >
               <div className="flex items-baseline justify-between gap-3">
                 <SkeletonBlock width="42%" height="1rem" />
                 <SkeletonBlock width="26%" height="1rem" />
@@ -56,7 +60,7 @@ export function InvoiceHistoryList({
       {!isLoading && loadError ? <FeedbackMessage variant="error">{loadError}</FeedbackMessage> : null}
 
       {!isLoading && !loadError && invoices.length > 0 ? (
-        <div className="rounded-xl bg-surface-container-low p-3">
+        <div className="rounded-[var(--radius-document)] bg-surface-container-low p-3">
           <ul className="flex flex-col gap-3">
             {invoices.map((invoice) => {
               const primaryLabel = invoice.title ?? invoice.doc_number;
@@ -69,7 +73,7 @@ export function InvoiceHistoryList({
                 <li key={invoice.id}>
                   <button
                     type="button"
-                    className="w-full cursor-pointer rounded-xl bg-surface-container-lowest p-4 text-left ghost-shadow transition active:scale-[0.98] active:bg-surface-container-low"
+                    className="w-full cursor-pointer rounded-[var(--radius-document)] bg-surface-container-lowest p-4 text-left ghost-shadow transition active:scale-[0.98] active:bg-surface-container-low"
                     onClick={() => onInvoiceClick(invoice.id)}
                   >
                     <div className="flex items-baseline justify-between gap-3">

--- a/frontend/src/features/customers/components/QuoteHistoryList.tsx
+++ b/frontend/src/features/customers/components/QuoteHistoryList.tsx
@@ -1,5 +1,6 @@
 import type { QuoteListItem } from "@/features/quotes/types/quote.types";
 import { formatCurrency, formatDate } from "@/shared/lib/formatters";
+import { Eyebrow } from "@/ui/Eyebrow";
 import { StatusPill } from "@/ui/StatusPill";
 
 interface QuoteHistoryListProps {
@@ -21,17 +22,13 @@ export function QuoteHistoryList({
     <section>
       {showHeader ? (
         <div className="mb-2 flex items-center justify-between">
-          <p className="text-[0.6875rem] font-bold uppercase tracking-widest text-outline">
-            Quote History
-          </p>
-          <p className="text-[0.6875rem] font-bold uppercase tracking-widest text-outline">
-            {quoteCountLabel}
-          </p>
+          <Eyebrow>Quote History</Eyebrow>
+          <Eyebrow>{quoteCountLabel}</Eyebrow>
         </div>
       ) : null}
 
       {quotes.length > 0 ? (
-        <div className="rounded-xl bg-surface-container-low p-3">
+        <div className="rounded-[var(--radius-document)] bg-surface-container-low p-3">
           <ul className="flex flex-col gap-3">
             {quotes.map((quote) => {
               const itemCountLabel = `${quote.item_count} ${quote.item_count === 1 ? "item" : "items"}`;
@@ -46,7 +43,7 @@ export function QuoteHistoryList({
                 <li key={quote.id}>
                   <button
                     type="button"
-                    className="w-full cursor-pointer rounded-xl bg-surface-container-lowest p-4 text-left ghost-shadow transition active:scale-[0.98] active:bg-surface-container-low"
+                    className="w-full cursor-pointer rounded-[var(--radius-document)] bg-surface-container-lowest p-4 text-left ghost-shadow transition active:scale-[0.98] active:bg-surface-container-low"
                     onClick={() => onQuoteClick(quote.id)}
                   >
                     <div className="flex items-baseline justify-between gap-3">

--- a/frontend/src/features/customers/tests/QuoteHistoryList.test.tsx
+++ b/frontend/src/features/customers/tests/QuoteHistoryList.test.tsx
@@ -46,7 +46,7 @@ describe("QuoteHistoryList", () => {
     expect(screen.getByText(/Mar 14, 2026\s*·\s*1 item/)).toBeInTheDocument();
 
     const quoteButton = screen.getByRole("button", { name: /front yard refresh/i });
-    expect(quoteButton).toHaveClass("rounded-xl");
+    expect(quoteButton).toHaveClass("rounded-[var(--radius-document)]");
     expect(quoteButton).toHaveClass("active:scale-[0.98]");
     expect(quoteButton).toHaveClass("active:bg-surface-container-low");
   });


### PR DESCRIPTION
## Summary
- adopt document-radius styling (`rounded-[var(--radius-document)]`) for customer create/detail/edit surfaces in Task #514 scope
- align quote/invoice history containers + rows with adoption surface styling and use `Eyebrow` for section labels
- keep behavior/copy/routing/API contracts unchanged; update class assertion in `QuoteHistoryList` test

## Verification
- `cd frontend && npx vitest run src/features/customers/tests/`
- `cd frontend && npx tsc --noEmit`
- `cd frontend && npx eslint src/features/customers/components/`
- `make frontend-verify`

## Task checklist
- Closes #514
- Confirmed `StatusBadge` is absent under `frontend/src/features/customers` (PR-A dependency reflected in branch state)
