### PR TITLE
Task #556: Spec 3 audio blob lifecycle hardening

### DIFF
--- a/frontend/src/features/quotes/components/CaptureInputPanel.tsx
+++ b/frontend/src/features/quotes/components/CaptureInputPanel.tsx
@@ -1,9 +1,6 @@
 import { formatElapsed } from "@/features/quotes/components/captureScreenHelpers";
 import type { VoiceClip } from "@/features/quotes/hooks/useVoiceCapture";
-import {
-  MAX_AUDIO_CLIPS_PER_REQUEST,
-  NOTE_INPUT_MAX_CHARS,
-} from "@/shared/lib/inputLimits";
+import { NOTE_INPUT_MAX_CHARS } from "@/shared/lib/inputLimits";
 import { Button } from "@/shared/components/Button";
 import { Eyebrow } from "@/ui/Eyebrow";
 
@@ -146,7 +143,7 @@ export function CaptureInputPanel({
           <Eyebrow as="span" className="text-xs tracking-widest">TAP TO START</Eyebrow>
           {hasReachedClipLimit ? (
             <p className="text-center text-xs text-outline">
-              Maximum of {MAX_AUDIO_CLIPS_PER_REQUEST} clips per request reached.
+              Maximum clips reached.
             </p>
           ) : null}
           <button

--- a/frontend/src/features/quotes/components/CaptureScreen.tsx
+++ b/frontend/src/features/quotes/components/CaptureScreen.tsx
@@ -11,7 +11,7 @@ import { classifySubmitFailure } from "@/features/quotes/offline/classifySubmitF
 import { getLocalCaptureStatusCopy } from "@/features/quotes/offline/localCaptureStatusCopy";
 import { useLocalCaptureSession } from "@/features/quotes/offline/useLocalCaptureSession";
 import { resolveCaptureLaunchOrigin } from "@/features/quotes/utils/workflowNavigation";
-import { useVoiceCapture } from "@/features/quotes/hooks/useVoiceCapture";
+import { MAX_VOICE_CLIPS_PER_CAPTURE, useVoiceCapture } from "@/features/quotes/hooks/useVoiceCapture";
 import { quoteService } from "@/features/quotes/services/quoteService";
 import type { QuoteDetail, QuoteSourceType } from "@/features/quotes/types/quote.types";
 import { Button } from "@/shared/components/Button";
@@ -34,17 +34,6 @@ export function CaptureScreen(): React.ReactElement {
   const { setDraft } = useQuoteDraft();
   const isMountedRef = useRef(true);
   const extractionStageTimerRefs = useRef<number[]>([]);
-  const {
-    clips,
-    elapsedSeconds,
-    error: voiceError,
-    isRecording,
-    isSupported,
-    startRecording,
-    stopRecording,
-    removeClip,
-    clearError,
-  } = useVoiceCapture();
   const searchParams = useMemo(() => new URLSearchParams(location.search), [location.search]);
   const localSessionQueryParam = searchParams.get("localSession");
   const autoExtractOnLoad = searchParams.get("autoExtract") === "1";
@@ -57,12 +46,25 @@ export function CaptureScreen(): React.ReactElement {
     hydrationError: localHydrationError,
     saveState: localSaveState,
     saveError: localSaveError,
+    ensureSession: ensureLocalCaptureSession,
+    setClipIds: setLocalCaptureClipIds,
     markStatus: markLocalCaptureStatus,
   } = useLocalCaptureSession({
     userId: user?.id,
     customerId,
     initialSessionId: localSessionQueryParam,
   });
+  const {
+    clips,
+    elapsedSeconds,
+    error: voiceError,
+    isRecording,
+    isSupported,
+    startRecording,
+    stopRecording,
+    removeClip,
+    clearError,
+  } = useVoiceCapture(localSessionId, user?.id);
 
   const [extractionStage, setExtractionStage] = useState<string | null>(null);
   const [pendingExitTarget, setPendingExitTarget] = useState<string | null>(null);
@@ -120,6 +122,10 @@ export function CaptureScreen(): React.ReactElement {
       }
     };
   }, [clearError, error, localHydrationError, localSaveError, voiceError]);
