### PR TITLE
fix: Sheet keyboard-obscure + LineItemEditSheet field reorder

### DIFF
--- a/frontend/src/features/quotes/components/LineItemEditSheet.tsx
+++ b/frontend/src/features/quotes/components/LineItemEditSheet.tsx
@@ -378,6 +378,27 @@ export function LineItemEditSheet({
                     />
                   </section>
                   <section className="space-y-2">
+                    <label htmlFor="line-item-sheet-price" className="font-headline text-sm font-bold text-on-surface">
+                      Price
+                    </label>
+                    <NumericField
+                      id="line-item-sheet-price"
+                      placeholder="$ 0.00"
+                      value={priceInput}
+                      onChange={(nextValue) => {
+                        setPriceInput(nextValue);
+                        if (savedCatalogItem) {
+                          setSavedCatalogItem(null);
+                        }
+                        if (formError) {
+                          setFormError(null);
+                        }
+                      }}
+                      showStepControls={false}
+                      formatOnBlur={false}
+                    />
+                  </section>
+                  <section className="space-y-2">
                     <div className="flex items-end justify-between">
                       <label htmlFor="line-item-sheet-details" className="font-headline text-sm font-bold text-on-surface">
                         Details
@@ -399,27 +420,6 @@ export function LineItemEditSheet({
                         }
                       }}
                       className="w-full rounded-[var(--radius-document)] border border-outline-variant/30 bg-surface-container-high p-4 text-sm text-on-surface placeholder:text-outline/70 outline-none transition-all focus:border-primary focus:bg-surface-container-lowest focus:ring-2 focus:ring-primary/20"
-                    />
-                  </section>
-                  <section className="space-y-2">
-                    <label htmlFor="line-item-sheet-price" className="font-headline text-sm font-bold text-on-surface">
-                      Price
-                    </label>
-                    <NumericField
-                      id="line-item-sheet-price"
-                      placeholder="$ 0.00"
-                      value={priceInput}
-                      onChange={(nextValue) => {
-                        setPriceInput(nextValue);
-                        if (savedCatalogItem) {
-                          setSavedCatalogItem(null);
-                        }
-                        if (formError) {
-                          setFormError(null);
-                        }
-                      }}
-                      showStepControls={false}
-                      formatOnBlur={false}
                     />
                   </section>
                 </div>

--- a/frontend/src/ui/Sheet.tsx
+++ b/frontend/src/ui/Sheet.tsx
@@ -29,9 +29,9 @@ interface SheetCloseButtonProps {
 }
 
 const sheetSizeClasses: Record<SheetSize, string> = {
-  sm: "max-w-sm max-h-[70vh]",
-  md: "max-w-md max-h-[85vh]",
-  lg: "max-w-2xl max-h-[85vh]",
+  sm: "max-w-sm max-h-[70dvh]",
+  md: "max-w-md max-h-[85dvh]",
+  lg: "max-w-2xl max-h-[85dvh]",
   full: "h-[100dvh] max-w-none rounded-none md:max-w-4xl md:rounded-[var(--radius-document)]",
 };
 
@@ -68,7 +68,7 @@ export function Sheet({
     containerClassName,
   );
   const contentClassName = joinClasses(
-    "pointer-events-auto w-full border border-outline-variant/20 glass-surface ghost-shadow backdrop-blur-md rounded-[var(--radius-document)] p-6 pb-[max(env(safe-area-inset-bottom),1.25rem)] outline-none md:pb-6",
+    "pointer-events-auto w-full border border-outline-variant/20 glass-surface ghost-shadow backdrop-blur-md rounded-[var(--radius-document)] p-6 pb-[max(env(safe-area-inset-bottom),1.25rem)] outline-none overflow-y-auto md:pb-6",
     sheetSizeClasses[size],
     contentProps?.className,
   );


### PR DESCRIPTION
## Summary

Fixes mobile keyboard obscuring the Price field in LineItemEditSheet.

### Changes

- **Sheet.tsx**: Switch max-height from vh → dvh units so sheets resize correctly when software keyboards open on mobile. Add overflow-y-auto to the Dialog.Content wrapper so content remains scrollable when the sheet shrinks.
- **LineItemEditSheet.tsx**: Reorder manual-tab fields so Price appears above Details, putting the required critical field earlier in the form.

### Verification

- `Sheet.test.tsx` passes (2 tests)
- `LineItemEditSheet.test.tsx` passes (21 tests)
- `make frontend-verify` passes (560 tests, build clean)

Closes #547