### PR TITLE
fix: CustomerDetailScreen action button layout and overflow delete

### DIFF
--- a/frontend/src/features/customers/components/CustomerDetailScreen.tsx
+++ b/frontend/src/features/customers/components/CustomerDetailScreen.tsx
@@ -17,6 +17,7 @@ import type { QuoteListItem } from "@/features/quotes/types/quote.types";
 import { BottomNav } from "@/shared/components/BottomNav";
 import { Button } from "@/shared/components/Button";
 import { FeedbackMessage } from "@/shared/components/FeedbackMessage";
+import { OverflowMenu } from "@/shared/components/OverflowMenu";
 import { ScreenHeader } from "@/shared/components/ScreenHeader";
 import { Eyebrow } from "@/ui/Eyebrow";
 import { useToast } from "@/ui/Toast";
@@ -282,6 +283,19 @@ export function CustomerDetailScreen(): React.ReactElement {
         title={customer?.name ?? "Customer"}
         backLabel="Back to customers"
         onBack={() => navigate("/customers")}
+        trailing={customer ? (
+          <OverflowMenu
+            triggerLabel="Customer actions"
+            items={[
+              {
+                label: "Delete Customer",
+                icon: "delete",
+                tone: "destructive",
+                onSelect: openDeleteConfirmation,
+              },
+            ]}
+          />
+        ) : null}
       />
       <section className="mx-auto w-full max-w-3xl space-y-4 px-4 pt-20">
         {isLoading ? (
@@ -324,11 +338,11 @@ export function CustomerDetailScreen(): React.ReactElement {
                     </div>
                   </dl>
 
-                  <div className="flex gap-2 pt-1">
+                  <div className="flex flex-col gap-2 pt-1">
                     <Button
                       type="button"
                       variant="primary"
-                      className="flex-1"
+                      className="w-full"
                       onClick={quoteCreateFlow.openCreateEntry}
                     >
                       Create Document
@@ -336,18 +350,10 @@ export function CustomerDetailScreen(): React.ReactElement {
                     <Button
                       type="button"
                       variant="secondary"
-                      size="md"
+                      className="w-full"
                       onClick={openEditMode}
                     >
                       Edit
-                    </Button>
-                    <Button
-                      type="button"
-                      variant="destructive"
-                      size="md"
-                      onClick={openDeleteConfirmation}
-                    >
-                      Delete Customer
                     </Button>
                   </div>
                 </div>

--- a/frontend/src/features/customers/tests/CustomerDetailScreen.test.tsx
+++ b/frontend/src/features/customers/tests/CustomerDetailScreen.test.tsx
@@ -111,6 +111,12 @@ async function switchToInvoicesTab(): Promise<void> {
   fireEvent.click(screen.getByRole("button", { name: "Invoices" }));
 }
 
+async function openDeleteCustomerModal(): Promise<void> {
+  fireEvent.click(screen.getByRole("button", { name: /customer actions/i }));
+  fireEvent.click(await screen.findByRole("menuitem", { name: /delete customer/i }));
+  await screen.findByRole("dialog", { name: "Delete customer?" });
+}
+
 beforeEach(() => {
   mockedCustomerService.getCustomer.mockResolvedValue({
     id: "cust-1",
@@ -193,6 +199,12 @@ describe("CustomerDetailScreen", () => {
     expect(screen.getByText("555-0101")).toBeInTheDocument();
     expect(screen.getByText("alice@example.com")).toBeInTheDocument();
     expect(screen.getByText("1 Main St")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /create document/i })).toHaveClass("w-full");
+    expect(screen.getByRole("button", { name: /^edit$/i })).toHaveClass("w-full");
+    expect(screen.getByRole("button", { name: /customer actions/i })).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /^delete customer$/i }),
+    ).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Quotes" })).toHaveAttribute(
       "aria-pressed",
       "true",
@@ -504,9 +516,7 @@ describe("CustomerDetailScreen", () => {
     renderScreen();
     await screen.findByRole("heading", { level: 1, name: "Alice Johnson" });
 
-    fireEvent.click(screen.getByRole("button", { name: /delete customer/i }));
-
-    expect(await screen.findByRole("dialog", { name: "Delete customer?" })).toBeInTheDocument();
+    await openDeleteCustomerModal();
     expect(screen.getByText("This cannot be undone.")).toBeInTheDocument();
     const deleteButton = screen.getByRole("button", { name: /^delete customer$/i });
     expect(deleteButton).toBeDisabled();
@@ -526,7 +536,7 @@ describe("CustomerDetailScreen", () => {
     renderScreen();
     await screen.findByRole("heading", { level: 1, name: "Alice Johnson" });
 
-    fireEvent.click(screen.getByRole("button", { name: /delete customer/i }));
+    await openDeleteCustomerModal();
     fireEvent.change(screen.getByLabelText("Type Alice Johnson to confirm"), {
       target: { value: "Alice Johnson" },
     });
@@ -548,7 +558,7 @@ describe("CustomerDetailScreen", () => {
     renderScreen();
     await screen.findByRole("heading", { level: 1, name: "Alice Johnson" });
 
-    fireEvent.click(screen.getByRole("button", { name: /delete customer/i }));
+    await openDeleteCustomerModal();
     fireEvent.change(screen.getByLabelText("Type Alice Johnson to confirm"), {
       target: { value: "Alice Johnson" },
     });

--- a/frontend/src/shared/components/OverflowMenu.test.tsx
+++ b/frontend/src/shared/components/OverflowMenu.test.tsx
@@ -99,4 +99,29 @@ describe("OverflowMenu", () => {
       expect(screen.getByRole("button", { name: "After" })).toHaveFocus();
     });
   });
+
+  it("renders a compact menu panel with left-aligned action rows", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <OverflowMenu
+        items={[
+          {
+            label: "Delete Customer",
+            icon: "delete",
+            onSelect: vi.fn(),
+          },
+        ]}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /more actions/i }));
+
+    const menu = screen.getByRole("menu");
+    const row = screen.getByRole("menuitem", { name: /delete customer/i });
+
+    expect(menu).toHaveClass("w-52");
+    expect(row).toHaveClass("grid");
+    expect(row).toHaveClass("grid-cols-[1.25rem_minmax(0,1fr)]");
+  });
 });

--- a/frontend/src/shared/components/OverflowMenu.tsx
+++ b/frontend/src/shared/components/OverflowMenu.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useId, useRef, useState } from "react";
-import { Button } from "@/shared/components/Button";
 
 export interface OverflowMenuItem {
   label: string;
@@ -81,7 +80,7 @@ export function OverflowMenu({
   }
 
   const itemClassName =
-    "flex w-full items-center gap-3 rounded-[var(--radius-document)] px-3 py-2.5 text-left text-sm font-medium transition-colors hover:bg-surface-container-low focus-visible:bg-surface-container-low focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-40";
+    "grid w-full grid-cols-[1.25rem_minmax(0,1fr)] items-center gap-2.5 rounded-[var(--radius-document)] px-2.5 py-2.5 text-left text-sm font-medium transition-colors hover:bg-surface-container-low focus-visible:bg-surface-container-low focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-40";
 
   return (
     <div ref={containerRef} className="relative">
@@ -105,7 +104,7 @@ export function OverflowMenu({
           id={menuId}
           role="menu"
           aria-label={triggerLabel}
-          className="absolute right-0 top-full z-50 mt-2 w-56 max-w-[calc(100vw-2rem)] rounded-[var(--radius-document)] border border-outline-variant/30 bg-surface-container-lowest p-2 ghost-shadow"
+          className="absolute right-0 top-full z-50 mt-2 w-52 max-w-[calc(100vw-2rem)] rounded-[var(--radius-document)] border border-outline-variant/30 bg-surface-container-lowest p-1.5 ghost-shadow"
         >
           {items.map((item) => {
             const toneClassName = item.tone === "destructive" ? "text-error" : "text-on-surface";
@@ -126,20 +125,18 @@ export function OverflowMenu({
                     item.onSelect?.();
                   }}
                 >
-                  <span className="material-symbols-outlined text-[1.125rem]">{item.icon}</span>
-                  <span>{item.label}</span>
+                  <span className="material-symbols-outlined block text-[1.125rem] leading-none">{item.icon}</span>
+                  <span className="whitespace-nowrap leading-none">{item.label}</span>
                 </a>
               );
             }
 
             return (
-              <Button
+              <button
                 key={item.label}
                 type="button"
-                variant="ghost"
-                size="sm"
                 role="menuitem"
-                className={`${itemClassName} ${toneClassName}`}
+                className={`${itemClassName} ${toneClassName} cursor-pointer`}
                 disabled={item.disabled}
                 onClick={() => {
                   setIsOpen(false);
@@ -147,9 +144,9 @@ export function OverflowMenu({
                   item.onSelect?.();
                 }}
               >
-                <span className="material-symbols-outlined text-[1.125rem]">{item.icon}</span>
-                <span>{item.label}</span>
-              </Button>
+                <span className="material-symbols-outlined block text-[1.125rem] leading-none">{item.icon}</span>
+                <span className="whitespace-nowrap leading-none">{item.label}</span>
+              </button>
             );
           })}
         </div>

--- a/frontend/src/ui/RAW_BUTTON_WHITELIST.md
+++ b/frontend/src/ui/RAW_BUTTON_WHITELIST.md
@@ -55,7 +55,8 @@ Custom interaction behaviors and geometry tighter than the shared button abstrac
 - `src/ui/PasswordField.tsx:24` — Show / Hide visibility toggle (text-only input adornment).
 - `src/ui/Toast.tsx:85` — Dismiss `×` button (h-6×w-6; too small for `<Button>`).
 - `src/shared/components/OverflowMenu.tsx:88` — overflow menu trigger (custom-geometry circular chrome button).
-- **Reason:** custom interaction behaviors, geometry, or size constraints are tighter than the shared `<Button>` abstraction.
+- `src/shared/components/OverflowMenu.tsx:135` — overflow menu action row (`role="menuitem"` with icon/label grid and tight padding).
+- **Reason:** custom interaction behaviors, geometry, or size constraints are tighter than the shared `<Button>` abstraction; overflow menu action rows require a 2-column icon/label grid and compact spacing that do not map cleanly to the shared `<Button>` content layout.
 
 ### Test-only
 - Test files may continue to use raw `<button>` markup for focused behavior fixtures.


### PR DESCRIPTION
## Summary
- move `Delete Customer` action from inline card button to `ScreenHeader` overflow menu
- stack `Create Document` and `Edit` as full-width card actions
- update `CustomerDetailScreen` tests for overflow-triggered delete flow and button layout expectations

## Verification
- cd frontend && rtk proxy npx vitest run src/features/customers
- cd frontend && rtk proxy npx tsc --noEmit
- rtk proxy make frontend-verify

Closes #551