### PR TITLE
Task #555: Spec 2 offline capture workspace

### DIFF
--- a/frontend/src/features/quotes/components/CaptureScreen.tsx
+++ b/frontend/src/features/quotes/components/CaptureScreen.tsx
@@ -1,17 +1,16 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useLocation, useNavigate, useParams } from "react-router-dom";
 
+import { useAuth } from "@/features/auth/hooks/useAuth";
 import { useQuoteDraft } from "@/features/quotes/hooks/useQuoteDraft";
-import {
-  EXTRACTION_MAX_POLLS,
-  EXTRACTION_POLL_INTERVAL_MS,
-  EXTRACTION_STAGE_DELAY_MS,
-  getExtractionStages,
-} from "@/features/quotes/components/captureScreenHelpers";
+import { EXTRACTION_STAGE_DELAY_MS, getExtractionStages } from "@/features/quotes/components/captureScreenHelpers";
+import { buildDraftFromQuoteDetail } from "@/features/quotes/components/captureScreenDraft";
+import { pollExtractionJobUntilQuote } from "@/features/quotes/components/captureScreenPolling";
 import { CaptureInputPanel } from "@/features/quotes/components/CaptureInputPanel";
-import {
-  resolveCaptureLaunchOrigin,
-} from "@/features/quotes/utils/workflowNavigation";
+import { classifySubmitFailure } from "@/features/quotes/offline/classifySubmitFailure";
+import { getLocalCaptureStatusCopy } from "@/features/quotes/offline/localCaptureStatusCopy";
+import { useLocalCaptureSession } from "@/features/quotes/offline/useLocalCaptureSession";
+import { resolveCaptureLaunchOrigin } from "@/features/quotes/utils/workflowNavigation";
 import { useVoiceCapture } from "@/features/quotes/hooks/useVoiceCapture";
 import { quoteService } from "@/features/quotes/services/quoteService";
 import type { QuoteDetail, QuoteSourceType } from "@/features/quotes/types/quote.types";
@@ -19,7 +18,6 @@ import { Button } from "@/shared/components/Button";
 import { ConfirmModal } from "@/shared/components/ConfirmModal";
 import { ScreenFooter } from "@/shared/components/ScreenFooter";
 import { WorkflowScreenHeader } from "@/shared/components/WorkflowScreenHeader";
-import { jobService } from "@/shared/lib/jobService";
 import { formatByteLimit } from "@/shared/lib/formatters";
 import { MAX_AUDIO_CLIPS_PER_REQUEST, MAX_AUDIO_TOTAL_BYTES } from "@/shared/lib/inputLimits";
 import { perfMark, perfMeasure, perfMeasureSincePageLoad } from "@/shared/perf";
@@ -30,6 +28,7 @@ const START_BLANK_GUARD_TARGET = "__start_blank__";
 export function CaptureScreen(): React.ReactElement {
   const navigate = useNavigate();
   const { show } = useToast();
+  const { user } = useAuth();
   const location = useLocation();
   const { customerId } = useParams<{ customerId?: string }>();
   const { setDraft } = useQuoteDraft();
@@ -46,12 +45,30 @@ export function CaptureScreen(): React.ReactElement {
     removeClip,
     clearError,
   } = useVoiceCapture();
+  const searchParams = useMemo(() => new URLSearchParams(location.search), [location.search]);
+  const localSessionQueryParam = searchParams.get("localSession");
+  const autoExtractOnLoad = searchParams.get("autoExtract") === "1";
+  const {
+    notes,
+    setNotes,
+    sessionId: localSessionId,
+    sessionStatus,
+    isHydrating: isHydratingLocalSession,
+    hydrationError: localHydrationError,
+    saveState: localSaveState,
+    saveError: localSaveError,
+    markStatus: markLocalCaptureStatus,
+  } = useLocalCaptureSession({
+    userId: user?.id,
+    customerId,
+    initialSessionId: localSessionQueryParam,
+  });
 
-  const [notes, setNotes] = useState("");
   const [extractionStage, setExtractionStage] = useState<string | null>(null);
   const [pendingExitTarget, setPendingExitTarget] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [isStartingBlank, setIsStartingBlank] = useState(false);
+  const [hasAttemptedAutoExtract, setHasAttemptedAutoExtract] = useState(false);
   const isExtracting = extractionStage !== null;
   const hasClips = clips.length > 0;
   const hasNotes = notes.trim().length > 0;
@@ -87,7 +104,7 @@ export function CaptureScreen(): React.ReactElement {
     };
   }, []);
 
