### PR TITLE
PR-P: add page transition shell

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -25,6 +25,7 @@ import { DocumentEditScreen } from "@/features/quotes/components/ReviewScreen";
 import { QuoteList } from "@/features/quotes/components/QuoteList";
 import { QuotePreview } from "@/features/quotes/components/QuotePreview";
 import { SettingsScreen } from "@/features/settings/components/SettingsScreen";
+import { PageTransition } from "@/ui/PageTransition";
 import { ToastProvider } from "@/ui/Toast";
 
 function ProtectedRoute(): React.ReactElement {
@@ -91,61 +92,63 @@ export default function App(): React.ReactElement {
   return (
     <ToastProvider>
       <Routes>
-        <Route
-          path="/login"
-          element={
-            <PublicRoute>
-              <LoginForm />
-            </PublicRoute>
-          }
-        />
-        <Route
-          path="/register"
-          element={
-            <PublicRoute>
-              <RegisterForm />
-            </PublicRoute>
-          }
-        />
-        <Route
-          path="/forgot-password"
-          element={
-            <PublicRoute>
-              <ForgotPasswordPage />
-            </PublicRoute>
-          }
-        />
-        <Route
-          path="/reset-password"
-          element={
-            <PublicRoute>
-              <ResetPasswordPage />
-            </PublicRoute>
-          }
-        />
-        <Route path="/" element={<RootHome />} />
-        <Route path="/doc/:token" element={<PublicQuotePage />} />
-        <Route element={<OnboardingRoute />}>
-          <Route path="/onboarding" element={<OnboardingForm />} />
+        <Route element={<PageTransition />}>
+          <Route
+            path="/login"
+            element={
+              <PublicRoute>
+                <LoginForm />
+              </PublicRoute>
+            }
+          />
+          <Route
+            path="/register"
+            element={
+              <PublicRoute>
+                <RegisterForm />
+              </PublicRoute>
+            }
+          />
+          <Route
+            path="/forgot-password"
+            element={
+              <PublicRoute>
+                <ForgotPasswordPage />
+              </PublicRoute>
+            }
+          />
+          <Route
+            path="/reset-password"
+            element={
+              <PublicRoute>
+                <ResetPasswordPage />
+              </PublicRoute>
+            }
+          />
+          <Route path="/" element={<RootHome />} />
+          <Route path="/doc/:token" element={<PublicQuotePage />} />
+          <Route element={<OnboardingRoute />}>
+            <Route path="/onboarding" element={<OnboardingForm />} />
+          </Route>
+          <Route element={<ProtectedRoute />}>
+            <Route path="/customers" element={<CustomerListScreen />} />
+            <Route path="/customers/new" element={<CustomerCreateScreen />} />
+            <Route path="/customers/:id" element={<CustomerDetailScreen />} />
+            <Route path="/settings" element={<SettingsScreen />} />
+            <Route path="/settings/line-item-catalog" element={<LineItemCatalogSettingsScreen />} />
+            <Route path="/invoices/:id" element={<InvoiceDetailScreen />} />
+            <Route path="/invoices/:id/edit" element={<InvoiceEditRedirect />} />
+            <Route path="/invoices/:id/edit/line-items/:lineItemIndex/edit" element={<InvoiceEditRedirect />} />
+            <Route path="/quotes/new" element={<Navigate to="/quotes/capture" replace />} />
+            <Route path="/quotes/capture" element={<CaptureScreen />} />
+            <Route path="/quotes/capture/:customerId" element={<CaptureScreen />} />
+            <Route path="/documents/:id/edit" element={<DocumentEditScreen />} />
+            <Route path="/quotes/:id/review" element={<QuoteEditRedirect />} />
+            <Route path="/quotes/:id/edit" element={<QuoteEditRedirect />} />
+            <Route path="/quotes/:id/preview" element={<QuotePreview />} />
+          </Route>
+          <Route path="*" element={<Navigate to="/login" replace />} />
         </Route>
-        <Route element={<ProtectedRoute />}>
-          <Route path="/customers" element={<CustomerListScreen />} />
-          <Route path="/customers/new" element={<CustomerCreateScreen />} />
-          <Route path="/customers/:id" element={<CustomerDetailScreen />} />
-          <Route path="/settings" element={<SettingsScreen />} />
-          <Route path="/settings/line-item-catalog" element={<LineItemCatalogSettingsScreen />} />
-          <Route path="/invoices/:id" element={<InvoiceDetailScreen />} />
-          <Route path="/invoices/:id/edit" element={<InvoiceEditRedirect />} />
-          <Route path="/invoices/:id/edit/line-items/:lineItemIndex/edit" element={<InvoiceEditRedirect />} />
-          <Route path="/quotes/new" element={<Navigate to="/quotes/capture" replace />} />
-          <Route path="/quotes/capture" element={<CaptureScreen />} />
-          <Route path="/quotes/capture/:customerId" element={<CaptureScreen />} />
-          <Route path="/documents/:id/edit" element={<DocumentEditScreen />} />
-          <Route path="/quotes/:id/review" element={<QuoteEditRedirect />} />
-          <Route path="/quotes/:id/edit" element={<QuoteEditRedirect />} />
-          <Route path="/quotes/:id/preview" element={<QuotePreview />} />
-        </Route>
-        <Route path="*" element={<Navigate to="/login" replace />} />
       </Routes>
     </ToastProvider>
   );

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -319,6 +319,64 @@
   animation: shimmer 1.5s linear infinite;
 }
 
+.page-transition-root {
+  min-height: 100%;
+}
+
+.page-transition-content {
+  opacity: 1;
+  transition: opacity 170ms ease;
+}
+
+@starting-style {
+  .page-transition-content {
+    opacity: 0;
+  }
+}
+
+@keyframes page-transition-fade-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes page-transition-fade-out {
+  from {
+    opacity: 1;
+  }
+  to {
+    opacity: 0;
+  }
+}
+
+::view-transition-old(root),
+::view-transition-new(root) {
+  animation-duration: 170ms;
+  animation-timing-function: ease;
+}
+
+::view-transition-old(root) {
+  animation-name: page-transition-fade-out;
+}
+
+::view-transition-new(root) {
+  animation-name: page-transition-fade-in;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .page-transition-content {
+    transition: none;
+  }
+
+  ::view-transition-old(root),
+  ::view-transition-new(root) {
+    animation-duration: 1ms;
+  }
+}
+
 body {
   margin: 0;
   background-color: var(--color-background);

--- a/frontend/src/ui/PageTransition.test.tsx
+++ b/frontend/src/ui/PageTransition.test.tsx
@@ -1,0 +1,65 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Link, MemoryRouter, Route, Routes } from "react-router-dom";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { PageTransition } from "@/ui/PageTransition";
+
+type StartViewTransition = (updateCallback: () => void) => unknown;
+
+function renderWithRouter(initialPath = "/"): void {
+  render(
+    <MemoryRouter initialEntries={[initialPath]}>
+      <Routes>
+        <Route element={<PageTransition />}>
+          <Route
+            path="/"
+            element={
+              <>
+                <h1>Quotes</h1>
+                <Link to="/review">Go review</Link>
+              </>
+            }
+          />
+          <Route path="/review" element={<h1>Review</h1>} />
+        </Route>
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+afterEach(() => {
+  Reflect.deleteProperty(document, "startViewTransition");
+});
+
+describe("PageTransition", () => {
+  it("navigates without view transition support", async () => {
+    const user = userEvent.setup();
+    renderWithRouter("/");
+
+    expect(screen.getByRole("heading", { name: "Quotes" })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("link", { name: "Go review" }));
+
+    expect(screen.getByRole("heading", { name: "Review" })).toBeInTheDocument();
+  });
+
+  it("wraps navigation in document.startViewTransition when available", async () => {
+    const startViewTransition = vi.fn((updateCallback: () => void) => {
+      updateCallback();
+      return {};
+    });
+    Object.defineProperty(document, "startViewTransition", {
+      configurable: true,
+      value: startViewTransition as StartViewTransition,
+    });
+
+    const user = userEvent.setup();
+    renderWithRouter("/");
+
+    await user.click(screen.getByRole("link", { name: "Go review" }));
+
+    expect(startViewTransition).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole("heading", { name: "Review" })).toBeInTheDocument();
+  });
+});

--- a/frontend/src/ui/PageTransition.test.tsx
+++ b/frontend/src/ui/PageTransition.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Link, MemoryRouter, Route, Routes } from "react-router-dom";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -30,6 +30,7 @@ function renderWithRouter(initialPath = "/"): void {
 
 afterEach(() => {
   Reflect.deleteProperty(document, "startViewTransition");
+  vi.useRealTimers();
 });
 
 describe("PageTransition", () => {
@@ -61,5 +62,23 @@ describe("PageTransition", () => {
 
     expect(startViewTransition).toHaveBeenCalledTimes(1);
     expect(screen.getByRole("heading", { name: "Review" })).toBeInTheDocument();
+  });
+
+  it("falls back to normal navigation when startViewTransition does not run callback", async () => {
+    const startViewTransition = vi.fn(() => ({}));
+    Object.defineProperty(document, "startViewTransition", {
+      configurable: true,
+      value: startViewTransition as StartViewTransition,
+    });
+
+    const user = userEvent.setup();
+    renderWithRouter("/");
+
+    await user.click(screen.getByRole("link", { name: "Go review" }));
+
+    expect(startViewTransition).toHaveBeenCalledTimes(1);
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: "Review" })).toBeInTheDocument();
+    });
   });
 });

