### PR TITLE
Task #550: add capture performance instrumentation baseline

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -32,6 +32,7 @@
         "globals": "^16.5.0",
         "jsdom": "^26.1.0",
         "msw": "^2.13.2",
+        "rollup-plugin-visualizer": "^6.0.5",
         "tailwindcss": "^4.1.0",
         "typescript": "~5.9.3",
         "typescript-eslint": "^8.58.1",
@@ -3861,6 +3862,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/define-lazy-prop": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
+      "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/dequal": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
@@ -4603,6 +4614,22 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-docker": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -4649,6 +4676,19 @@
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/is-wsl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -5408,6 +5448,24 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/open": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-8.4.2.tgz",
+      "integrity": "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-lazy-prop": "^2.0.0",
+        "is-docker": "^2.1.1",
+        "is-wsl": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -5928,6 +5986,37 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/rollup-plugin-visualizer": {
+      "version": "6.0.11",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-visualizer/-/rollup-plugin-visualizer-6.0.11.tgz",
+      "integrity": "sha512-TBwVHVY7buHjIKVLqr9scTVFwqZqMXINcCphPwIWKPDCOBIa+jCQfafvbjRJDZgXdq/A996Dy6yGJ/+/NtAXDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "open": "^8.0.0",
+        "picomatch": "^4.0.2",
+        "source-map": "^0.7.4",
+        "yargs": "^17.5.1"
+      },
+      "bin": {
+        "rollup-plugin-visualizer": "dist/bin/cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "rolldown": "1.x || ^1.0.0-beta",
+        "rollup": "2.x || 3.x || 4.x"
+      },
+      "peerDependenciesMeta": {
+        "rolldown": {
+          "optional": true
+        },
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/rrweb-cssom": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
@@ -6018,6 +6107,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/source-map-js": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -37,6 +37,7 @@
     "globals": "^16.5.0",
     "jsdom": "^26.1.0",
     "msw": "^2.13.2",
+    "rollup-plugin-visualizer": "^6.0.5",
     "tailwindcss": "^4.1.0",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.58.1",

--- a/frontend/src/features/quotes/components/CaptureScreen.tsx
+++ b/frontend/src/features/quotes/components/CaptureScreen.tsx
@@ -22,7 +22,7 @@ import { WorkflowScreenHeader } from "@/shared/components/WorkflowScreenHeader";
 import { jobService } from "@/shared/lib/jobService";
 import { formatByteLimit } from "@/shared/lib/formatters";
 import { MAX_AUDIO_CLIPS_PER_REQUEST, MAX_AUDIO_TOTAL_BYTES } from "@/shared/lib/inputLimits";
-import { perfMark, perfMeasure } from "@/shared/perf";
+import { perfMark, perfMeasure, perfMeasureSincePageLoad } from "@/shared/perf";
 import { useToast } from "@/ui/Toast";
 
 const START_BLANK_GUARD_TARGET = "__start_blank__";
@@ -77,7 +77,7 @@ export function CaptureScreen(): React.ReactElement {
   useEffect(() => {
     isMountedRef.current = true;
     perfMark("capture:route:mounted");
-    perfMeasure("capture:route:load_ms", "navigationStart", "capture:route:mounted");
+    perfMeasureSincePageLoad("capture:route:load_ms");
     return () => {
       isMountedRef.current = false;
       extractionStageTimerRefs.current.forEach((timerId) => {

--- a/frontend/src/features/quotes/components/CaptureScreen.tsx
+++ b/frontend/src/features/quotes/components/CaptureScreen.tsx
@@ -22,6 +22,7 @@ import { WorkflowScreenHeader } from "@/shared/components/WorkflowScreenHeader";
 import { jobService } from "@/shared/lib/jobService";
 import { formatByteLimit } from "@/shared/lib/formatters";
 import { MAX_AUDIO_CLIPS_PER_REQUEST, MAX_AUDIO_TOTAL_BYTES } from "@/shared/lib/inputLimits";
+import { perfMark, perfMeasure } from "@/shared/perf";
 import { useToast } from "@/ui/Toast";
 
 const START_BLANK_GUARD_TARGET = "__start_blank__";
@@ -75,6 +76,8 @@ export function CaptureScreen(): React.ReactElement {
 
   useEffect(() => {
     isMountedRef.current = true;
+    perfMark("capture:route:mounted");
+    perfMeasure("capture:route:load_ms", "navigationStart", "capture:route:mounted");
     return () => {
       isMountedRef.current = false;
       extractionStageTimerRefs.current.forEach((timerId) => {
@@ -142,8 +145,11 @@ export function CaptureScreen(): React.ReactElement {
     quoteId: string,
     sourceType: QuoteSourceType,
   ): Promise<void> {
+    perfMark("capture:draft:hydrate_start");
     const persistedQuote = await quoteService.getQuote(quoteId);
     applyDraftFromQuoteDetail(sourceType, persistedQuote, quoteId);
+    perfMark("capture:draft:ready");
+    perfMeasure("capture:draft:hydrate_ms", "capture:draft:hydrate_start", "capture:draft:ready");
   }
 
   function navigateToReview(quoteId: string): void {
@@ -151,6 +157,7 @@ export function CaptureScreen(): React.ReactElement {
   }
 
   async function onExtract(): Promise<void> {
+    // TODO(spec1): perfMark("capture:local:save_start") / perfMark("capture:local:save_done")
     clearActionErrors();
     if (clips.length > MAX_AUDIO_CLIPS_PER_REQUEST) {
       setError(
@@ -168,6 +175,7 @@ export function CaptureScreen(): React.ReactElement {
       );
       return;
     }
+    perfMark("capture:extract:start");
     clearExtractionStageTimers();
     const stages = getExtractionStages(hasClips, hasNotes);
     setExtractionStage(stages[0]);
@@ -190,6 +198,12 @@ export function CaptureScreen(): React.ReactElement {
         notes,
         customerId,
       });
+      perfMark("capture:extract:response");
+      perfMeasure(
+        "capture:extract:submit_to_response_ms",
+        "capture:extract:start",
+        "capture:extract:response",
+      );
       if (!isMountedRef.current) {
         return;
       }

--- a/frontend/src/features/quotes/hooks/useVoiceCapture.ts
+++ b/frontend/src/features/quotes/hooks/useVoiceCapture.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
+import { perfMark, perfMeasure } from "@/shared/perf";
 
 const MIME_TYPE_CANDIDATES = [
   "audio/webm;codecs=opus",
@@ -134,12 +135,14 @@ export function useVoiceCapture(): UseVoiceCaptureResult {
       return;
     }
 
+    perfMark("capture:record:tap");
     setError(null);
     setElapsedSeconds(0);
 
     try {
       const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
       streamRef.current = stream;
+      perfMark("capture:record:stream_ready");
 
       const preferredMimeType = resolvePreferredMimeType();
       const recorder = preferredMimeType
@@ -199,6 +202,9 @@ export function useVoiceCapture(): UseVoiceCaptureResult {
       };
 
       recorder.start();
+      perfMark("capture:record:active");
+      perfMeasure("capture:record:tap_to_stream_ms", "capture:record:tap", "capture:record:stream_ready");
+      perfMeasure("capture:record:tap_to_active_ms", "capture:record:tap", "capture:record:active");
       setIsRecording(true);
       timerRef.current = window.setInterval(() => {
         setElapsedSeconds((currentSeconds) => currentSeconds + 1);

--- a/frontend/src/shared/perf.ts
+++ b/frontend/src/shared/perf.ts
@@ -27,3 +27,20 @@ export function perfMeasure(
     return 0;
   }
 }
+
+export function perfMeasureSincePageLoad(name: string): number {
+  try {
+    const entry = performance.measure(name, {
+      start: 0,
+      end: performance.now(),
+    });
+
+    if (DEV) {
+      console.debug(`[perf] ${name}: ${entry.duration.toFixed(1)}ms`);
+    }
+
+    return entry.duration;
+  } catch {
+    return 0;
+  }
+}

--- a/frontend/src/shared/perf.ts
+++ b/frontend/src/shared/perf.ts
@@ -1,0 +1,29 @@
+const DEV = import.meta.env.DEV;
+
+export function perfMark(name: string): void {
+  try {
+    performance.mark(name);
+  } catch {
+    // Ignore unsupported or unavailable performance APIs.
+  }
+}
+
+export function perfMeasure(
+  name: string,
+  startMark: string,
+  endMark?: string,
+): number {
+  try {
+    const entry = endMark
+      ? performance.measure(name, startMark, endMark)
+      : performance.measure(name, startMark);
+
+    if (DEV) {
+      console.debug(`[perf] ${name}: ${entry.duration.toFixed(1)}ms`);
+    }
+
+    return entry.duration;
+  } catch {
+    return 0;
+  }
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -4,11 +4,16 @@ import { fileURLToPath } from "node:url";
 import { defineConfig } from "vitest/config";
 import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
+import { visualizer } from "rollup-plugin-visualizer";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig({
-  plugins: [react(), tailwindcss()],
+  plugins: [
+    react(),
+    tailwindcss(),
+    process.env.ANALYZE === "true" && visualizer({ open: true, gzipSize: true }),
+  ].filter(Boolean),
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),

--- a/plans/2026-04-24/p0-spec0-perf-baseline.md
+++ b/plans/2026-04-24/p0-spec0-perf-baseline.md
@@ -24,6 +24,7 @@ New file: `frontend/src/shared/perf.ts`
 Exports:
 - `perfMark(name: string): void` — wraps `performance.mark(name)`; no-op on error
 - `perfMeasure(name: string, startMark: string, endMark?: string): number` — wraps `performance.measure`, returns duration in ms, logs to `console.debug` in dev only, no-op on error (returns 0)
+- `perfMeasureSincePageLoad(name: string): number` — records a measure entry from page-load time origin to now
 
 ```ts
 const DEV = import.meta.env.DEV;
@@ -41,6 +42,14 @@ export function perfMeasure(name: string, startMark: string, endMark?: string): 
     return entry.duration;
   } catch { return 0; }
 }
+
+export function perfMeasureSincePageLoad(name: string): number {
+  try {
+    const entry = performance.measure(name, { start: 0, end: performance.now() });
+    if (DEV) console.debug(`[perf] ${name}: ${entry.duration.toFixed(1)}ms`);
+    return entry.duration;
+  } catch { return 0; }
+}
 ```
 
 ### 2. Capture route load
@@ -51,7 +60,7 @@ In the mount `useEffect` (the one that sets `isMountedRef.current = true`), add 
 
 ```ts
 perfMark("capture:route:mounted");
-perfMeasure("capture:route:load_ms", "navigationStart", "capture:route:mounted");
+perfMeasureSincePageLoad("capture:route:load_ms");
 ```
 
 > **Note (React Strict Mode):** In development, React Strict Mode runs effects twice, producing two `capture:route:mounted` marks and two `capture:route:load_ms` entries. This is expected and harmless — production builds see exactly one entry. If single-entry dev behavior is required, guard with a `useRef` flag.

--- a/plans/2026-04-24/p0-spec0-perf-baseline.md
+++ b/plans/2026-04-24/p0-spec0-perf-baseline.md
@@ -1,0 +1,193 @@
+# Spec 0 — Performance Baseline & Instrumentation
+
+Date: 2026-04-24
+Scope: frontend — capture flow timing instrumentation + bundle audit
+
+---
+
+## Goal
+
+Make Stima's key user flows measurable before large offline/PWA changes land, so regressions are visible during PR review and offline work is not merged blindly without before/after timings.
+
+## Why now
+
+P0 offline work (IndexedDB, outbox, PWA shell) will touch CaptureScreen, useVoiceCapture, draft persistence, and the extraction path. Without baseline marks, there is no way to know whether a PR regresses tap-to-record latency or capture route load time.
+
+---
+
+## Scope
+
+### 1. Timing utility
+
+New file: `frontend/src/shared/perf.ts`
+
+Exports:
+- `perfMark(name: string): void` — wraps `performance.mark(name)`; no-op on error
+- `perfMeasure(name: string, startMark: string, endMark?: string): number` — wraps `performance.measure`, returns duration in ms, logs to `console.debug` in dev only, no-op on error (returns 0)
+
+```ts
+const DEV = import.meta.env.DEV;
+
+export function perfMark(name: string): void {
+  try { performance.mark(name); } catch { /* ignore */ }
+}
+
+export function perfMeasure(name: string, startMark: string, endMark?: string): number {
+  try {
+    const entry = endMark
+      ? performance.measure(name, startMark, endMark)
+      : performance.measure(name, startMark);
+    if (DEV) console.debug(`[perf] ${name}: ${entry.duration.toFixed(1)}ms`);
+    return entry.duration;
+  } catch { return 0; }
+}
+```
+
+### 2. Capture route load
+
+File: `frontend/src/features/quotes/components/CaptureScreen.tsx`
+
+In the mount `useEffect` (the one that sets `isMountedRef.current = true`), add after the mount flag:
+
+```ts
+perfMark("capture:route:mounted");
+perfMeasure("capture:route:load_ms", "navigationStart", "capture:route:mounted");
+```
+
+> **Note (React Strict Mode):** In development, React Strict Mode runs effects twice, producing two `capture:route:mounted` marks and two `capture:route:load_ms` entries. This is expected and harmless — production builds see exactly one entry. If single-entry dev behavior is required, guard with a `useRef` flag.
+
+### 3. Tap-to-record
+
+File: `frontend/src/features/quotes/hooks/useVoiceCapture.ts`
+
+In `startRecording` (line 127):
+- Add `perfMark("capture:record:tap")` after both guard checks (after the `if (isRecording) { return; }` at line 135), before `setError(null)`. Placing after guards ensures the mark only fires when a legitimate recording will proceed; paired end marks are always created, so measures are never dangling.
+- Add `perfMark("capture:record:stream_ready")` after `streamRef.current = stream` (line 142) and before `resolvePreferredMimeType()` (line 144).
+- Add `perfMark("capture:record:active")` immediately after `recorder.start()` (line 201).
+- Add one measure call after `capture:record:active`:
+
+```ts
+perfMeasure("capture:record:tap_to_stream_ms", "capture:record:tap", "capture:record:stream_ready");
+perfMeasure("capture:record:tap_to_active_ms", "capture:record:tap", "capture:record:active");
+```
+
+### 4. Extract submit and response
+
+File: `frontend/src/features/quotes/components/CaptureScreen.tsx`
+
+In `onExtract()` (line 153):
+- Add `perfMark("capture:extract:start")` after the validation guards (after the `totalClipBytes` guard at line 170), before `clearExtractionStageTimers()`. Placing after guards means the mark only fires when extraction actually submits; no dangling mark on validation failure.
+- Add `perfMark("capture:extract:response")` immediately after `quoteService.extract(...)` resolves (after line 192, before the `isMountedRef` check at line 193).
+- Add measure:
+
+```ts
+perfMeasure("capture:extract:submit_to_response_ms", "capture:extract:start", "capture:extract:response");
+```
+
+### 5. Draft hydration
+
+File: `frontend/src/features/quotes/components/CaptureScreen.tsx`
+
+In `hydrateFromPersistedQuote()` (line 141):
+- Add `perfMark("capture:draft:hydrate_start")` at entry.
+- Add `perfMark("capture:draft:ready")` after `applyDraftFromQuoteDetail(...)` returns (line 146).
+- Add measure:
+
+```ts
+perfMeasure("capture:draft:hydrate_ms", "capture:draft:hydrate_start", "capture:draft:ready");
+```
+
+### 6. Local save placeholder
+
+Add a `// TODO(spec1): perfMark("capture:local:save_start") / perfMark("capture:local:save_done")` comment at the top of `onExtract()` noting where the IndexedDB save mark belongs once Spec 1 lands. Do not add live marks for a code path that does not exist yet.
+
+### 7. Bundle audit (one-time)
+
+Run `npx vite build 2>&1 | grep "kB"` from `frontend/` and record the gzip sizes of the main chunks in this spec under **Current bundle baseline** below.
+
+Note the App.tsx eager-import pattern as a route-splitting candidate. Do not implement code splitting in this spec — that belongs to a separate task if the baseline warrants it.
+
+Add `rollup-plugin-visualizer` to `frontend/package.json` devDependencies and wire it into `vite.config.ts` behind `process.env.ANALYZE === "true"`:
+
+```ts
+import { visualizer } from "rollup-plugin-visualizer";
+
+plugins: [
+  react(),
+  tailwindcss(),
+  process.env.ANALYZE === "true" && visualizer({ open: true, gzipSize: true }),
+].filter(Boolean),
+```
+
+---
+
+## Current bundle baseline
+
+Measured on 2026-04-24 via `cd frontend && npx vite build`:
+
+- `dist/assets/index-w5JgiP1a.js`: `570.28 kB` (gzip `167.07 kB`)
+- `dist/assets/index-Z-2kqtAX.css`: `59.34 kB` (gzip `10.36 kB`)
+- `dist/index.html`: `1.95 kB` (gzip `0.75 kB`)
+
+Route-splitting candidate noted:
+
+- `frontend/src/App.tsx` currently eager-imports many route screens into the main bundle; defer code splitting to a follow-up task (out of scope for Spec 0).
+
+---
+
+## Non-goals
+
+- Remote analytics or telemetry pipeline (marks are dev-only console output for now)
+- Route code splitting (note the opportunity, do not implement)
+- Backend timing or server-side instrumentation
+- Service worker / PWA performance
+- IndexedDB save timing (placeholder comment only; live mark lands with Spec 1)
+- Audio clip save timing (lands with Spec 3)
+- Performance regression CI gate (future work)
+
+---
+
+## Acceptance criteria
+
+- `perfMark` and `perfMeasure` are importable from `@/shared/perf`.
+- Running `npm run dev` (local dev server, where `import.meta.env.DEV` is `true`), `console.debug` entries appear for each measure when the corresponding flow runs.
+- `performance.getEntriesByType("measure")` in the browser console returns entries for:
+  - `capture:route:load_ms`
+  - `capture:record:tap_to_stream_ms`
+  - `capture:record:tap_to_active_ms`
+  - `capture:extract:submit_to_response_ms`
+  - `capture:draft:hydrate_ms`
+- `capture:route:load_ms` is under 1000ms on local dev (warm).
+- `capture:record:tap_to_active_ms` is under 500ms on local dev (warm, mic already granted).
+- Bundle baseline is recorded in this spec before the PR merges.
+- `ANALYZE=true npx vite build` opens the visualizer without error.
+- No marks are added for code paths that do not yet exist (IndexedDB, local save).
+- Frontend tests (`make frontend-verify`) pass unchanged — marks are side-effect-free.
+
+---
+
+## Verification
+
+**Tier 1 (during implementation)**
+- `cd frontend && npx tsc --noEmit` — no new type errors.
+- Open the app locally, navigate to Capture, tap record, submit an extraction. Inspect `performance.getEntriesByType("measure")` in browser devtools and confirm all five measures appear with plausible values.
+- Confirm `console.debug` log lines appear in dev mode.
+
+**Tier 2 (PR gate)**
+- `make frontend-verify` passes.
+- `ANALYZE=true npx vite build` opens the bundle visualizer without error.
+- Bundle baseline numbers recorded in this spec.
+
+---
+
+## Target metrics (for future regression reference)
+
+From the roadmap — to validate against in later PRs, not enforced by this spec:
+
+| Metric | Target |
+|---|---|
+| Tap-to-record visible state (warm) | < 150ms |
+| Local note save (p95) | < 50ms (lands with Spec 1) |
+| Local clip save after stop (p95) | < 200ms (lands with Spec 3) |
+| Reopen local capture/draft (p95) | < 400ms (lands with Spec 1) |
+| Capture route interactive (p75 mid-range mobile) | < 2000ms |


### PR DESCRIPTION
## Summary
- add shared `perfMark`/`perfMeasure` utility in `@/shared/perf`
- instrument capture route mount, draft hydration, extract submit->response, and voice tap->record timings
- add TODO placeholder for future local save timing in Spec 1
- add `rollup-plugin-visualizer` behind `ANALYZE=true` in Vite config
- record current frontend bundle baseline numbers in `plans/2026-04-24/p0-spec0-perf-baseline.md`

## Verification
- `cd frontend && rtk proxy npx tsc --noEmit`
- `cd frontend && rtk proxy npx vite build`
- `cd frontend && ANALYZE=true rtk proxy npx vite build`
- `rtk make frontend-verify`

Closes #550