### PR TITLE
Task #521: shared component polish sweep

### DIFF
--- a/frontend/src/shared/components/DetailPageSkeleton.tsx
+++ b/frontend/src/shared/components/DetailPageSkeleton.tsx
@@ -7,7 +7,7 @@ interface DetailPageSkeletonProps {
 export function DetailPageSkeleton({ className }: DetailPageSkeletonProps): React.ReactElement {
   return (
     <div className={`space-y-4 ${className ?? ""}`.trim()}>
-      <div className="rounded-xl bg-surface-container-lowest p-4 ghost-shadow">
+      <div className="rounded-[var(--radius-document)] bg-surface-container-lowest p-4 ghost-shadow">
         <div className="flex items-center justify-between gap-3">
           <SkeletonBlock width="48%" height="1.5rem" />
           <SkeletonBlock width="28%" height="1.5rem" borderRadius="9999px" />
@@ -15,7 +15,7 @@ export function DetailPageSkeleton({ className }: DetailPageSkeletonProps): Reac
         <SkeletonBlock className="mt-3" width="36%" height="0.875rem" />
       </div>
 
-      <div className="space-y-3 rounded-xl bg-surface-container-low p-4">
+      <div className="space-y-3 rounded-[var(--radius-document)] bg-surface-container-low p-4">
         <SkeletonBlock width="100%" height="4.5rem" />
         <SkeletonBlock width="100%" height="4.5rem" />
         <SkeletonBlock width="100%" height="4.5rem" />

--- a/frontend/src/shared/components/DocumentCardSkeleton.tsx
+++ b/frontend/src/shared/components/DocumentCardSkeleton.tsx
@@ -2,7 +2,7 @@ import { SkeletonBlock } from "@/shared/components/SkeletonBlock";
 
 export function DocumentCardSkeleton(): React.ReactElement {
   return (
-    <div className="w-full rounded-xl bg-surface-container-lowest p-4 ghost-shadow">
+    <div className="w-full rounded-[var(--radius-document)] bg-surface-container-lowest p-4 ghost-shadow">
       <div className="flex items-baseline justify-between gap-3">
         <SkeletonBlock width="52%" height="1rem" />
         <SkeletonBlock width="26%" height="1rem" />

--- a/frontend/src/shared/components/FeedbackMessage.tsx
+++ b/frontend/src/shared/components/FeedbackMessage.tsx
@@ -14,7 +14,7 @@ export function FeedbackMessage({
   children,
 }: FeedbackMessageProps): React.ReactElement {
   return (
-    <p role="alert" className={`rounded-lg p-4 text-sm ${variantClasses[variant]}`}>
+    <p role="alert" className={`rounded-[var(--radius-document)] p-4 text-sm ${variantClasses[variant]}`}>
       {children}
     </p>
   );

--- a/frontend/src/shared/components/OptionalPricingBanner.tsx
+++ b/frontend/src/shared/components/OptionalPricingBanner.tsx
@@ -1,4 +1,4 @@
-import { Button } from "@/shared/components/Button";
+import { Banner } from "@/ui/Banner";
 
 interface OptionalPricingBannerProps {
   message: string;
@@ -12,18 +12,12 @@ export function OptionalPricingBanner({
   dismissLabel = "Dismiss TBD pricing hint",
 }: OptionalPricingBannerProps): React.ReactElement {
   return (
-    <div className="flex items-start justify-between gap-3 rounded-lg border border-warning/20 bg-warning-container px-3 py-2 text-xs text-warning">
-      <p>{message}</p>
-      <Button
-        type="button"
-        variant="iconButton"
-        size="xs"
-        aria-label={dismissLabel}
-        onClick={onDismiss}
-        className="shrink-0 text-warning hover:bg-warning/10"
-      >
-        <span className="material-symbols-outlined text-base">close</span>
-      </Button>
-    </div>
+    <Banner
+      kind="warn"
+      title="Optional Pricing"
+      message={message}
+      onDismiss={onDismiss}
+      dismissLabel={dismissLabel}
+    />
   );
 }

--- a/frontend/src/shared/components/TradeTypeSelector.tsx
+++ b/frontend/src/shared/components/TradeTypeSelector.tsx
@@ -21,7 +21,7 @@ export function TradeTypeSelector({
             aria-pressed={isSelected}
             onClick={() => onChange(option)}
             className={[
-              "cursor-pointer py-3 rounded-lg font-label text-sm",
+              "cursor-pointer py-3 rounded-[var(--radius-document)] font-label text-sm",
               isSelected
                 ? "ghost-shadow border border-primary/30 bg-surface-container-lowest text-on-surface font-semibold"
                 : "border border-outline-variant/30 bg-surface-container-low text-on-surface-variant",


### PR DESCRIPTION
## Summary
- migrate OptionalPricingBanner to the shared Banner wrapper (kind=warn)
- replace stale rounded-xl/rounded-lg classes with rounded-[var(--radius-document)] in shared skeleton/message components
- align TradeTypeSelector option button radius with document radius token

## Verification
- cd frontend && npx vitest run src/shared/components/ --passWithNoTests
- cd frontend && npx tsc --noEmit
- cd frontend && npx eslint src/shared/components/OptionalPricingBanner.tsx src/shared/components/DetailPageSkeleton.tsx src/shared/components/DocumentCardSkeleton.tsx src/shared/components/FeedbackMessage.tsx src/shared/components/TradeTypeSelector.tsx
- make frontend-verify

Closes #521