--- a/frontend/src/ui/PageTransition.tsx
+++ b/frontend/src/ui/PageTransition.tsx
@@ -1,0 +1,102 @@
+import { flushSync } from "react-dom";
+import { useEffect, useMemo, useState } from "react";
+import { useLocation, useNavigationType, useOutlet } from "react-router-dom";
+
+type StartViewTransition = (updateCallback: () => void) => unknown;
+
+function usePrefersReducedMotion(): boolean {
+  const mediaQuery = useMemo(
+    () =>
+      typeof window === "undefined" || typeof window.matchMedia !== "function"
+        ? null
+        : window.matchMedia("(prefers-reduced-motion: reduce)"),
+    [],
+  );
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState(
+    mediaQuery?.matches ?? false,
+  );
+
+  useEffect(() => {
+    if (!mediaQuery) {
+      return;
+    }
+
+    const handleChange = () => {
+      setPrefersReducedMotion(mediaQuery.matches);
+    };
+
+    handleChange();
+    mediaQuery.addEventListener("change", handleChange);
+    return () => {
+      mediaQuery.removeEventListener("change", handleChange);
+    };
+  }, [mediaQuery]);
+
+  return prefersReducedMotion;
+}
+
+export function PageTransition(): React.ReactElement {
+  const location = useLocation();
+  const navigationType = useNavigationType();
+  const outlet = useOutlet();
+  const prefersReducedMotion = usePrefersReducedMotion();
+  const startViewTransition = (
+    document as Document & { startViewTransition?: StartViewTransition }
+  ).startViewTransition;
+
+  const [displayLocationKey, setDisplayLocationKey] = useState(location.key);
+  const [displayOutlet, setDisplayOutlet] = useState(outlet);
+  const shouldAnimateNavigation =
+    location.key !== displayLocationKey &&
+    navigationType === "PUSH" &&
+    !prefersReducedMotion &&
+    typeof startViewTransition === "function";
+
+  useEffect(() => {
+    if (location.key === displayLocationKey) {
+      return;
+    }
+
+    const commitNavigation = (sync = false) => {
+      const applyNavigation = () => {
+        setDisplayLocationKey(location.key);
+        setDisplayOutlet(outlet);
+      };
+
+      if (sync) {
+        flushSync(applyNavigation);
+        return;
+      }
+
+      applyNavigation();
+    };
+
+    if (shouldAnimateNavigation) {
+      let isCancelled = false;
+      queueMicrotask(() => {
+        if (isCancelled) {
+          return;
+        }
+        startViewTransition(() => {
+          commitNavigation(true);
+        });
+      });
+      return () => {
+        isCancelled = true;
+      };
+    }
+
+    commitNavigation(false);
+  }, [displayLocationKey, location.key, outlet, shouldAnimateNavigation, startViewTransition]);
+
+  const routedContent = shouldAnimateNavigation ? displayOutlet : outlet;
+  const contentKey = shouldAnimateNavigation ? displayLocationKey : location.key;
+
+  return (
+    <div className="page-transition-root">
+      <div key={contentKey} className="page-transition-content">
+        {routedContent}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/ui/PageTransition.tsx
+++ b/frontend/src/ui/PageTransition.tsx
@@ -3,6 +3,7 @@ import { useEffect, useMemo, useState } from "react";
 import { useLocation, useNavigationType, useOutlet } from "react-router-dom";
 
 type StartViewTransition = (updateCallback: () => void) => unknown;
+const TRANSITION_FALLBACK_MS = 220;
 
 function usePrefersReducedMotion(): boolean {
   const mediaQuery = useMemo(
@@ -73,16 +74,43 @@ export function PageTransition(): React.ReactElement {
 
     if (shouldAnimateNavigation) {
       let isCancelled = false;
+      let hasCommitted = false;
+      let fallbackTimer: ReturnType<typeof setTimeout> | null = null;
+
+      const commitOnce = (sync = false) => {
+        if (hasCommitted) {
+          return;
+        }
+        hasCommitted = true;
+        commitNavigation(sync);
+      };
+
       queueMicrotask(() => {
         if (isCancelled) {
           return;
         }
-        startViewTransition(() => {
-          commitNavigation(true);
-        });
+
+        fallbackTimer = setTimeout(() => {
+          if (isCancelled) {
+            return;
+          }
+          commitOnce(false);
+        }, TRANSITION_FALLBACK_MS);
+
+        try {
+          startViewTransition(() => {
+            commitOnce(true);
+          });
+        } catch {
+          commitOnce(false);
+        }
       });
+
       return () => {
         isCancelled = true;
+        if (fallbackTimer) {
+          clearTimeout(fallbackTimer);
+        }
       };
     }
 


### PR DESCRIPTION
Closes #517

## Summary
- add `PageTransition` route shell that uses the View Transitions API when available
- wrap app routes in `PageTransition` and keep redirect/state semantics intact
- add global cross-fade CSS with reduced-motion opt-out and fallback fade
- add `PageTransition` smoke tests for non-supporting and supporting envs

## Verification
- cd frontend && npx vitest run src/ui/PageTransition.test.tsx
- cd frontend && npx tsc --noEmit
- cd frontend && npx eslint src/ui/PageTransition.tsx src/App.tsx src/ui/PageTransition.test.tsx
- make frontend-verify