### PR TITLE
Task #515: consolidate remaining eyebrow labels to Eyebrow

### DIFF
--- a/frontend/src/features/customers/components/CustomerDetailScreen.tsx
+++ b/frontend/src/features/customers/components/CustomerDetailScreen.tsx
@@ -18,6 +18,7 @@ import { BottomNav } from "@/shared/components/BottomNav";
 import { Button } from "@/shared/components/Button";
 import { FeedbackMessage } from "@/shared/components/FeedbackMessage";
 import { ScreenHeader } from "@/shared/components/ScreenHeader";
+import { Eyebrow } from "@/ui/Eyebrow";
 import { useToast } from "@/ui/Toast";
 type HistoryMode = "quotes" | "invoices";
 
@@ -298,24 +299,24 @@ export function CustomerDetailScreen(): React.ReactElement {
                 <div className="flex flex-col gap-3">
                   <dl className="flex flex-col gap-1.5">
                     <div className="flex items-center gap-3">
-                      <dt className="w-16 shrink-0 text-[0.6875rem] font-bold uppercase tracking-widest text-outline">
-                        Phone
+                      <dt className="w-16 shrink-0">
+                        <Eyebrow>Phone</Eyebrow>
                       </dt>
                       <dd className="text-sm text-on-surface">
                         {formatSummaryValue(customer.phone, "—")}
                       </dd>
                     </div>
                     <div className="flex items-center gap-3">
-                      <dt className="w-16 shrink-0 text-[0.6875rem] font-bold uppercase tracking-widest text-outline">
-                        Email
+                      <dt className="w-16 shrink-0">
+                        <Eyebrow>Email</Eyebrow>
                       </dt>
                       <dd className="min-w-0 truncate text-sm text-on-surface">
                         {formatSummaryValue(customer.email, "—")}
                       </dd>
                     </div>
                     <div className="flex items-start gap-3">
-                      <dt className="w-16 shrink-0 pt-0.5 text-[0.6875rem] font-bold uppercase tracking-widest text-outline">
-                        Address
+                      <dt className="w-16 shrink-0 pt-0.5">
+                        <Eyebrow>Address</Eyebrow>
                       </dt>
                       <dd className="whitespace-pre-wrap text-sm text-on-surface">
                         {formatSummaryValue(customer.address, "—")}
@@ -398,9 +399,7 @@ export function CustomerDetailScreen(): React.ReactElement {
                     Invoices
                   </button>
                 </div>
-                <p className="shrink-0 text-[0.6875rem] font-bold uppercase tracking-widest text-outline">
-                  {activeHistoryCountLabel}
-                </p>
+                <Eyebrow className="shrink-0">{activeHistoryCountLabel}</Eyebrow>
               </div>
 
               {historyMode === "quotes" ? (

--- a/frontend/src/features/public/components/PublicQuotePage.tsx
+++ b/frontend/src/features/public/components/PublicQuotePage.tsx
@@ -271,9 +271,7 @@ export function PublicQuotePage(): React.ReactElement {
 
             <section>
               <div className="flex items-center justify-between gap-3">
-                <h2>
-                  <Eyebrow>Line Items</Eyebrow>
-                </h2>
+                <Eyebrow as="h2">Line Items</Eyebrow>
                 <span className="text-xs text-on-surface-variant">
                   {documentData.line_items.length} item{documentData.line_items.length === 1 ? "" : "s"}
                 </span>
@@ -329,9 +327,7 @@ export function PublicQuotePage(): React.ReactElement {
 
             {documentData.notes ? (
               <section className="rounded-[var(--radius-document)] border border-surface-container-high bg-surface-container-lowest p-4">
-                <h2>
-                  <Eyebrow>Notes</Eyebrow>
-                </h2>
+                <Eyebrow as="h2">Notes</Eyebrow>
                 <p className="mt-3 whitespace-pre-wrap text-sm leading-6 text-on-surface-variant">
                   {documentData.notes}
                 </p>

--- a/frontend/src/features/public/components/PublicQuotePage.tsx
+++ b/frontend/src/features/public/components/PublicQuotePage.tsx
@@ -271,8 +271,8 @@ export function PublicQuotePage(): React.ReactElement {
 
             <section>
               <div className="flex items-center justify-between gap-3">
-                <h2 className="text-sm font-semibold uppercase tracking-[0.25em] text-outline">
-                  Line Items
+                <h2>
+                  <Eyebrow>Line Items</Eyebrow>
                 </h2>
                 <span className="text-xs text-on-surface-variant">
                   {documentData.line_items.length} item{documentData.line_items.length === 1 ? "" : "s"}
@@ -329,8 +329,8 @@ export function PublicQuotePage(): React.ReactElement {
 
             {documentData.notes ? (
               <section className="rounded-[var(--radius-document)] border border-surface-container-high bg-surface-container-lowest p-4">
-                <h2 className="text-sm font-semibold uppercase tracking-[0.25em] text-outline">
-                  Notes
+                <h2>
+                  <Eyebrow>Notes</Eyebrow>
                 </h2>
                 <p className="mt-3 whitespace-pre-wrap text-sm leading-6 text-on-surface-variant">
                   {documentData.notes}

--- a/frontend/src/features/quotes/components/CaptureDetailsSheet.tsx
+++ b/frontend/src/features/quotes/components/CaptureDetailsSheet.tsx
@@ -50,9 +50,7 @@ export function CaptureDetailsSheet({
 
       <SheetBody className="max-h-[70vh] space-y-5 overflow-y-auto pr-1">
               <section className="space-y-2">
-                <h3>
-                  <Eyebrow>Actionable Capture Details</Eyebrow>
-                </h3>
+                <Eyebrow as="h3">Actionable Capture Details</Eyebrow>
                 {actionableItems.length > 0 ? (
                   <ul className="space-y-2">
                     {actionableItems.map((item) => (
@@ -67,11 +65,11 @@ export function CaptureDetailsSheet({
                             type="button"
                             variant="ghost"
                             size="sm"
-                            className="rounded-md border border-outline-variant/40 px-2 py-1"
+                            className="rounded-md border border-outline-variant/40 px-2 py-1 text-[0.6875rem] uppercase tracking-wide"
                             disabled={isMutating || !onDismissHiddenItem}
                             onClick={() => { void onDismissHiddenItem?.(item.id); }}
                           >
-                            <Eyebrow className="text-inherit tracking-wide">Dismiss</Eyebrow>
+                            Dismiss
                           </Button>
                         </div>
                       </li>
@@ -83,9 +81,7 @@ export function CaptureDetailsSheet({
               </section>
 
               <section className="space-y-2">
-                <h3>
-                  <Eyebrow>Transcript</Eyebrow>
-                </h3>
+                <Eyebrow as="h3">Transcript</Eyebrow>
                 <div className="rounded-lg border border-outline-variant/30 bg-surface-container-high p-3 text-sm leading-6 text-on-surface whitespace-pre-wrap">
                   {transcript.trim().length > 0 ? transcript : "No transcript notes captured."}
                 </div>

--- a/frontend/src/features/quotes/components/CaptureDetailsSheet.tsx
+++ b/frontend/src/features/quotes/components/CaptureDetailsSheet.tsx
@@ -65,7 +65,7 @@ export function CaptureDetailsSheet({
                             type="button"
                             variant="ghost"
                             size="sm"
-                            className="rounded-md border border-outline-variant/40 px-2 py-1 text-[0.6875rem] uppercase tracking-wide"
+                            className="rounded-md border border-outline-variant/40 px-2 py-1 text-xs font-medium uppercase tracking-wide"
                             disabled={isMutating || !onDismissHiddenItem}
                             onClick={() => { void onDismissHiddenItem?.(item.id); }}
                           >

--- a/frontend/src/features/quotes/components/CaptureDetailsSheet.tsx
+++ b/frontend/src/features/quotes/components/CaptureDetailsSheet.tsx
@@ -3,6 +3,7 @@ import * as Dialog from "@radix-ui/react-dialog";
 import type { ExtractionReviewHiddenDetails, HiddenItemState } from "@/features/quotes/types/quote.types";
 import { resolveCaptureDetailsActionableItems } from "@/features/quotes/utils/captureDetails";
 import { Button } from "@/shared/components/Button";
+import { Eyebrow } from "@/ui/Eyebrow";
 import { Sheet, SheetBody, SheetCloseButton, SheetFooter, SheetHeader } from "@/ui/Sheet";
 
 interface CaptureDetailsSheetProps {
@@ -49,8 +50,8 @@ export function CaptureDetailsSheet({
 
       <SheetBody className="max-h-[70vh] space-y-5 overflow-y-auto pr-1">
               <section className="space-y-2">
-                <h3 className="text-[0.6875rem] font-bold uppercase tracking-widest text-outline">
-                  Actionable Capture Details
+                <h3>
+                  <Eyebrow>Actionable Capture Details</Eyebrow>
                 </h3>
                 {actionableItems.length > 0 ? (
                   <ul className="space-y-2">
@@ -66,11 +67,11 @@ export function CaptureDetailsSheet({
                             type="button"
                             variant="ghost"
                             size="sm"
-                            className="rounded-md border border-outline-variant/40 px-2 py-1 text-[0.6875rem] uppercase tracking-wide"
+                            className="rounded-md border border-outline-variant/40 px-2 py-1"
                             disabled={isMutating || !onDismissHiddenItem}
                             onClick={() => { void onDismissHiddenItem?.(item.id); }}
                           >
-                            Dismiss
+                            <Eyebrow className="text-inherit tracking-wide">Dismiss</Eyebrow>
                           </Button>
                         </div>
                       </li>
@@ -82,8 +83,8 @@ export function CaptureDetailsSheet({
               </section>
 
               <section className="space-y-2">
-                <h3 className="text-[0.6875rem] font-bold uppercase tracking-widest text-outline">
-                  Transcript
+                <h3>
+                  <Eyebrow>Transcript</Eyebrow>
                 </h3>
                 <div className="rounded-lg border border-outline-variant/30 bg-surface-container-high p-3 text-sm leading-6 text-on-surface whitespace-pre-wrap">
                   {transcript.trim().length > 0 ? transcript : "No transcript notes captured."}

--- a/frontend/src/features/quotes/components/CaptureInputPanel.tsx
+++ b/frontend/src/features/quotes/components/CaptureInputPanel.tsx
@@ -43,7 +43,7 @@ export function CaptureInputPanel({
       <section className="mb-4 rounded-[var(--radius-document)] border border-outline-variant/20 bg-surface-container-low p-4">
         <div className="mb-3 flex items-center justify-between">
           <Eyebrow className="text-on-surface">RECORDED CLIPS</Eyebrow>
-          <Eyebrow className="rounded-full bg-surface-container-lowest px-2.5 py-1 tracking-widest">
+          <Eyebrow as="span" className="rounded-full bg-surface-container-lowest px-2.5 py-1 tracking-widest">
             {clips.length} CLIPS
           </Eyebrow>
         </div>
@@ -141,7 +141,7 @@ export function CaptureInputPanel({
         </div>
       ) : (
         <div className="mt-auto mb-2 flex flex-col items-center gap-3 pt-4 sm:pt-6">
-          <Eyebrow className="text-xs tracking-widest">TAP TO START</Eyebrow>
+          <Eyebrow as="span" className="text-xs tracking-widest">TAP TO START</Eyebrow>
           {hasReachedClipLimit ? (
             <p className="text-center text-xs text-outline">
               Maximum of {MAX_AUDIO_CLIPS_PER_REQUEST} clips per request reached.

--- a/frontend/src/features/quotes/components/CaptureInputPanel.tsx
+++ b/frontend/src/features/quotes/components/CaptureInputPanel.tsx
@@ -43,9 +43,9 @@ export function CaptureInputPanel({
       <section className="mb-4 rounded-[var(--radius-document)] border border-outline-variant/20 bg-surface-container-low p-4">
         <div className="mb-3 flex items-center justify-between">
           <Eyebrow className="text-on-surface">RECORDED CLIPS</Eyebrow>
-          <span className="rounded-full bg-surface-container-lowest px-2.5 py-1 text-[0.6875rem] font-bold uppercase tracking-widest text-outline">
+          <Eyebrow className="rounded-full bg-surface-container-lowest px-2.5 py-1 tracking-widest">
             {clips.length} CLIPS
-          </span>
+          </Eyebrow>
         </div>
 
         {clips.length === 0 ? (
@@ -141,9 +141,7 @@ export function CaptureInputPanel({
         </div>
       ) : (
         <div className="mt-auto mb-2 flex flex-col items-center gap-3 pt-4 sm:pt-6">
-          <p className="text-xs uppercase tracking-widest text-outline">
-            TAP TO START
-          </p>
+          <Eyebrow className="text-xs tracking-widest">TAP TO START</Eyebrow>
           {hasReachedClipLimit ? (
             <p className="text-center text-xs text-outline">
               Maximum of {MAX_AUDIO_CLIPS_PER_REQUEST} clips per request reached.

--- a/frontend/src/features/quotes/components/LineItemCard.tsx
+++ b/frontend/src/features/quotes/components/LineItemCard.tsx
@@ -1,4 +1,5 @@
 import type { PointerEvent as ReactPointerEvent } from "react";
+import { Eyebrow } from "@/ui/Eyebrow";
 
 interface LineItemCardProps {
   description: string;
@@ -78,9 +79,9 @@ export function LineItemCard({
           <div className="flex items-center gap-2">
             <p className="truncate font-bold text-on-surface">{description}</p>
             {flagged ? (
-              <span className="rounded-full bg-warning-container px-2.5 py-1 text-[0.6875rem] font-bold uppercase tracking-wide text-warning">
+              <Eyebrow className="rounded-full bg-warning-container px-2.5 py-1 text-warning">
                 REVIEW
-              </span>
+              </Eyebrow>
             ) : null}
           </div>
           {details ? <p className="mt-0.5 text-sm text-on-surface-variant">{details}</p> : null}

--- a/frontend/src/features/quotes/components/LineItemCard.tsx
+++ b/frontend/src/features/quotes/components/LineItemCard.tsx
@@ -79,7 +79,7 @@ export function LineItemCard({
           <div className="flex items-center gap-2">
             <p className="truncate font-bold text-on-surface">{description}</p>
             {flagged ? (
-              <Eyebrow className="rounded-full bg-warning-container px-2.5 py-1 text-warning">
+              <Eyebrow as="span" className="rounded-full bg-warning-container px-2.5 py-1 text-warning">
                 REVIEW
               </Eyebrow>
             ) : null}

--- a/frontend/src/features/quotes/components/ReviewCustomerRow.tsx
+++ b/frontend/src/features/quotes/components/ReviewCustomerRow.tsx
@@ -23,9 +23,9 @@ export function ReviewCustomerRow({
       <div className="flex items-center justify-between gap-3">
         <Eyebrow>Customer</Eyebrow>
         {requiresCustomerAssignment ? (
-          <span className="rounded-full bg-warning-container px-2.5 py-1 text-[0.6875rem] font-bold uppercase tracking-wide text-warning">
+          <Eyebrow className="rounded-full bg-warning-container px-2.5 py-1 text-warning">
             Needs customer
-          </span>
+          </Eyebrow>
         ) : null}
       </div>
 

--- a/frontend/src/features/quotes/components/ReviewCustomerRow.tsx
+++ b/frontend/src/features/quotes/components/ReviewCustomerRow.tsx
@@ -23,7 +23,7 @@ export function ReviewCustomerRow({
       <div className="flex items-center justify-between gap-3">
         <Eyebrow>Customer</Eyebrow>
         {requiresCustomerAssignment ? (
-          <Eyebrow className="rounded-full bg-warning-container px-2.5 py-1 text-warning">
+          <Eyebrow as="span" className="rounded-full bg-warning-container px-2.5 py-1 text-warning">
             Needs customer
           </Eyebrow>
         ) : null}

--- a/frontend/src/features/settings/tests/SettingsScreen.test.tsx
+++ b/frontend/src/features/settings/tests/SettingsScreen.test.tsx
@@ -132,7 +132,6 @@ describe("SettingsScreen", () => {
     expect(screen.getByLabelText(/timezone/i)).toHaveValue("America/New_York");
     expect(screen.getByText("owner@example.com")).toBeInTheDocument();
     expect(screen.getByText("Email")).toHaveClass(
-      "text-[0.6875rem]",
       "font-bold",
       "uppercase",
       "tracking-[0.12em]",

--- a/frontend/src/shared/components/ErrorFallback.tsx
+++ b/frontend/src/shared/components/ErrorFallback.tsx
@@ -1,6 +1,7 @@
 import type { ReactElement } from "react";
 
 import { Button } from "@/shared/components/Button";
+import { Eyebrow } from "@/ui/Eyebrow";
 
 export function ErrorFallback(): ReactElement {
   return (
@@ -9,9 +10,7 @@ export function ErrorFallback(): ReactElement {
         role="alert"
         className="ghost-shadow w-full max-w-md rounded-xl border border-outline-variant/30 bg-surface-container-lowest p-8 text-center"
       >
-        <p className="text-sm font-semibold uppercase tracking-[0.2em] text-error">
-          Something went wrong
-        </p>
+        <Eyebrow className="text-error">Something went wrong</Eyebrow>
         <h1 className="mt-4 text-3xl font-semibold text-on-surface">Please reload Stima</h1>
         <p className="mt-3 text-sm leading-6 text-on-surface-variant">
           We hit an unexpected error and recorded it for follow-up. Reload to try again.

--- a/frontend/src/shared/components/ScreenHeader.tsx
+++ b/frontend/src/shared/components/ScreenHeader.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from "react";
 import { Button } from "@/shared/components/Button";
+import { Eyebrow } from "@/ui/Eyebrow";
 
 interface ScreenHeaderProps {
   title: string;
@@ -47,7 +48,7 @@ export function ScreenHeader({
         ) : null}
         <div className={["min-w-0 flex-1", isTopLevelLayout ? "text-right" : ""].join(" ")}>
           {eyebrow ? (
-            <p className="truncate text-[0.6875rem] font-bold uppercase tracking-wider text-outline">{eyebrow}</p>
+            <Eyebrow className="truncate">{eyebrow}</Eyebrow>
           ) : null}
           <h1 className="truncate font-headline text-lg font-bold tracking-tight text-on-surface">{title}</h1>
           {subtitle ? <p className="truncate text-xs text-on-surface-variant">{subtitle}</p> : null}

--- a/frontend/src/ui/Eyebrow.test.tsx
+++ b/frontend/src/ui/Eyebrow.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { Eyebrow } from "@/ui/Eyebrow";
+
+describe("Eyebrow", () => {
+  it("keeps base size when only text color override is provided", () => {
+    render(<Eyebrow className="text-warning">Label</Eyebrow>);
+
+    const label = screen.getByText("Label");
+    expect(label).toHaveClass("text-[0.6875rem]");
+    expect(label).toHaveClass("text-warning");
+    expect(label).not.toHaveClass("text-outline");
+  });
+
+  it("keeps base color when only text size override is provided", () => {
+    render(<Eyebrow className="text-xs">Label</Eyebrow>);
+
+    const label = screen.getByText("Label");
+    expect(label).toHaveClass("text-xs");
+    expect(label).toHaveClass("text-outline");
+    expect(label).not.toHaveClass("text-[0.6875rem]");
+  });
+
+  it("drops base size and color when both size and color overrides are provided", () => {
+    render(<Eyebrow className="text-xs text-warning">Label</Eyebrow>);
+
+    const label = screen.getByText("Label");
+    expect(label).toHaveClass("text-xs");
+    expect(label).toHaveClass("text-warning");
+    expect(label).not.toHaveClass("text-[0.6875rem]");
+    expect(label).not.toHaveClass("text-outline");
+  });
+
+  it("keeps base size and color when no text override is provided", () => {
+    render(<Eyebrow>Label</Eyebrow>);
+
+    const label = screen.getByText("Label");
+    expect(label).toHaveClass("text-[0.6875rem]");
+    expect(label).toHaveClass("text-outline");
+  });
+});

--- a/frontend/src/ui/Eyebrow.tsx
+++ b/frontend/src/ui/Eyebrow.tsx
@@ -1,12 +1,31 @@
-interface EyebrowProps {
-  children: React.ReactNode;
-  className?: string;
+import type { ElementType, HTMLAttributes, ReactNode } from "react";
+
+interface EyebrowProps extends Omit<HTMLAttributes<HTMLElement>, "children"> {
+  as?: ElementType;
+  children: ReactNode;
 }
 
-export function Eyebrow({ children, className }: EyebrowProps): React.ReactElement {
+function mergeEyebrowClasses(className?: string): string {
+  const extra = className?.trim() ? className.trim().split(/\s+/) : [];
+  const hasTextOverride = extra.some((token) => token.startsWith("text-"));
+  const hasTrackingOverride = extra.some((token) => token.startsWith("tracking-"));
+  const hasFontOverride = extra.some((token) => token.startsWith("font-"));
+
+  const base = [
+    hasTextOverride ? null : "text-[0.6875rem]",
+    hasFontOverride ? null : "font-bold",
+    "uppercase",
+    hasTrackingOverride ? null : "tracking-[0.12em]",
+    hasTextOverride ? null : "text-outline",
+  ].filter(Boolean);
+
+  return [...base, ...extra].join(" ");
+}
+
+export function Eyebrow({ as: Component = "p", children, className, ...rest }: EyebrowProps): React.ReactElement {
   return (
-    <p className={["text-[0.6875rem] font-bold uppercase tracking-[0.12em] text-outline", className].filter(Boolean).join(" ")}>
+    <Component className={mergeEyebrowClasses(className)} {...rest}>
       {children}
-    </p>
+    </Component>
   );
 }

--- a/frontend/src/ui/Eyebrow.tsx
+++ b/frontend/src/ui/Eyebrow.tsx
@@ -7,16 +7,18 @@ interface EyebrowProps extends Omit<HTMLAttributes<HTMLElement>, "children"> {
 
 function mergeEyebrowClasses(className?: string): string {
   const extra = className?.trim() ? className.trim().split(/\s+/) : [];
-  const hasTextOverride = extra.some((token) => token.startsWith("text-"));
+  const sizeClassPattern = /^text-(?:xs|sm|base|lg|[0-9]+xl|\[)/;
+  const hasSizeOverride = extra.some((token) => sizeClassPattern.test(token));
+  const hasColorOverride = extra.some((token) => token.startsWith("text-") && !sizeClassPattern.test(token));
   const hasTrackingOverride = extra.some((token) => token.startsWith("tracking-"));
   const hasFontOverride = extra.some((token) => token.startsWith("font-"));
 
   const base = [
-    hasTextOverride ? null : "text-[0.6875rem]",
+    hasSizeOverride ? null : "text-[0.6875rem]",
     hasFontOverride ? null : "font-bold",
     "uppercase",
     hasTrackingOverride ? null : "tracking-[0.12em]",
-    hasTextOverride ? null : "text-outline",
+    hasColorOverride ? null : "text-outline",
   ].filter(Boolean);
 
   return [...base, ...extra].join(" ");


### PR DESCRIPTION
## Summary
- migrated remaining hand-rolled eyebrow label spans/headings to the shared `<Eyebrow>` primitive in customers, quotes, public, and shared components
- preserved existing copy and semantics by nesting `<Eyebrow>` where heading/description list structure mattered (`h2`, `h3`, `dt`)
- updated the settings screen class assertion to match the primitive-based class source

## Verification
- `cd frontend && npx vitest run src/features/customers/tests/ src/features/settings/tests/ src/features/quotes/tests/CaptureDetailsSheet.test.tsx --passWithNoTests`
- `cd frontend && npx tsc --noEmit`
- `cd frontend && npx eslint $(rg -l "uppercase tracking-" src -g "*.tsx")`
- `make frontend-verify`
- `rg "text-\[0\.6875rem\]|uppercase tracking-\[0\.[0-9]+em\]|uppercase tracking-widest" frontend/src -g '*.tsx'`

Closes #515