### PR TITLE
Task #554: Spec 1 IndexedDB repository foundation

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -29,6 +29,7 @@
         "eslint": "^9.39.0",
         "eslint-plugin-react-hooks": "^7.0.0",
         "eslint-plugin-react-refresh": "^0.5.2",
+        "fake-indexeddb": "^6.2.5",
         "globals": "^16.5.0",
         "jsdom": "^26.1.0",
         "msw": "^2.13.2",
@@ -4228,6 +4229,16 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fake-indexeddb": {
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/fake-indexeddb/-/fake-indexeddb-6.2.5.tgz",
+      "integrity": "sha512-CGnyrvbhPlWYMngksqrSSUT1BAVP49dZocrHuK0SvtR0D5TMs5wP0o3j7jexDJW01KSadjBp1M/71o/KR3nD1w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/fast-deep-equal": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -34,6 +34,7 @@
     "eslint": "^9.39.0",
     "eslint-plugin-react-hooks": "^7.0.0",
     "eslint-plugin-react-refresh": "^0.5.2",
+    "fake-indexeddb": "^6.2.5",
     "globals": "^16.5.0",
     "jsdom": "^26.1.0",
     "msw": "^2.13.2",

--- a/frontend/src/features/quotes/offline/captureDb.ts
+++ b/frontend/src/features/quotes/offline/captureDb.ts
@@ -1,0 +1,183 @@
+export const CAPTURE_DB_NAME = "stima-local";
+export const CAPTURE_DB_VERSION = 1;
+
+export const CAPTURE_STORE_NAMES = {
+  captureSessions: "capture_sessions",
+  syncEvents: "sync_events",
+  audioClips: "audio_clips",
+  localDrafts: "local_drafts",
+  outboxJobs: "outbox_jobs",
+} as const;
+
+type CaptureStoreName = (typeof CAPTURE_STORE_NAMES)[keyof typeof CAPTURE_STORE_NAMES];
+
+type StoreDefinition = {
+  name: CaptureStoreName;
+  keyPath: string;
+  indexes: Array<{
+    name: string;
+    keyPath: string | string[];
+    options?: IDBIndexParameters;
+  }>;
+};
+
+const STORE_DEFINITIONS: StoreDefinition[] = [
+  {
+    name: CAPTURE_STORE_NAMES.captureSessions,
+    keyPath: "sessionId",
+    indexes: [
+      { name: "userId", keyPath: "userId" },
+      { name: "status", keyPath: "status" },
+      { name: "updatedAt", keyPath: "updatedAt" },
+    ],
+  },
+  {
+    name: CAPTURE_STORE_NAMES.syncEvents,
+    keyPath: "eventId",
+    indexes: [
+      { name: "sessionId", keyPath: "sessionId" },
+      { name: "userId", keyPath: "userId" },
+    ],
+  },
+  {
+    name: CAPTURE_STORE_NAMES.audioClips,
+    keyPath: "clipId",
+    indexes: [
+      { name: "sessionId", keyPath: "sessionId" },
+      { name: "userId", keyPath: "userId" },
+    ],
+  },
+  {
+    name: CAPTURE_STORE_NAMES.localDrafts,
+    keyPath: "draftKey",
+    indexes: [
+      { name: "userId", keyPath: "userId" },
+      { name: "documentId", keyPath: "documentId" },
+    ],
+  },
+  {
+    name: CAPTURE_STORE_NAMES.outboxJobs,
+    keyPath: "jobId",
+    indexes: [
+      { name: "userId", keyPath: "userId" },
+      { name: "status", keyPath: "status" },
+      { name: "sessionId", keyPath: "sessionId" },
+    ],
+  },
+];
+
+export class LocalStorageUnavailableError extends Error {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, options);
+    this.name = "LocalStorageUnavailableError";
+  }
+}
+
+let dbPromise: Promise<IDBDatabase> | null = null;
+
+export async function getDb(): Promise<IDBDatabase> {
+  if (!dbPromise) {
+    dbPromise = openDb();
+  }
+
+  return dbPromise;
+}
+
+async function openDb(): Promise<IDBDatabase> {
+  if (typeof indexedDB === "undefined") {
+    throw new LocalStorageUnavailableError("IndexedDB is unavailable in this environment.");
+  }
+
+  return new Promise<IDBDatabase>((resolve, reject) => {
+    const request = indexedDB.open(CAPTURE_DB_NAME, CAPTURE_DB_VERSION);
+
+    request.onupgradeneeded = (event) => {
+      const transaction = request.transaction;
+      if (!transaction) {
+        throw new LocalStorageUnavailableError("IndexedDB upgrade transaction is missing.");
+      }
+
+      const oldVersion = typeof event.oldVersion === "number" ? event.oldVersion : 0;
+      applyMigrations(request.result, transaction, oldVersion);
+    };
+
+    request.onerror = () => {
+      reject(
+        new LocalStorageUnavailableError("Failed to open IndexedDB.", {
+          cause: request.error,
+        }),
+      );
+    };
+
+    request.onblocked = () => {
+      reject(new LocalStorageUnavailableError("IndexedDB open was blocked by another connection."));
+    };
+
+    request.onsuccess = () => {
+      const db = request.result;
+      db.onversionchange = () => {
+        db.close();
+      };
+      resolve(db);
+    };
+  });
+}
+
+function applyMigrations(db: IDBDatabase, transaction: IDBTransaction, oldVersion: number): void {
+  const normalizedOldVersion = Number.isFinite(oldVersion) ? oldVersion : 0;
+  const startVersion = Math.max(normalizedOldVersion + 1, 1);
+  for (let version = startVersion; version <= CAPTURE_DB_VERSION; version += 1) {
+    if (version === 1) {
+      createVersionOneSchema(db, transaction);
+    }
+  }
+}
+
+function createVersionOneSchema(db: IDBDatabase, transaction: IDBTransaction): void {
+  for (const definition of STORE_DEFINITIONS) {
+    ensureStore(db, transaction, definition);
+  }
+}
+
+function ensureStore(
+  db: IDBDatabase,
+  transaction: IDBTransaction,
+  definition: StoreDefinition,
+): void {
+  let store: IDBObjectStore;
+  if (db.objectStoreNames.contains(definition.name)) {
+    store = transaction.objectStore(definition.name);
+  } else {
+    store = db.createObjectStore(definition.name, { keyPath: definition.keyPath });
+  }
+
+  for (const index of definition.indexes) {
+    if (!store.indexNames.contains(index.name)) {
+      store.createIndex(index.name, index.keyPath, index.options);
+    }
+  }
+}
+
+export async function resetCaptureDbForTests(): Promise<void> {
+  if (dbPromise) {
+    try {
+      const db = await dbPromise;
+      db.close();
+    } catch {
+      // Ignore stale open errors while resetting in tests.
+    } finally {
+      dbPromise = null;
+    }
+  }
+
+  if (typeof indexedDB === "undefined") {
+    return;
+  }
+
+  await new Promise<void>((resolve, reject) => {
+    const request = indexedDB.deleteDatabase(CAPTURE_DB_NAME);
+    request.onerror = () => reject(request.error ?? new Error("Failed to reset IndexedDB."));
+    request.onblocked = () => resolve();
+    request.onsuccess = () => resolve();
+  });
+}