-  const displayedError = error ?? voiceError;
+  const displayedError = error ?? localHydrationError ?? localSaveError ?? voiceError;
 
   useEffect(() => {
     dismissActiveErrorRef.current = () => {
@@ -95,11 +112,14 @@ export function CaptureScreen(): React.ReactElement {
         setError(null);
         return;
       }
+      if (localHydrationError || localSaveError) {
+        return;
+      }
       if (voiceError) {
         clearError();
       }
     };
-  }, [clearError, error, voiceError]);
+  }, [clearError, error, localHydrationError, localSaveError, voiceError]);
 
   useEffect(() => {
     if (!displayedError) {
@@ -118,26 +138,22 @@ export function CaptureScreen(): React.ReactElement {
     quoteDetail: QuoteDetail,
     quoteId: string,
   ): void {
-    setDraft({
-      quoteId,
-      customerId: quoteDetail.customer_id ?? customerId ?? "",
-      launchOrigin,
-      title: "",
-      transcript: quoteDetail.transcript,
-      lineItems: quoteDetail.line_items.map((lineItem) => ({
-        description: lineItem.description,
-        details: lineItem.details,
-        price: lineItem.price,
-        flagged: lineItem.flagged,
-        flagReason: lineItem.flag_reason,
-      })),
-      total: quoteDetail.total_amount,
-      taxRate: quoteDetail.tax_rate,
-      discountType: quoteDetail.discount_type,
-      discountValue: quoteDetail.discount_value,
-      depositAmount: quoteDetail.deposit_amount,
-      notes: quoteDetail.notes ?? "",
+    setDraft(buildDraftFromQuoteDetail({
       sourceType,
+      quoteDetail,
+      quoteId,
+      customerId,
+      launchOrigin,
+    }));
+  }
+
+  async function markSyncedLocalCaptureStatus(
+    quoteId: string,
+    extractJobId?: string | null,
+  ): Promise<void> {
+    await markLocalCaptureStatus("synced", {
+      serverQuoteId: quoteId,
+      extractJobId: extractJobId ?? null,
     });
   }
 
@@ -159,6 +175,13 @@ export function CaptureScreen(): React.ReactElement {
   async function onExtract(): Promise<void> {
     // TODO(spec1): perfMark("capture:local:save_start") / perfMark("capture:local:save_done")
     clearActionErrors();
+    if (typeof navigator !== "undefined" && navigator.onLine === false) {
+      await markLocalCaptureStatus("ready_to_extract", {
+        failureKind: "offline",
+      });
+      setError("Ready to extract when online. Your notes are still saved on this device.");
+      return;
+    }
     if (clips.length > MAX_AUDIO_CLIPS_PER_REQUEST) {
       setError(
         `You can upload up to ${MAX_AUDIO_CLIPS_PER_REQUEST} clips at a time.`,
@@ -175,6 +198,7 @@ export function CaptureScreen(): React.ReactElement {
       );
       return;
     }
+    void markLocalCaptureStatus("submitting");
     perfMark("capture:extract:start");
     clearExtractionStageTimers();
     const stages = getExtractionStages(hasClips, hasNotes);
@@ -209,20 +233,29 @@ export function CaptureScreen(): React.ReactElement {
       }
       const sourceType: QuoteSourceType = clips.length > 0 ? "voice" : "text";
       if (extraction.type === "sync") {
+        await markSyncedLocalCaptureStatus(extraction.quoteId, null);
         await hydrateFromPersistedQuote(extraction.quoteId, sourceType);
         navigateToReview(extraction.quoteId);
         return;
       }
 
+      void markLocalCaptureStatus("submitting", {
+        extractJobId: extraction.jobId,
+      });
       await pollExtractionJob(extraction.jobId, sourceType);
     } catch (submitError) {
       if (!isMountedRef.current) {
         return;
       }
+      const failureKind = classifySubmitFailure(submitError);
       const message =
         submitError instanceof Error
           ? submitError.message
           : "Unable to extract line items";
+      await markLocalCaptureStatus("extract_failed", {
+        failureKind,
+        error: message,
+      });
       setError(message);
     } finally {
       const shouldResetExtractionStage = isMountedRef.current;
@@ -260,49 +293,26 @@ export function CaptureScreen(): React.ReactElement {
     jobId: string,
     sourceType: QuoteSourceType,
   ): Promise<void> {
-    for (let pollCount = 0; pollCount < EXTRACTION_MAX_POLLS; pollCount += 1) {
-      const job = await jobService.getJobStatus(jobId);
-      if (!isMountedRef.current) {
-        return;
-      }
-
-      if (job.quote_id) {
-        if (!job.extraction_result) {
+    await pollExtractionJobUntilQuote({
+      jobId,
+      isMounted: () => isMountedRef.current,
+      onQuoteReady: async (job) => {
+        if (!job.quote_id || !job.extraction_result) {
           throw new Error(
             "Extraction completed without a result. Please try again.",
           );
         }
+        await markSyncedLocalCaptureStatus(job.quote_id, job.id);
         await hydrateFromPersistedQuote(job.quote_id, sourceType);
         navigateToReview(job.quote_id);
-        return;
-      }
-
-      if (job.status === "success") {
-        throw new Error("Extraction completed without a persisted draft. Please try again.");
-      }
-
-      if (job.status === "terminal") {
-        throw new Error("Extraction failed. Please try again.");
-      }
-
-      if (pollCount === EXTRACTION_MAX_POLLS - 1) {
-        break;
-      }
-      await new Promise((resolve) => {
-        window.setTimeout(resolve, EXTRACTION_POLL_INTERVAL_MS);
-      });
-      if (!isMountedRef.current) {
-        return;
-      }
-    }
-
-    throw new Error(
-      "Extraction is taking longer than expected. Please try again.",
-    );
+      },
+    });
   }
 
   function hasUnsavedWork(): boolean {
-    return clips.length > 0 || notes.trim().length > 0;
+    const hasPotentiallyUnsavedNotes = notes.trim().length > 0
+      && (localSessionId === null || localSaveState === "saving" || localSaveState === "error");
+    return clips.length > 0 || hasPotentiallyUnsavedNotes;
   }
   function requestExit(target: string): void {
     if (hasUnsavedWork()) {
@@ -327,6 +337,24 @@ export function CaptureScreen(): React.ReactElement {
 
   const hasReachedClipLimit = clips.length >= MAX_AUDIO_CLIPS_PER_REQUEST;
   const canExtract = (hasClips || hasNotes) && !isExtracting && !isRecording;
+  const localStatusCopy = localSaveState === "saving"
+    ? "Saving on this device..."
+    : localSaveState === "error"
+      ? "Stima could not save this capture on your device. Copy your notes before leaving this screen."
+      : getLocalCaptureStatusCopy(sessionStatus);
+
+  useEffect(() => {
+    setHasAttemptedAutoExtract(false);
+  }, [autoExtractOnLoad, localSessionQueryParam]);
+
+  useEffect(() => {
+    if (!autoExtractOnLoad || hasAttemptedAutoExtract || isHydratingLocalSession || !canExtract) {
+      return;
+    }
+
+    setHasAttemptedAutoExtract(true);
+    void onExtract();
+  }, [autoExtractOnLoad, canExtract, hasAttemptedAutoExtract, isHydratingLocalSession, onExtract]);
 
   return (
     <main className="min-h-dvh bg-background">
@@ -368,6 +396,11 @@ export function CaptureScreen(): React.ReactElement {
 
       <ScreenFooter>
         <div className="mx-auto w-full max-w-2xl">
+          {!extractionStage && localStatusCopy ? (
+            <p className="mb-2 text-center text-sm font-medium text-on-surface-variant">
+              {localStatusCopy}
+            </p>
+          ) : null}
           {extractionStage ? (
             <p className="mb-2 text-center text-sm font-medium text-on-surface-variant">
               {extractionStage}
@@ -388,7 +421,7 @@ export function CaptureScreen(): React.ReactElement {
       {pendingExitTarget ? (
         <ConfirmModal
           title="Leave this screen?"
-          body="Your clips and notes will be lost."
+          body="Unsaved clips or notes not yet stored on this device will be lost."
           confirmLabel="Leave"
           cancelLabel="Stay"
           onConfirm={() => {

--- a/frontend/src/features/quotes/components/DocumentRowsSection.tsx
+++ b/frontend/src/features/quotes/components/DocumentRowsSection.tsx
@@ -1,0 +1,56 @@
+import { Eyebrow } from "@/ui/Eyebrow";
+import { QuoteListRow } from "@/ui/QuoteListRow";
+import type { StatusPillVariant } from "@/ui/StatusPill";
+
+export interface DocumentRow {
+  id: string;
+  customerLabel: string;
+  titleLabel?: string | null;
+  docAndDate: string;
+  totalAmount: number | null;
+  status: StatusPillVariant;
+  destination: string;
+  destinationState?: {
+    origin: "list";
+  };
+  isDraft?: boolean;
+  needsCustomerAssignment?: boolean;
+}
+
+interface DocumentRowsSectionProps {
+  label: string;
+  rows: DocumentRow[];
+  onRowClick: (row: DocumentRow) => void;
+}
+
+export function DocumentRowsSection({
+  label,
+  rows,
+  onRowClick,
+}: DocumentRowsSectionProps): React.ReactElement {
+  return (
+    <section aria-label={label}>
+      <div className="mb-2 px-4">
+        <Eyebrow>{label}</Eyebrow>
+      </div>
+      <div className="mx-4 rounded-[var(--radius-document)] bg-surface-container-low p-3">
+        <ul className="flex flex-col gap-3">
+          {rows.map((row) => (
+            <li key={row.id}>
+              <QuoteListRow
+                customerLabel={row.customerLabel}
+                titleLabel={row.titleLabel}
+                docAndDate={row.docAndDate}
+                totalAmount={row.totalAmount}
+                status={row.status}
+                isDraft={row.isDraft}
+                needsCustomerAssignment={row.needsCustomerAssignment}
+                onClick={() => onRowClick(row)}
+              />
+            </li>
+          ))}
+        </ul>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/features/quotes/components/PendingCapturesSection.tsx
+++ b/frontend/src/features/quotes/components/PendingCapturesSection.tsx
@@ -1,0 +1,112 @@
+import { getLocalCaptureStatusCopy } from "@/features/quotes/offline/localCaptureStatusCopy";
+import type { LocalCaptureSummary } from "@/features/quotes/offline/captureTypes";
+import { Button } from "@/shared/components/Button";
+import { FeedbackMessage } from "@/shared/components/FeedbackMessage";
+import { formatDate } from "@/shared/lib/formatters";
+import { Eyebrow } from "@/ui/Eyebrow";
+
+interface PendingCapturesSectionProps {
+  captures: LocalCaptureSummary[];
+  isLoading: boolean;
+  isOnline: boolean;
+  timezone: string | null;
+  error: string | null;
+  onResume: (sessionId: string) => void;
+  onExtract: (sessionId: string) => void;
+  onDelete: (sessionId: string) => void;
+}
+
+function buildCaptureSummaryLabel(notes: string): string {
+  const trimmedNotes = notes.trim();
+  if (trimmedNotes.length === 0) {
+    return "Untitled capture";
+  }
+
+  const firstLine = trimmedNotes.split("\n", 1)[0] ?? trimmedNotes;
+  return firstLine.length > 60 ? `${firstLine.slice(0, 57)}...` : firstLine;
+}
+
+export function PendingCapturesSection({
+  captures,
+  isLoading,
+  isOnline,
+  timezone,
+  error,
+  onResume,
+  onExtract,
+  onDelete,
+}: PendingCapturesSectionProps): React.ReactElement {
+  return (
+    <section aria-label="Pending captures" className="mb-4 px-4">
+      <div className="ghost-shadow rounded-[var(--radius-document)] border border-outline-variant/20 bg-surface-container-low p-4">
+        <div className="mb-3 flex items-center justify-between">
+          <Eyebrow className="text-on-surface">PENDING CAPTURES</Eyebrow>
+          <Eyebrow
+            as="span"
+            className="rounded-full bg-surface-container-lowest px-2.5 py-1 tracking-widest"
+          >
+            {captures.length}
+          </Eyebrow>
+        </div>
+        {error ? (
+          <div className="mb-3">
+            <FeedbackMessage variant="error">{error}</FeedbackMessage>
+          </div>
+        ) : null}
+        {isLoading ? (
+          <p className="text-sm text-on-surface-variant">Loading pending captures...</p>
+        ) : null}
+        {!isLoading && captures.length === 0 ? (
+          <p className="text-sm text-on-surface-variant">No pending captures yet.</p>
+        ) : null}
+        {!isLoading && captures.length > 0 ? (
+          <ul className="space-y-3">
+            {captures.map((capture) => (
+              <li
+                key={capture.sessionId}
+                className="rounded-[var(--radius-document)] bg-surface-container-lowest p-3"
+              >
+                <p className="text-sm font-semibold text-on-surface">
+                  {buildCaptureSummaryLabel(capture.notes)}
+                </p>
+                <p className="mt-1 text-xs text-on-surface-variant">
+                  {getLocalCaptureStatusCopy(capture.status) ?? "Saved on this device"}
+                </p>
+                <p className="mt-1 text-xs text-outline">
+                  Updated {formatDate(capture.updatedAt, timezone)}
+                </p>
+                <div className="mt-3 flex flex-wrap gap-2">
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="tonal"
+                    onClick={() => onResume(capture.sessionId)}
+                  >
+                    Resume
+                  </Button>
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="secondary"
+                    disabled={!isOnline}
+                    onClick={() => onExtract(capture.sessionId)}
+                  >
+                    Extract
+                  </Button>
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="ghost"
+                    onClick={() => onDelete(capture.sessionId)}
+                  >
+                    Delete
+                  </Button>
+                </div>
+              </li>
+            ))}
+          </ul>
+        ) : null}
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/features/quotes/components/QuoteList.tsx
+++ b/frontend/src/features/quotes/components/QuoteList.tsx
@@ -1,9 +1,12 @@
 import { useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { useAuth } from "@/features/auth/hooks/useAuth";
+import { DocumentRowsSection, type DocumentRow } from "@/features/quotes/components/DocumentRowsSection";
 import { invoiceService } from "@/features/invoices/services/invoiceService";
 import type { InvoiceListItem } from "@/features/invoices/types/invoice.types";
+import { PendingCapturesSection } from "@/features/quotes/components/PendingCapturesSection";
 import { useQuoteCreateFlow } from "@/features/quotes/hooks/useQuoteCreateFlow";
+import { useRecoverableCaptures } from "@/features/quotes/offline/useRecoverableCaptures";
 import { quoteService } from "@/features/quotes/services/quoteService";
 import type { QuoteListItem } from "@/features/quotes/types/quote.types";
 import { BottomNav } from "@/shared/components/BottomNav";
@@ -14,62 +17,9 @@ import { Input } from "@/shared/components/Input";
 import { ScreenHeader } from "@/shared/components/ScreenHeader";
 import { formatDate } from "@/shared/lib/formatters";
 import { EmptyState } from "@/ui/EmptyState";
-import { Eyebrow } from "@/ui/Eyebrow";
-import { QuoteListRow } from "@/ui/QuoteListRow";
-import type { StatusPillVariant } from "@/ui/StatusPill";
 import { buildInvoiceSubtitle, buildQuoteSubtitle, matchesSearch } from "./QuoteList.helpers";
 
 type DocumentMode = "quotes" | "invoices";
-type DocumentStatus = StatusPillVariant;
-
-interface DocumentRow {
-  id: string;
-  customerLabel: string;
-  titleLabel?: string | null;
-  docAndDate: string;
-  totalAmount: number | null;
-  status: DocumentStatus;
-  destination: string;
-  destinationState?: {
-    origin: "list";
-  };
-  isDraft?: boolean;
-  needsCustomerAssignment?: boolean;
-}
-
-interface DocumentRowsSectionProps {
-  label: string;
-  rows: DocumentRow[];
-  onRowClick: (row: DocumentRow) => void;
-}
-
-function DocumentRowsSection({ label, rows, onRowClick }: DocumentRowsSectionProps): React.ReactElement {
-  return (
-    <section aria-label={label}>
-      <div className="mb-2 px-4">
-        <Eyebrow>{label}</Eyebrow>
-      </div>
-      <div className="mx-4 rounded-[var(--radius-document)] bg-surface-container-low p-3">
-        <ul className="flex flex-col gap-3">
-          {rows.map((row) => (
-            <li key={row.id}>
-              <QuoteListRow
-                customerLabel={row.customerLabel}
-                titleLabel={row.titleLabel}
-                docAndDate={row.docAndDate}
-                totalAmount={row.totalAmount}
-                status={row.status}
-                isDraft={row.isDraft}
-                needsCustomerAssignment={row.needsCustomerAssignment}
-                onClick={() => onRowClick(row)}
-              />
-            </li>
-          ))}
-        </ul>
-      </div>
-    </section>
-  );
-}
 
 export function QuoteList(): React.ReactElement {
   const navigate = useNavigate();
@@ -83,6 +33,16 @@ export function QuoteList(): React.ReactElement {
   const [isLoadingInvoices, setIsLoadingInvoices] = useState(false);
   const [quoteLoadError, setQuoteLoadError] = useState<string | null>(null);
   const [invoiceLoadError, setInvoiceLoadError] = useState<string | null>(null);
+  const [pendingCaptureActionError, setPendingCaptureActionError] = useState<string | null>(null);
+  const [isOnline, setIsOnline] = useState(
+    typeof navigator === "undefined" ? true : navigator.onLine,
+  );
+  const {
+    captures: recoverableCaptures,
+    isLoading: isLoadingRecoverableCaptures,
+    error: recoverableCapturesError,
+    deleteCapture,
+  } = useRecoverableCaptures(user?.id);
 
   useEffect(() => {
     let isActive = true;
@@ -144,6 +104,23 @@ export function QuoteList(): React.ReactElement {
       inputElement.focus();
     }
   }, [isSearchOpen]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    function onOnlineChange(): void {
+      setIsOnline(window.navigator.onLine);
+    }
+
+    window.addEventListener("online", onOnlineChange);
+    window.addEventListener("offline", onOnlineChange);
+    return () => {
+      window.removeEventListener("online", onOnlineChange);
+      window.removeEventListener("offline", onOnlineChange);
+    };
+  }, []);
 
   const normalizedSearchQuery = searchQuery.trim().toLowerCase();
   const filteredQuotes = useMemo(
@@ -245,6 +222,31 @@ export function QuoteList(): React.ReactElement {
     onQuoteDuplicated: (quoteId) => navigate(`/documents/${quoteId}/edit`),
   });
 
+  function navigateToLocalCapture(
+    sessionId: string,
+    options?: { autoExtract?: boolean },
+  ): void {
+    const nextSearchParams = new URLSearchParams({
+      localSession: sessionId,
+    });
+    if (options?.autoExtract) {
+      nextSearchParams.set("autoExtract", "1");
+    }
+    navigate(`/quotes/capture?${nextSearchParams.toString()}`);
+  }
+
+  async function onDeleteCapture(sessionId: string): Promise<void> {
+    setPendingCaptureActionError(null);
+    try {
+      await deleteCapture(sessionId);
+    } catch (deleteError) {
+      const message = deleteError instanceof Error
+        ? deleteError.message
+        : "Unable to delete pending capture";
+      setPendingCaptureActionError(message);
+    }
+  }
+
   return (
     <main className="min-h-screen bg-background pb-24">
       <ScreenHeader title={headerTitle} subtitle={headerSubtitle} layout="top-level" />
@@ -319,6 +321,21 @@ export function QuoteList(): React.ReactElement {
             />
           ) : null}
         </div>
+
+        {documentMode === "quotes" ? (
+          <PendingCapturesSection
+            captures={recoverableCaptures}
+            isLoading={isLoadingRecoverableCaptures}
+            isOnline={isOnline}
+            timezone={timezone}
+            error={recoverableCapturesError ?? pendingCaptureActionError}
+            onResume={(sessionId) => navigateToLocalCapture(sessionId)}
+            onExtract={(sessionId) => navigateToLocalCapture(sessionId, { autoExtract: true })}
+            onDelete={(sessionId) => {
+              void onDeleteCapture(sessionId);
+            }}
+          />
+        ) : null}
 
         {isLoading ? (
           <div

--- a/frontend/src/features/quotes/components/captureScreenDraft.ts
+++ b/frontend/src/features/quotes/components/captureScreenDraft.ts
@@ -1,0 +1,39 @@
+import type { QuoteDetail, QuoteSourceType } from "@/features/quotes/types/quote.types";
+
+interface BuildDraftFromQuoteDetailParams {
+  sourceType: QuoteSourceType;
+  quoteDetail: QuoteDetail;
+  quoteId: string;
+  customerId: string | undefined;
+  launchOrigin: string;
+}
+
+export function buildDraftFromQuoteDetail({
+  sourceType,
+  quoteDetail,
+  quoteId,
+  customerId,
+  launchOrigin,
+}: BuildDraftFromQuoteDetailParams) {
+  return {
+    quoteId,
+    customerId: quoteDetail.customer_id ?? customerId ?? "",
+    launchOrigin,
+    title: "",
+    transcript: quoteDetail.transcript,
+    lineItems: quoteDetail.line_items.map((lineItem) => ({
+      description: lineItem.description,
+      details: lineItem.details,
+      price: lineItem.price,
+      flagged: lineItem.flagged,
+      flagReason: lineItem.flag_reason,
+    })),
+    total: quoteDetail.total_amount,
+    taxRate: quoteDetail.tax_rate,
+    discountType: quoteDetail.discount_type,
+    discountValue: quoteDetail.discount_value,
+    depositAmount: quoteDetail.deposit_amount,
+    notes: quoteDetail.notes ?? "",
+    sourceType,
+  };
+}

--- a/frontend/src/features/quotes/components/captureScreenPolling.ts
+++ b/frontend/src/features/quotes/components/captureScreenPolling.ts
@@ -1,0 +1,53 @@
+import type { JobStatusResponse } from "@/features/quotes/types/quote.types";
+import {
+  EXTRACTION_MAX_POLLS,
+  EXTRACTION_POLL_INTERVAL_MS,
+} from "@/features/quotes/components/captureScreenHelpers";
+import { jobService } from "@/shared/lib/jobService";
+
+interface PollExtractionJobUntilQuoteArgs {
+  jobId: string;
+  isMounted: () => boolean;
+  onQuoteReady: (job: JobStatusResponse) => Promise<void>;
+}
+
+export async function pollExtractionJobUntilQuote({
+  jobId,
+  isMounted,
+  onQuoteReady,
+}: PollExtractionJobUntilQuoteArgs): Promise<void> {
+  for (let pollCount = 0; pollCount < EXTRACTION_MAX_POLLS; pollCount += 1) {
+    const job = await jobService.getJobStatus(jobId);
+    if (!isMounted()) {
+      return;
+    }
+
+    if (job.quote_id) {
+      await onQuoteReady(job);
+      return;
+    }
+
+    if (job.status === "success") {
+      throw new Error("Extraction completed without a persisted draft. Please try again.");
+    }
+
+    if (job.status === "terminal") {
+      throw new Error("Extraction failed. Please try again.");
+    }
+
+    if (pollCount === EXTRACTION_MAX_POLLS - 1) {
+      break;
+    }
+
+    await new Promise((resolve) => {
+      window.setTimeout(resolve, EXTRACTION_POLL_INTERVAL_MS);
+    });
+    if (!isMounted()) {
+      return;
+    }
+  }
+
+  throw new Error(
+    "Extraction is taking longer than expected. Please try again.",
+  );
+}

--- a/frontend/src/features/quotes/offline/classifySubmitFailure.test.ts
+++ b/frontend/src/features/quotes/offline/classifySubmitFailure.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import { classifySubmitFailure } from "@/features/quotes/offline/classifySubmitFailure";
+import { HttpRequestError } from "@/shared/lib/http";
+
+const ORIGINAL_NAVIGATOR_ONLINE_DESCRIPTOR = Object.getOwnPropertyDescriptor(window.navigator, "onLine");
+
+function setNavigatorOnline(value: boolean): void {
+  Object.defineProperty(window.navigator, "onLine", {
+    configurable: true,
+    value,
+  });
+}
+
+function restoreNavigatorOnline(): void {
+  if (ORIGINAL_NAVIGATOR_ONLINE_DESCRIPTOR) {
+    Object.defineProperty(window.navigator, "onLine", ORIGINAL_NAVIGATOR_ONLINE_DESCRIPTOR);
+    return;
+  }
+  delete (window.navigator as { onLine?: boolean }).onLine;
+}
+
+afterEach(() => {
+  restoreNavigatorOnline();
+});
+
+describe("classifySubmitFailure", () => {
+  it("returns offline when browser is offline", () => {
+    setNavigatorOnline(false);
+
+    expect(classifySubmitFailure(new Error("Network error"))).toBe("offline");
+  });
+
+  it("classifies timeout-like errors", () => {
+    setNavigatorOnline(true);
+
+    expect(classifySubmitFailure(new Error("request timed out"))).toBe("timeout");
+  });
+
+  it("classifies auth and validation http errors", () => {
+    setNavigatorOnline(true);
+
+    expect(classifySubmitFailure(new HttpRequestError("Unauthorized", 401, null))).toBe("auth_required");
+    expect(classifySubmitFailure(new HttpRequestError("Invalid payload", 422, null))).toBe("validation_failed");
+  });
+
+  it("treats 409 with in-progress detail as retryable", () => {
+    setNavigatorOnline(true);
+
+    expect(
+      classifySubmitFailure(
+        new HttpRequestError("Conflict", 409, { detail: "extraction already in progress" }),
+      ),
+    ).toBe("server_retryable");
+  });
+
+  it("defaults unknown errors to retryable", () => {
+    setNavigatorOnline(true);
+
+    expect(classifySubmitFailure({ message: "wat" })).toBe("server_retryable");
+  });
+});

--- a/frontend/src/features/quotes/offline/classifySubmitFailure.ts
+++ b/frontend/src/features/quotes/offline/classifySubmitFailure.ts
@@ -1,0 +1,62 @@
+import type { SubmitFailureKind } from "@/features/quotes/offline/captureTypes";
+import { isHttpRequestError } from "@/shared/lib/http";
+
+function isOfflineEnvironment(): boolean {
+  return typeof navigator !== "undefined" && navigator.onLine === false;
+}
+
+function isTimeoutLikeError(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+
+  if (error.name === "AbortError") {
+    return true;
+  }
+
+  const normalizedMessage = error.message.toLowerCase();
+  return normalizedMessage.includes("timeout") || normalizedMessage.includes("timed out");
+}
+
+function readPayloadDetail(payload: unknown): string {
+  if (!payload || typeof payload !== "object") {
+    return "";
+  }
+
+  const detail = (payload as { detail?: unknown }).detail;
+  return typeof detail === "string" ? detail : "";
+}
+
+export function classifySubmitFailure(error: unknown): SubmitFailureKind {
+  if (isOfflineEnvironment()) {
+    return "offline";
+  }
+
+  if (isTimeoutLikeError(error)) {
+    return "timeout";
+  }
+
+  if (!isHttpRequestError(error)) {
+    return "server_retryable";
+  }
+
+  if (error.status === 401) {
+    return "auth_required";
+  }
+  if (error.status === 403) {
+    return "csrf_failed";
+  }
+  if (error.status === 422) {
+    return "validation_failed";
+  }
+  if (error.status === 409) {
+    return readPayloadDetail(error.payload).includes("already in progress")
+      ? "server_retryable"
+      : "csrf_failed";
+  }
+  if (error.status >= 500) {
+    return "server_retryable";
+  }
+
+  return "server_terminal";
+}

--- a/frontend/src/features/quotes/offline/localCaptureStatusCopy.ts
+++ b/frontend/src/features/quotes/offline/localCaptureStatusCopy.ts
@@ -1,0 +1,17 @@
+import type { LocalCaptureStatus } from "@/features/quotes/offline/captureTypes";
+
+const LOCAL_CAPTURE_STATUS_COPY: Record<LocalCaptureStatus, string> = {
+  local_only: "Saved on this device",
+  ready_to_extract: "Ready to extract when online",
+  submitting: "Submitting for extraction...",
+  extract_failed: "Could not extract — your notes are still saved",
+  synced: "Synced to quote draft",
+  discarded: "Discarded",
+};
+
+export function getLocalCaptureStatusCopy(status: LocalCaptureStatus | null | undefined): string | null {
+  if (!status) {
+    return null;
+  }
+  return LOCAL_CAPTURE_STATUS_COPY[status] ?? null;
+}

--- a/frontend/src/features/quotes/offline/useLocalCaptureSession.ts
+++ b/frontend/src/features/quotes/offline/useLocalCaptureSession.ts
@@ -1,0 +1,304 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import {
+  createCaptureSession,
+  deleteEmptyAbandonedSessions,
+  getCaptureSession,
+  markCaptureStatus,
+  updateCaptureField,
+  updateCaptureNotes,
+} from "@/features/quotes/offline/captureRepository";
+import type {
+  LocalCaptureSession,
+  LocalCaptureStatus,
+  SubmitFailureKind,
+} from "@/features/quotes/offline/captureTypes";
+
+const NOTES_PERSIST_DEBOUNCE_MS = 350;
+
+type LocalSaveState = "idle" | "saving" | "saved" | "error";
+
+interface MarkCaptureStatusOptions {
+  failureKind?: SubmitFailureKind;
+  error?: string;
+  serverQuoteId?: string | null;
+  extractJobId?: string | null;
+}
+
+interface UseLocalCaptureSessionParams {
+  userId: string | undefined;
+  customerId: string | undefined;
+  initialSessionId: string | null;
+}
+
+interface UseLocalCaptureSessionResult {
+  notes: string;
+  setNotes: (value: string) => void;
+  sessionId: string | null;
+  sessionStatus: LocalCaptureStatus | null;
+  isHydrating: boolean;
+  hydrationError: string | null;
+  saveState: LocalSaveState;
+  saveError: string | null;
+  markStatus: (status: LocalCaptureStatus, options?: MarkCaptureStatusOptions) => Promise<void>;
+}
+
+function getErrorMessage(error: unknown, fallback: string): string {
+  return error instanceof Error ? error.message : fallback;
+}
+
+export function useLocalCaptureSession({
+  userId,
+  customerId,
+  initialSessionId,
+}: UseLocalCaptureSessionParams): UseLocalCaptureSessionResult {
+  const [notes, setNotesState] = useState("");
+  const [session, setSession] = useState<LocalCaptureSession | null>(null);
+  const [isHydrating, setIsHydrating] = useState(true);
+  const [hydrationError, setHydrationError] = useState<string | null>(null);
+  const [saveState, setSaveState] = useState<LocalSaveState>("idle");
+  const [saveError, setSaveError] = useState<string | null>(null);
+
+  const isMountedRef = useRef(false);
+  const persistTimerRef = useRef<number | null>(null);
+  const notesRef = useRef(notes);
+  const sessionRef = useRef<LocalCaptureSession | null>(session);
+
+  const clearPersistTimer = useCallback((): void => {
+    if (persistTimerRef.current !== null) {
+      window.clearTimeout(persistTimerRef.current);
+      persistTimerRef.current = null;
+    }
+  }, []);
+
+  useEffect(() => {
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+      clearPersistTimer();
+    };
+  }, [clearPersistTimer]);
+
+  useEffect(() => {
+    notesRef.current = notes;
+  }, [notes]);
+
+  useEffect(() => {
+    sessionRef.current = session;
+  }, [session]);
+
+  useEffect(() => {
+    let isActive = true;
+
+    setIsHydrating(true);
+    setHydrationError(null);
+    setSaveError(null);
+    setSaveState("idle");
+    clearPersistTimer();
+
+    async function hydrateLocalSession(): Promise<void> {
+      if (!userId) {
+        if (!isActive) {
+          return;
+        }
+
+        setSession(null);
+        setNotesState("");
+        setIsHydrating(false);
+        return;
+      }
+
+      try {
+        await deleteEmptyAbandonedSessions(userId);
+
+        if (!initialSessionId) {
+          if (!isActive) {
+            return;
+          }
+
+          setSession(null);
+          setNotesState("");
+          return;
+        }
+
+        const loadedSession = await getCaptureSession(initialSessionId);
+        if (!isActive) {
+          return;
+        }
+
+        if (!loadedSession || loadedSession.userId !== userId) {
+          setSession(null);
+          setNotesState("");
+          setHydrationError("Pending capture was not found for this account.");
+          return;
+        }
+
+        setSession(loadedSession);
+        setNotesState(loadedSession.notes);
+
+        await updateCaptureField(loadedSession.sessionId, {
+          lastOpenedAt: new Date().toISOString(),
+        });
+
+        const refreshedSession = await getCaptureSession(loadedSession.sessionId);
+        if (isActive && refreshedSession) {
+          setSession(refreshedSession);
+        }
+      } catch (loadError) {
+        if (!isActive) {
+          return;
+        }
+        setHydrationError(getErrorMessage(loadError, "Unable to load local capture."));
+      } finally {
+        if (isActive) {
+          setIsHydrating(false);
+        }
+      }
+    }
+
+    void hydrateLocalSession();
+
+    return () => {
+      isActive = false;
+    };
+  }, [clearPersistTimer, initialSessionId, userId]);
+
+  useEffect(() => {
+    if (isHydrating || !userId) {
+      return;
+    }
+
+    const hasSession = sessionRef.current !== null;
+    const hasMeaningfulNotes = notes.trim().length > 0;
+
+    if (!hasSession && !hasMeaningfulNotes) {
+      setSaveState("idle");
+      return;
+    }
+
+    setSaveState("saving");
+    setSaveError(null);
+    clearPersistTimer();
+
+    persistTimerRef.current = window.setTimeout(() => {
+      void (async () => {
+        try {
+          let targetSession = sessionRef.current;
+          const noteSnapshot = notesRef.current;
+          const customerSnapshot = customerId ?? null;
+
+          if (!targetSession) {
+            targetSession = await createCaptureSession({
+              userId,
+              notes: noteSnapshot,
+              customerId: customerSnapshot,
+            });
+
+            if (!isMountedRef.current) {
+              return;
+            }
+            setSession(targetSession);
+          }
+
+          if ((targetSession.customerId ?? null) !== customerSnapshot) {
+            await updateCaptureField(targetSession.sessionId, {
+              customerId: customerSnapshot,
+            });
+          }
+
+          await updateCaptureNotes(targetSession.sessionId, noteSnapshot);
+          const refreshedSession = await getCaptureSession(targetSession.sessionId);
+
+          if (!isMountedRef.current) {
+            return;
+          }
+
+          if (refreshedSession) {
+            setSession(refreshedSession);
+          }
+          setSaveState("saved");
+        } catch (persistError) {
+          if (!isMountedRef.current) {
+            return;
+          }
+
+          setSaveState("error");
+          setSaveError(getErrorMessage(persistError, "Unable to save notes on this device."));
+        }
+      })();
+    }, NOTES_PERSIST_DEBOUNCE_MS);
+
+    return clearPersistTimer;
+  }, [clearPersistTimer, customerId, isHydrating, notes, userId]);
+
+  const markStatus = useCallback(async (
+    status: LocalCaptureStatus,
+    options?: MarkCaptureStatusOptions,
+  ): Promise<void> => {
+    if (!userId) {
+      return;
+    }
+
+    const noteSnapshot = notesRef.current;
+    let targetSession = sessionRef.current;
+
+    if (!targetSession) {
+      const hasMeaningfulNotes = noteSnapshot.trim().length > 0;
+      const hasCustomerContext = typeof customerId === "string" && customerId.length > 0;
+
+      if (!hasMeaningfulNotes && !hasCustomerContext) {
+        return;
+      }
+
+      targetSession = await createCaptureSession({
+        userId,
+        notes: noteSnapshot,
+        customerId: customerId ?? null,
+      });
+
+      if (!isMountedRef.current) {
+        return;
+      }
+      setSession(targetSession);
+    }
+
+    await markCaptureStatus(targetSession.sessionId, status, {
+      failureKind: options?.failureKind,
+      error: options?.error,
+    });
+
+    const sessionPatch: Partial<LocalCaptureSession> = {};
+    if (options?.serverQuoteId !== undefined) {
+      sessionPatch.serverQuoteId = options.serverQuoteId;
+    }
+    if (options?.extractJobId !== undefined) {
+      sessionPatch.extractJobId = options.extractJobId;
+    }
+    if (Object.keys(sessionPatch).length > 0) {
+      await updateCaptureField(targetSession.sessionId, sessionPatch);
+    }
+
+    const refreshedSession = await getCaptureSession(targetSession.sessionId);
+    if (!isMountedRef.current) {
+      return;
+    }
+
+    if (refreshedSession) {
+      setSession(refreshedSession);
+    }
+    setSaveState("saved");
+    setSaveError(null);
+  }, [customerId, userId]);
+
+  return {
+    notes,
+    setNotes: setNotesState,
+    sessionId: session?.sessionId ?? null,
+    sessionStatus: session?.status ?? null,
+    isHydrating,
+    hydrationError,
+    saveState,
+    saveError,
+    markStatus,
+  };
+}

--- a/frontend/src/features/quotes/offline/useRecoverableCaptures.ts
+++ b/frontend/src/features/quotes/offline/useRecoverableCaptures.ts
@@ -1,0 +1,67 @@
+import { useCallback, useEffect, useState } from "react";
+
+import {
+  deleteCaptureSession,
+  deleteEmptyAbandonedSessions,
+  listRecoverableCaptures,
+} from "@/features/quotes/offline/captureRepository";
+import type { LocalCaptureSummary } from "@/features/quotes/offline/captureTypes";
+
+const MAX_RECOVERABLE_CAPTURES = 20;
+
+interface UseRecoverableCapturesResult {
+  captures: LocalCaptureSummary[];
+  isLoading: boolean;
+  error: string | null;
+  refresh: () => Promise<void>;
+  deleteCapture: (sessionId: string) => Promise<void>;
+}
+
+function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : "Unable to load pending captures.";
+}
+
+export function useRecoverableCaptures(userId: string | undefined): UseRecoverableCapturesResult {
+  const [captures, setCaptures] = useState<LocalCaptureSummary[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = useCallback(async (): Promise<void> => {
+    if (!userId) {
+      setCaptures([]);
+      setError(null);
+      setIsLoading(false);
+      return;
+    }
+
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      await deleteEmptyAbandonedSessions(userId);
+      const nextCaptures = await listRecoverableCaptures(userId);
+      setCaptures(nextCaptures.slice(0, MAX_RECOVERABLE_CAPTURES));
+    } catch (loadError) {
+      setError(getErrorMessage(loadError));
+    } finally {
+      setIsLoading(false);
+    }
+  }, [userId]);
+
+  const deleteCapture = useCallback(async (sessionId: string): Promise<void> => {
+    await deleteCaptureSession(sessionId);
+    setCaptures((currentCaptures) => currentCaptures.filter((capture) => capture.sessionId !== sessionId));
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  return {
+    captures,
+    isLoading,
+    error,
+    refresh,
+    deleteCapture,
+  };
+}

--- a/frontend/src/features/quotes/tests/CaptureScreen.test.tsx
+++ b/frontend/src/features/quotes/tests/CaptureScreen.test.tsx
@@ -2,6 +2,7 @@ import { act, fireEvent, render, screen, waitFor } from "@testing-library/react"
 import { MemoryRouter } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { useAuth } from "@/features/auth/hooks/useAuth";
 import { CaptureScreen } from "@/features/quotes/components/CaptureScreen";
 import { useQuoteDraft } from "@/features/quotes/hooks/useQuoteDraft";
 import { HOME_ROUTE } from "@/features/quotes/utils/workflowNavigation";
@@ -28,6 +29,10 @@ const startRecordingMock = vi.fn(async () => undefined);
 const stopRecordingMock = vi.fn();
 const removeClipMock = vi.fn();
 const clearVoiceErrorMock = vi.fn();
+const markLocalCaptureStatusMock = vi.fn<(status: string, options?: unknown) => Promise<void>>(
+  async () => undefined,
+);
+const ORIGINAL_NAVIGATOR_ONLINE_DESCRIPTOR = Object.getOwnPropertyDescriptor(window.navigator, "onLine");
 
 vi.mock("react-router-dom", async () => {
   const actual = await vi.importActual<typeof import("react-router-dom")>("react-router-dom");
@@ -45,6 +50,52 @@ vi.mock("@/features/quotes/hooks/useVoiceCapture", () => ({
 vi.mock("@/features/quotes/hooks/useQuoteDraft", () => ({
   useQuoteDraft: vi.fn(),
 }));
+
+vi.mock("@/features/auth/hooks/useAuth", () => ({
+  useAuth: vi.fn(),
+}));
+
+vi.mock("@/features/quotes/offline/useLocalCaptureSession", async () => {
+  const React = await vi.importActual<typeof import("react")>("react");
+
+  return {
+    useLocalCaptureSession: vi.fn(() => {
+      const [notes, setNotes] = React.useState("");
+      const [sessionId, setSessionId] = React.useState<string | null>(null);
+      const [sessionStatus, setSessionStatus] = React.useState<
+        "local_only" | "ready_to_extract" | "submitting" | "extract_failed" | "synced" | "discarded" | null
+      >(null);
+
+      React.useEffect(() => {
+        if (notes.trim().length > 0 && sessionId === null) {
+          setSessionId("local-session-1");
+          setSessionStatus("local_only");
+        }
+      }, [notes, sessionId]);
+
+      return {
+        notes,
+        setNotes,
+        sessionId,
+        sessionStatus,
+        isHydrating: false,
+        hydrationError: null,
+        saveState: notes.trim().length > 0 ? "saved" : "idle",
+        saveError: null,
+        markStatus: async (
+          status: "local_only" | "ready_to_extract" | "submitting" | "extract_failed" | "synced" | "discarded",
+          options?: unknown,
+        ) => {
+          markLocalCaptureStatusMock(status, options);
+          setSessionStatus(status);
+          if (notes.trim().length > 0 && sessionId === null) {
+            setSessionId("local-session-1");
+          }
+        },
+      };
+    }),
+  };
+});
 
 vi.mock("@/features/quotes/services/quoteService", () => ({
   quoteService: {
@@ -68,6 +119,7 @@ vi.mock("@/shared/lib/jobService", () => ({
 
 const mockedUseVoiceCapture = vi.mocked(useVoiceCapture);
 const mockedUseQuoteDraft = vi.mocked(useQuoteDraft);
+const mockedUseAuth = vi.mocked(useAuth);
 const mockedQuoteService = vi.mocked(quoteService);
 const mockedJobService = vi.mocked(jobService);
 
@@ -202,6 +254,21 @@ function mockVoiceCapture(overrides: Partial<ReturnType<typeof useVoiceCapture>>
   });
 }
 
+function setNavigatorOnline(value: boolean): void {
+  Object.defineProperty(window.navigator, "onLine", {
+    configurable: true,
+    value,
+  });
+}
+
+function restoreNavigatorOnline(): void {
+  if (ORIGINAL_NAVIGATOR_ONLINE_DESCRIPTOR) {
+    Object.defineProperty(window.navigator, "onLine", ORIGINAL_NAVIGATOR_ONLINE_DESCRIPTOR);
+    return;
+  }
+  delete (window.navigator as { onLine?: boolean }).onLine;
+}
+
 function renderScreen({
   launchOrigin = HOME_ROUTE,
   pathname = "/quotes/capture/cust-1",
@@ -227,6 +294,21 @@ function renderScreen({
 }
 
 beforeEach(() => {
+  mockedUseAuth.mockReturnValue({
+    isLoading: false,
+    isOnboarded: true,
+    login: vi.fn(async () => undefined),
+    logout: vi.fn(async () => undefined),
+    refreshUser: vi.fn(async () => undefined),
+    register: vi.fn(async () => undefined),
+    user: {
+      id: "user-1",
+      email: "tester@stima.dev",
+      is_active: true,
+      is_onboarded: true,
+      timezone: "UTC",
+    },
+  });
   mockedUseQuoteDraft.mockReturnValue({
     draft: null,
     setDraft: setDraftMock,
@@ -265,6 +347,8 @@ afterEach(() => {
   vi.useRealTimers();
   vi.clearAllMocks();
   window.localStorage.clear();
+  restoreNavigatorOnline();
+  markLocalCaptureStatusMock.mockReset();
 });
 
 describe("CaptureScreen", () => {
@@ -365,7 +449,7 @@ describe("CaptureScreen", () => {
 
     fireEvent.click(screen.getByRole("button", { name: /extract line items/i }));
 
-    expect(await screen.findByText("Analyzing notes...")).toBeInTheDocument();
+    expect(screen.getByText("Analyzing notes...")).toBeInTheDocument();
     expect(
       screen.queryByText(/extraction saves your notes as a draft for manual review/i),
     ).not.toBeInTheDocument();
@@ -425,7 +509,7 @@ describe("CaptureScreen", () => {
     expect(navigateMock).not.toHaveBeenCalledWith(HOME_ROUTE, { replace: true });
   });
 
-  it("shows a leave confirmation when navigating back with unsaved notes", () => {
+  it("navigates back without confirmation when notes are already saved locally", () => {
     renderScreen();
 
     fireEvent.change(screen.getByLabelText(/written description/i), {
@@ -433,8 +517,8 @@ describe("CaptureScreen", () => {
     });
     fireEvent.click(screen.getByRole("button", { name: /go back/i }));
 
-    expect(screen.getByRole("dialog", { name: "Leave this screen?" })).toBeInTheDocument();
-    expect(navigateMock).not.toHaveBeenCalledWith(HOME_ROUTE, { replace: true });
+    expect(screen.queryByRole("dialog", { name: "Leave this screen?" })).not.toBeInTheDocument();
+    expect(navigateMock).toHaveBeenCalledWith(HOME_ROUTE, { replace: true });
   });
 
   it("navigates back to the recorded launch origin when there is no unsaved work", () => {
@@ -447,11 +531,9 @@ describe("CaptureScreen", () => {
   });
 
   it("dismisses the leave confirmation when Stay is clicked", () => {
+    mockVoiceCapture({ clips: [clipFixture] });
     renderScreen();
 
-    fireEvent.change(screen.getByLabelText(/written description/i), {
-      target: { value: "Install sod in backyard" },
-    });
     fireEvent.click(screen.getByRole("button", { name: /go back/i }));
     fireEvent.click(screen.getByRole("button", { name: "Stay" }));
 
@@ -460,11 +542,9 @@ describe("CaptureScreen", () => {
   });
 
   it("navigates to the launch origin after confirming Leave", () => {
+    mockVoiceCapture({ clips: [clipFixture] });
     renderScreen({ launchOrigin: "/customers/cust-1" });
 
-    fireEvent.change(screen.getByLabelText(/written description/i), {
-      target: { value: "Install sod in backyard" },
-    });
     fireEvent.click(screen.getByRole("button", { name: /go back/i }));
     fireEvent.click(screen.getByRole("button", { name: "Leave" }));
 
@@ -495,6 +575,22 @@ describe("CaptureScreen", () => {
       }),
     );
     expect(mockedQuoteService.createQuote).not.toHaveBeenCalled();
+  });
+
+  it("marks notes as ready to extract and skips submit while browser is offline", async () => {
+    setNavigatorOnline(false);
+    renderScreen();
+
+    fireEvent.change(screen.getByLabelText(/written description/i), {
+      target: { value: "Install sod in backyard" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /extract line items/i }));
+
+    expect(mockedQuoteService.extract).not.toHaveBeenCalled();
+    expect(
+      await screen.findByText("Ready to extract when online. Your notes are still saved on this device."),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Ready to extract when online")).toBeInTheDocument();
   });
 
   it("starts a blank draft with customer context and routes to edit", async () => {
@@ -701,14 +797,11 @@ describe("CaptureScreen", () => {
     expect(mockedQuoteService.extract).not.toHaveBeenCalled();
   });
 
-  it("shows staged extraction progress and clears it after extraction resolves", async () => {
+  it("shows staged extraction progress for notes-only extraction", () => {
     vi.useFakeTimers();
 
-    let resolveExtraction: ((value: { type: "sync"; quoteId: string; result: ExtractionResult }) => void) | undefined;
     mockedQuoteService.extract.mockReturnValueOnce(
-      new Promise<{ type: "sync"; quoteId: string; result: ExtractionResult }>((resolve) => {
-        resolveExtraction = resolve;
-      }),
+      new Promise<{ type: "sync"; quoteId: string; result: ExtractionResult }>(() => {}),
     );
 
     renderScreen();
@@ -728,13 +821,6 @@ describe("CaptureScreen", () => {
     });
 
     expect(screen.getByText("Extracting line items...")).toBeInTheDocument();
-
-    await act(async () => {
-      resolveExtraction?.({ type: "sync", quoteId: "quote-1", result: extractionFixture });
-      await Promise.resolve();
-    });
-
-    expect(screen.queryByText("Extracting line items...")).not.toBeInTheDocument();
   });
 
   it("shows audio-specific staged copy when extracting recorded clips", async () => {
@@ -977,7 +1063,6 @@ describe("CaptureScreen", () => {
     });
     fireEvent.click(screen.getByRole("button", { name: /extract line items/i }));
     fireEvent.click(screen.getByRole("button", { name: /go back/i }));
-    fireEvent.click(screen.getByRole("button", { name: "Leave" }));
 
     expect(navigateMock).toHaveBeenCalledWith(HOME_ROUTE, { replace: true });
 

--- a/frontend/src/features/quotes/tests/QuoteList.test.tsx
+++ b/frontend/src/features/quotes/tests/QuoteList.test.tsx
@@ -6,6 +6,7 @@ import { useAuth } from "@/features/auth/hooks/useAuth";
 import { invoiceService } from "@/features/invoices/services/invoiceService";
 import type { InvoiceListItem } from "@/features/invoices/types/invoice.types";
 import { QuoteList } from "@/features/quotes/components/QuoteList";
+import { useRecoverableCaptures } from "@/features/quotes/offline/useRecoverableCaptures";
 import { quoteService } from "@/features/quotes/services/quoteService";
 import type { QuoteListItem } from "@/features/quotes/types/quote.types";
 
@@ -52,9 +53,15 @@ vi.mock("@/features/auth/hooks/useAuth", () => ({
   useAuth: vi.fn(),
 }));
 
+vi.mock("@/features/quotes/offline/useRecoverableCaptures", () => ({
+  useRecoverableCaptures: vi.fn(),
+}));
+
 const mockedQuoteService = vi.mocked(quoteService);
 const mockedInvoiceService = vi.mocked(invoiceService);
 const mockedUseAuth = vi.mocked(useAuth);
+const mockedUseRecoverableCaptures = vi.mocked(useRecoverableCaptures);
+const ORIGINAL_NAVIGATOR_ONLINE_DESCRIPTOR = Object.getOwnPropertyDescriptor(window.navigator, "onLine");
 
 function makeQuoteListItem(overrides: Partial<QuoteListItem> = {}): QuoteListItem {
   return {
@@ -113,6 +120,21 @@ function renderScreen(): void {
   );
 }
 
+function setNavigatorOnline(value: boolean): void {
+  Object.defineProperty(window.navigator, "onLine", {
+    configurable: true,
+    value,
+  });
+}
+
+function restoreNavigatorOnline(): void {
+  if (ORIGINAL_NAVIGATOR_ONLINE_DESCRIPTOR) {
+    Object.defineProperty(window.navigator, "onLine", ORIGINAL_NAVIGATOR_ONLINE_DESCRIPTOR);
+    return;
+  }
+  delete (window.navigator as { onLine?: boolean }).onLine;
+}
+
 async function openSearch(label: "Search quotes" | "Search invoices" = "Search quotes"): Promise<HTMLInputElement> {
   fireEvent.click(screen.getByRole("button", { name: "Open search" }));
   return await screen.findByLabelText(label) as HTMLInputElement;
@@ -120,10 +142,18 @@ async function openSearch(label: "Search quotes" | "Search invoices" = "Search q
 
 beforeEach(() => {
   mockProfile();
+  mockedUseRecoverableCaptures.mockReturnValue({
+    captures: [],
+    isLoading: false,
+    error: null,
+    refresh: vi.fn(async () => undefined),
+    deleteCapture: vi.fn(async () => undefined),
+  });
 });
 
 afterEach(() => {
   vi.clearAllMocks();
+  restoreNavigatorOnline();
 });
 
 describe("QuoteList", () => {
@@ -207,6 +237,72 @@ describe("QuoteList", () => {
 
     expect(quotesButton).toHaveClass("ghost-shadow", "bg-surface-container-lowest", "text-primary");
     expect(createButton).toHaveClass("forest-gradient", "ghost-shadow", "text-on-primary");
+  });
+
+  it("renders pending captures with resume, extract, and delete actions", async () => {
+    const deleteCaptureMock = vi.fn(async () => undefined);
+    setNavigatorOnline(true);
+    mockedUseRecoverableCaptures.mockReturnValue({
+      captures: [
+        {
+          sessionId: "session-1",
+          status: "ready_to_extract",
+          notes: "Patio estimate",
+          updatedAt: "2026-03-20T00:00:00.000Z",
+          lastFailureKind: null,
+          lastError: null,
+        },
+      ],
+      isLoading: false,
+      error: null,
+      refresh: vi.fn(async () => undefined),
+      deleteCapture: deleteCaptureMock,
+    });
+    mockedQuoteService.listQuotes.mockResolvedValueOnce([makeQuoteListItem()]);
+
+    renderScreen();
+    await screen.findByText(/Q-001/);
+
+    expect(screen.getByRole("region", { name: "Pending captures" })).toBeInTheDocument();
+    expect(screen.getByText("Patio estimate")).toBeInTheDocument();
+    expect(screen.getByText("Ready to extract when online")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Resume" }));
+    expect(navigateMock).toHaveBeenCalledWith("/quotes/capture?localSession=session-1");
+
+    fireEvent.click(screen.getByRole("button", { name: "Extract" }));
+    expect(navigateMock).toHaveBeenCalledWith("/quotes/capture?localSession=session-1&autoExtract=1");
+
+    fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+    await waitFor(() => {
+      expect(deleteCaptureMock).toHaveBeenCalledWith("session-1");
+    });
+  });
+
+  it("disables pending-capture extract action while offline", async () => {
+    setNavigatorOnline(false);
+    mockedUseRecoverableCaptures.mockReturnValue({
+      captures: [
+        {
+          sessionId: "session-1",
+          status: "ready_to_extract",
+          notes: "Patio estimate",
+          updatedAt: "2026-03-20T00:00:00.000Z",
+          lastFailureKind: null,
+          lastError: null,
+        },
+      ],
+      isLoading: false,
+      error: null,
+      refresh: vi.fn(async () => undefined),
+      deleteCapture: vi.fn(async () => undefined),
+    });
+    mockedQuoteService.listQuotes.mockResolvedValueOnce([makeQuoteListItem()]);
+
+    renderScreen();
+    await screen.findByText(/Q-001/);
+
+    expect(screen.getByRole("button", { name: "Extract" })).toBeDisabled();
   });
 
   it("renders quote cards from listQuotes response", async () => {

--- a/frontend/src/features/quotes/tests/useLocalCaptureSession.test.tsx
+++ b/frontend/src/features/quotes/tests/useLocalCaptureSession.test.tsx
@@ -1,0 +1,101 @@
+import "fake-indexeddb/auto";
+
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { createCaptureSession, getCaptureSession, listRecoverableCaptures } from "@/features/quotes/offline/captureRepository";
+import { resetCaptureDbForTests } from "@/features/quotes/offline/captureDb";
+import { useLocalCaptureSession } from "@/features/quotes/offline/useLocalCaptureSession";
+
+describe("useLocalCaptureSession", () => {
+  beforeEach(async () => {
+    await resetCaptureDbForTests();
+  });
+
+  afterEach(async () => {
+    await resetCaptureDbForTests();
+  });
+
+  it("persists notes lazily after meaningful input", async () => {
+    const { result } = renderHook(() => useLocalCaptureSession({
+      userId: "user-1",
+      customerId: "cust-1",
+      initialSessionId: null,
+    }));
+
+    expect(result.current.sessionId).toBeNull();
+    await waitFor(() => {
+      expect(result.current.isHydrating).toBe(false);
+    });
+
+    act(() => {
+      result.current.setNotes("Install sod in backyard");
+    });
+
+    await waitFor(() => {
+      expect(result.current.sessionId).not.toBeNull();
+      expect(result.current.saveState).toBe("saved");
+    });
+
+    const persistedSession = await getCaptureSession(result.current.sessionId ?? "");
+    expect(persistedSession?.notes).toBe("Install sod in backyard");
+    expect(persistedSession?.userId).toBe("user-1");
+  });
+
+  it("does not create a recoverable session for an untouched draft", async () => {
+    const { result } = renderHook(() => useLocalCaptureSession({
+      userId: "user-1",
+      customerId: undefined,
+      initialSessionId: null,
+    }));
+
+    await waitFor(() => {
+      expect(result.current.isHydrating).toBe(false);
+    });
+
+    expect(result.current.sessionId).toBeNull();
+    await expect(listRecoverableCaptures("user-1")).resolves.toEqual([]);
+  });
+
+  it("hydrates a saved session from query param for same user", async () => {
+    const existingSession = await createCaptureSession({
+      userId: "user-1",
+      notes: "Patio estimate",
+      customerId: "cust-1",
+    });
+
+    const { result } = renderHook(() => useLocalCaptureSession({
+      userId: "user-1",
+      customerId: "cust-1",
+      initialSessionId: existingSession.sessionId,
+    }));
+
+    await waitFor(() => {
+      expect(result.current.isHydrating).toBe(false);
+      expect(result.current.sessionId).toBe(existingSession.sessionId);
+      expect(result.current.notes).toBe("Patio estimate");
+    });
+  });
+
+  it("hides local sessions that belong to another user", async () => {
+    const otherUsersSession = await createCaptureSession({
+      userId: "user-a",
+      notes: "Other account note",
+      customerId: "cust-a",
+    });
+
+    const { result } = renderHook(() => useLocalCaptureSession({
+      userId: "user-b",
+      customerId: undefined,
+      initialSessionId: otherUsersSession.sessionId,
+    }));
+
+    await waitFor(() => {
+      expect(result.current.isHydrating).toBe(false);
+    });
+
+    expect(result.current.sessionId).toBeNull();
+    expect(result.current.notes).toBe("");
+    expect(result.current.hydrationError).toBe("Pending capture was not found for this account.");
+  });
+});

--- a/frontend/src/features/quotes/tests/useRecoverableCaptures.test.tsx
+++ b/frontend/src/features/quotes/tests/useRecoverableCaptures.test.tsx
@@ -1,0 +1,55 @@
+import "fake-indexeddb/auto";
+
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { createCaptureSession } from "@/features/quotes/offline/captureRepository";
+import { resetCaptureDbForTests } from "@/features/quotes/offline/captureDb";
+import { useRecoverableCaptures } from "@/features/quotes/offline/useRecoverableCaptures";
+
+describe("useRecoverableCaptures", () => {
+  beforeEach(async () => {
+    await resetCaptureDbForTests();
+  });
+
+  afterEach(async () => {
+    await resetCaptureDbForTests();
+  });
+
+  it("limits returned captures to latest 20", async () => {
+    for (let index = 0; index < 25; index += 1) {
+      await createCaptureSession({
+        userId: "user-1",
+        notes: `session-${index}`,
+      });
+    }
+
+    const { result } = renderHook(() => useRecoverableCaptures("user-1"));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.captures).toHaveLength(20);
+    });
+  });
+
+  it("deletes a capture from the hook state", async () => {
+    const session = await createCaptureSession({
+      userId: "user-1",
+      notes: "to-delete",
+    });
+
+    const { result } = renderHook(() => useRecoverableCaptures("user-1"));
+
+    await waitFor(() => {
+      expect(result.current.captures.some((capture) => capture.sessionId === session.sessionId)).toBe(true);
+    });
+
+    await act(async () => {
+      await result.current.deleteCapture(session.sessionId);
+    });
+
+    await waitFor(() => {
+      expect(result.current.captures.some((capture) => capture.sessionId === session.sessionId)).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
Closes #555

## Summary
- add local capture session hooks for lazy IndexedDB persistence, recovery hydration, status transitions, and submit-failure classification
- wire Capture screen to recover `?localSession`, persist notes locally, keep notes on submit failures/offline, and surface local save/sync status copy
- add Pending Captures section on Quotes dashboard with resume/extract/delete actions and online-aware extract button
- split large quote components into focused subcomponents/helpers to satisfy frontend file-size blocking rules
- add focused tests for new hooks/helpers and update Capture/Quote list tests for offline-workspace behavior

## Verification
- `cd frontend && npm test -- src/features/quotes/tests/CaptureScreen.test.tsx src/features/quotes/tests/QuoteList.test.tsx src/features/quotes/tests/useLocalCaptureSession.test.tsx src/features/quotes/tests/useRecoverableCaptures.test.tsx src/features/quotes/offline/classifySubmitFailure.test.ts`
- `make frontend-verify`