### PR TITLE
PR-S — Audit closeout sweep

### DIFF
--- a/frontend/src/features/customers/components/CustomerCreateScreen.tsx
+++ b/frontend/src/features/customers/components/CustomerCreateScreen.tsx
@@ -98,7 +98,7 @@ export function CustomerCreateScreen(): React.ReactElement {
                 maxLength={CUSTOMER_ADDRESS_MAX_CHARS}
                 value={address}
                 onChange={(event) => setAddress(event.target.value)}
-                className="w-full rounded-lg bg-surface-container-high px-4 py-3 font-body text-sm text-on-surface placeholder:text-outline transition-all focus:bg-surface-container-lowest focus:ring-2 focus:ring-primary/30 focus:outline-none"
+                className="w-full rounded-[var(--radius-document)] bg-surface-container-high px-4 py-3 font-body text-sm text-on-surface placeholder:text-outline transition-all focus:bg-surface-container-lowest focus:ring-2 focus:ring-primary/30 focus:outline-none"
               />
             </div>
 

--- a/frontend/src/features/customers/components/CustomerInfoForm.tsx
+++ b/frontend/src/features/customers/components/CustomerInfoForm.tsx
@@ -66,7 +66,7 @@ export function CustomerInfoForm({
             maxLength={CUSTOMER_ADDRESS_MAX_CHARS}
             value={address}
             onChange={onAddressChange}
-            className="w-full rounded-lg bg-surface-container-high px-4 py-3 font-body text-sm text-on-surface placeholder:text-outline transition-all focus:bg-surface-container-lowest focus:ring-2 focus:ring-primary/30 focus:outline-none"
+            className="w-full rounded-[var(--radius-document)] bg-surface-container-high px-4 py-3 font-body text-sm text-on-surface placeholder:text-outline transition-all focus:bg-surface-container-lowest focus:ring-2 focus:ring-primary/30 focus:outline-none"
           />
         </div>
 

--- a/frontend/src/features/customers/components/CustomerInlineCreateForm.tsx
+++ b/frontend/src/features/customers/components/CustomerInlineCreateForm.tsx
@@ -63,7 +63,7 @@ export function CustomerInlineCreateForm({
             maxLength={CUSTOMER_ADDRESS_MAX_CHARS}
             value={address}
             onChange={onAddressChange}
-            className="w-full rounded-lg bg-surface-container-high px-4 py-3 font-body text-sm text-on-surface placeholder:text-outline transition-all focus:bg-surface-container-lowest focus:ring-2 focus:ring-primary/30 focus:outline-none"
+            className="w-full rounded-[var(--radius-document)] bg-surface-container-high px-4 py-3 font-body text-sm text-on-surface placeholder:text-outline transition-all focus:bg-surface-container-lowest focus:ring-2 focus:ring-primary/30 focus:outline-none"
           />
         </div>
 

--- a/frontend/src/features/customers/components/CustomerListScreen.tsx
+++ b/frontend/src/features/customers/components/CustomerListScreen.tsx
@@ -115,13 +115,13 @@ export function CustomerListScreen(): React.ReactElement {
         ) : null}
 
         {!isLoading && !loadError && filteredCustomers.length > 0 ? (
-          <div className="mx-4 rounded-xl bg-surface-container-low p-3">
+          <div className="mx-4 rounded-[var(--radius-document)] bg-surface-container-low p-3">
             <ul className="flex flex-col gap-3">
               {filteredCustomers.map((customer) => (
                 <li key={customer.id}>
                   <button
                     type="button"
-                    className="flex w-full cursor-pointer items-center justify-between rounded-xl bg-surface-container-lowest p-4 text-left ghost-shadow transition-all active:scale-[0.98] active:bg-surface-container-low"
+                    className="flex w-full cursor-pointer items-center justify-between rounded-[var(--radius-document)] bg-surface-container-lowest p-4 text-left ghost-shadow transition-all active:scale-[0.98] active:bg-surface-container-low"
                     onClick={() => navigate(`/customers/${customer.id}`)}
                   >
                     <div>

--- a/frontend/src/features/marketing/components/LandingPage.tsx
+++ b/frontend/src/features/marketing/components/LandingPage.tsx
@@ -32,7 +32,7 @@ export function LandingPage(): React.ReactElement {
 
   return (
     <main className="screen-radial-backdrop min-h-screen bg-background text-on-surface" data-testid="landing-page">
-      <header className="glass-surface glass-shadow-top fixed top-0 z-50 w-full border-b border-outline-variant/20 backdrop-blur-md">
+      <header className="glass-surface glass-shadow-top safe-top fixed top-0 z-50 w-full border-b border-outline-variant/20 backdrop-blur-md">
         <div className="mx-auto flex h-16 w-full max-w-5xl items-center justify-between gap-4 px-4 sm:px-6">
           <p className="font-headline text-[2rem] font-bold leading-none text-primary">Stima</p>
           <div className="flex items-center gap-3">

--- a/frontend/src/features/quotes/components/CaptureDetailsSheet.tsx
+++ b/frontend/src/features/quotes/components/CaptureDetailsSheet.tsx
@@ -1,10 +1,8 @@
-import * as Dialog from "@radix-ui/react-dialog";
-
 import type { ExtractionReviewHiddenDetails, HiddenItemState } from "@/features/quotes/types/quote.types";
 import { resolveCaptureDetailsActionableItems } from "@/features/quotes/utils/captureDetails";
 import { Button } from "@/shared/components/Button";
 import { Eyebrow } from "@/ui/Eyebrow";
-import { Sheet, SheetBody, SheetCloseButton, SheetFooter, SheetHeader } from "@/ui/Sheet";
+import { Sheet, SheetBody, SheetCloseButton, SheetDescription, SheetFooter, SheetHeader, SheetTitle } from "@/ui/Sheet";
 
 interface CaptureDetailsSheetProps {
   open: boolean;
@@ -38,12 +36,10 @@ export function CaptureDetailsSheet({
     >
       <SheetHeader>
         <div>
-            <Dialog.Title className="font-headline text-xl font-bold tracking-tight text-on-surface">
-              Capture Details
-            </Dialog.Title>
-            <Dialog.Description className="mt-2 text-sm leading-6 text-on-surface-variant">
-              Secondary capture output for review. Main review inputs stay focused on line items, notes, and pricing.
-            </Dialog.Description>
+          <SheetTitle>Capture Details</SheetTitle>
+          <SheetDescription>
+            Secondary capture output for review. Main review inputs stay focused on line items, notes, and pricing.
+          </SheetDescription>
         </div>
         <SheetCloseButton />
       </SheetHeader>
@@ -56,7 +52,7 @@ export function CaptureDetailsSheet({
                     {actionableItems.map((item) => (
                       <li
                         key={item.id}
-                        className="rounded-lg border border-outline-variant/30 bg-surface-container-high p-3 text-sm text-on-surface"
+                        className="rounded-[var(--radius-document)] border border-outline-variant/30 bg-surface-container-high p-3 text-sm text-on-surface"
                       >
                         <p className="font-semibold">{item.label}</p>
                         <p className="mt-1 whitespace-pre-wrap text-on-surface-variant">{item.text}</p>
@@ -65,7 +61,7 @@ export function CaptureDetailsSheet({
                             type="button"
                             variant="ghost"
                             size="sm"
-                            className="rounded-md border border-outline-variant/40 px-2 py-1 text-xs font-medium uppercase tracking-wide"
+                            className="border border-outline-variant/40 px-2 py-1"
                             disabled={isMutating || !onDismissHiddenItem}
                             onClick={() => { void onDismissHiddenItem?.(item.id); }}
                           >
@@ -82,7 +78,7 @@ export function CaptureDetailsSheet({
 
               <section className="space-y-2">
                 <Eyebrow as="h3">Transcript</Eyebrow>
-                <div className="rounded-lg border border-outline-variant/30 bg-surface-container-high p-3 text-sm leading-6 text-on-surface whitespace-pre-wrap">
+                <div className="rounded-[var(--radius-document)] border border-outline-variant/30 bg-surface-container-high p-3 text-sm leading-6 text-on-surface whitespace-pre-wrap">
                   {transcript.trim().length > 0 ? transcript : "No transcript notes captured."}
                 </div>
               </section>
@@ -92,7 +88,7 @@ export function CaptureDetailsSheet({
         <Button
           type="button"
           variant="secondary"
-          className="w-full rounded-lg border border-outline-variant/30 py-3"
+          className="w-full border border-outline-variant/30 py-3"
           onClick={onClose}
         >
           Close

--- a/frontend/src/features/quotes/components/CaptureInputPanel.tsx
+++ b/frontend/src/features/quotes/components/CaptureInputPanel.tsx
@@ -78,7 +78,7 @@ export function CaptureInputPanel({
                   <Button
                     type="button"
                     variant="iconButton"
-                    size="xs"
+                    size="sm"
                     aria-label={`Delete clip ${clipNumber}`}
                     className="text-outline hover:bg-surface-container-low"
                     onClick={() => removeClip(clip.id)}
@@ -112,14 +112,15 @@ export function CaptureInputPanel({
           className="w-full resize-none rounded-[var(--radius-document)] border border-outline-variant/25 bg-surface-container-high px-4 py-3 font-body text-sm text-on-surface placeholder:text-outline transition-all focus:border-primary/40 focus:bg-surface-container-lowest focus:ring-2 focus:ring-primary/30 focus:outline-none"
         />
         {onStartBlank ? (
-          <button
+          <Button
             type="button"
-            className="mt-3 cursor-pointer text-sm text-primary underline decoration-primary/60 underline-offset-4 transition-colors hover:text-primary/80 disabled:cursor-not-allowed disabled:text-outline"
+            variant="ghost"
+            className="mt-3 text-sm text-primary underline decoration-primary/60 underline-offset-4 hover:text-primary/80 disabled:text-outline"
             onClick={onStartBlank}
             disabled={isStartBlankDisabled}
           >
             Or start with a blank document
-          </button>
+          </Button>
         ) : null}
       </section>
 

--- a/frontend/src/features/quotes/components/CaptureInputPanel.tsx
+++ b/frontend/src/features/quotes/components/CaptureInputPanel.tsx
@@ -115,6 +115,7 @@ export function CaptureInputPanel({
           <Button
             type="button"
             variant="ghost"
+            size="sm"
             className="mt-3 text-sm text-primary underline decoration-primary/60 underline-offset-4 hover:text-primary/80 disabled:text-outline"
             onClick={onStartBlank}
             disabled={isStartBlankDisabled}

--- a/frontend/src/features/quotes/components/LineItemEditSheet.tsx
+++ b/frontend/src/features/quotes/components/LineItemEditSheet.tsx
@@ -1,18 +1,19 @@
 import { useEffect, useRef, useState } from "react";
-import * as Dialog from "@radix-ui/react-dialog";
 import type { LineItemCatalogItem } from "@/features/line-item-catalog/types/lineItemCatalog.types";
 import type { LineItemDraftWithFlags } from "@/features/quotes/types/quote.types";
 import { LineItemCatalogTabPanel } from "@/features/quotes/components/LineItemCatalogTabPanel";
 import { resolveLineItemReviewExplanation } from "@/features/quotes/utils/lineItemFlags";
 import { Button } from "@/shared/components/Button";
 import { FeedbackMessage } from "@/shared/components/FeedbackMessage";
+import { Input } from "@/shared/components/Input";
 import {
   LINE_ITEM_DESCRIPTION_MAX_CHARS,
   LINE_ITEM_DETAILS_MAX_CHARS,
 } from "@/shared/lib/inputLimits";
 import { Card } from "@/ui/Card";
 import { Eyebrow } from "@/ui/Eyebrow";
-import { Sheet } from "@/ui/Sheet";
+import { NumericField } from "@/ui/NumericField";
+import { Sheet, SheetDescription, SheetTitle } from "@/ui/Sheet";
 interface LineItemEditSheetProps {
   open: boolean;
   mode: "add" | "edit";
@@ -229,9 +230,7 @@ export function LineItemEditSheet({
       }}
     >
             <div className="flex items-start justify-between gap-4">
-              <Dialog.Title className="font-headline text-xl font-bold tracking-tight text-on-surface">
-                {title}
-              </Dialog.Title>
+              <SheetTitle>{title}</SheetTitle>
               <div className="flex items-center gap-2">
                 {onSaveToCatalog && showManualFields ? (
                   <Button
@@ -284,12 +283,9 @@ export function LineItemEditSheet({
               </div>
             </div>
             {!showManualFields ? (
-              <Dialog.Description
-                id="line-item-sheet-catalog-description"
-                className="mt-2 text-sm leading-6 text-on-surface-variant"
-              >
+              <SheetDescription id="line-item-sheet-catalog-description">
                 Pick a catalog item to insert.
-              </Dialog.Description>
+              </SheetDescription>
             ) : null}
             <div className="mt-4 space-y-4">
               {formError ? <FeedbackMessage variant="error">{formError}</FeedbackMessage> : null}
@@ -297,16 +293,18 @@ export function LineItemEditSheet({
                 <Card accent="warn" className="bg-warning-container/50">
                   <Eyebrow className="text-warning">Review needed</Eyebrow>
                   <p className="mt-1 text-sm leading-6 text-warning">{reviewExplanation}</p>
-                  <button
+                  <Button
                     type="button"
-                    className="mt-3 inline-flex min-h-11 cursor-pointer items-center justify-center rounded-[var(--radius-document)] border border-warning-accent/50 bg-warning-container px-3.5 py-2 text-xs font-bold uppercase tracking-wide text-warning transition-all hover:bg-warning-container/80 active:scale-[0.98]"
+                    variant="ghost"
+                    size="sm"
+                    className="mt-3 border border-warning-accent/50 bg-warning-container text-warning hover:bg-warning-container/80"
                     onClick={() => {
                       setLineItemFlagged(false);
                       setLineItemFlagReason(null);
                     }}
                   >
                     Dismiss
-                  </button>
+                  </Button>
                 </Card>
               ) : null}
               {mode === "add" ? (
@@ -321,7 +319,7 @@ export function LineItemEditSheet({
                     type="button"
                     aria-controls="line-item-tabpanel-manual"
                     aria-selected={activeAddTab === "manual"}
-                    className={`min-h-11 rounded-full px-3 py-2 text-xs font-bold uppercase tracking-wide transition-all active:scale-[0.98] ${
+                    className={`min-h-11 rounded-full px-3 py-2 transition-all active:scale-[0.98] ${
                       activeAddTab === "manual"
                         ? "bg-surface-container-lowest text-primary"
                         : "text-on-surface-variant hover:text-on-surface"
@@ -331,7 +329,7 @@ export function LineItemEditSheet({
                       setActiveAddTab("manual");
                     }}
                   >
-                    Manual
+                    <Eyebrow as="span">Manual</Eyebrow>
                   </button>
                   <button
                     id="line-item-tab-catalog"
@@ -339,7 +337,7 @@ export function LineItemEditSheet({
                     type="button"
                     aria-controls="line-item-tabpanel-catalog"
                     aria-selected={activeAddTab === "catalog"}
-                    className={`min-h-11 rounded-full px-3 py-2 text-xs font-bold uppercase tracking-wide transition-all active:scale-[0.98] ${
+                    className={`min-h-11 rounded-full px-3 py-2 transition-all active:scale-[0.98] ${
                       activeAddTab === "catalog"
                         ? "bg-surface-container-lowest text-primary"
                         : "text-on-surface-variant hover:text-on-surface"
@@ -350,7 +348,7 @@ export function LineItemEditSheet({
                       void loadCatalogItems();
                     }}
                   >
-                    Catalog
+                    <Eyebrow as="span">Catalog</Eyebrow>
                   </button>
                 </div>
               ) : null}
@@ -363,10 +361,9 @@ export function LineItemEditSheet({
                       </label>
                       <span className="text-xs font-bold uppercase text-primary">Required</span>
                     </div>
-                    <input
-                      id="line-item-sheet-description"
+                    <Input
                       ref={descriptionInputRef}
-                      type="text"
+                      id="line-item-sheet-description"
                       maxLength={LINE_ITEM_DESCRIPTION_MAX_CHARS}
                       value={description}
                       onChange={(event) => {
@@ -378,7 +375,6 @@ export function LineItemEditSheet({
                           setFormError(null);
                         }
                       }}
-                      className="w-full rounded-[var(--radius-document)] bg-surface-container-high px-4 py-3 font-body text-sm text-on-surface placeholder:text-outline transition-all focus:bg-surface-container-lowest focus:outline-none focus:ring-2 focus:ring-primary/30"
                     />
                   </section>
                   <section className="space-y-2">
@@ -409,14 +405,12 @@ export function LineItemEditSheet({
                     <label htmlFor="line-item-sheet-price" className="font-headline text-sm font-bold text-on-surface">
                       Price
                     </label>
-                    <input
+                    <NumericField
                       id="line-item-sheet-price"
-                      type="text"
-                      inputMode="decimal"
                       placeholder="$ 0.00"
                       value={priceInput}
-                      onChange={(event) => {
-                        setPriceInput(event.target.value);
+                      onChange={(nextValue) => {
+                        setPriceInput(nextValue);
                         if (savedCatalogItem) {
                           setSavedCatalogItem(null);
                         }
@@ -424,7 +418,8 @@ export function LineItemEditSheet({
                           setFormError(null);
                         }
                       }}
-                      className="w-full rounded-[var(--radius-document)] bg-surface-container-high px-4 py-3 font-body text-sm text-on-surface placeholder:text-outline transition-all focus:bg-surface-container-lowest focus:outline-none focus:ring-2 focus:ring-primary/30"
+                      showStepControls={false}
+                      formatOnBlur={false}
                     />
                   </section>
                 </div>

--- a/frontend/src/features/quotes/components/QuoteCreateEntrySheet.tsx
+++ b/frontend/src/features/quotes/components/QuoteCreateEntrySheet.tsx
@@ -1,6 +1,5 @@
-import * as Dialog from "@radix-ui/react-dialog";
 import { Button } from "@/shared/components/Button";
-import { Sheet, SheetBody, SheetCloseButton, SheetHeader } from "@/ui/Sheet";
+import { Sheet, SheetBody, SheetCloseButton, SheetDescription, SheetHeader, SheetTitle } from "@/ui/Sheet";
 
 interface QuoteCreateEntrySheetProps {
   open: boolean;
@@ -28,12 +27,8 @@ export function QuoteCreateEntrySheet({
     >
       <SheetHeader>
         <div>
-          <Dialog.Title className="font-headline text-xl font-bold tracking-tight text-on-surface">
-            {title}
-          </Dialog.Title>
-          <Dialog.Description className="mt-2 text-sm leading-6 text-on-surface-variant">
-            {description}
-          </Dialog.Description>
+          <SheetTitle>{title}</SheetTitle>
+          <SheetDescription>{description}</SheetDescription>
         </div>
         <SheetCloseButton />
       </SheetHeader>

--- a/frontend/src/features/quotes/components/QuoteList.tsx
+++ b/frontend/src/features/quotes/components/QuoteList.tsx
@@ -49,7 +49,7 @@ function DocumentRowsSection({ label, rows, onRowClick }: DocumentRowsSectionPro
       <div className="mb-2 px-4">
         <Eyebrow>{label}</Eyebrow>
       </div>
-      <div className="mx-4 rounded-xl bg-surface-container-low p-3">
+      <div className="mx-4 rounded-[var(--radius-document)] bg-surface-container-low p-3">
         <ul className="flex flex-col gap-3">
           {rows.map((row) => (
             <li key={row.id}>

--- a/frontend/src/features/quotes/components/QuoteReuseChooser.tsx
+++ b/frontend/src/features/quotes/components/QuoteReuseChooser.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useMemo, useState } from "react";
-import * as Dialog from "@radix-ui/react-dialog";
 
 import { quoteService } from "@/features/quotes/services/quoteService";
 import type { QuoteReuseCandidate } from "@/features/quotes/types/quote.types";
@@ -7,7 +6,7 @@ import { Button } from "@/shared/components/Button";
 import { FeedbackMessage } from "@/shared/components/FeedbackMessage";
 import { Input } from "@/shared/components/Input";
 import { StatusPill } from "@/ui/StatusPill";
-import { Sheet, SheetBody, SheetCloseButton, SheetFooter, SheetHeader } from "@/ui/Sheet";
+import { Sheet, SheetBody, SheetCloseButton, SheetDescription, SheetFooter, SheetHeader, SheetTitle } from "@/ui/Sheet";
 import { formatCurrency, formatDate } from "@/shared/lib/formatters";
 
 interface QuoteReuseChooserProps {
@@ -155,12 +154,8 @@ export function QuoteReuseChooser({
     >
       <SheetHeader>
         <div>
-            <Dialog.Title className="font-headline text-xl font-bold tracking-tight text-on-surface">
-              Create from existing
-            </Dialog.Title>
-            <Dialog.Description className="mt-2 text-sm leading-6 text-on-surface-variant">
-              Pick a quote to duplicate into a new draft.
-            </Dialog.Description>
+          <SheetTitle>Create from existing</SheetTitle>
+          <SheetDescription>Pick a quote to duplicate into a new draft.</SheetDescription>
         </div>
         <SheetCloseButton />
       </SheetHeader>
@@ -206,7 +201,7 @@ export function QuoteReuseChooser({
 
             <div className="mt-4 max-h-[52vh] space-y-3 overflow-y-auto pr-1">
               {isLoading ? (
-                <div role="status" aria-label="Loading quotes" className="rounded-xl bg-surface-container-low p-4 text-sm text-on-surface-variant">
+                <div role="status" aria-label="Loading quotes" className="rounded-[var(--radius-document)] bg-surface-container-low p-4 text-sm text-on-surface-variant">
                   Loading quotes...
                 </div>
               ) : null}
@@ -220,7 +215,7 @@ export function QuoteReuseChooser({
               ) : null}
 
               {!isLoading && !loadError && visibleCandidates.length === 0 ? (
-                <section className="rounded-xl bg-surface-container-low p-4 text-sm text-on-surface-variant">
+                <section className="rounded-[var(--radius-document)] bg-surface-container-low p-4 text-sm text-on-surface-variant">
                   {emptyStateMessage}
                 </section>
               ) : null}
@@ -231,7 +226,7 @@ export function QuoteReuseChooser({
                     <li key={candidate.id}>
                       <button
                         type="button"
-                        className="w-full cursor-pointer rounded-xl border border-outline-variant/30 bg-surface-container-low p-4 text-left transition-colors hover:bg-surface-container-lowest disabled:cursor-not-allowed disabled:opacity-70"
+                        className="w-full cursor-pointer rounded-[var(--radius-document)] border border-outline-variant/30 bg-surface-container-low p-4 text-left transition-colors hover:bg-surface-container-lowest disabled:cursor-not-allowed disabled:opacity-70"
                         disabled={duplicatingId !== null}
                         onClick={() => { void onCandidateSelect(candidate.id); }}
                       >

--- a/frontend/src/features/quotes/components/ReviewCustomerAssignmentSheet.tsx
+++ b/frontend/src/features/quotes/components/ReviewCustomerAssignmentSheet.tsx
@@ -1,12 +1,12 @@
 import { useEffect, useMemo, useState } from "react";
-import * as Dialog from "@radix-ui/react-dialog";
 
 import { customerService } from "@/features/customers/services/customerService";
 import type { Customer, CustomerCreateRequest } from "@/features/customers/types/customer.types";
 import { Button } from "@/shared/components/Button";
 import { FeedbackMessage } from "@/shared/components/FeedbackMessage";
 import { Input } from "@/shared/components/Input";
-import { Sheet, SheetBody, SheetCloseButton, SheetHeader } from "@/ui/Sheet";
+import { Eyebrow } from "@/ui/Eyebrow";
+import { Sheet, SheetBody, SheetCloseButton, SheetDescription, SheetHeader, SheetTitle } from "@/ui/Sheet";
 
 interface ReviewCustomerAssignmentSheetProps {
   open: boolean;
@@ -149,13 +149,10 @@ export function ReviewCustomerAssignmentSheet({
     >
       <SheetHeader>
         <div>
-            <Dialog.Title className="font-headline text-xl font-bold tracking-tight text-on-surface">
-              Assign Customer
-            </Dialog.Title>
-
-            <Dialog.Description className="mt-2 text-sm leading-6 text-on-surface-variant">
-              Search existing customers or create one inline, then apply the assignment.
-            </Dialog.Description>
+          <SheetTitle>Assign Customer</SheetTitle>
+          <SheetDescription>
+            Search existing customers or create one inline, then apply the assignment.
+          </SheetDescription>
         </div>
         <SheetCloseButton />
       </SheetHeader>
@@ -185,7 +182,7 @@ export function ReviewCustomerAssignmentSheet({
                       <button
                         key={customer.id}
                         type="button"
-                        className="flex w-full cursor-pointer items-center justify-between rounded-lg bg-surface-container-low px-4 py-3 text-left transition-colors hover:bg-surface-container-high disabled:cursor-not-allowed disabled:opacity-60"
+                        className="flex w-full cursor-pointer items-center justify-between rounded-[var(--radius-document)] bg-surface-container-low px-4 py-3 text-left transition-colors hover:bg-surface-container-high disabled:cursor-not-allowed disabled:opacity-60"
                         disabled={isSubmitting}
                         onClick={() => void assignCustomer(customer.id)}
                       >
@@ -196,7 +193,7 @@ export function ReviewCustomerAssignmentSheet({
                           </span>
                         </span>
                         {currentCustomerId === customer.id ? (
-                          <span className="text-xs font-bold uppercase tracking-wide text-primary">Current</span>
+                          <Eyebrow className="text-primary">Current</Eyebrow>
                         ) : null}
                       </button>
                     ))
@@ -204,7 +201,7 @@ export function ReviewCustomerAssignmentSheet({
                 </div>
               )}
 
-              <div className="rounded-lg bg-surface-container-low p-4">
+              <div className="rounded-[var(--radius-document)] bg-surface-container-low p-4">
                 <Button
                   type="button"
                   variant="ghost"

--- a/frontend/src/features/quotes/components/TotalAmountSection.test.tsx
+++ b/frontend/src/features/quotes/components/TotalAmountSection.test.tsx
@@ -105,11 +105,11 @@ describe("TotalAmountSection", () => {
 
     const taxCheckbox = screen.getByRole("checkbox", { name: "Tax" });
     expect(taxCheckbox).not.toBeChecked();
-    expect(screen.queryByRole("spinbutton", { name: /tax rate/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("textbox", { name: /tax rate/i })).not.toBeInTheDocument();
 
     fireEvent.click(taxCheckbox);
 
-    const taxInput = screen.getByRole("spinbutton", { name: /tax rate/i }) as HTMLInputElement;
+    const taxInput = screen.getByRole("textbox", { name: /tax rate/i }) as HTMLInputElement;
     expect(taxInput.value).toBe("8.25");
   });
 
@@ -118,14 +118,14 @@ describe("TotalAmountSection", () => {
 
     fireEvent.click(screen.getByRole("button", { name: /optional pricing/i }));
 
-    expect(screen.queryByRole("spinbutton", { name: /tax rate/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("textbox", { name: /tax rate/i })).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("checkbox", { name: "Discount" }));
     const discountInput = screen.getByPlaceholderText("25") as HTMLInputElement;
     expect(discountInput.value).toBe("");
 
     fireEvent.click(screen.getByRole("checkbox", { name: "Tax" }));
-    const taxInput = screen.getByRole("spinbutton", { name: /tax rate/i }) as HTMLInputElement;
+    const taxInput = screen.getByRole("textbox", { name: /tax rate/i }) as HTMLInputElement;
     expect(taxInput.value).toBe("8.25");
 
     fireEvent.click(screen.getByRole("checkbox", { name: "Deposit" }));

--- a/frontend/src/features/quotes/components/TotalAmountSection.tsx
+++ b/frontend/src/features/quotes/components/TotalAmountSection.tsx
@@ -183,7 +183,7 @@ export function TotalAmountSection({
                     step={0.01}
                     disabled={disabled}
                     value={String(discountValue ?? "")}
-                    onChange={(v) => onDiscountValueChange(v ? Number(v) : null)}
+                    onChange={(v) => onDiscountValueChange(v.trim() ? Number(v) : null)}
                     showStepControls={false}
                     formatOnBlur={false}
                     placeholder={discountType === "percent" ? "10" : "25"}
@@ -260,7 +260,7 @@ export function TotalAmountSection({
                     step={0.01}
                     disabled={disabled}
                     value={String(depositAmount ?? "")}
-                    onChange={(v) => onDepositAmountChange(v ? Number(v) : null)}
+                    onChange={(v) => onDepositAmountChange(v.trim() ? Number(v) : null)}
                     showStepControls={false}
                     formatOnBlur={false}
                     placeholder="50"

--- a/frontend/src/features/quotes/components/TotalAmountSection.tsx
+++ b/frontend/src/features/quotes/components/TotalAmountSection.tsx
@@ -177,16 +177,15 @@ export function TotalAmountSection({
                       <span className="material-symbols-outlined block text-sm leading-none">expand_more</span>
                     </span>
                   </div>
-                  <input
-                    type="number"
-                    step="0.01"
+                  <NumericField
+                    label="Discount value"
+                    hideLabel
+                    step={0.01}
                     disabled={disabled}
-                    value={discountValue ?? ""}
-                    onChange={(event) => {
-                      const nextValue = event.target.value.trim();
-                      onDiscountValueChange(nextValue.length > 0 ? Number(nextValue) : null);
-                    }}
-                    className="w-full rounded-[var(--radius-document)] border border-outline-variant/30 bg-surface-container-high px-4 py-3 text-sm text-on-surface transition-all focus:border-primary/40 focus:bg-surface-container-lowest focus:outline-none focus:ring-2 focus:ring-primary/25"
+                    value={String(discountValue ?? "")}
+                    onChange={(v) => onDiscountValueChange(v ? Number(v) : null)}
+                    showStepControls={false}
+                    formatOnBlur={false}
                     placeholder={discountType === "percent" ? "10" : "25"}
                   />
                 </div>
@@ -214,20 +213,19 @@ export function TotalAmountSection({
                 <span className="font-semibold">Tax</span>
               </label>
               {isTaxEnabled ? (
-                <div className="relative mt-3">
-                  <input
-                    type="number"
-                    step="0.01"
-                    aria-label="Tax rate (%)"
+                <div className="mt-3">
+                  <NumericField
+                    label="Tax rate (%)"
+                    hideLabel
+                    step={0.01}
                     disabled={disabled}
                     value={toTaxPercentDisplay(taxRate)}
-                    onChange={(event) => onTaxRateChange(parseTaxPercentInput(event.target.value))}
-                    className="w-full rounded-[var(--radius-document)] border border-outline-variant/30 bg-surface-container-high px-4 py-3 pr-10 text-sm text-on-surface transition-all focus:border-primary/40 focus:bg-surface-container-lowest focus:outline-none focus:ring-2 focus:ring-primary/25"
+                    onChange={(v) => onTaxRateChange(parseTaxPercentInput(v))}
+                    showStepControls={false}
+                    formatOnBlur={false}
                     placeholder="8.25"
+                    trailingAdornment={<span className="text-sm text-outline">%</span>}
                   />
-                  <span className="pointer-events-none absolute right-4 top-1/2 -translate-y-1/2 text-sm text-outline">
-                    %
-                  </span>
                 </div>
               ) : null}
             </section>
@@ -255,18 +253,19 @@ export function TotalAmountSection({
                 <span className="font-semibold">Deposit</span>
               </label>
               {isDepositEnabled ? (
-                <input
-                  type="number"
-                  step="0.01"
-                  disabled={disabled}
-                  value={depositAmount ?? ""}
-                  onChange={(event) => {
-                    const nextValue = event.target.value.trim();
-                    onDepositAmountChange(nextValue.length > 0 ? Number(nextValue) : null);
-                  }}
-                  className="mt-3 w-full rounded-[var(--radius-document)] border border-outline-variant/30 bg-surface-container-high px-4 py-3 text-sm text-on-surface transition-all focus:border-primary/40 focus:bg-surface-container-lowest focus:outline-none focus:ring-2 focus:ring-primary/25"
-                  placeholder="50"
-                />
+                <div className="mt-3">
+                  <NumericField
+                    label="Deposit amount"
+                    hideLabel
+                    step={0.01}
+                    disabled={disabled}
+                    value={String(depositAmount ?? "")}
+                    onChange={(v) => onDepositAmountChange(v ? Number(v) : null)}
+                    showStepControls={false}
+                    formatOnBlur={false}
+                    placeholder="50"
+                  />
+                </div>
               ) : null}
             </section>
           </div>

--- a/frontend/src/features/settings/components/SettingsScreen.tsx
+++ b/frontend/src/features/settings/components/SettingsScreen.tsx
@@ -217,7 +217,7 @@ export function SettingsScreen(): React.ReactElement {
                         data-testid="settings-logo-preview-tile"
                         className="flex h-[128px] w-[128px] rounded-[var(--radius-document)] bg-surface-container-lowest p-2"
                       >
-                        <div className="flex h-full w-full items-center justify-center rounded-lg bg-surface-container p-2">
+                        <div className="flex h-full w-full items-center justify-center rounded-[var(--radius-document)] bg-surface-container p-2">
                           {hasLogo ? (
                             <img
                               key={logoPreviewVersion}

--- a/frontend/src/shared/components/DocumentActionSurface.tsx
+++ b/frontend/src/shared/components/DocumentActionSurface.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from "react";
 
 import { FeedbackMessage } from "@/shared/components/FeedbackMessage";
+import { Input } from "@/shared/components/Input";
 
 const utilityGridClassNames = {
   1: "grid grid-cols-1 gap-2",
@@ -101,16 +102,12 @@ export function DocumentActionManualCopyField({
 }: ManualCopyFieldProps): React.ReactElement {
   return (
     <div className="mx-4 mt-3">
-      <label className="block text-sm font-medium text-on-surface" htmlFor="manual-share-url">
-        {label}
-      </label>
-      <input
+      <Input
         id="manual-share-url"
-        type="text"
+        label={label}
         readOnly
         value={url}
         onFocus={(event) => event.currentTarget.select()}
-        className="mt-2 w-full rounded-lg border border-outline-variant/30 bg-surface-container-low px-4 py-3 text-sm text-on-surface focus:outline-none focus:ring-2 focus:ring-primary/30"
       />
     </div>
   );

--- a/frontend/src/shared/components/DocumentActionSurface.tsx
+++ b/frontend/src/shared/components/DocumentActionSurface.tsx
@@ -90,7 +90,7 @@ export function DocumentActionError({ children }: MessageProps): React.ReactElem
 
 export function DocumentActionSuccessMessage({ children }: MessageProps): React.ReactElement {
   return (
-    <p className="mx-4 mt-3 rounded-md bg-success-container p-3 text-sm text-success">
+    <p className="mx-4 mt-3 rounded-[var(--radius-document)] bg-success-container p-3 text-sm text-success">
       {children}
     </p>
   );

--- a/frontend/src/shared/components/ErrorFallback.tsx
+++ b/frontend/src/shared/components/ErrorFallback.tsx
@@ -8,7 +8,7 @@ export function ErrorFallback(): ReactElement {
     <div className="flex min-h-screen items-center justify-center bg-background px-6 text-on-background">
       <div
         role="alert"
-        className="ghost-shadow w-full max-w-md rounded-xl border border-outline-variant/30 bg-surface-container-lowest p-8 text-center"
+        className="ghost-shadow w-full max-w-md rounded-[var(--radius-document)] border border-outline-variant/30 bg-surface-container-lowest p-8 text-center"
       >
         <Eyebrow className="text-error">Something went wrong</Eyebrow>
         <h1 className="mt-4 text-3xl font-semibold text-on-surface">Please reload Stima</h1>

--- a/frontend/src/shared/components/Input.test.tsx
+++ b/frontend/src/shared/components/Input.test.tsx
@@ -13,12 +13,11 @@ describe("Input", () => {
     expect(input.closest("div")).toHaveClass("rounded-[var(--radius-document)]");
   });
 
-  it("renders input without label and id when omitted", () => {
+  it("renders input without label when label is omitted", () => {
     render(<Input placeholder="Search quotes" value="" onChange={vi.fn()} />);
 
     const input = screen.getByRole("textbox");
-    expect(screen.queryByText("Search quotes")).not.toBeInTheDocument();
-    expect(input).not.toHaveAttribute("id");
+    expect(screen.queryByRole("textbox", { name: "Search quotes" })).not.toBeInTheDocument();
     expect(input).toHaveAttribute("placeholder", "Search quotes");
   });
 

--- a/frontend/src/shared/components/Input.tsx
+++ b/frontend/src/shared/components/Input.tsx
@@ -1,4 +1,4 @@
-import { useId, type ChangeEvent, type FocusEvent, type ReactNode } from "react";
+import { forwardRef, useId, type ChangeEvent, type FocusEvent, type ReactNode } from "react";
 
 export interface InputProps {
   label?: string;
@@ -10,10 +10,11 @@ export interface InputProps {
   autoComplete?: string;
   required?: boolean;
   disabled?: boolean;
+  readOnly?: boolean;
   hideLabel?: boolean;
   maxLength?: number;
   value: string;
-  onChange: (event: ChangeEvent<HTMLInputElement>) => void;
+  onChange?: (event: ChangeEvent<HTMLInputElement>) => void;
   error?: string;
   hint?: string;
   startAdornment?: ReactNode;
@@ -25,7 +26,7 @@ export interface InputProps {
   onFocus?: (event: FocusEvent<HTMLInputElement>) => void;
 }
 
-export function Input({
+export const Input = forwardRef<HTMLInputElement, InputProps>(function Input({
   label,
   id,
   placeholder,
@@ -35,6 +36,7 @@ export function Input({
   autoComplete,
   required = false,
   disabled = false,
+  readOnly = false,
   hideLabel = false,
   maxLength,
   value,
@@ -48,7 +50,7 @@ export function Input({
   inputMode,
   onBlur,
   onFocus,
-}: InputProps): React.ReactElement {
+}: InputProps, ref) {
   const generatedId = useId();
   const accessibilityBaseId = id ?? `input-${generatedId.replaceAll(":", "")}`;
   const hintId = hint ? `${accessibilityBaseId}-hint` : undefined;
@@ -78,7 +80,7 @@ export function Input({
     <div className="flex flex-col gap-1">
       {label ? (
         <label
-          htmlFor={id}
+          htmlFor={accessibilityBaseId}
           className={[
             hideLabel ? "sr-only" : "text-sm font-medium",
             hasError ? "text-error" : "text-on-surface",
@@ -94,13 +96,15 @@ export function Input({
           </span>
         ) : null}
         <input
-          id={id}
+          ref={ref}
+          id={accessibilityBaseId}
           type={type}
           autoComplete={autoComplete}
           value={value}
           onChange={onChange}
           required={required}
           disabled={disabled}
+          readOnly={readOnly}
           aria-required={required}
           aria-invalid={hasError}
           aria-describedby={describedBy}
@@ -129,4 +133,4 @@ export function Input({
       ) : null}
     </div>
   );
-}
+});

--- a/frontend/src/shared/components/LoadingScreen.tsx
+++ b/frontend/src/shared/components/LoadingScreen.tsx
@@ -1,7 +1,7 @@
 export function LoadingScreen(): React.ReactElement {
   return (
     <main className="screen-radial-backdrop flex min-h-screen items-center justify-center px-6 py-10 text-on-surface">
-      <div className="glass-surface-strong ghost-shadow w-full max-w-xs rounded-xl border border-outline-variant/50 px-8 py-9 text-center">
+      <div className="glass-surface-strong ghost-shadow w-full max-w-xs rounded-[var(--radius-document)] border border-outline-variant/50 px-8 py-9 text-center">
         <p className="font-headline text-3xl font-bold tracking-tight text-primary">Stima</p>
         <div role="status" aria-label="Loading app" aria-live="polite" className="mt-6 flex flex-col items-center gap-3">
           <span className="relative flex h-12 w-12 items-center justify-center">

--- a/frontend/src/shared/components/OverflowMenu.tsx
+++ b/frontend/src/shared/components/OverflowMenu.tsx
@@ -81,7 +81,7 @@ export function OverflowMenu({
   }
 
   const itemClassName =
-    "flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-left text-sm font-medium transition-colors hover:bg-surface-container-low focus-visible:bg-surface-container-low focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-40";
+    "flex w-full items-center gap-3 rounded-[var(--radius-document)] px-3 py-2.5 text-left text-sm font-medium transition-colors hover:bg-surface-container-low focus-visible:bg-surface-container-low focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-40";
 
   return (
     <div ref={containerRef} className="relative">
@@ -105,7 +105,7 @@ export function OverflowMenu({
           id={menuId}
           role="menu"
           aria-label={triggerLabel}
-          className="absolute right-0 top-full z-50 mt-2 w-56 max-w-[calc(100vw-2rem)] rounded-xl border border-outline-variant/30 bg-surface-container-lowest p-2 ghost-shadow"
+          className="absolute right-0 top-full z-50 mt-2 w-56 max-w-[calc(100vw-2rem)] rounded-[var(--radius-document)] border border-outline-variant/30 bg-surface-container-lowest p-2 ghost-shadow"
         >
           {items.map((item) => {
             const toneClassName = item.tone === "destructive" ? "text-error" : "text-on-surface";

--- a/frontend/src/ui/Banner.test.tsx
+++ b/frontend/src/ui/Banner.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { Banner } from "@/ui/Banner";
+
+describe("Banner", () => {
+  it("renders title and message", () => {
+    render(<Banner title="Heads up" message="Something happened." />);
+    expect(screen.getByText("Heads up")).toBeInTheDocument();
+    expect(screen.getByText("Something happened.")).toBeInTheDocument();
+  });
+
+  it.each(["warn", "info", "success", "error"] as const)("renders %s kind without error", (kind) => {
+    render(<Banner title="Title" message="Msg" kind={kind} />);
+    expect(screen.getByText("Title")).toBeInTheDocument();
+  });
+
+  it("renders dismiss button when onDismiss provided", () => {
+    render(<Banner title="T" message="M" onDismiss={vi.fn()} dismissLabel="Close banner" />);
+    expect(screen.getByRole("button", { name: "Close banner" })).toBeInTheDocument();
+  });
+
+  it("calls onDismiss when dismiss button clicked", async () => {
+    const user = userEvent.setup();
+    const onDismiss = vi.fn();
+    render(<Banner title="T" message="M" onDismiss={onDismiss} dismissLabel="Close banner" />);
+    await user.click(screen.getByRole("button", { name: "Close banner" }));
+    expect(onDismiss).toHaveBeenCalledOnce();
+  });
+
+  it("does not render dismiss button when onDismiss absent", () => {
+    render(<Banner title="T" message="M" />);
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/ui/Card.test.tsx
+++ b/frontend/src/ui/Card.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { Card } from "@/ui/Card";
+
+describe("Card", () => {
+  it("renders children", () => {
+    render(<Card>Card content</Card>);
+    expect(screen.getByText("Card content")).toBeInTheDocument();
+  });
+
+  it("applies primary accent border when accent is primary", () => {
+    const { container } = render(<Card accent="primary">content</Card>);
+    expect(container.firstChild).toHaveClass("border-primary");
+    expect(container.firstChild).toHaveClass("border-l-4");
+  });
+
+  it("applies warning accent border when accent is warn", () => {
+    const { container } = render(<Card accent="warn">content</Card>);
+    expect(container.firstChild).toHaveClass("border-warning-accent");
+    expect(container.firstChild).toHaveClass("border-l-4");
+  });
+
+  it("applies no accent border when accent is omitted", () => {
+    const { container } = render(<Card>content</Card>);
+    expect(container.firstChild).not.toHaveClass("border-l-4");
+  });
+
+  it("forwards className override", () => {
+    const { container } = render(<Card className="custom-class">content</Card>);
+    expect(container.firstChild).toHaveClass("custom-class");
+  });
+});

--- a/frontend/src/ui/QuoteListRow.tsx
+++ b/frontend/src/ui/QuoteListRow.tsx
@@ -13,14 +13,10 @@ interface QuoteListRowProps {
   onClick: () => void;
 }
 
-const pillBase = "text-[0.6875rem] font-bold uppercase tracking-wide px-2.5 py-1 rounded-full";
-
 const baseRowClasses =
   "w-full cursor-pointer rounded-[var(--radius-document)] bg-surface-container-lowest px-4 py-3 text-left ghost-shadow transition active:scale-[0.98] active:bg-surface-container-low";
 const draftRowClasses =
   "glass-surface w-full cursor-pointer rounded-[var(--radius-document)] border-l-4 border-warning-accent px-4 py-3 text-left backdrop-blur-md ghost-shadow transition active:scale-[0.98] active:bg-surface-container-low";
-const needsCustomerPillClasses = `${pillBase} shrink-0 whitespace-nowrap bg-warning-container text-warning`;
-
 export function QuoteListRow({
   customerLabel,
   titleLabel,
@@ -48,7 +44,9 @@ export function QuoteListRow({
         <div className="flex items-center gap-3">
           <p className="text-xs text-on-surface-variant">{docAndDate}</p>
           {needsCustomerAssignment ? (
-            <span className={`${needsCustomerPillClasses} ml-auto`}>Needs customer</span>
+            <span className="ml-auto">
+              <StatusPill variant="needs_customer" />
+            </span>
           ) : (
             <span className="ml-auto">
               <StatusPill variant={status} />

--- a/frontend/src/ui/RAW_BUTTON_WHITELIST.md
+++ b/frontend/src/ui/RAW_BUTTON_WHITELIST.md
@@ -26,3 +26,9 @@ This file documents production `<button>` usages that intentionally stay raw and
 
 - Test-only `<button>` elements:
   - Test files may continue to use raw `<button>` markup for focused behavior fixtures.
+
+## Additions (2026-04-23)
+
+- `CustomerDetailScreen.tsx:377,389` — history mode filter toggles (`aria-pressed`) — structural segmented control.
+- `QuoteReuseChooser.tsx:181,193` — tab toggles (`aria-pressed`) — structural.
+- `OverflowMenu.tsx:88` — custom-geometry trigger — structural chrome.

--- a/frontend/src/ui/Sheet.tsx
+++ b/frontend/src/ui/Sheet.tsx
@@ -20,6 +20,7 @@ interface SheetProps extends Omit<Dialog.DialogProps, "children"> {
 interface SheetRegionProps {
   children: ReactNode;
   className?: string;
+  id?: string;
 }
 
 interface SheetCloseButtonProps {
@@ -117,6 +118,37 @@ export function SheetBody({ children, className }: SheetRegionProps): React.Reac
 
 export function SheetFooter({ children, className }: SheetRegionProps): React.ReactElement {
   return <div className={joinClasses("mt-6", className)}>{children}</div>;
+}
+
+export function SheetTitle({
+  children,
+  className,
+}: SheetRegionProps): React.ReactElement {
+  return (
+    <Dialog.Title
+      className={joinClasses(
+        "font-headline text-xl font-bold tracking-tight text-on-surface",
+        className,
+      )}
+    >
+      {children}
+    </Dialog.Title>
+  );
+}
+
+export function SheetDescription({
+  children,
+  className,
+  id,
+}: SheetRegionProps): React.ReactElement {
+  return (
+    <Dialog.Description
+      id={id}
+      className={joinClasses("mt-2 text-sm leading-6 text-on-surface-variant", className)}
+    >
+      {children}
+    </Dialog.Description>
+  );
 }
 
 export function SheetCloseButton({

--- a/frontend/src/ui/StatusPill.test.tsx
+++ b/frontend/src/ui/StatusPill.test.tsx
@@ -1,0 +1,69 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { StatusPill } from "@/ui/StatusPill";
+import type { StatusPillVariant } from "@/ui/StatusPill";
+
+const variants: StatusPillVariant[] = [
+  "draft",
+  "ready",
+  "shared",
+  "viewed",
+  "approved",
+  "declined",
+  "sent",
+  "paid",
+  "void",
+  "needs_customer",
+];
+
+describe("StatusPill", () => {
+  it.each(variants)("renders label for variant %s", (variant) => {
+    render(<StatusPill variant={variant} />);
+    const pill = screen.getByText(/./i, { selector: "span" });
+    expect(pill).toBeInTheDocument();
+  });
+
+  it("renders 'Draft' label for draft variant", () => {
+    render(<StatusPill variant="draft" />);
+    expect(screen.getByText("Draft")).toBeInTheDocument();
+  });
+
+  it("renders 'Needs customer' label for needs_customer variant", () => {
+    render(<StatusPill variant="needs_customer" />);
+    expect(screen.getByText("Needs customer")).toBeInTheDocument();
+  });
+
+  it("applies warning styles for needs_customer variant", () => {
+    render(<StatusPill variant="needs_customer" />);
+    const pill = screen.getByText("Needs customer");
+    expect(pill).toHaveClass("bg-warning-container");
+    expect(pill).toHaveClass("text-warning");
+  });
+
+  it("applies correct className for viewed variant", () => {
+    render(<StatusPill variant="viewed" />);
+    const pill = screen.getByText("Viewed");
+    expect(pill).toHaveClass("bg-warning-container");
+    expect(pill).toHaveClass("text-warning");
+  });
+
+  it("applies correct className for approved variant", () => {
+    render(<StatusPill variant="approved" />);
+    const pill = screen.getByText("Approved");
+    expect(pill).toHaveClass("bg-success-container");
+    expect(pill).toHaveClass("text-success");
+  });
+
+  it("applies correct className for declined variant", () => {
+    render(<StatusPill variant="declined" />);
+    const pill = screen.getByText("Declined");
+    expect(pill).toHaveClass("bg-error-container");
+    expect(pill).toHaveClass("text-error");
+  });
+
+  it("renders as a span element", () => {
+    const { container } = render(<StatusPill variant="draft" />);
+    expect(container.firstChild?.nodeName).toBe("SPAN");
+  });
+});

--- a/frontend/src/ui/StatusPill.tsx
+++ b/frontend/src/ui/StatusPill.tsx
@@ -7,7 +7,8 @@ export type StatusPillVariant =
   | "declined"
   | "sent"
   | "paid"
-  | "void";
+  | "void"
+  | "needs_customer";
 
 interface StatusPillProps {
   variant: StatusPillVariant;
@@ -23,6 +24,7 @@ const styles: Record<StatusPillVariant, string> = {
   sent: "bg-info-container text-info",
   paid: "bg-success-container text-success",
   void: "bg-neutral-container text-on-surface-variant line-through",
+  needs_customer: "bg-warning-container text-warning",
 };
 
 const labels: Record<StatusPillVariant, string> = {
@@ -35,6 +37,7 @@ const labels: Record<StatusPillVariant, string> = {
   sent: "Sent",
   paid: "Paid",
   void: "Void",
+  needs_customer: "Needs customer",
 };
 
 const pillBase = "text-[0.6875rem] font-bold uppercase tracking-wide px-2.5 py-1 rounded-full";

--- a/frontend/src/ui/Toast.tsx
+++ b/frontend/src/ui/Toast.tsx
@@ -85,7 +85,7 @@ export function Toast({ toast, onDismiss }: ToastProps): React.ReactElement {
         <button
           type="button"
           aria-label="Dismiss"
-          className="inline-flex h-6 w-6 shrink-0 cursor-pointer items-center justify-center rounded-full text-base leading-none transition-colors hover:bg-black/10"
+          className="inline-flex h-6 w-6 shrink-0 cursor-pointer items-center justify-center rounded-full text-base leading-none transition-colors hover:bg-surface-container"
           onClick={onDismiss}
         >
           ×


### PR DESCRIPTION
## Summary

- **`Input` forwardRef + readOnly**: Converts `Input` to `forwardRef<HTMLInputElement>`, adds optional `readOnly` prop, always wires `accessibilityBaseId` to both `htmlFor` and `id` so sr-only/hidden labels connect correctly.
- **`StatusPill` `needs_customer` variant**: Adds the missing variant and migrates the inline pill in `QuoteListRow`.
- **`Sheet` sub-components**: Exports `SheetTitle` and `SheetDescription` (both wrapping Radix Dialog primitives); migrates all four sheets from raw `Dialog.Title`/`Dialog.Description` imports.
- **Bare `<input>` migration**: `LineItemEditSheet` (description + price) and `DocumentActionSurface` (manual copy URL) migrated to `Input`/`NumericField`.
- **`TotalAmountSection` numeric fields**: Replaces three `<input type="number">` elements with `NumericField` (type="text", role=textbox); updates test role assertions accordingly.
- **Radius token sweep**: Zeroes all `rounded-xl`, `rounded-lg`, `rounded-md` violations across 13 files — everything normalised to `rounded-[var(--radius-document)]`.
- **Button primitive sweep**: `CaptureInputPanel` start-blank and delete-clip size migrated to `Button`; `LineItemEditSheet` dismiss migrated to `Button variant="ghost"`.
- **`LandingPage` safe-top**: Adds `safe-top` to fixed header for notched-display safety.
- **Toast hover fix**: `hover:bg-black/10` → `hover:bg-surface-container`.
- **New tests**: `Banner.test.tsx`, `Card.test.tsx`, `StatusPill.test.tsx`.
- **`RAW_BUTTON_WHITELIST.md`**: Documents three new intentional raw-button sites.

## Test plan

- [x] `make frontend-verify` — all tests pass, no type errors
- [x] `Input` forwardRef: `Input.test.tsx` — labeled input, no-label, error+onChange, hint+adornments+aria-describedby, invalid visuals
- [x] `TotalAmountSection`: role assertions updated from `spinbutton` → `textbox`; all 7 tests pass
- [x] `StatusPill.test.tsx` — all 10 variants, needs_customer label, span element
- [x] `Banner.test.tsx` — all 4 kinds, dismiss callback
- [x] `Card.test.tsx` — children, accent variants, className forwarding

Closes #544