--- a/frontend/src/features/quotes/offline/captureDb.ts
+++ b/frontend/src/features/quotes/offline/captureDb.ts
@@ -77,7 +77,10 @@ let dbPromise: Promise<IDBDatabase> | null = null;
 
 export async function getDb(): Promise<IDBDatabase> {
   if (!dbPromise) {
-    dbPromise = openDb();
+    dbPromise = openDb().catch((error) => {
+      dbPromise = null;
+      throw error;
+    });
   }
 
   return dbPromise;
@@ -116,6 +119,7 @@ async function openDb(): Promise<IDBDatabase> {
     request.onsuccess = () => {
       const db = request.result;
       db.onversionchange = () => {
+        dbPromise = null;
         db.close();
       };
       resolve(db);

--- a/frontend/src/features/quotes/offline/captureRepository.test.ts
+++ b/frontend/src/features/quotes/offline/captureRepository.test.ts
@@ -95,6 +95,12 @@ describe("captureRepository", () => {
     expect(updatedSession?.updatedAt).not.toBe(firstUpdatedAt);
   });
 
+  it("throws when updating notes for a missing session", async () => {
+    await expect(updateCaptureNotes("missing-session", "new notes")).rejects.toThrowError(
+      "Capture session not found: missing-session",
+    );
+  });
+
   it("updates arbitrary mutable fields without changing immutable fields", async () => {
     const session = await createCaptureSession({
       userId: "user-a",
@@ -116,6 +122,35 @@ describe("captureRepository", () => {
     expect(updatedSession?.status).toBe("ready_to_extract");
     expect(updatedSession?.notes).toBe("patched note");
     expect(updatedSession?.customerSnapshot).toEqual({ name: "Ada Lovelace" });
+  });
+
+  it("throws when updating fields for a missing session", async () => {
+    await expect(updateCaptureField("missing-session", { notes: "new notes" })).rejects.toThrowError(
+      "Capture session not found: missing-session",
+    );
+  });
+
+  it("rejects invalid enumerated patch values", async () => {
+    const session = await createCaptureSession({
+      userId: "user-a",
+      notes: "first note",
+    });
+
+    await expect(
+      updateCaptureField(session.sessionId, {
+        status: "invalid" as unknown as LocalCaptureSession["status"],
+      }),
+    ).rejects.toThrowError("Invalid capture status patch: invalid");
+
+    await expect(
+      updateCaptureField(session.sessionId, {
+        lastFailureKind: "not-a-kind" as unknown as LocalCaptureSession["lastFailureKind"],
+      }),
+    ).rejects.toThrowError("Invalid capture failure kind patch: not-a-kind");
+
+    const loadedSession = await getCaptureSession(session.sessionId);
+    expect(loadedSession?.status).toBe("local_only");
+    expect(loadedSession?.lastFailureKind).toBeNull();
   });
 
   it("lists only recoverable captures for the requested user", async () => {

--- a/frontend/src/features/quotes/offline/captureRepository.test.ts
+++ b/frontend/src/features/quotes/offline/captureRepository.test.ts
@@ -1,0 +1,355 @@
+import "fake-indexeddb/auto";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  CAPTURE_DB_VERSION,
+  CAPTURE_STORE_NAMES,
+  getDb,
+  resetCaptureDbForTests,
+} from "@/features/quotes/offline/captureDb";
+import {
+  appendSyncEvent,
+  createCaptureSession,
+  deleteCaptureSession,
+  deleteEmptyAbandonedSessions,
+  getCaptureSession,
+  listRecoverableCaptures,
+  listSyncEvents,
+  markCaptureStatus,
+  updateCaptureField,
+  updateCaptureNotes,
+} from "@/features/quotes/offline/captureRepository";
+import type { LocalCaptureSession } from "@/features/quotes/offline/captureTypes";
+import { getStorageEstimate, isStoragePressured } from "@/features/quotes/offline/storageHealth";
+
+const ORIGINAL_NAVIGATOR_STORAGE_DESCRIPTOR = Object.getOwnPropertyDescriptor(window.navigator, "storage");
+
+describe("captureDb schema", () => {
+  beforeEach(async () => {
+    await resetCaptureDbForTests();
+  });
+
+  afterEach(async () => {
+    restoreNavigatorStorage();
+    await resetCaptureDbForTests();
+  });
+
+  it("opens schema v1 with all required stores", async () => {
+    const db = await getDb();
+
+    expect(db.version).toBe(CAPTURE_DB_VERSION);
+    expect(db.objectStoreNames.contains(CAPTURE_STORE_NAMES.captureSessions)).toBe(true);
+    expect(db.objectStoreNames.contains(CAPTURE_STORE_NAMES.syncEvents)).toBe(true);
+    expect(db.objectStoreNames.contains(CAPTURE_STORE_NAMES.audioClips)).toBe(true);
+    expect(db.objectStoreNames.contains(CAPTURE_STORE_NAMES.localDrafts)).toBe(true);
+    expect(db.objectStoreNames.contains(CAPTURE_STORE_NAMES.outboxJobs)).toBe(true);
+  });
+});
+
+describe("captureRepository", () => {
+  beforeEach(async () => {
+    await resetCaptureDbForTests();
+  });
+
+  afterEach(async () => {
+    restoreNavigatorStorage();
+    await resetCaptureDbForTests();
+  });
+
+  it("creates and loads capture sessions", async () => {
+    const session = await createCaptureSession({
+      userId: "user-a",
+      notes: "roof quote",
+      customerId: "customer-1",
+    });
+    const loadedSession = await getCaptureSession(session.sessionId);
+
+    expect(session.status).toBe("local_only");
+    expect(session.clipIds).toEqual([]);
+    expect(loadedSession).toEqual(session);
+  });
+
+  it("returns null for unknown capture session", async () => {
+    const loadedSession = await getCaptureSession("missing-session");
+    expect(loadedSession).toBeNull();
+  });
+
+  it("updates notes and updatedAt while preserving other fields", async () => {
+    const session = await createCaptureSession({
+      userId: "user-a",
+      notes: "first note",
+      customerId: "customer-1",
+    });
+    const createdAt = session.createdAt;
+    const firstUpdatedAt = session.updatedAt;
+
+    await new Promise((resolve) => setTimeout(resolve, 2));
+    await updateCaptureNotes(session.sessionId, "edited note");
+
+    const updatedSession = await getCaptureSession(session.sessionId);
+    expect(updatedSession).not.toBeNull();
+    expect(updatedSession?.notes).toBe("edited note");
+    expect(updatedSession?.customerId).toBe("customer-1");
+    expect(updatedSession?.createdAt).toBe(createdAt);
+    expect(updatedSession?.updatedAt).not.toBe(firstUpdatedAt);
+  });
+
+  it("updates arbitrary mutable fields without changing immutable fields", async () => {
+    const session = await createCaptureSession({
+      userId: "user-a",
+      notes: "first note",
+    });
+
+    await updateCaptureField(session.sessionId, {
+      status: "ready_to_extract",
+      notes: "patched note",
+      sessionId: "do-not-change",
+      createdAt: "do-not-change",
+      customerSnapshot: { name: "Ada Lovelace" },
+    });
+
+    const updatedSession = await getCaptureSession(session.sessionId);
+    expect(updatedSession).not.toBeNull();
+    expect(updatedSession?.sessionId).toBe(session.sessionId);
+    expect(updatedSession?.createdAt).toBe(session.createdAt);
+    expect(updatedSession?.status).toBe("ready_to_extract");
+    expect(updatedSession?.notes).toBe("patched note");
+    expect(updatedSession?.customerSnapshot).toEqual({ name: "Ada Lovelace" });
+  });
+
+  it("lists only recoverable captures for the requested user", async () => {
+    const keepOne = await createCaptureSession({
+      userId: "user-a",
+      notes: "keep",
+    });
+    const syncedSession = await createCaptureSession({
+      userId: "user-a",
+      notes: "already synced",
+    });
+    await markCaptureStatus(syncedSession.sessionId, "synced");
+    await createCaptureSession({
+      userId: "user-b",
+      notes: "other user",
+    });
+
+    const recoverable = await listRecoverableCaptures("user-a");
+
+    expect(recoverable).toHaveLength(1);
+    expect(recoverable[0]?.sessionId).toBe(keepOne.sessionId);
+    expect(recoverable[0]?.status).toBe("local_only");
+  });
+
+  it("applies failure metadata when marking capture status", async () => {
+    const session = await createCaptureSession({
+      userId: "user-a",
+      notes: "capture",
+    });
+
+    await markCaptureStatus(session.sessionId, "extract_failed", {
+      failureKind: "timeout",
+      error: "request timed out",
+    });
+
+    const updatedSession = await getCaptureSession(session.sessionId);
+    expect(updatedSession?.status).toBe("extract_failed");
+    expect(updatedSession?.lastFailureKind).toBe("timeout");
+    expect(updatedSession?.lastError).toBe("request timed out");
+  });
+
+  it("deletes capture session records", async () => {
+    const session = await createCaptureSession({
+      userId: "user-a",
+      notes: "to delete",
+    });
+
+    await deleteCaptureSession(session.sessionId);
+
+    expect(await getCaptureSession(session.sessionId)).toBeNull();
+  });
+
+  it("deletes only empty abandoned local-only sessions", async () => {
+    const now = Date.now();
+    const staleTimestamp = new Date(now - 3 * 24 * 60 * 60 * 1000).toISOString();
+    const freshTimestamp = new Date(now - 30 * 60 * 1000).toISOString();
+
+    await putCaptureSessionRecord({
+      sessionId: "stale-empty",
+      userId: "user-a",
+      status: "local_only",
+      notes: "",
+      clipIds: [],
+      createdAt: staleTimestamp,
+      updatedAt: staleTimestamp,
+    });
+    await putCaptureSessionRecord({
+      sessionId: "stale-with-notes",
+      userId: "user-a",
+      status: "local_only",
+      notes: "do not remove",
+      clipIds: [],
+      createdAt: staleTimestamp,
+      updatedAt: staleTimestamp,
+    });
+    await putCaptureSessionRecord({
+      sessionId: "fresh-empty",
+      userId: "user-a",
+      status: "local_only",
+      notes: "",
+      clipIds: [],
+      createdAt: freshTimestamp,
+      updatedAt: freshTimestamp,
+    });
+
+    await deleteEmptyAbandonedSessions("user-a");
+
+    expect(await getCaptureSession("stale-empty")).toBeNull();
+    expect(await getCaptureSession("stale-with-notes")).not.toBeNull();
+    expect(await getCaptureSession("fresh-empty")).not.toBeNull();
+  });
+
+  it("ignores corrupt records when listing recoverable captures", async () => {
+    await putCaptureSessionRecord({
+      sessionId: "good-session",
+      userId: "user-a",
+      status: "local_only",
+      notes: "",
+      clipIds: [],
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+    await putRawCaptureSessionRecord({
+      sessionId: "corrupt-session",
+      userId: "user-a",
+      status: "local_only",
+      notes: 42,
+      clipIds: [],
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+
+    const recoverable = await listRecoverableCaptures("user-a");
+
+    expect(recoverable).toHaveLength(1);
+    expect(recoverable[0]?.sessionId).toBe("good-session");
+  });
+
+  it("appends and lists sync events per session", async () => {
+    await appendSyncEvent({
+      sessionId: "session-a",
+      userId: "user-a",
+      level: "info",
+      message: "queued",
+    });
+    await new Promise((resolve) => setTimeout(resolve, 2));
+    await appendSyncEvent({
+      sessionId: "session-a",
+      userId: "user-a",
+      level: "warning",
+      message: "retrying",
+    });
+    await appendSyncEvent({
+      sessionId: "session-b",
+      userId: "user-a",
+      level: "error",
+      message: "different session",
+    });
+
+    const events = await listSyncEvents("session-a");
+
+    expect(events).toHaveLength(2);
+    expect(events[0]?.message).toBe("queued");
+    expect(events[1]?.message).toBe("retrying");
+  });
+});
+
+describe("storageHealth", () => {
+  beforeEach(async () => {
+    await resetCaptureDbForTests();
+  });
+
+  afterEach(async () => {
+    restoreNavigatorStorage();
+    await resetCaptureDbForTests();
+  });
+
+  it("returns null estimate values when navigator.storage is unavailable", async () => {
+    setNavigatorStorage(undefined);
+
+    await expect(getStorageEstimate()).resolves.toEqual({
+      usedBytes: null,
+      quotaBytes: null,
+      percentUsed: null,
+    });
+  });
+
+  it("returns usage values from navigator.storage.estimate", async () => {
+    setNavigatorStorage({
+      estimate: async () => ({ usage: 250, quota: 1000 }),
+    } as StorageManager);
+
+    await expect(getStorageEstimate()).resolves.toEqual({
+      usedBytes: 250,
+      quotaBytes: 1000,
+      percentUsed: 25,
+    });
+  });
+
+  it("reports pressure state using the threshold", async () => {
+    setNavigatorStorage({
+      estimate: async () => ({ usage: 850, quota: 1000 }),
+    } as StorageManager);
+
+    await expect(isStoragePressured()).resolves.toBe(true);
+    await expect(isStoragePressured(90)).resolves.toBe(false);
+  });
+});
+
+async function putCaptureSessionRecord(
+  patch: Pick<LocalCaptureSession, "sessionId" | "userId" | "status" | "notes" | "clipIds" | "createdAt" | "updatedAt">,
+): Promise<void> {
+  await putRawCaptureSessionRecord({
+    ...patch,
+    customerId: null,
+    customerSnapshot: null,
+    idempotencyKey: null,
+    outboxJobId: null,
+    serverQuoteId: null,
+    extractJobId: null,
+    lastFailureKind: null,
+    lastError: null,
+  });
+}
+
+async function putRawCaptureSessionRecord(record: unknown): Promise<void> {
+  const db = await getDb();
+  const transaction = db.transaction(CAPTURE_STORE_NAMES.captureSessions, "readwrite");
+  const store = transaction.objectStore(CAPTURE_STORE_NAMES.captureSessions);
+  store.put(record);
+  await transactionDone(transaction);
+}
+
+function setNavigatorStorage(storageManager: StorageManager | undefined): void {
+  Object.defineProperty(window.navigator, "storage", {
+    configurable: true,
+    writable: true,
+    value: storageManager,
+  });
+}
+
+function restoreNavigatorStorage(): void {
+  if (ORIGINAL_NAVIGATOR_STORAGE_DESCRIPTOR) {
+    Object.defineProperty(window.navigator, "storage", ORIGINAL_NAVIGATOR_STORAGE_DESCRIPTOR);
+    return;
+  }
+
+  Reflect.deleteProperty(window.navigator, "storage");
+}
+
+function transactionDone(transaction: IDBTransaction): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    transaction.oncomplete = () => resolve();
+    transaction.onerror = () => reject(transaction.error ?? new Error("IndexedDB transaction failed."));
+    transaction.onabort = () => reject(transaction.error ?? new Error("IndexedDB transaction aborted."));
+  });
+}

--- a/frontend/src/features/quotes/offline/captureRepository.ts
+++ b/frontend/src/features/quotes/offline/captureRepository.ts
@@ -92,6 +92,7 @@ export async function updateCaptureField(
   sessionId: string,
   patch: Partial<LocalCaptureSession>,
 ): Promise<void> {
+  validateCapturePatch(patch);
   const db = await getDb();
   const transaction = db.transaction(CAPTURE_STORE_NAMES.captureSessions, "readwrite");
   const store = transaction.objectStore(CAPTURE_STORE_NAMES.captureSessions);
@@ -108,6 +109,24 @@ export async function updateCaptureField(
   session.updatedAt = new Date().toISOString();
   store.put(session);
   await transactionDone(transaction);
+}
+
+function validateCapturePatch(patch: Partial<LocalCaptureSession>): void {
+  if (
+    patch.status !== undefined &&
+    (typeof patch.status !== "string" || !CAPTURE_STATUSES.has(patch.status as LocalCaptureStatus))
+  ) {
+    throw new Error(`Invalid capture status patch: ${String(patch.status)}`);
+  }
+
+  if (
+    patch.lastFailureKind !== undefined &&
+    patch.lastFailureKind !== null &&
+    (typeof patch.lastFailureKind !== "string" ||
+      !SUBMIT_FAILURE_KINDS.has(patch.lastFailureKind as SubmitFailureKind))
+  ) {
+    throw new Error(`Invalid capture failure kind patch: ${String(patch.lastFailureKind)}`);
+  }
 }
 
 export async function listRecoverableCaptures(userId: string): Promise<LocalCaptureSummary[]> {

--- a/frontend/src/features/quotes/offline/captureRepository.ts
+++ b/frontend/src/features/quotes/offline/captureRepository.ts
@@ -1,0 +1,403 @@
+import { CAPTURE_STORE_NAMES, getDb } from "@/features/quotes/offline/captureDb";
+import type {
+  CreateLocalCaptureInput,
+  CreateLocalSyncEventInput,
+  LocalCaptureSession,
+  LocalCaptureStatus,
+  LocalCaptureSummary,
+  LocalSyncEvent,
+  SubmitFailureKind,
+} from "@/features/quotes/offline/captureTypes";
+
+const ABANDONED_SESSION_MAX_AGE_MS = 24 * 60 * 60 * 1000;
+const RECOVERABLE_CAPTURE_STATUSES = new Set<LocalCaptureStatus>([
+  "local_only",
+  "ready_to_extract",
+  "submitting",
+  "extract_failed",
+]);
+const CAPTURE_STATUSES = new Set<LocalCaptureStatus>([
+  "local_only",
+  "ready_to_extract",
+  "submitting",
+  "extract_failed",
+  "synced",
+  "discarded",
+]);
+const SYNC_EVENT_LEVELS = new Set<LocalSyncEvent["level"]>(["info", "warning", "error"]);
+const SUBMIT_FAILURE_KINDS = new Set<SubmitFailureKind>([
+  "offline",
+  "timeout",
+  "auth_required",
+  "csrf_failed",
+  "validation_failed",
+  "server_retryable",
+  "server_terminal",
+]);
+const IMMUTABLE_CAPTURE_FIELDS = new Set<keyof LocalCaptureSession>(["sessionId", "createdAt"]);
+
+type UnknownRecord = Record<string, unknown>;
+
+export async function createCaptureSession(
+  input: CreateLocalCaptureInput,
+): Promise<LocalCaptureSession> {
+  const now = new Date().toISOString();
+  const session: LocalCaptureSession = {
+    sessionId: buildLocalId(),
+    userId: input.userId,
+    status: "local_only",
+    notes: input.notes ?? "",
+    customerId: input.customerId ?? null,
+    customerSnapshot: input.customerSnapshot ?? null,
+    clipIds: [],
+    idempotencyKey: null,
+    outboxJobId: null,
+    serverQuoteId: null,
+    extractJobId: null,
+    lastFailureKind: null,
+    lastError: null,
+    createdAt: now,
+    updatedAt: now,
+  };
+
+  const db = await getDb();
+  const transaction = db.transaction(CAPTURE_STORE_NAMES.captureSessions, "readwrite");
+  const store = transaction.objectStore(CAPTURE_STORE_NAMES.captureSessions);
+  store.put(session);
+  await transactionDone(transaction);
+  return session;
+}
+
+export async function getCaptureSession(sessionId: string): Promise<LocalCaptureSession | null> {
+  const db = await getDb();
+  const transaction = db.transaction(CAPTURE_STORE_NAMES.captureSessions, "readonly");
+  const store = transaction.objectStore(CAPTURE_STORE_NAMES.captureSessions);
+  const rawRecord = await requestToPromise(store.get(sessionId));
+  await transactionDone(transaction);
+  return parseStoredCapture(rawRecord);
+}
+
+export async function updateCaptureNotes(sessionId: string, notes: string): Promise<void> {
+  const db = await getDb();
+  const transaction = db.transaction(CAPTURE_STORE_NAMES.captureSessions, "readwrite");
+  const store = transaction.objectStore(CAPTURE_STORE_NAMES.captureSessions);
+  const session = await getWritableCaptureSession(store, sessionId);
+  session.notes = notes;
+  session.updatedAt = new Date().toISOString();
+  store.put(session);
+  await transactionDone(transaction);
+}
+
+export async function updateCaptureField(
+  sessionId: string,
+  patch: Partial<LocalCaptureSession>,
+): Promise<void> {
+  const db = await getDb();
+  const transaction = db.transaction(CAPTURE_STORE_NAMES.captureSessions, "readwrite");
+  const store = transaction.objectStore(CAPTURE_STORE_NAMES.captureSessions);
+  const session = await getWritableCaptureSession(store, sessionId);
+  const mutablePatch = Object.entries(patch).filter(([key, value]) => {
+    return value !== undefined && !IMMUTABLE_CAPTURE_FIELDS.has(key as keyof LocalCaptureSession);
+  });
+
+  for (const [key, value] of mutablePatch as Array<
+    [keyof LocalCaptureSession, LocalCaptureSession[keyof LocalCaptureSession]]
+  >) {
+    session[key] = value as never;
+  }
+  session.updatedAt = new Date().toISOString();
+  store.put(session);
+  await transactionDone(transaction);
+}
+
+export async function listRecoverableCaptures(userId: string): Promise<LocalCaptureSummary[]> {
+  const db = await getDb();
+  const transaction = db.transaction(CAPTURE_STORE_NAMES.captureSessions, "readonly");
+  const store = transaction.objectStore(CAPTURE_STORE_NAMES.captureSessions);
+  const userIndex = store.index("userId");
+  const records = await requestToPromise(userIndex.getAll(IDBKeyRange.only(userId)));
+  await transactionDone(transaction);
+
+  const summaries = records
+    .map(parseStoredCapture)
+    .filter((record): record is LocalCaptureSession => record !== null)
+    .filter((record) => record.userId === userId && RECOVERABLE_CAPTURE_STATUSES.has(record.status))
+    .sort((left, right) => right.updatedAt.localeCompare(left.updatedAt))
+    .map((record) => ({
+      sessionId: record.sessionId,
+      status: record.status,
+      notes: record.notes,
+      updatedAt: record.updatedAt,
+      lastFailureKind: record.lastFailureKind ?? null,
+      lastError: record.lastError ?? null,
+    }));
+
+  return summaries;
+}
+
+export async function markCaptureStatus(
+  sessionId: string,
+  status: LocalCaptureStatus,
+  options?: { failureKind?: SubmitFailureKind; error?: string },
+): Promise<void> {
+  const db = await getDb();
+  const transaction = db.transaction(CAPTURE_STORE_NAMES.captureSessions, "readwrite");
+  const store = transaction.objectStore(CAPTURE_STORE_NAMES.captureSessions);
+  const session = await getWritableCaptureSession(store, sessionId);
+
+  session.status = status;
+  session.lastFailureKind = options?.failureKind ?? null;
+  session.lastError = options?.error ?? null;
+  session.updatedAt = new Date().toISOString();
+
+  store.put(session);
+  await transactionDone(transaction);
+}
+
+export async function deleteCaptureSession(sessionId: string): Promise<void> {
+  const db = await getDb();
+  const transaction = db.transaction(CAPTURE_STORE_NAMES.captureSessions, "readwrite");
+  const store = transaction.objectStore(CAPTURE_STORE_NAMES.captureSessions);
+  store.delete(sessionId);
+  await transactionDone(transaction);
+}
+
+export async function deleteEmptyAbandonedSessions(userId: string): Promise<void> {
+  const db = await getDb();
+  const transaction = db.transaction(CAPTURE_STORE_NAMES.captureSessions, "readwrite");
+  const store = transaction.objectStore(CAPTURE_STORE_NAMES.captureSessions);
+  const userIndex = store.index("userId");
+  const records = await requestToPromise(userIndex.getAll(IDBKeyRange.only(userId)));
+  const nowMs = Date.now();
+
+  for (const rawRecord of records) {
+    const session = parseStoredCapture(rawRecord);
+    if (!session) {
+      continue;
+    }
+
+    const updatedAtMs = Date.parse(session.updatedAt);
+    if (Number.isNaN(updatedAtMs)) {
+      continue;
+    }
+
+    const isOldEnough = nowMs - updatedAtMs >= ABANDONED_SESSION_MAX_AGE_MS;
+    const hasNoNotes = session.notes.trim().length === 0;
+    const hasNoClips = session.clipIds.length === 0;
+    const isLocalOnly = session.status === "local_only";
+
+    if (isOldEnough && hasNoNotes && hasNoClips && isLocalOnly) {
+      store.delete(session.sessionId);
+    }
+  }
+
+  await transactionDone(transaction);
+}
+
+export async function appendSyncEvent(event: CreateLocalSyncEventInput): Promise<void> {
+  const db = await getDb();
+  const transaction = db.transaction(CAPTURE_STORE_NAMES.syncEvents, "readwrite");
+  const store = transaction.objectStore(CAPTURE_STORE_NAMES.syncEvents);
+  const syncEvent: LocalSyncEvent = {
+    eventId: buildLocalId(),
+    createdAt: new Date().toISOString(),
+    ...event,
+  };
+  store.put(syncEvent);
+  await transactionDone(transaction);
+}
+
+export async function listSyncEvents(sessionId: string): Promise<LocalSyncEvent[]> {
+  const db = await getDb();
+  const transaction = db.transaction(CAPTURE_STORE_NAMES.syncEvents, "readonly");
+  const store = transaction.objectStore(CAPTURE_STORE_NAMES.syncEvents);
+  const sessionIndex = store.index("sessionId");
+  const records = await requestToPromise(sessionIndex.getAll(IDBKeyRange.only(sessionId)));
+  await transactionDone(transaction);
+
+  return records
+    .map(parseStoredSyncEvent)
+    .filter((record): record is LocalSyncEvent => record !== null)
+    .sort((left, right) => left.createdAt.localeCompare(right.createdAt));
+}
+
+async function getWritableCaptureSession(
+  store: IDBObjectStore,
+  sessionId: string,
+): Promise<LocalCaptureSession> {
+  const rawRecord = await requestToPromise(store.get(sessionId));
+  if (rawRecord === undefined) {
+    throw new Error(`Capture session not found: ${sessionId}`);
+  }
+
+  const parsedRecord = parseStoredCapture(rawRecord);
+  if (!parsedRecord) {
+    throw new Error(`Stored capture session is invalid: ${sessionId}`);
+  }
+
+  return parsedRecord;
+}
+
+function parseStoredCapture(value: unknown): LocalCaptureSession | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  const sessionId = value.sessionId;
+  const userId = value.userId;
+  const status = value.status;
+  const notes = value.notes;
+  const clipIds = value.clipIds;
+  const createdAt = value.createdAt;
+  const updatedAt = value.updatedAt;
+  if (
+    typeof sessionId !== "string" ||
+    typeof userId !== "string" ||
+    typeof status !== "string" ||
+    typeof notes !== "string" ||
+    !Array.isArray(clipIds) ||
+    clipIds.some((clipId) => typeof clipId !== "string") ||
+    typeof createdAt !== "string" ||
+    typeof updatedAt !== "string"
+  ) {
+    return null;
+  }
+
+  if (!CAPTURE_STATUSES.has(status as LocalCaptureStatus)) {
+    return null;
+  }
+
+  const customerId = value.customerId;
+  const customerSnapshot = parseCustomerSnapshot(value.customerSnapshot);
+  const idempotencyKey = value.idempotencyKey;
+  const outboxJobId = value.outboxJobId;
+  const serverQuoteId = value.serverQuoteId;
+  const extractJobId = value.extractJobId;
+  const lastFailureKind = value.lastFailureKind;
+  const lastError = value.lastError;
+  const lastOpenedAt = value.lastOpenedAt;
+
+  if (
+    !isOptionalNullableString(customerId) ||
+    customerSnapshot === undefined ||
+    !isOptionalNullableString(idempotencyKey) ||
+    !isOptionalNullableString(outboxJobId) ||
+    !isOptionalNullableString(serverQuoteId) ||
+    !isOptionalNullableString(extractJobId) ||
+    !isOptionalNullableString(lastError) ||
+    (lastOpenedAt !== undefined && typeof lastOpenedAt !== "string")
+  ) {
+    return null;
+  }
+
+  if (
+    lastFailureKind !== undefined &&
+    lastFailureKind !== null &&
+    (typeof lastFailureKind !== "string" ||
+      !SUBMIT_FAILURE_KINDS.has(lastFailureKind as SubmitFailureKind))
+  ) {
+    return null;
+  }
+
+  return {
+    sessionId,
+    userId,
+    status: status as LocalCaptureStatus,
+    notes,
+    customerId: customerId as string | null | undefined,
+    customerSnapshot,
+    clipIds: [...clipIds],
+    idempotencyKey: idempotencyKey as string | null | undefined,
+    outboxJobId: outboxJobId as string | null | undefined,
+    serverQuoteId: serverQuoteId as string | null | undefined,
+    extractJobId: extractJobId as string | null | undefined,
+    lastFailureKind: (lastFailureKind as SubmitFailureKind | null | undefined) ?? null,
+    lastError: (lastError as string | null | undefined) ?? null,
+    createdAt,
+    updatedAt,
+    lastOpenedAt: lastOpenedAt as string | undefined,
+  };
+}
+
+function parseStoredSyncEvent(value: unknown): LocalSyncEvent | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  const { eventId, sessionId, userId, level, message, createdAt } = value;
+  if (
+    typeof eventId !== "string" ||
+    typeof sessionId !== "string" ||
+    typeof userId !== "string" ||
+    typeof level !== "string" ||
+    typeof message !== "string" ||
+    typeof createdAt !== "string"
+  ) {
+    return null;
+  }
+
+  if (!SYNC_EVENT_LEVELS.has(level as LocalSyncEvent["level"])) {
+    return null;
+  }
+
+  return {
+    eventId,
+    sessionId,
+    userId,
+    level: level as LocalSyncEvent["level"],
+    message,
+    createdAt,
+  };
+}
+
+function parseCustomerSnapshot(value: unknown): LocalCaptureSession["customerSnapshot"] | undefined {
+  if (value === undefined || value === null) {
+    return value as LocalCaptureSession["customerSnapshot"];
+  }
+
+  if (!isRecord(value)) {
+    return undefined;
+  }
+
+  const { name, email, phone, address } = value;
+  if (
+    (name !== undefined && typeof name !== "string") ||
+    (email !== undefined && typeof email !== "string") ||
+    (phone !== undefined && typeof phone !== "string") ||
+    (address !== undefined && typeof address !== "string")
+  ) {
+    return undefined;
+  }
+
+  return { name, email, phone, address };
+}
+
+function isOptionalNullableString(value: unknown): boolean {
+  return value === undefined || value === null || typeof value === "string";
+}
+
+function isRecord(value: unknown): value is UnknownRecord {
+  return typeof value === "object" && value !== null;
+}
+
+function buildLocalId(): string {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID();
+  }
+  return `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+}
+
+function requestToPromise<T>(request: IDBRequest<T>): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error ?? new Error("IndexedDB request failed."));
+  });
+}
+
+function transactionDone(transaction: IDBTransaction): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    transaction.oncomplete = () => resolve();
+    transaction.onerror = () => reject(transaction.error ?? new Error("IndexedDB transaction failed."));
+    transaction.onabort = () => reject(transaction.error ?? new Error("IndexedDB transaction aborted."));
+  });
+}

--- a/frontend/src/features/quotes/offline/captureTypes.ts
+++ b/frontend/src/features/quotes/offline/captureTypes.ts
@@ -1,0 +1,99 @@
+export type LocalCaptureStatus =
+  | "local_only"
+  | "ready_to_extract"
+  | "submitting"
+  | "extract_failed"
+  | "synced"
+  | "discarded";
+
+export type SubmitFailureKind =
+  | "offline"
+  | "timeout"
+  | "auth_required"
+  | "csrf_failed"
+  | "validation_failed"
+  | "server_retryable"
+  | "server_terminal";
+
+export interface LocalCaptureCustomerSnapshot {
+  name?: string;
+  email?: string;
+  phone?: string;
+  address?: string;
+}
+
+export interface LocalCaptureSession {
+  sessionId: string;
+  userId: string;
+  status: LocalCaptureStatus;
+  notes: string;
+  customerId?: string | null;
+  customerSnapshot?: LocalCaptureCustomerSnapshot | null;
+  clipIds: string[];
+  idempotencyKey?: string | null;
+  outboxJobId?: string | null;
+  serverQuoteId?: string | null;
+  extractJobId?: string | null;
+  lastFailureKind?: SubmitFailureKind | null;
+  lastError?: string | null;
+  createdAt: string;
+  updatedAt: string;
+  lastOpenedAt?: string;
+}
+
+export interface CreateLocalCaptureInput {
+  userId: string;
+  notes?: string;
+  customerId?: string | null;
+  customerSnapshot?: LocalCaptureSession["customerSnapshot"];
+}
+
+export type LocalCaptureSummary = Pick<
+  LocalCaptureSession,
+  "sessionId" | "status" | "notes" | "updatedAt" | "lastFailureKind" | "lastError"
+>;
+
+export interface LocalSyncEvent {
+  eventId: string;
+  sessionId: string;
+  userId: string;
+  level: "info" | "warning" | "error";
+  message: string;
+  createdAt: string;
+}
+
+export type CreateLocalSyncEventInput = Omit<LocalSyncEvent, "eventId" | "createdAt">;
+
+export interface LocalAudioClip {
+  clipId: string;
+  sessionId: string;
+  userId: string;
+  blob: Blob;
+  mimeType: string;
+  sizeBytes: number;
+  durationSeconds?: number;
+  sequenceNumber: number;
+  objectUrl?: never;
+  createdAt: string;
+}
+
+export interface LocalDraftRecord {
+  draftKey: string;
+  userId: string;
+  documentId: string;
+  docType: "quote" | "invoice";
+  payload: unknown;
+  updatedAt: string;
+}
+
+export type LocalOutboxStatus = "pending" | "processing" | "failed" | "succeeded";
+
+export interface LocalOutboxJob {
+  jobId: string;
+  sessionId: string;
+  userId: string;
+  status: LocalOutboxStatus;
+  attempts: number;
+  createdAt: string;
+  updatedAt: string;
+}

--- a/frontend/src/features/quotes/offline/storageHealth.ts
+++ b/frontend/src/features/quotes/offline/storageHealth.ts
@@ -1,0 +1,51 @@
+export type StorageEstimate = {
+  usedBytes: number | null;
+  quotaBytes: number | null;
+  percentUsed: number | null;
+};
+
+const DEFAULT_PRESSURE_THRESHOLD_PERCENT = 85;
+
+export async function getStorageEstimate(): Promise<StorageEstimate> {
+  if (
+    typeof navigator === "undefined" ||
+    !navigator.storage ||
+    typeof navigator.storage.estimate !== "function"
+  ) {
+    return {
+      usedBytes: null,
+      quotaBytes: null,
+      percentUsed: null,
+    };
+  }
+
+  try {
+    const estimate = await navigator.storage.estimate();
+    const usedBytes = typeof estimate.usage === "number" ? estimate.usage : null;
+    const quotaBytes = typeof estimate.quota === "number" ? estimate.quota : null;
+
+    const percentUsed =
+      usedBytes !== null && quotaBytes !== null && quotaBytes > 0
+        ? (usedBytes / quotaBytes) * 100
+        : null;
+
+    return {
+      usedBytes,
+      quotaBytes,
+      percentUsed,
+    };
+  } catch {
+    return {
+      usedBytes: null,
+      quotaBytes: null,
+      percentUsed: null,
+    };
+  }
+}
+
+export async function isStoragePressured(
+  thresholdPercent: number = DEFAULT_PRESSURE_THRESHOLD_PERCENT,
+): Promise<boolean> {
+  const { percentUsed } = await getStorageEstimate();
+  return percentUsed !== null && percentUsed >= thresholdPercent;
+}


### PR DESCRIPTION
## Summary
- add `frontend/src/features/quotes/offline/` foundation modules for IndexedDB schema, types, repository CRUD, and storage health checks
- define schema `stima-local` version `1` with stores `capture_sessions`, `sync_events`, `audio_clips`, `local_drafts`, and `outbox_jobs`
- add unit coverage with `fake-indexeddb` for repository behavior, user scoping, cleanup, corrupt record handling, and jsdom storage-estimate guards
- add frontend dev dependency `fake-indexeddb`

## Verification
- `cd frontend && npx vitest run src/features/quotes/offline/captureRepository.test.ts`
- `cd frontend && npx tsc --noEmit`
- `make frontend-verify`

Closes #554