+
+  useEffect(() => {
+    void setLocalCaptureClipIds(clips.map((clip) => clip.id));
+  }, [clips, setLocalCaptureClipIds]);
 
   useEffect(() => {
     if (!displayedError) {
@@ -189,7 +195,7 @@ export function CaptureScreen(): React.ReactElement {
       return;
     }
     const totalClipBytes = clips.reduce(
-      (runningTotal, clip) => runningTotal + clip.blob.size,
+      (runningTotal, clip) => runningTotal + clip.sizeBytes,
       0,
     );
     if (totalClipBytes > MAX_AUDIO_TOTAL_BYTES) {
@@ -218,7 +224,7 @@ export function CaptureScreen(): React.ReactElement {
 
     try {
       const extraction = await quoteService.extract({
-        clips: clips.map((clip) => clip.blob),
+        clipIds: clips.map((clip) => clip.id),
         notes,
         customerId,
       });
@@ -335,7 +341,7 @@ export function CaptureScreen(): React.ReactElement {
     void onStartBlank();
   }
 
-  const hasReachedClipLimit = clips.length >= MAX_AUDIO_CLIPS_PER_REQUEST;
+  const hasReachedClipLimit = clips.length >= MAX_VOICE_CLIPS_PER_CAPTURE;
   const canExtract = (hasClips || hasNotes) && !isExtracting && !isRecording;
   const localStatusCopy = localSaveState === "saving"
     ? "Saving on this device..."
@@ -385,7 +391,10 @@ export function CaptureScreen(): React.ReactElement {
             hasReachedClipLimit={hasReachedClipLimit}
             isSupported={isSupported}
             onStartRecording={() => {
-              void startRecording();
+              void (async () => {
+                const ensuredSessionId = await ensureLocalCaptureSession();
+                await startRecording(ensuredSessionId);
+              })();
             }}
             onStopRecording={stopRecording}
             onStartBlank={onStartBlankClick}

--- a/frontend/src/features/quotes/hooks/useVoiceCapture.helpers.ts
+++ b/frontend/src/features/quotes/hooks/useVoiceCapture.helpers.ts
@@ -1,0 +1,127 @@
+import { listClipsForSession } from "@/features/quotes/offline/audioRepository";
+import { getTotalAudioBytes, saveAudioClip } from "@/features/quotes/offline/audioRepository";
+import { MAX_AUDIO_TOTAL_BYTES } from "@/shared/lib/inputLimits";
+
+const MIME_TYPE_CANDIDATES = [
+  "audio/webm;codecs=opus",
+  "audio/webm",
+  "audio/mp4",
+  "audio/ogg;codecs=opus",
+];
+
+export const CLIP_SAVE_FAILURE_MESSAGE =
+  "Stima could not save this clip. Free up device storage or remove an existing clip, then try again.";
+export const EMPTY_CLIP_MESSAGE = "Recorded clip was empty. Please try again.";
+export const CLIP_LIMIT_REACHED_MESSAGE = "Maximum clips reached.";
+export const CLIP_LENGTH_LIMIT_REACHED_MESSAGE = "Clip length limit reached.";
+export const STORAGE_SOFT_CAP_MESSAGE =
+  "Local audio storage is above 100 MB. Remove old clips if recordings stop saving.";
+
+export const MAX_VOICE_CLIPS_PER_CAPTURE = 5;
+export const MAX_VOICE_CLIP_DURATION_SECONDS = 120;
+
+export interface VoiceClip {
+  id: string;
+  url?: string | null;
+  durationSeconds: number;
+  sequenceNumber?: number;
+  sizeBytes: number;
+  mimeType: string;
+}
+
+export function canUseMediaRecorder(): boolean {
+  if (typeof window === "undefined") {
+    return false;
+  }
+
+  return (
+    typeof MediaRecorder !== "undefined" &&
+    !!navigator.mediaDevices &&
+    typeof navigator.mediaDevices.getUserMedia === "function"
+  );
+}
+
+export function resolvePreferredMimeType(): string | undefined {
+  if (!canUseMediaRecorder()) {
+    return undefined;
+  }
+
+  for (const candidate of MIME_TYPE_CANDIDATES) {
+    if (MediaRecorder.isTypeSupported(candidate)) {
+      return candidate;
+    }
+  }
+
+  return undefined;
+}
+
+export function stopStream(stream: MediaStream | null): void {
+  if (!stream) {
+    return;
+  }
+  for (const track of stream.getTracks()) {
+    track.stop();
+  }
+}
+
+export function revokeClipUrl(url: string | undefined | null): void {
+  if (!url) {
+    return;
+  }
+  URL.revokeObjectURL(url);
+}
+
+export async function loadPersistedVoiceClips(
+  sessionId: string,
+): Promise<{ clips: VoiceClip[]; maxSequence: number }> {
+  const persistedClips = await listClipsForSession(sessionId);
+  const clips = persistedClips.map((clip) => ({
+    id: clip.clipId,
+    durationSeconds: clip.durationSeconds ?? 0,
+    sequenceNumber: clip.sequenceNumber,
+    sizeBytes: clip.sizeBytes,
+    mimeType: clip.mimeType,
+  }));
+  const maxSequence = clips.reduce(
+    (currentMax, clip) => Math.max(currentMax, clip.sequenceNumber ?? 0),
+    0,
+  );
+  return { clips, maxSequence };
+}
+
+export async function persistRecordedClip(params: {
+  clipIdSequence: number;
+  sessionId: string;
+  userId: string;
+  blob: Blob;
+  recorderMimeType: string;
+  durationSeconds: number;
+}): Promise<{ clip: VoiceClip; nextSequenceNumber: number; exceededSoftCap: boolean }> {
+  const nextSequenceNumber = params.clipIdSequence + 1;
+  const clipId = `clip-${params.clipIdSequence}`;
+  const mimeType = params.blob.type || params.recorderMimeType || "audio/webm";
+
+  await saveAudioClip({
+    clipId,
+    sessionId: params.sessionId,
+    userId: params.userId,
+    blob: params.blob,
+    mimeType,
+    sizeBytes: params.blob.size,
+    durationSeconds: params.durationSeconds,
+    sequenceNumber: nextSequenceNumber,
+  });
+
+  const totalAudioBytes = await getTotalAudioBytes(params.userId);
+  return {
+    clip: {
+      id: clipId,
+      durationSeconds: params.durationSeconds,
+      sequenceNumber: nextSequenceNumber,
+      sizeBytes: params.blob.size,
+      mimeType,
+    },
+    nextSequenceNumber,
+    exceededSoftCap: totalAudioBytes > MAX_AUDIO_TOTAL_BYTES,
+  };
+}

--- a/frontend/src/features/quotes/hooks/useVoiceCapture.ts
+++ b/frontend/src/features/quotes/hooks/useVoiceCapture.ts
@@ -1,122 +1,140 @@
 import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  deleteAllClipsForSession,
+  deleteAudioClip,
+} from "@/features/quotes/offline/audioRepository";
+import {
+  canUseMediaRecorder,
+  CLIP_LENGTH_LIMIT_REACHED_MESSAGE,
+  CLIP_LIMIT_REACHED_MESSAGE,
+  CLIP_SAVE_FAILURE_MESSAGE,
+  EMPTY_CLIP_MESSAGE,
+  loadPersistedVoiceClips,
+  MAX_VOICE_CLIP_DURATION_SECONDS,
+  MAX_VOICE_CLIPS_PER_CAPTURE,
+  persistRecordedClip,
+  resolvePreferredMimeType,
+  revokeClipUrl,
+  STORAGE_SOFT_CAP_MESSAGE,
+  stopStream,
+} from "@/features/quotes/hooks/useVoiceCapture.helpers";
+import type { VoiceClip } from "@/features/quotes/hooks/useVoiceCapture.helpers";
 import { perfMark, perfMeasure } from "@/shared/perf";
-
-const MIME_TYPE_CANDIDATES = [
-  "audio/webm;codecs=opus",
-  "audio/webm",
-  "audio/mp4",
-  "audio/ogg;codecs=opus",
-];
-
-export interface VoiceClip {
-  id: string;
-  blob: Blob;
-  url: string;
-  durationSeconds: number;
-  sequenceNumber?: number;
-}
-
+export {
+  MAX_VOICE_CLIP_DURATION_SECONDS,
+  MAX_VOICE_CLIPS_PER_CAPTURE,
+} from "@/features/quotes/hooks/useVoiceCapture.helpers";
+export type { VoiceClip } from "@/features/quotes/hooks/useVoiceCapture.helpers";
 interface UseVoiceCaptureResult {
   clips: VoiceClip[];
   elapsedSeconds: number;
   error: string | null;
   isRecording: boolean;
   isSupported: boolean;
-  startRecording: () => Promise<void>;
+  startRecording: (sessionIdOverride?: string | null) => Promise<void>;
   stopRecording: () => void;
   removeClip: (clipId: string) => void;
   clearClips: () => void;
   clearError: () => void;
 }
-
-function canUseMediaRecorder(): boolean {
-  if (typeof window === "undefined") {
-    return false;
-  }
-
-  return (
-    typeof MediaRecorder !== "undefined" &&
-    !!navigator.mediaDevices &&
-    typeof navigator.mediaDevices.getUserMedia === "function"
-  );
-}
-
-function resolvePreferredMimeType(): string | undefined {
-  if (!canUseMediaRecorder()) {
-    return undefined;
-  }
-
-  for (const candidate of MIME_TYPE_CANDIDATES) {
-    if (MediaRecorder.isTypeSupported(candidate)) {
-      return candidate;
-    }
-  }
-
-  return undefined;
-}
-
-function stopStream(stream: MediaStream | null): void {
-  if (!stream) {
-    return;
-  }
-  for (const track of stream.getTracks()) {
-    track.stop();
-  }
-}
-
-function revokeClipUrls(clips: VoiceClip[]): void {
-  for (const clip of clips) {
-    URL.revokeObjectURL(clip.url);
-  }
-}
-
-export function useVoiceCapture(): UseVoiceCaptureResult {
+export function useVoiceCapture(
+  sessionId: string | null,
+  userId: string | undefined,
+): UseVoiceCaptureResult {
   const [clips, setClips] = useState<VoiceClip[]>([]);
   const [elapsedSeconds, setElapsedSeconds] = useState(0);
   const [error, setError] = useState<string | null>(null);
   const [isRecording, setIsRecording] = useState(false);
   const [isSupported] = useState(canUseMediaRecorder);
-
   const mediaRecorderRef = useRef<MediaRecorder | null>(null);
   const streamRef = useRef<MediaStream | null>(null);
   const timerRef = useRef<number | null>(null);
+  const durationLimitRef = useRef<number | null>(null);
   const recordingStartRef = useRef<number | null>(null);
   const chunksRef = useRef<BlobPart[]>([]);
   const clipIdSequenceRef = useRef(0);
   const clipsRef = useRef<VoiceClip[]>([]);
-
+  const clipUrlByIdRef = useRef<Map<string, string>>(new Map());
+  const sessionIdRef = useRef<string | null>(sessionId);
+  const userIdRef = useRef<string | undefined>(userId);
+  const recordingSessionIdRef = useRef<string | null>(null);
   useEffect(() => {
     clipsRef.current = clips;
   }, [clips]);
-
+  useEffect(() => {
+    sessionIdRef.current = sessionId;
+  }, [sessionId]);
+  useEffect(() => {
+    userIdRef.current = userId;
+  }, [userId]);
+  useEffect(() => {
+    let isActive = true;
+    if (!sessionId) {
+      setClips([]);
+      clipIdSequenceRef.current = 0;
+      return () => {
+        isActive = false;
+      };
+    }
+    void (async () => {
+      try {
+        const { clips: persistedClips, maxSequence } = await loadPersistedVoiceClips(sessionId);
+        if (!isActive) {
+          return;
+        }
+        setClips(persistedClips);
+        clipIdSequenceRef.current = maxSequence;
+      } catch {
+        if (isActive) {
+          setError("Unable to load saved clips on this device.");
+        }
+      }
+    })();
+    return () => {
+      isActive = false;
+    };
+  }, [sessionId]);
   const stopTimer = useCallback(() => {
     if (timerRef.current !== null) {
       window.clearInterval(timerRef.current);
       timerRef.current = null;
     }
   }, []);
-
+  const clearDurationLimitTimer = useCallback(() => {
+    if (durationLimitRef.current !== null) {
+      window.clearTimeout(durationLimitRef.current);
+      durationLimitRef.current = null;
+    }
+  }, []);
   const clearError = useCallback(() => {
     setError(null);
   }, []);
-
   const removeClip = useCallback((clipId: string) => {
-    setClips((currentClips) => {
-      const clipToRemove = currentClips.find((clip) => clip.id === clipId);
-      if (clipToRemove) {
-        URL.revokeObjectURL(clipToRemove.url);
-      }
-      return currentClips.filter((clip) => clip.id !== clipId);
+    const trackedUrl = clipUrlByIdRef.current.get(clipId);
+    revokeClipUrl(trackedUrl);
+    clipUrlByIdRef.current.delete(clipId);
+    setClips((currentClips) => currentClips.filter((clip) => clip.id !== clipId));
+    if (!sessionIdRef.current) {
+      return;
+    }
+    void deleteAudioClip(clipId).catch(() => {
+      setError("Could not remove this clip from local storage.");
     });
   }, []);
-
   const clearClips = useCallback(() => {
-    setClips((currentClips) => {
-      revokeClipUrls(currentClips);
-      return [];
+    clipUrlByIdRef.current.forEach((objectUrl) => {
+      revokeClipUrl(objectUrl);
+    });
+    clipUrlByIdRef.current.clear();
+    setClips([]);
+    const activeSessionId = sessionIdRef.current;
+    if (!activeSessionId) {
+      return;
+    }
+    void deleteAllClipsForSession(activeSessionId).catch(() => {
+      setError("Could not clear local clips.");
     });
   }, []);
-
   const stopRecording = useCallback(() => {
     const recorder = mediaRecorderRef.current;
     if (!recorder || recorder.state === "inactive") {
@@ -124,83 +142,99 @@ export function useVoiceCapture(): UseVoiceCaptureResult {
     }
     recorder.stop();
   }, []);
-
-  const startRecording = useCallback(async () => {
+  const startRecording = useCallback(async (sessionIdOverride?: string | null) => {
     if (!isSupported) {
       setError("Voice capture is not supported in this browser.");
       return;
     }
-
     if (isRecording) {
       return;
     }
-
+    if (clipsRef.current.length >= MAX_VOICE_CLIPS_PER_CAPTURE) {
+      setError(CLIP_LIMIT_REACHED_MESSAGE);
+      return;
+    }
+    const activeSessionId = sessionIdOverride ?? sessionIdRef.current;
+    const activeUserId = userIdRef.current;
+    if (!activeSessionId || !activeUserId) {
+      setError(CLIP_SAVE_FAILURE_MESSAGE);
+      return;
+    }
     perfMark("capture:record:tap");
     setError(null);
     setElapsedSeconds(0);
-
     try {
       const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
       streamRef.current = stream;
       perfMark("capture:record:stream_ready");
-
       const preferredMimeType = resolvePreferredMimeType();
       const recorder = preferredMimeType
         ? new MediaRecorder(stream, { mimeType: preferredMimeType })
         : new MediaRecorder(stream);
-
       mediaRecorderRef.current = recorder;
       chunksRef.current = [];
       recordingStartRef.current = Date.now();
-
+      recordingSessionIdRef.current = activeSessionId;
       recorder.ondataavailable = (event: BlobEvent) => {
         if (event.data.size > 0) {
           chunksRef.current.push(event.data);
         }
       };
-
       recorder.onerror = () => {
         setError("Voice recording failed. Please try again.");
       };
-
       recorder.onstop = () => {
-        stopTimer();
-        const chunks = [...chunksRef.current];
-        chunksRef.current = [];
-
-        const recordingStart = recordingStartRef.current;
-        const durationSeconds = recordingStart
-          ? Math.max(1, Math.round((Date.now() - recordingStart) / 1000))
-          : 1;
-
-        if (chunks.length > 0) {
-          const blob = new Blob(chunks, { type: recorder.mimeType || "audio/webm" });
-          if (blob.size > 0) {
-            const nextSequenceNumber = clipIdSequenceRef.current + 1;
-            const nextClip: VoiceClip = {
-              id: `clip-${clipIdSequenceRef.current}`,
+        void (async () => {
+          stopTimer();
+          clearDurationLimitTimer();
+          const chunks = [...chunksRef.current];
+          chunksRef.current = [];
+          const recordingStart = recordingStartRef.current;
+          const durationSeconds = recordingStart
+            ? Math.max(1, Math.round((Date.now() - recordingStart) / 1000))
+            : 1;
+          try {
+            if (chunks.length === 0) {
+              setError(EMPTY_CLIP_MESSAGE);
+              return;
+            }
+            const blob = new Blob(chunks, { type: recorder.mimeType || "audio/webm" });
+            if (blob.size === 0) {
+              setError(EMPTY_CLIP_MESSAGE);
+              return;
+            }
+            const targetSessionId = recordingSessionIdRef.current;
+            const targetUserId = userIdRef.current;
+            if (!targetSessionId || !targetUserId) {
+              setError(CLIP_SAVE_FAILURE_MESSAGE);
+              return;
+            }
+            const { clip, nextSequenceNumber, exceededSoftCap } = await persistRecordedClip({
+              clipIdSequence: clipIdSequenceRef.current,
+              sessionId: targetSessionId,
+              userId: targetUserId,
               blob,
-              url: URL.createObjectURL(blob),
+              recorderMimeType: recorder.mimeType,
               durationSeconds,
-              sequenceNumber: nextSequenceNumber,
-            };
-            clipIdSequenceRef.current += 1;
-            setClips((currentClips) => [...currentClips, nextClip]);
-          } else {
-            setError("Recorded clip was empty. Please try again.");
+            });
+            clipIdSequenceRef.current = nextSequenceNumber;
+            setClips((currentClips) => [...currentClips, clip]);
+            if (exceededSoftCap) {
+              setError(STORAGE_SOFT_CAP_MESSAGE);
+            }
+          } catch {
+            setError(CLIP_SAVE_FAILURE_MESSAGE);
+          } finally {
+            stopStream(streamRef.current);
+            streamRef.current = null;
+            mediaRecorderRef.current = null;
+            recordingSessionIdRef.current = null;
+            recordingStartRef.current = null;
+            setElapsedSeconds(0);
+            setIsRecording(false);
           }
-        } else {
-          setError("Recorded clip was empty. Please try again.");
-        }
-
-        stopStream(streamRef.current);
-        streamRef.current = null;
-        mediaRecorderRef.current = null;
-        recordingStartRef.current = null;
-        setElapsedSeconds(0);
-        setIsRecording(false);
+        })();
       };
-
       recorder.start();
       perfMark("capture:record:active");
       perfMeasure("capture:record:tap_to_stream_ms", "capture:record:tap", "capture:record:stream_ready");
@@ -209,28 +243,37 @@ export function useVoiceCapture(): UseVoiceCaptureResult {
       timerRef.current = window.setInterval(() => {
         setElapsedSeconds((currentSeconds) => currentSeconds + 1);
       }, 1000);
+      durationLimitRef.current = window.setTimeout(() => {
+        setError(CLIP_LENGTH_LIMIT_REACHED_MESSAGE);
+        stopRecording();
+      }, MAX_VOICE_CLIP_DURATION_SECONDS * 1000);
     } catch {
       stopTimer();
+      clearDurationLimitTimer();
       stopStream(streamRef.current);
       streamRef.current = null;
       mediaRecorderRef.current = null;
+      recordingSessionIdRef.current = null;
       setIsRecording(false);
       setError("Microphone access was denied or unavailable.");
     }
-  }, [isRecording, isSupported, stopTimer]);
-
+  }, [clearDurationLimitTimer, isRecording, isSupported, stopRecording, stopTimer]);
   useEffect(() => {
+    const clipUrlById = clipUrlByIdRef.current;
     return () => {
       stopTimer();
+      clearDurationLimitTimer();
       stopStream(streamRef.current);
       const recorder = mediaRecorderRef.current;
       if (recorder && recorder.state !== "inactive") {
         recorder.stop();
       }
-      revokeClipUrls(clipsRef.current);
+      clipUrlById.forEach((objectUrl) => {
+        revokeClipUrl(objectUrl);
+      });
+      clipUrlById.clear();
     };
-  }, [stopTimer]);
-
+  }, [clearDurationLimitTimer, stopTimer]);
   return {
     clips,
     elapsedSeconds,

--- a/frontend/src/features/quotes/offline/audioRepository.test.ts
+++ b/frontend/src/features/quotes/offline/audioRepository.test.ts
@@ -1,0 +1,189 @@
+import "fake-indexeddb/auto";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  deleteAllClipsForSession,
+  deleteAudioClip,
+  getAudioClip,
+  getTotalAudioBytes,
+  listClipsForSession,
+  saveAudioClip,
+} from "@/features/quotes/offline/audioRepository";
+import { resetCaptureDbForTests } from "@/features/quotes/offline/captureDb";
+
+describe("audioRepository", () => {
+  beforeEach(async () => {
+    await resetCaptureDbForTests();
+  });
+
+  afterEach(async () => {
+    await resetCaptureDbForTests();
+  });
+
+  it("round-trips clip blobs with save/get", async () => {
+    const blob = new Blob(["clip-a"], { type: "audio/webm" });
+    await saveAudioClip({
+      clipId: "clip-1",
+      sessionId: "session-1",
+      userId: "user-1",
+      blob,
+      mimeType: blob.type,
+      sizeBytes: blob.size,
+      durationSeconds: 4,
+      sequenceNumber: 1,
+    });
+
+    const clip = await getAudioClip("clip-1");
+
+    expect(clip).not.toBeNull();
+    expect(clip?.clipId).toBe("clip-1");
+    expect(clip?.sessionId).toBe("session-1");
+    expect(clip?.blob.size).toBe(blob.size);
+    expect(clip?.mimeType).toBe("audio/webm");
+    expect(clip?.createdAt).toEqual(expect.any(String));
+  });
+
+  it("lists metadata for one session only", async () => {
+    const firstBlob = new Blob(["a"], { type: "audio/webm" });
+    const secondBlob = new Blob(["b"], { type: "audio/mp4" });
+
+    await saveAudioClip({
+      clipId: "clip-a",
+      sessionId: "session-a",
+      userId: "user-1",
+      blob: firstBlob,
+      mimeType: firstBlob.type,
+      sizeBytes: firstBlob.size,
+      durationSeconds: 2,
+      sequenceNumber: 1,
+    });
+    await saveAudioClip({
+      clipId: "clip-b",
+      sessionId: "session-a",
+      userId: "user-1",
+      blob: secondBlob,
+      mimeType: secondBlob.type,
+      sizeBytes: secondBlob.size,
+      durationSeconds: 3,
+      sequenceNumber: 2,
+    });
+    await saveAudioClip({
+      clipId: "clip-other",
+      sessionId: "session-b",
+      userId: "user-1",
+      blob: new Blob(["c"], { type: "audio/webm" }),
+      mimeType: "audio/webm",
+      sizeBytes: 1,
+      durationSeconds: 1,
+      sequenceNumber: 1,
+    });
+
+    const clips = await listClipsForSession("session-a");
+
+    expect(clips).toHaveLength(2);
+    expect(clips[0]).toEqual(
+      expect.objectContaining({
+        clipId: "clip-a",
+        sequenceNumber: 1,
+      }),
+    );
+    expect(clips[1]).toEqual(
+      expect.objectContaining({
+        clipId: "clip-b",
+        sequenceNumber: 2,
+      }),
+    );
+    expect("blob" in clips[0]).toBe(false);
+  });
+
+  it("deletes a single clip", async () => {
+    await saveAudioClip({
+      clipId: "clip-1",
+      sessionId: "session-1",
+      userId: "user-1",
+      blob: new Blob(["clip-a"], { type: "audio/webm" }),
+      mimeType: "audio/webm",
+      sizeBytes: 6,
+      durationSeconds: 3,
+      sequenceNumber: 1,
+    });
+
+    await deleteAudioClip("clip-1");
+
+    await expect(getAudioClip("clip-1")).resolves.toBeNull();
+  });
+
+  it("deletes all clips for a session", async () => {
+    await saveAudioClip({
+      clipId: "clip-1",
+      sessionId: "session-1",
+      userId: "user-1",
+      blob: new Blob(["clip-a"], { type: "audio/webm" }),
+      mimeType: "audio/webm",
+      sizeBytes: 6,
+      durationSeconds: 3,
+      sequenceNumber: 1,
+    });
+    await saveAudioClip({
+      clipId: "clip-2",
+      sessionId: "session-1",
+      userId: "user-1",
+      blob: new Blob(["clip-b"], { type: "audio/webm" }),
+      mimeType: "audio/webm",
+      sizeBytes: 7,
+      durationSeconds: 4,
+      sequenceNumber: 2,
+    });
+    await saveAudioClip({
+      clipId: "clip-3",
+      sessionId: "session-2",
+      userId: "user-1",
+      blob: new Blob(["clip-c"], { type: "audio/webm" }),
+      mimeType: "audio/webm",
+      sizeBytes: 8,
+      durationSeconds: 5,
+      sequenceNumber: 1,
+    });
+
+    await deleteAllClipsForSession("session-1");
+
+    await expect(listClipsForSession("session-1")).resolves.toEqual([]);
+    await expect(getAudioClip("clip-3")).resolves.not.toBeNull();
+  });
+
+  it("sums total bytes for a user", async () => {
+    await saveAudioClip({
+      clipId: "clip-1",
+      sessionId: "session-1",
+      userId: "user-1",
+      blob: new Blob(["clip-a"], { type: "audio/webm" }),
+      mimeType: "audio/webm",
+      sizeBytes: 10,
+      durationSeconds: 3,
+      sequenceNumber: 1,
+    });
+    await saveAudioClip({
+      clipId: "clip-2",
+      sessionId: "session-2",
+      userId: "user-1",
+      blob: new Blob(["clip-b"], { type: "audio/webm" }),
+      mimeType: "audio/webm",
+      sizeBytes: 25,
+      durationSeconds: 4,
+      sequenceNumber: 2,
+    });
+    await saveAudioClip({
+      clipId: "clip-3",
+      sessionId: "session-2",
+      userId: "user-2",
+      blob: new Blob(["clip-c"], { type: "audio/webm" }),
+      mimeType: "audio/webm",
+      sizeBytes: 99,
+      durationSeconds: 5,
+      sequenceNumber: 1,
+    });
+
+    await expect(getTotalAudioBytes("user-1")).resolves.toBe(35);
+  });
+});

--- a/frontend/src/features/quotes/offline/audioRepository.ts
+++ b/frontend/src/features/quotes/offline/audioRepository.ts
@@ -1,0 +1,220 @@
+import { CAPTURE_STORE_NAMES, getDb } from "@/features/quotes/offline/captureDb";
+import type { LocalAudioClip, LocalAudioClipMeta } from "@/features/quotes/offline/captureTypes";
+
+type UnknownRecord = Record<string, unknown>;
+
+type SaveAudioClipInput = Omit<LocalAudioClip, "createdAt">;
+
+export async function saveAudioClip(clip: SaveAudioClipInput): Promise<void> {
+  const blobData = await readBlobAsArrayBuffer(clip.blob);
+  const db = await getDb();
+  const transaction = db.transaction(CAPTURE_STORE_NAMES.audioClips, "readwrite");
+  const store = transaction.objectStore(CAPTURE_STORE_NAMES.audioClips);
+  store.put({
+    clipId: clip.clipId,
+    sessionId: clip.sessionId,
+    userId: clip.userId,
+    blobData,
+    mimeType: clip.mimeType,
+    sizeBytes: clip.sizeBytes,
+    durationSeconds: clip.durationSeconds,
+    sequenceNumber: clip.sequenceNumber,
+    createdAt: new Date().toISOString(),
+  });
+  await transactionDone(transaction);
+}
+
+export async function getAudioClip(clipId: string): Promise<LocalAudioClip | null> {
+  const db = await getDb();
+  const transaction = db.transaction(CAPTURE_STORE_NAMES.audioClips, "readonly");
+  const store = transaction.objectStore(CAPTURE_STORE_NAMES.audioClips);
+  const rawRecord = await requestToPromise(store.get(clipId));
+  await transactionDone(transaction);
+  return parseStoredAudioClip(rawRecord);
+}
+
+export async function listClipsForSession(sessionId: string): Promise<LocalAudioClipMeta[]> {
+  const db = await getDb();
+  const transaction = db.transaction(CAPTURE_STORE_NAMES.audioClips, "readonly");
+  const store = transaction.objectStore(CAPTURE_STORE_NAMES.audioClips);
+  const sessionIndex = store.index("sessionId");
+  const rawRecords = await requestToPromise(sessionIndex.getAll(IDBKeyRange.only(sessionId)));
+  await transactionDone(transaction);
+
+  return rawRecords
+    .map(parseStoredAudioClip)
+    .filter((clip): clip is LocalAudioClip => clip !== null && clip.sessionId === sessionId)
+    .sort((left, right) => {
+      const sequenceDifference = left.sequenceNumber - right.sequenceNumber;
+      if (sequenceDifference !== 0) {
+        return sequenceDifference;
+      }
+      return left.createdAt.localeCompare(right.createdAt);
+    })
+    .map((clip) => {
+      const clipMeta = { ...clip };
+      Reflect.deleteProperty(clipMeta, "blob");
+      return clipMeta as LocalAudioClipMeta;
+    });
+}
+
+export async function deleteAudioClip(clipId: string): Promise<void> {
+  const db = await getDb();
+  const transaction = db.transaction(CAPTURE_STORE_NAMES.audioClips, "readwrite");
+  const store = transaction.objectStore(CAPTURE_STORE_NAMES.audioClips);
+  store.delete(clipId);
+  await transactionDone(transaction);
+}
+
+export async function deleteAllClipsForSession(sessionId: string): Promise<void> {
+  const db = await getDb();
+  const transaction = db.transaction(CAPTURE_STORE_NAMES.audioClips, "readwrite");
+  const store = transaction.objectStore(CAPTURE_STORE_NAMES.audioClips);
+  const sessionIndex = store.index("sessionId");
+  const clipIds = await requestToPromise(sessionIndex.getAllKeys(IDBKeyRange.only(sessionId)));
+
+  for (const clipId of clipIds) {
+    store.delete(clipId);
+  }
+
+  await transactionDone(transaction);
+}
+
+export async function getTotalAudioBytes(userId: string): Promise<number> {
+  const db = await getDb();
+  const transaction = db.transaction(CAPTURE_STORE_NAMES.audioClips, "readonly");
+  const store = transaction.objectStore(CAPTURE_STORE_NAMES.audioClips);
+  const userIndex = store.index("userId");
+  const rawRecords = await requestToPromise(userIndex.getAll(IDBKeyRange.only(userId)));
+  await transactionDone(transaction);
+
+  return rawRecords
+    .map(parseStoredAudioClip)
+    .filter((clip): clip is LocalAudioClip => clip !== null && clip.userId === userId)
+    .reduce((runningTotal, clip) => runningTotal + clip.sizeBytes, 0);
+}
+
+function parseStoredAudioClip(value: unknown): LocalAudioClip | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  const {
+    clipId,
+    sessionId,
+    userId,
+    mimeType,
+    sizeBytes,
+    durationSeconds,
+    sequenceNumber,
+    createdAt,
+  } = value;
+
+  if (
+    typeof clipId !== "string" ||
+    typeof sessionId !== "string" ||
+    typeof userId !== "string" ||
+    typeof mimeType !== "string" ||
+    typeof sizeBytes !== "number" ||
+    !Number.isFinite(sizeBytes) ||
+    (durationSeconds !== undefined && (typeof durationSeconds !== "number" || !Number.isFinite(durationSeconds))) ||
+    typeof sequenceNumber !== "number" ||
+    !Number.isFinite(sequenceNumber) ||
+    typeof createdAt !== "string"
+  ) {
+    return null;
+  }
+
+  const blob = resolveStoredBlob(value, mimeType);
+  if (!blob) {
+    return null;
+  }
+
+  return {
+    clipId,
+    sessionId,
+    userId,
+    blob: blob as Blob,
+    mimeType,
+    sizeBytes,
+    durationSeconds: durationSeconds as number | undefined,
+    sequenceNumber,
+    createdAt,
+  };
+}
+
+function resolveStoredBlob(record: UnknownRecord, mimeType: string): Blob | null {
+  const inlineBlob = record.blob;
+  if (inlineBlob instanceof Blob) {
+    return inlineBlob;
+  }
+
+  if (
+    isRecord(inlineBlob) &&
+    typeof inlineBlob.size === "number" &&
+    typeof inlineBlob.type === "string" &&
+    typeof inlineBlob.arrayBuffer === "function"
+  ) {
+    return inlineBlob as unknown as Blob;
+  }
+
+  const blobData = record.blobData;
+  if (blobData instanceof ArrayBuffer) {
+    return new Blob([blobData], { type: mimeType });
+  }
+  if (ArrayBuffer.isView(blobData)) {
+    const copiedBytes = new Uint8Array(blobData.byteLength);
+    copiedBytes.set(new Uint8Array(blobData.buffer, blobData.byteOffset, blobData.byteLength));
+    return new Blob([copiedBytes.buffer], { type: mimeType });
+  }
+  if (isRecord(blobData) && typeof blobData.byteLength === "number") {
+    const sourceBytes = new Uint8Array(blobData as unknown as ArrayBufferLike);
+    const copiedBytes = new Uint8Array(sourceBytes.byteLength);
+    copiedBytes.set(sourceBytes);
+    return new Blob([copiedBytes.buffer], { type: mimeType });
+  }
+
+  return null;
+}
+
+async function readBlobAsArrayBuffer(blob: Blob): Promise<ArrayBuffer> {
+  const blobWithArrayBuffer = blob as Blob & { arrayBuffer?: () => Promise<ArrayBuffer> };
+  if (typeof blobWithArrayBuffer.arrayBuffer === "function") {
+    return blobWithArrayBuffer.arrayBuffer();
+  }
+
+  if (typeof FileReader !== "undefined") {
+    return new Promise<ArrayBuffer>((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = () => resolve(reader.result as ArrayBuffer);
+      reader.onerror = () => reject(reader.error ?? new Error("Failed to read blob data."));
+      reader.readAsArrayBuffer(blob);
+    });
+  }
+
+  if (typeof Response !== "undefined") {
+    return new Response(blob).arrayBuffer();
+  }
+
+  throw new Error("Unable to read blob data for persistence.");
+}
+
+function isRecord(value: unknown): value is UnknownRecord {
+  return typeof value === "object" && value !== null;
+}
+
+
+function requestToPromise<T>(request: IDBRequest<T>): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error ?? new Error("IndexedDB request failed."));
+  });
+}
+
+function transactionDone(transaction: IDBTransaction): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    transaction.oncomplete = () => resolve();
+    transaction.onerror = () => reject(transaction.error ?? new Error("IndexedDB transaction failed."));
+    transaction.onabort = () => reject(transaction.error ?? new Error("IndexedDB transaction aborted."));
+  });
+}

--- a/frontend/src/features/quotes/offline/captureRepository.test.ts
+++ b/frontend/src/features/quotes/offline/captureRepository.test.ts
@@ -20,6 +20,7 @@ import {
   updateCaptureField,
   updateCaptureNotes,
 } from "@/features/quotes/offline/captureRepository";
+import { getAudioClip, saveAudioClip } from "@/features/quotes/offline/audioRepository";
 import type { LocalCaptureSession } from "@/features/quotes/offline/captureTypes";
 import { getStorageEstimate, isStoragePressured } from "@/features/quotes/offline/storageHealth";
 
@@ -197,10 +198,21 @@ describe("captureRepository", () => {
       userId: "user-a",
       notes: "to delete",
     });
+    await saveAudioClip({
+      clipId: "clip-1",
+      sessionId: session.sessionId,
+      userId: "user-a",
+      blob: new Blob(["clip-a"], { type: "audio/webm" }),
+      mimeType: "audio/webm",
+      sizeBytes: 6,
+      durationSeconds: 3,
+      sequenceNumber: 1,
+    });
 
     await deleteCaptureSession(session.sessionId);
 
     expect(await getCaptureSession(session.sessionId)).toBeNull();
+    expect(await getAudioClip("clip-1")).toBeNull();
   });
 
   it("deletes only empty abandoned local-only sessions", async () => {

--- a/frontend/src/features/quotes/offline/captureRepository.ts
+++ b/frontend/src/features/quotes/offline/captureRepository.ts
@@ -1,4 +1,5 @@
 import { CAPTURE_STORE_NAMES, getDb } from "@/features/quotes/offline/captureDb";
+import { deleteAllClipsForSession } from "@/features/quotes/offline/audioRepository";
 import type {
   CreateLocalCaptureInput,
   CreateLocalSyncEventInput,
@@ -174,6 +175,7 @@ export async function markCaptureStatus(
 }
 
 export async function deleteCaptureSession(sessionId: string): Promise<void> {
+  await deleteAllClipsForSession(sessionId);
   const db = await getDb();
   const transaction = db.transaction(CAPTURE_STORE_NAMES.captureSessions, "readwrite");
   const store = transaction.objectStore(CAPTURE_STORE_NAMES.captureSessions);

--- a/frontend/src/features/quotes/offline/captureTypes.ts
+++ b/frontend/src/features/quotes/offline/captureTypes.ts
@@ -64,6 +64,16 @@ export interface LocalSyncEvent {
 
 export type CreateLocalSyncEventInput = Omit<LocalSyncEvent, "eventId" | "createdAt">;
 
+export class AudioClipMissingError extends Error {
+  clipId: string;
+
+  constructor(clipId: string) {
+    super(`Audio clip is missing from local storage: ${clipId}`);
+    this.name = "AudioClipMissingError";
+    this.clipId = clipId;
+  }
+}
+
 export interface LocalAudioClip {
   clipId: string;
   sessionId: string;
@@ -76,6 +86,8 @@ export interface LocalAudioClip {
   objectUrl?: never;
   createdAt: string;
 }
+
+export type LocalAudioClipMeta = Omit<LocalAudioClip, "blob">;
 
 export interface LocalDraftRecord {
   draftKey: string;

--- a/frontend/src/features/quotes/offline/useLocalCaptureSession.ts
+++ b/frontend/src/features/quotes/offline/useLocalCaptureSession.ts
@@ -8,6 +8,7 @@ import {
   updateCaptureField,
   updateCaptureNotes,
 } from "@/features/quotes/offline/captureRepository";
+import { deleteAllClipsForSession } from "@/features/quotes/offline/audioRepository";
 import type {
   LocalCaptureSession,
   LocalCaptureStatus,
@@ -15,6 +16,8 @@ import type {
 } from "@/features/quotes/offline/captureTypes";
 
 const NOTES_PERSIST_DEBOUNCE_MS = 350;
+const SYNCED_AUDIO_CLEANUP_DELAY_MS = 60_000;
+const syncedAudioCleanupTimerBySession = new Map<string, number>();
 
 type LocalSaveState = "idle" | "saving" | "saved" | "error";
 
@@ -40,11 +43,46 @@ interface UseLocalCaptureSessionResult {
   hydrationError: string | null;
   saveState: LocalSaveState;
   saveError: string | null;
-  markStatus: (status: LocalCaptureStatus, options?: MarkCaptureStatusOptions) => Promise<void>;
+  ensureSession: () => Promise<string | null>;
+  setClipIds: (clipIds: string[]) => Promise<void>;
+  markStatus: (status: LocalCaptureStatus, options?: MarkCaptureStatusOptions) => Promise<string | null>;
 }
 
 function getErrorMessage(error: unknown, fallback: string): string {
   return error instanceof Error ? error.message : fallback;
+}
+
+function clearSyncedAudioCleanupTimer(sessionId: string): void {
+  const timerId = syncedAudioCleanupTimerBySession.get(sessionId);
+  if (timerId === undefined) {
+    return;
+  }
+  if (typeof window !== "undefined") {
+    window.clearTimeout(timerId);
+  }
+  syncedAudioCleanupTimerBySession.delete(sessionId);
+}
+
+function scheduleSyncedAudioCleanup(sessionId: string): void {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  clearSyncedAudioCleanupTimer(sessionId);
+
+  const timerId = window.setTimeout(() => {
+    syncedAudioCleanupTimerBySession.delete(sessionId);
+    void (async () => {
+      try {
+        await deleteAllClipsForSession(sessionId);
+        await updateCaptureField(sessionId, { clipIds: [] });
+      } catch {
+        // Ignore cleanup retries; stale clips can still be removed manually.
+      }
+    })();
+  }, SYNCED_AUDIO_CLEANUP_DELAY_MS);
+
+  syncedAudioCleanupTimerBySession.set(sessionId, timerId);
 }
 
 export function useLocalCaptureSession({
@@ -86,6 +124,36 @@ export function useLocalCaptureSession({
   useEffect(() => {
     sessionRef.current = session;
   }, [session]);
+
+  const ensureSessionRecord = useCallback(async (): Promise<LocalCaptureSession | null> => {
+    if (!userId) {
+      return null;
+    }
+
+    let targetSession = sessionRef.current;
+    if (targetSession) {
+      return targetSession;
+    }
+
+    targetSession = await createCaptureSession({
+      userId,
+      notes: notesRef.current,
+      customerId: customerId ?? null,
+    });
+
+    if (isMountedRef.current) {
+      setSession(targetSession);
+      setSaveState("saved");
+      setSaveError(null);
+    }
+
+    return targetSession;
+  }, [customerId, userId]);
+
+  const ensureSession = useCallback(async (): Promise<string | null> => {
+    const targetSession = await ensureSessionRecord();
+    return targetSession?.sessionId ?? null;
+  }, [ensureSessionRecord]);
 
   useEffect(() => {
     let isActive = true;
@@ -135,6 +203,14 @@ export function useLocalCaptureSession({
 
         setSession(loadedSession);
         setNotesState(loadedSession.notes);
+
+        if (
+          loadedSession.status === "synced" &&
+          loadedSession.serverQuoteId &&
+          loadedSession.clipIds.length > 0
+        ) {
+          scheduleSyncedAudioCleanup(loadedSession.sessionId);
+        }
 
         await updateCaptureField(loadedSession.sessionId, {
           lastOpenedAt: new Date().toISOString(),
@@ -231,35 +307,41 @@ export function useLocalCaptureSession({
     return clearPersistTimer;
   }, [clearPersistTimer, customerId, isHydrating, notes, userId]);
 
-  const markStatus = useCallback(async (
-    status: LocalCaptureStatus,
-    options?: MarkCaptureStatusOptions,
-  ): Promise<void> => {
-    if (!userId) {
+  const setClipIds = useCallback(async (clipIds: string[]): Promise<void> => {
+    const normalizedClipIds = Array.from(new Set(clipIds));
+    let targetSession = sessionRef.current;
+
+    if (!targetSession && normalizedClipIds.length > 0) {
+      targetSession = await ensureSessionRecord();
+    }
+
+    if (!targetSession) {
       return;
     }
 
-    const noteSnapshot = notesRef.current;
-    let targetSession = sessionRef.current;
+    await updateCaptureField(targetSession.sessionId, {
+      clipIds: normalizedClipIds,
+    });
 
+    const refreshedSession = await getCaptureSession(targetSession.sessionId);
+    if (!isMountedRef.current) {
+      return;
+    }
+
+    if (refreshedSession) {
+      setSession(refreshedSession);
+    }
+    setSaveState("saved");
+    setSaveError(null);
+  }, [ensureSessionRecord]);
+
+  const markStatus = useCallback(async (
+    status: LocalCaptureStatus,
+    options?: MarkCaptureStatusOptions,
+  ): Promise<string | null> => {
+    const targetSession = await ensureSessionRecord();
     if (!targetSession) {
-      const hasMeaningfulNotes = noteSnapshot.trim().length > 0;
-      const hasCustomerContext = typeof customerId === "string" && customerId.length > 0;
-
-      if (!hasMeaningfulNotes && !hasCustomerContext) {
-        return;
-      }
-
-      targetSession = await createCaptureSession({
-        userId,
-        notes: noteSnapshot,
-        customerId: customerId ?? null,
-      });
-
-      if (!isMountedRef.current) {
-        return;
-      }
-      setSession(targetSession);
+      return null;
     }
 
     await markCaptureStatus(targetSession.sessionId, status, {
@@ -280,7 +362,7 @@ export function useLocalCaptureSession({
 
     const refreshedSession = await getCaptureSession(targetSession.sessionId);
     if (!isMountedRef.current) {
-      return;
+      return targetSession.sessionId;
     }
 
     if (refreshedSession) {
@@ -288,7 +370,13 @@ export function useLocalCaptureSession({
     }
     setSaveState("saved");
     setSaveError(null);
-  }, [customerId, userId]);
+
+    if (status === "synced" && options?.serverQuoteId) {
+      scheduleSyncedAudioCleanup(targetSession.sessionId);
+    }
+
+    return targetSession.sessionId;
+  }, [ensureSessionRecord]);
 
   return {
     notes,
@@ -299,6 +387,8 @@ export function useLocalCaptureSession({
     hydrationError,
     saveState,
     saveError,
+    ensureSession,
+    setClipIds,
     markStatus,
   };
 }

--- a/frontend/src/features/quotes/services/quoteService.ts
+++ b/frontend/src/features/quotes/services/quoteService.ts
@@ -12,6 +12,8 @@ import type {
   QuoteReuseCandidate,
   QuoteUpdateRequest,
 } from "@/features/quotes/types/quote.types";
+import { getAudioClip } from "@/features/quotes/offline/audioRepository";
+import { AudioClipMissingError } from "@/features/quotes/offline/captureTypes";
 import { buildIdempotencyKey } from "@/shared/lib/idempotency";
 import { request, requestWithMetadata } from "@/shared/lib/http";
 
@@ -50,12 +52,20 @@ interface PersistedExtractionPayload extends ExtractionResult {
   quote_id: string;
 }
 
-function buildExtractionFormData(params: { clips?: Blob[]; notes?: string; customerId?: string }): FormData {
+async function buildExtractionFormDataFromIds(params: {
+  clipIds?: string[];
+  notes?: string;
+  customerId?: string;
+}): Promise<FormData> {
   const formData = new FormData();
-  (params.clips ?? []).forEach((clip, index) => {
-    const extension = resolveAudioExtensionFromMimeType(clip.type);
-    formData.append("clips", clip, `clip-${index + 1}.${extension}`);
-  });
+  for (const [index, clipId] of (params.clipIds ?? []).entries()) {
+    const clip = await getAudioClip(clipId);
+    if (!clip) {
+      throw new AudioClipMissingError(clipId);
+    }
+    const extension = resolveAudioExtensionFromMimeType(clip.mimeType);
+    formData.append("clips", clip.blob, `clip-${index + 1}.${extension}`);
+  }
 
   const notes = params.notes?.trim() ?? "";
   if (notes.length > 0) {
@@ -71,9 +81,9 @@ function buildExtractionFormData(params: { clips?: Blob[]; notes?: string; custo
 
 async function submitExtraction(
   path: string,
-  params: { clips?: Blob[]; notes?: string; customerId?: string },
+  params: { clipIds?: string[]; notes?: string; customerId?: string },
 ): Promise<QuoteExtractResponse> {
-  const formData = buildExtractionFormData(params);
+  const formData = await buildExtractionFormDataFromIds(params);
 
   const response = await requestWithMetadata<PersistedExtractionPayload | JobStatusResponse>(path, {
     method: "POST",
@@ -96,7 +106,7 @@ async function submitExtraction(
   };
 }
 
-async function extract(params: { clips?: Blob[]; notes?: string; customerId?: string }): Promise<QuoteExtractResponse> {
+async function extract(params: { clipIds?: string[]; notes?: string; customerId?: string }): Promise<QuoteExtractResponse> {
   return submitExtraction("/api/quotes/extract", params);
 }
 

--- a/frontend/src/features/quotes/tests/CaptureScreen.test.tsx
+++ b/frontend/src/features/quotes/tests/CaptureScreen.test.tsx
@@ -6,7 +6,7 @@ import { useAuth } from "@/features/auth/hooks/useAuth";
 import { CaptureScreen } from "@/features/quotes/components/CaptureScreen";
 import { useQuoteDraft } from "@/features/quotes/hooks/useQuoteDraft";
 import { HOME_ROUTE } from "@/features/quotes/utils/workflowNavigation";
-import { useVoiceCapture, type VoiceClip } from "@/features/quotes/hooks/useVoiceCapture";
+import { MAX_VOICE_CLIPS_PER_CAPTURE, useVoiceCapture, type VoiceClip } from "@/features/quotes/hooks/useVoiceCapture";
 import { quoteService } from "@/features/quotes/services/quoteService";
 import type {
   ExtractionResult,
@@ -15,7 +15,6 @@ import type {
 } from "@/features/quotes/types/quote.types";
 import { jobService } from "@/shared/lib/jobService";
 import {
-  MAX_AUDIO_CLIPS_PER_REQUEST,
   MAX_AUDIO_TOTAL_BYTES,
   NOTE_INPUT_MAX_CHARS,
 } from "@/shared/lib/inputLimits";
@@ -45,6 +44,7 @@ vi.mock("react-router-dom", async () => {
 
 vi.mock("@/features/quotes/hooks/useVoiceCapture", () => ({
   useVoiceCapture: vi.fn(),
+  MAX_VOICE_CLIPS_PER_CAPTURE: 5,
 }));
 
 vi.mock("@/features/quotes/hooks/useQuoteDraft", () => ({
@@ -82,6 +82,13 @@ vi.mock("@/features/quotes/offline/useLocalCaptureSession", async () => {
         hydrationError: null,
         saveState: notes.trim().length > 0 ? "saved" : "idle",
         saveError: null,
+        ensureSession: async () => {
+          if (sessionId === null) {
+            setSessionId("local-session-1");
+          }
+          return "local-session-1";
+        },
+        setClipIds: async () => undefined,
         markStatus: async (
           status: "local_only" | "ready_to_extract" | "submitting" | "extract_failed" | "synced" | "discarded",
           options?: unknown,
@@ -91,6 +98,7 @@ vi.mock("@/features/quotes/offline/useLocalCaptureSession", async () => {
           if (notes.trim().length > 0 && sessionId === null) {
             setSessionId("local-session-1");
           }
+          return "local-session-1";
         },
       };
     }),
@@ -213,9 +221,9 @@ const quoteDetailFixture: QuoteDetail = {
 
 const clipFixture: VoiceClip = {
   id: "clip-1",
-  blob: new Blob(["clip-1"], { type: "audio/webm" }),
-  url: "blob:clip-1",
   durationSeconds: 4,
+  sizeBytes: 6,
+  mimeType: "audio/webm",
 };
 
 function makeJobStatusResponse(
@@ -394,7 +402,7 @@ describe("CaptureScreen", () => {
   });
 
   it("renders recorded clips inside a bounded scroll region", () => {
-    mockVoiceCapture({ clips: [clipFixture, { ...clipFixture, id: "clip-2", url: "blob:clip-2" }] });
+    mockVoiceCapture({ clips: [clipFixture, { ...clipFixture, id: "clip-2" }] });
     renderScreen();
 
     const scrollRegion = screen.getByTestId("recorded-clips-scroll-region");
@@ -412,16 +420,15 @@ describe("CaptureScreen", () => {
   });
 
   it("disables recording when the clip-count limit is reached", () => {
-    const clips = Array.from({ length: MAX_AUDIO_CLIPS_PER_REQUEST }, (_, index) => ({
+    const clips = Array.from({ length: MAX_VOICE_CLIPS_PER_CAPTURE }, (_, index) => ({
       ...clipFixture,
       id: `clip-${index + 1}`,
-      url: `blob:clip-${index + 1}`,
     }));
     mockVoiceCapture({ clips });
     renderScreen();
 
     expect(
-      screen.getByText(`Maximum of ${MAX_AUDIO_CLIPS_PER_REQUEST} clips per request reached.`),
+      screen.getByText("Maximum clips reached."),
     ).toBeInTheDocument();
     const startButton = screen.getByText("mic").closest("button");
     expect(startButton).toBeDisabled();
@@ -562,7 +569,7 @@ describe("CaptureScreen", () => {
 
     await waitFor(() => {
       expect(mockedQuoteService.extract).toHaveBeenCalledWith({
-        clips: [clipFixture.blob],
+        clipIds: [clipFixture.id],
         notes: "  add travel surcharge  ",
         customerId: "cust-1",
       });
@@ -697,7 +704,7 @@ describe("CaptureScreen", () => {
 
     await waitFor(() => {
       expect(mockedQuoteService.extract).toHaveBeenCalledWith({
-        clips: [],
+        clipIds: [],
         notes: "Install sod in backyard",
         customerId: undefined,
       });
@@ -777,13 +784,11 @@ describe("CaptureScreen", () => {
   });
 
   it("derives the total audio limit error from the shared byte ceiling", async () => {
-    const oversizedBlob = new Blob(["clip-1"], { type: "audio/webm" });
-    Object.defineProperty(oversizedBlob, "size", { value: MAX_AUDIO_TOTAL_BYTES + 1 });
     mockVoiceCapture({
       clips: [
         {
           ...clipFixture,
-          blob: oversizedBlob,
+          sizeBytes: MAX_AUDIO_TOTAL_BYTES + 1,
         },
       ],
     });

--- a/frontend/src/features/quotes/tests/quoteService.extract.test.ts
+++ b/frontend/src/features/quotes/tests/quoteService.extract.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+import { AudioClipMissingError } from "@/features/quotes/offline/captureTypes";
+import { getAudioClip } from "@/features/quotes/offline/audioRepository";
 import { quoteService } from "@/features/quotes/services/quoteService";
 import { request, requestWithMetadata } from "@/shared/lib/http";
 
@@ -8,9 +10,13 @@ vi.mock("@/shared/lib/http", () => ({
   requestWithMetadata: vi.fn(),
   requestBlob: vi.fn(),
 }));
+vi.mock("@/features/quotes/offline/audioRepository", () => ({
+  getAudioClip: vi.fn(),
+}));
 
 const mockedRequestWithMetadata = vi.mocked(requestWithMetadata);
 const mockedRequest = vi.mocked(request);
+const mockedGetAudioClip = vi.mocked(getAudioClip);
 
 describe("quoteService.extract", () => {
   const extractionPayload = {
@@ -31,21 +37,42 @@ describe("quoteService.extract", () => {
   afterEach(() => {
     mockedRequestWithMetadata.mockReset();
     mockedRequest.mockReset();
+    mockedGetAudioClip.mockReset();
   });
 
-  it("builds multipart form data with clips and trimmed notes for async extraction", async () => {
+  it("builds multipart form data with clip IDs and trimmed notes for async extraction", async () => {
     mockedRequestWithMetadata.mockResolvedValue({
       status: 202,
       data: {
         id: "job-1",
       },
     });
+    mockedGetAudioClip
+      .mockResolvedValueOnce({
+        clipId: "clip-id-1",
+        sessionId: "session-1",
+        userId: "user-1",
+        blob: new Blob(["clip-a"], { type: "audio/mp4" }),
+        mimeType: "audio/mp4",
+        sizeBytes: 6,
+        durationSeconds: 2,
+        sequenceNumber: 1,
+        createdAt: "2026-04-24T00:00:00.000Z",
+      })
+      .mockResolvedValueOnce({
+        clipId: "clip-id-2",
+        sessionId: "session-1",
+        userId: "user-1",
+        blob: new Blob(["clip-b"], { type: "audio/webm;codecs=opus" }),
+        mimeType: "audio/webm;codecs=opus",
+        sizeBytes: 6,
+        durationSeconds: 3,
+        sequenceNumber: 2,
+        createdAt: "2026-04-24T00:00:01.000Z",
+      });
 
     const result = await quoteService.extract({
-      clips: [
-        new Blob(["clip-a"], { type: "audio/mp4" }),
-        new Blob(["clip-b"], { type: "audio/webm;codecs=opus" }),
-      ],
+      clipIds: ["clip-id-1", "clip-id-2"],
       notes: "  add 10% travel surcharge  ",
       customerId: "cust-1",
     });
@@ -99,9 +126,20 @@ describe("quoteService.extract", () => {
         transcript: "clips only",
       },
     });
+    mockedGetAudioClip.mockResolvedValueOnce({
+      clipId: "clip-id-1",
+      sessionId: "session-1",
+      userId: "user-1",
+      blob: new Blob(["clip-a"], { type: "audio/webm" }),
+      mimeType: "audio/webm",
+      sizeBytes: 6,
+      durationSeconds: 3,
+      sequenceNumber: 1,
+      createdAt: "2026-04-24T00:00:00.000Z",
+    });
 
     await quoteService.extract({
-      clips: [new Blob(["clip-a"], { type: "audio/webm" })],
+      clipIds: ["clip-id-1"],
     });
 
     const [, options] = mockedRequestWithMetadata.mock.calls[0] ?? [];
@@ -110,6 +148,18 @@ describe("quoteService.extract", () => {
     expect((formData.getAll("clips")[0] as File).name).toBe("clip-1.webm");
     expect(formData.get("notes")).toBeNull();
     expect(formData.get("customer_id")).toBeNull();
+  });
+
+  it("throws AudioClipMissingError and skips submit when a clip ID is missing from IndexedDB", async () => {
+    mockedGetAudioClip.mockResolvedValueOnce(null);
+
+    await expect(
+      quoteService.extract({
+        clipIds: ["missing-clip"],
+        notes: "Install sod in backyard",
+      }),
+    ).rejects.toBeInstanceOf(AudioClipMissingError);
+    expect(mockedRequestWithMetadata).not.toHaveBeenCalled();
   });
 
   it("creates manual draft with customer payload when customerId is provided", async () => {

--- a/frontend/src/features/quotes/tests/quoteService.integration.test.ts
+++ b/frontend/src/features/quotes/tests/quoteService.integration.test.ts
@@ -1,6 +1,10 @@
-import { http, HttpResponse } from "msw";
-import { afterEach, describe, expect, it } from "vitest";
+import "fake-indexeddb/auto";
 
+import { http, HttpResponse } from "msw";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { saveAudioClip } from "@/features/quotes/offline/audioRepository";
+import { resetCaptureDbForTests } from "@/features/quotes/offline/captureDb";
 import { quoteService } from "@/features/quotes/services/quoteService";
 import type {
   Quote,
@@ -12,8 +16,13 @@ import { clearCsrfToken, setCsrfToken } from "@/shared/lib/http";
 import { server } from "@/shared/tests/mocks/server";
 
 describe("quoteService integration (MSW)", () => {
-  afterEach(() => {
+  beforeEach(async () => {
+    await resetCaptureDbForTests();
+  });
+
+  afterEach(async () => {
     clearCsrfToken();
+    await resetCaptureDbForTests();
   });
 
   it("convertNotes returns parsed ExtractionResult and sends CSRF header", async () => {
@@ -395,6 +404,26 @@ describe("quoteService integration (MSW)", () => {
     setCsrfToken("integration-csrf-token");
     let capturedCsrfHeader: string | null = null;
     let capturedContentType: string | null = null;
+    await saveAudioClip({
+      clipId: "clip-id-1",
+      sessionId: "session-1",
+      userId: "user-1",
+      blob: new Blob(["clip-1"], { type: "audio/webm" }),
+      mimeType: "audio/webm",
+      sizeBytes: 6,
+      durationSeconds: 2,
+      sequenceNumber: 1,
+    });
+    await saveAudioClip({
+      clipId: "clip-id-2",
+      sessionId: "session-1",
+      userId: "user-1",
+      blob: new Blob(["clip-2"], { type: "audio/mp4" }),
+      mimeType: "audio/mp4",
+      sizeBytes: 6,
+      durationSeconds: 3,
+      sequenceNumber: 2,
+    });
 
     server.use(
       http.post("/api/quotes/extract", async ({ request }) => {
@@ -411,10 +440,7 @@ describe("quoteService integration (MSW)", () => {
     );
 
     const result = await quoteService.extract({
-      clips: [
-        new Blob(["clip-1"], { type: "audio/webm" }),
-        new Blob(["clip-2"], { type: "audio/mp4" }),
-      ],
+      clipIds: ["clip-id-1", "clip-id-2"],
       notes: "  add 10% travel surcharge  ",
       customerId: "cust-9",
     });
@@ -463,6 +489,16 @@ describe("quoteService integration (MSW)", () => {
 
   it("extract omits notes field when clips-only", async () => {
     setCsrfToken("integration-csrf-token");
+    await saveAudioClip({
+      clipId: "clip-id-1",
+      sessionId: "session-1",
+      userId: "user-1",
+      blob: new Blob(["clip-1"], { type: "audio/webm;codecs=opus" }),
+      mimeType: "audio/webm;codecs=opus",
+      sizeBytes: 6,
+      durationSeconds: 2,
+      sequenceNumber: 1,
+    });
 
     server.use(
       http.post("/api/quotes/extract", async ({ request }) => {
@@ -478,7 +514,7 @@ describe("quoteService integration (MSW)", () => {
     );
 
     const result = await quoteService.extract({
-      clips: [new Blob(["clip-1"], { type: "audio/webm;codecs=opus" })],
+      clipIds: ["clip-id-1"],
     });
 
     expect(result).toEqual({

--- a/frontend/src/features/quotes/tests/useVoiceCapture.test.tsx
+++ b/frontend/src/features/quotes/tests/useVoiceCapture.test.tsx
@@ -1,7 +1,24 @@
-import { act, renderHook } from "@testing-library/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { useVoiceCapture } from "@/features/quotes/hooks/useVoiceCapture";
+import {
+  MAX_VOICE_CLIPS_PER_CAPTURE,
+  useVoiceCapture,
+} from "@/features/quotes/hooks/useVoiceCapture";
+import {
+  deleteAudioClip,
+  getTotalAudioBytes,
+  listClipsForSession,
+  saveAudioClip,
+} from "@/features/quotes/offline/audioRepository";
+
+vi.mock("@/features/quotes/offline/audioRepository", () => ({
+  saveAudioClip: vi.fn(),
+  deleteAudioClip: vi.fn(),
+  deleteAllClipsForSession: vi.fn(),
+  getTotalAudioBytes: vi.fn(async () => 0),
+  listClipsForSession: vi.fn(async () => []),
+}));
 
 class FakeMediaRecorder {
   static isTypeSupported = vi.fn(() => true);
@@ -34,15 +51,21 @@ class FakeMediaRecorder {
 }
 
 describe("useVoiceCapture", () => {
-  const createObjectUrlMock = vi.fn(() => "blob:test-clip");
-  const revokeObjectUrlMock = vi.fn();
+  const mockedSaveAudioClip = vi.mocked(saveAudioClip);
+  const mockedDeleteAudioClip = vi.mocked(deleteAudioClip);
+  const mockedGetTotalAudioBytes = vi.mocked(getTotalAudioBytes);
+  const mockedListClipsForSession = vi.mocked(listClipsForSession);
   const stopTrackMock = vi.fn();
   const getUserMediaMock = vi.fn();
 
   beforeEach(() => {
-    vi.useFakeTimers();
-    createObjectUrlMock.mockClear();
-    revokeObjectUrlMock.mockClear();
+    mockedSaveAudioClip.mockReset();
+    mockedDeleteAudioClip.mockReset();
+    mockedGetTotalAudioBytes.mockReset();
+    mockedListClipsForSession.mockReset();
+    mockedDeleteAudioClip.mockResolvedValue(undefined);
+    mockedGetTotalAudioBytes.mockResolvedValue(0);
+    mockedListClipsForSession.mockResolvedValue([]);
     stopTrackMock.mockReset();
     getUserMediaMock.mockResolvedValue({
       getTracks: () => [{ stop: stopTrackMock }],
@@ -61,18 +84,6 @@ describe("useVoiceCapture", () => {
       writable: true,
       value: FakeMediaRecorder,
     });
-
-    Object.defineProperty(URL, "createObjectURL", {
-      configurable: true,
-      writable: true,
-      value: createObjectUrlMock,
-    });
-
-    Object.defineProperty(URL, "revokeObjectURL", {
-      configurable: true,
-      writable: true,
-      value: revokeObjectUrlMock,
-    });
   });
 
   afterEach(() => {
@@ -80,8 +91,8 @@ describe("useVoiceCapture", () => {
     vi.restoreAllMocks();
   });
 
-  it("handles recording lifecycle and accumulates clips", async () => {
-    const { result } = renderHook(() => useVoiceCapture());
+  it("records, persists clip metadata, and keeps blobs out of React state", async () => {
+    const { result } = renderHook(() => useVoiceCapture("session-1", "user-1"));
 
     await act(async () => {
       await result.current.startRecording();
@@ -89,26 +100,30 @@ describe("useVoiceCapture", () => {
 
     expect(result.current.isRecording).toBe(true);
 
-    await act(async () => {
-      vi.advanceTimersByTime(2100);
-    });
-
-    expect(result.current.elapsedSeconds).toBe(2);
-
     act(() => {
       result.current.stopRecording();
     });
 
-    expect(result.current.isRecording).toBe(false);
-    expect(result.current.elapsedSeconds).toBe(0);
-    expect(result.current.clips).toHaveLength(1);
-    expect(result.current.clips[0]?.durationSeconds).toBeGreaterThanOrEqual(1);
-    expect(createObjectUrlMock).toHaveBeenCalledTimes(1);
+    await waitFor(() => {
+      expect(result.current.clips).toHaveLength(1);
+    });
+
+    const storedClip = result.current.clips[0];
+    expect(storedClip).toEqual(
+      expect.objectContaining({
+        id: "clip-0",
+        sequenceNumber: 1,
+        mimeType: expect.stringContaining("audio/"),
+        sizeBytes: expect.any(Number),
+      }),
+    );
+    expect("blob" in storedClip).toBe(false);
+    expect(mockedSaveAudioClip).toHaveBeenCalledTimes(1);
     expect(stopTrackMock).toHaveBeenCalledTimes(1);
   });
 
-  it("removes individual clips and revokes object URLs", async () => {
-    const { result } = renderHook(() => useVoiceCapture());
+  it("removes a clip from state and local storage", async () => {
+    const { result } = renderHook(() => useVoiceCapture("session-1", "user-1"));
 
     await act(async () => {
       await result.current.startRecording();
@@ -117,73 +132,115 @@ describe("useVoiceCapture", () => {
       result.current.stopRecording();
     });
 
-    const clipId = result.current.clips[0]?.id;
-    expect(clipId).toBeDefined();
+    await waitFor(() => {
+      expect(result.current.clips).toHaveLength(1);
+    });
 
+    const clipId = result.current.clips[0]?.id;
     act(() => {
       result.current.removeClip(clipId ?? "");
     });
 
     expect(result.current.clips).toHaveLength(0);
-    expect(revokeObjectUrlMock).toHaveBeenCalledWith("blob:test-clip");
+    await waitFor(() => {
+      expect(mockedDeleteAudioClip).toHaveBeenCalledWith(clipId);
+    });
   });
 
-  it("clears all clips and revokes each URL", async () => {
-    const { result } = renderHook(() => useVoiceCapture());
+  it("hydrates persisted clips when session changes", async () => {
+    mockedListClipsForSession.mockResolvedValueOnce([
+      {
+        clipId: "clip-22",
+        sessionId: "session-22",
+        userId: "user-1",
+        mimeType: "audio/webm",
+        sizeBytes: 1234,
+        durationSeconds: 7,
+        sequenceNumber: 3,
+        createdAt: "2026-04-24T00:00:00.000Z",
+      },
+    ]);
 
-    await act(async () => {
-      await result.current.startRecording();
-    });
-    act(() => {
-      result.current.stopRecording();
-    });
+    const { result } = renderHook(() => useVoiceCapture("session-22", "user-1"));
 
-    await act(async () => {
-      await result.current.startRecording();
+    await waitFor(() => {
+      expect(result.current.clips).toEqual([
+        {
+          id: "clip-22",
+          durationSeconds: 7,
+          sequenceNumber: 3,
+          sizeBytes: 1234,
+          mimeType: "audio/webm",
+        },
+      ]);
     });
-    act(() => {
-      result.current.stopRecording();
-    });
-
-    expect(result.current.clips).toHaveLength(2);
-
-    act(() => {
-      result.current.clearClips();
-    });
-
-    expect(result.current.clips).toHaveLength(0);
-    expect(revokeObjectUrlMock).toHaveBeenCalledTimes(2);
   });
 
-  it("keeps clip sequence numbers stable after deleting earlier clips", async () => {
-    const { result } = renderHook(() => useVoiceCapture());
+  it("enforces max clip count before starting a recording", async () => {
+    mockedListClipsForSession.mockResolvedValueOnce(
+      Array.from({ length: MAX_VOICE_CLIPS_PER_CAPTURE }, (_, index) => ({
+        clipId: `clip-${index}`,
+        sessionId: "session-1",
+        userId: "user-1",
+        mimeType: "audio/webm",
+        sizeBytes: 100,
+        durationSeconds: 3,
+        sequenceNumber: index + 1,
+        createdAt: `2026-04-24T00:00:0${index}.000Z`,
+      })),
+    );
+
+    const { result } = renderHook(() => useVoiceCapture("session-1", "user-1"));
+
+    await waitFor(() => {
+      expect(result.current.clips).toHaveLength(MAX_VOICE_CLIPS_PER_CAPTURE);
+    });
 
     await act(async () => {
       await result.current.startRecording();
     });
-    act(() => {
-      result.current.stopRecording();
-    });
+
+    expect(result.current.error).toBe("Maximum clips reached.");
+    expect(getUserMediaMock).not.toHaveBeenCalled();
+  });
+
+  it("auto-stops recording at the 120-second duration cap", async () => {
+    vi.useFakeTimers();
+    const { result } = renderHook(() => useVoiceCapture("session-1", "user-1"));
 
     await act(async () => {
       await result.current.startRecording();
     });
-    act(() => {
-      result.current.stopRecording();
+
+    await act(async () => {
+      vi.advanceTimersByTime(120_000);
+      await Promise.resolve();
+      await Promise.resolve();
     });
 
-    expect(result.current.clips).toHaveLength(2);
-    expect(result.current.clips[0]?.sequenceNumber).toBe(1);
-    expect(result.current.clips[1]?.sequenceNumber).toBe(2);
-
-    const firstClipId = result.current.clips[0]?.id;
-    expect(firstClipId).toBeDefined();
-
-    act(() => {
-      result.current.removeClip(firstClipId ?? "");
-    });
-
+    expect(result.current.isRecording).toBe(false);
     expect(result.current.clips).toHaveLength(1);
-    expect(result.current.clips[0]?.sequenceNumber).toBe(2);
+    expect(result.current.error).toBe("Clip length limit reached.");
+    vi.useRealTimers();
+  });
+
+  it("shows a storage warning when clip persistence fails", async () => {
+    mockedSaveAudioClip.mockRejectedValueOnce(new Error("quota exceeded"));
+
+    const { result } = renderHook(() => useVoiceCapture("session-1", "user-1"));
+
+    await act(async () => {
+      await result.current.startRecording();
+    });
+    act(() => {
+      result.current.stopRecording();
+    });
+
+    await waitFor(() => {
+      expect(result.current.error).toBe(
+        "Stima could not save this clip. Free up device storage or remove an existing clip, then try again.",
+      );
+    });
+    expect(result.current.clips).toHaveLength(0);
   });
 });


### PR DESCRIPTION
## Summary
- add IndexedDB audio repository and metadata-only clip model
- persist/recover clips through `useVoiceCapture` + local session `clipIds`
- switch extract upload path to clip IDs with typed `AudioClipMissingError`
- cascade delete audio on capture-session delete and schedule synced cleanup
- update capture/quote tests for IDB-backed clip flow

## Verification
- `cd frontend && rtk proxy npx vitest run src/features/quotes/offline/audioRepository.test.ts src/features/quotes/offline/captureRepository.test.ts src/features/quotes/tests/useVoiceCapture.test.tsx src/features/quotes/tests/quoteService.extract.test.ts src/features/quotes/tests/CaptureScreen.test.tsx src/features/quotes/tests/useLocalCaptureSession.test.tsx src/features/quotes/tests/quoteService.integration.test.ts`
- `cd /home/odys/stima && rtk proxy make frontend-verify`

Closes #556