### PR TITLE
Task #557: Migrate local drafts to IndexedDB

### DIFF
--- a/frontend/src/features/auth/hooks/useAuth.ts
+++ b/frontend/src/features/auth/hooks/useAuth.ts
@@ -9,6 +9,7 @@ import {
 } from "react";
 
 import { authService } from "@/features/auth/services/authService";
+import { clearDraftsForUser, deleteStaleLocalDrafts } from "@/features/quotes/offline/draftRepository";
 import type { LoginRequest, RegisterRequest, User } from "@/features/auth/types/auth.types";
 import { LoadingScreen } from "@/shared/components/LoadingScreen";
 import { hydrateCsrfTokenFromCookie } from "@/shared/lib/http";
@@ -32,6 +33,9 @@ export function AuthProvider({ children }: { children: React.ReactNode }): React
   const refreshUser = useCallback(async () => {
     const currentUser = await authService.me();
     setUser(currentUser);
+    void deleteStaleLocalDrafts(currentUser.id, 7).catch((error) => {
+      console.warn("Unable to clean stale local drafts during auth refresh.", error);
+    });
   }, []);
 
   useEffect(() => {
@@ -43,6 +47,9 @@ export function AuthProvider({ children }: { children: React.ReactNode }): React
         const currentUser = await authService.me();
         if (active) {
           setUser(currentUser);
+          void deleteStaleLocalDrafts(currentUser.id, 7).catch((error) => {
+            console.warn("Unable to clean stale local drafts during auth bootstrap.", error);
+          });
         }
       } catch {
         if (active) {
@@ -74,9 +81,15 @@ export function AuthProvider({ children }: { children: React.ReactNode }): React
   }, [refreshUser]);
 
   const logout = useCallback(async () => {
+    const userId = user?.id;
     await authService.logout();
+    if (userId) {
+      await clearDraftsForUser(userId).catch((error) => {
+        console.warn("Unable to clear local drafts during logout.", error);
+      });
+    }
     setUser(null);
-  }, []);
+  }, [user]);
 
   const value = useMemo<AuthContextValue>(
     () => ({

--- a/frontend/src/features/auth/tests/useAuth.test.tsx
+++ b/frontend/src/features/auth/tests/useAuth.test.tsx
@@ -1,8 +1,9 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { AuthProvider, useAuth } from "@/features/auth/hooks/useAuth";
 import { authService } from "@/features/auth/services/authService";
+import { clearDraftsForUser, deleteStaleLocalDrafts } from "@/features/quotes/offline/draftRepository";
 import { hydrateCsrfTokenFromCookie } from "@/shared/lib/http";
 
 vi.mock("@/features/auth/services/authService", () => ({
@@ -12,6 +13,11 @@ vi.mock("@/features/auth/services/authService", () => ({
     logout: vi.fn(),
     me: vi.fn(),
   },
+}));
+
+vi.mock("@/features/quotes/offline/draftRepository", () => ({
+  clearDraftsForUser: vi.fn(),
+  deleteStaleLocalDrafts: vi.fn(),
 }));
 
 vi.mock("@/shared/lib/http", async () => {
@@ -25,6 +31,8 @@ vi.mock("@/shared/lib/http", async () => {
 
 const mockedAuthService = vi.mocked(authService);
 const mockedHydrateCsrf = vi.mocked(hydrateCsrfTokenFromCookie);
+const mockedClearDraftsForUser = vi.mocked(clearDraftsForUser);
+const mockedDeleteStaleLocalDrafts = vi.mocked(deleteStaleLocalDrafts);
 
 function AuthHarness(): React.ReactElement {
   const { user, register, logout } = useAuth();
@@ -50,12 +58,17 @@ function AuthHarness(): React.ReactElement {
   );
 }
 
+beforeEach(() => {
+  mockedClearDraftsForUser.mockResolvedValue(undefined);
+  mockedDeleteStaleLocalDrafts.mockResolvedValue(undefined);
+});
+
 afterEach(() => {
   vi.clearAllMocks();
 });
 
 describe("useAuth", () => {
-  it("hydrates CSRF on bootstrap and loads user when session exists", async () => {
+  it("hydrates CSRF on bootstrap, loads user, and prunes stale drafts", async () => {
     mockedAuthService.me.mockResolvedValueOnce({
       id: "user-1",
       email: "user@example.com",
@@ -72,9 +85,10 @@ describe("useAuth", () => {
 
     expect(await screen.findByText("user@example.com")).toBeInTheDocument();
     expect(mockedHydrateCsrf).toHaveBeenCalledTimes(1);
+    expect(mockedDeleteStaleLocalDrafts).toHaveBeenCalledWith("user-1", 7);
   });
 
-  it("registers, logs in, and then logs out", async () => {
+  it("registers, logs in, prunes stale drafts, and clears drafts on logout", async () => {
     mockedAuthService.me.mockRejectedValueOnce(new Error("Not authenticated"));
     mockedAuthService.register.mockResolvedValueOnce();
     mockedAuthService.login.mockResolvedValueOnce();
@@ -109,11 +123,13 @@ describe("useAuth", () => {
     expect(mockedAuthService.register.mock.invocationCallOrder[0]).toBeLessThan(
       mockedAuthService.login.mock.invocationCallOrder[0],
     );
+    expect(mockedDeleteStaleLocalDrafts).toHaveBeenCalledWith("user-2", 7);
 
     fireEvent.click(screen.getByRole("button", { name: "Logout" }));
 
     await waitFor(() => {
       expect(mockedAuthService.logout).toHaveBeenCalledTimes(1);
+      expect(mockedClearDraftsForUser).toHaveBeenCalledWith("user-2");
       expect(screen.getByTestId("auth-state")).toHaveTextContent("none");
     });
   });

--- a/frontend/src/features/quotes/components/CaptureScreen.tsx
+++ b/frontend/src/features/quotes/components/CaptureScreen.tsx
@@ -31,7 +31,7 @@ export function CaptureScreen(): React.ReactElement {
   const { user } = useAuth();
   const location = useLocation();
   const { customerId } = useParams<{ customerId?: string }>();
-  const { setDraft } = useQuoteDraft();
+  const { setDraft } = useQuoteDraft(user?.id);
   const isMountedRef = useRef(true);
   const extractionStageTimerRefs = useRef<number[]>([]);
   const searchParams = useMemo(() => new URLSearchParams(location.search), [location.search]);

--- a/frontend/src/features/quotes/components/ReviewScreen.tsx
+++ b/frontend/src/features/quotes/components/ReviewScreen.tsx
@@ -3,6 +3,7 @@ import { useBeforeUnload, useLocation, useNavigate, useParams } from "react-rout
 
 import { lineItemCatalogService } from "@/features/line-item-catalog/services/lineItemCatalogService";
 import { profileService } from "@/features/profile/services/profileService";
+import { useAuth } from "@/features/auth/hooks/useAuth";
 import { DocumentEditScreenView } from "@/features/quotes/components/DocumentEditScreenView";
 import { buildDefaultInvoiceDueDate, buildDocumentSnapshotKey, buildSaveValidationMessage, isInvoiceDocument, persistDocumentDraft } from "@/features/quotes/components/documentEditUtils";
 import { useHiddenDetailLifecycle } from "@/features/quotes/hooks/useHiddenDetailLifecycle";
@@ -19,6 +20,7 @@ import { useToast } from "@/ui/Toast";
 export function DocumentEditScreen(): React.ReactElement {
   const navigate = useNavigate();
   const { show } = useToast();
+  const { user } = useAuth();
   const location = useLocation();
   const { id } = useParams<{ id: string }>();
   const {
@@ -29,7 +31,7 @@ export function DocumentEditScreen(): React.ReactElement {
     isLoadingDocument,
     loadError,
     refreshDocument,
-  } = usePersistedReview(id);
+  } = usePersistedReview(id, user?.id);
 
   const [saveError, setSaveError] = useState<string | null>(null);
   const [toastMessage, setToastMessage] = useState<string | null>(null);

--- a/frontend/src/features/quotes/hooks/persistedDocumentDraft.ts
+++ b/frontend/src/features/quotes/hooks/persistedDocumentDraft.ts
@@ -1,5 +1,11 @@
 import type { InvoiceDetail } from "@/features/invoices/types/invoice.types";
 import type { LineItemDraftWithFlags, QuoteDetail } from "@/features/quotes/types/quote.types";
+import {
+  buildDocumentDraftKey,
+  deleteLocalDraft,
+  getLocalDraft,
+  saveLocalDraft,
+} from "@/features/quotes/offline/draftRepository";
 import { resolveLineItemAuthoritativeSubtotal } from "@/features/quotes/utils/lineItemDraftTotals";
 import { calculatePricingFromPersisted, type DiscountType, type PricingFields } from "@/shared/lib/pricing";
 
@@ -50,109 +56,152 @@ function isValidLineItemDraft(value: unknown): value is LineItemDraftWithFlags {
   );
 }
 
+function parseDraftFromValue(value: unknown): DocumentEditDraft | null {
+  if (!isObject(value)) {
+    return null;
+  }
+
+  const {
+    documentId,
+    docType,
+    title,
+    transcript,
+    lineItems,
+    total,
+    taxRate,
+    discountType,
+    discountValue,
+    depositAmount,
+    notes,
+    dueDate,
+  } = value;
+
+  if (
+    typeof documentId !== "string"
+    || (docType !== "quote" && docType !== "invoice")
+    || typeof title !== "string"
+    || typeof transcript !== "string"
+    || !Array.isArray(lineItems)
+    || typeof notes !== "string"
+    || typeof dueDate !== "string"
+  ) {
+    return null;
+  }
+
+  if (total !== null && typeof total !== "number") {
+    return null;
+  }
+  if (taxRate !== undefined && taxRate !== null && typeof taxRate !== "number") {
+    return null;
+  }
+  if (
+    discountType !== undefined
+    && discountType !== null
+    && discountType !== "fixed"
+    && discountType !== "percent"
+  ) {
+    return null;
+  }
+  if (discountValue !== undefined && discountValue !== null && typeof discountValue !== "number") {
+    return null;
+  }
+  if (depositAmount !== undefined && depositAmount !== null && typeof depositAmount !== "number") {
+    return null;
+  }
+  if (!lineItems.every(isValidLineItemDraft)) {
+    return null;
+  }
+
+  return {
+    documentId,
+    docType,
+    title,
+    transcript,
+    lineItems,
+    total,
+    taxRate: typeof taxRate === "number" ? taxRate : null,
+    discountType: discountType === "fixed" || discountType === "percent" ? discountType : null,
+    discountValue: typeof discountValue === "number" ? discountValue : null,
+    depositAmount: typeof depositAmount === "number" ? depositAmount : null,
+    notes,
+    dueDate,
+  };
+}
+
 function parseStoredDraft(raw: string | null): DocumentEditDraft | null {
   if (!raw) {
     return null;
   }
 
   try {
-    const parsed = JSON.parse(raw) as unknown;
-    if (!isObject(parsed)) {
-      return null;
-    }
-
-    const {
-      documentId,
-      docType,
-      title,
-      transcript,
-      lineItems,
-      total,
-      taxRate,
-      discountType,
-      discountValue,
-      depositAmount,
-      notes,
-      dueDate,
-    } = parsed;
-
-    if (
-      typeof documentId !== "string"
-      || (docType !== "quote" && docType !== "invoice")
-      || typeof title !== "string"
-      || typeof transcript !== "string"
-      || !Array.isArray(lineItems)
-      || typeof notes !== "string"
-      || typeof dueDate !== "string"
-    ) {
-      return null;
-    }
-
-    if (total !== null && typeof total !== "number") {
-      return null;
-    }
-    if (taxRate !== undefined && taxRate !== null && typeof taxRate !== "number") {
-      return null;
-    }
-    if (
-      discountType !== undefined
-      && discountType !== null
-      && discountType !== "fixed"
-      && discountType !== "percent"
-    ) {
-      return null;
-    }
-    if (discountValue !== undefined && discountValue !== null && typeof discountValue !== "number") {
-      return null;
-    }
-    if (depositAmount !== undefined && depositAmount !== null && typeof depositAmount !== "number") {
-      return null;
-    }
-    if (!lineItems.every(isValidLineItemDraft)) {
-      return null;
-    }
-
-    return {
-      documentId,
-      docType,
-      title,
-      transcript,
-      lineItems,
-      total,
-      taxRate: typeof taxRate === "number" ? taxRate : null,
-      discountType: discountType === "fixed" || discountType === "percent" ? discountType : null,
-      discountValue: typeof discountValue === "number" ? discountValue : null,
-      depositAmount: typeof depositAmount === "number" ? depositAmount : null,
-      notes,
-      dueDate,
-    };
+    return parseDraftFromValue(JSON.parse(raw) as unknown);
   } catch {
     return null;
   }
 }
 
-export function readDocumentDraftFromStorage(): DocumentEditDraft | null {
+async function migrateSessionStorageDraftIfPresent(userId: string): Promise<DocumentEditDraft | null> {
   if (typeof window === "undefined") {
     return null;
   }
 
-  return parseStoredDraft(window.sessionStorage.getItem(EDIT_STORAGE_KEY));
-}
-
-export function persistDocumentDraftToStorage(draft: DocumentEditDraft): void {
-  if (typeof window === "undefined") {
-    return;
+  const rawDraft = window.sessionStorage.getItem(EDIT_STORAGE_KEY);
+  if (!rawDraft) {
+    return null;
   }
 
-  window.sessionStorage.setItem(EDIT_STORAGE_KEY, JSON.stringify(draft));
-}
-
-export function clearDocumentDraftFromStorage(): void {
-  if (typeof window === "undefined") {
-    return;
+  const parsedDraft = parseStoredDraft(rawDraft);
+  if (parsedDraft) {
+    await persistDocumentDraftToIDB(parsedDraft, userId);
+  } else {
+    console.warn("Discarded malformed document edit draft from sessionStorage migration.");
   }
 
   window.sessionStorage.removeItem(EDIT_STORAGE_KEY);
+  return parsedDraft;
+}
+
+export async function readDocumentDraftFromIDB(
+  documentId: string,
+  docType: ReviewDocumentType,
+  userId: string,
+): Promise<DocumentEditDraft | null> {
+  const draftKey = buildDocumentDraftKey(documentId, docType);
+  const persistedRecord = await getLocalDraft<unknown>(draftKey, userId);
+  if (persistedRecord) {
+    const parsedDraft = parseDraftFromValue(persistedRecord.payload);
+    if (!parsedDraft) {
+      console.warn("Discarded malformed document edit draft from IndexedDB.");
+      return null;
+    }
+    return parsedDraft;
+  }
+
+  const migratedDraft = await migrateSessionStorageDraftIfPresent(userId);
+  if (!migratedDraft) {
+    return null;
+  }
+  if (migratedDraft.documentId === documentId && migratedDraft.docType === docType) {
+    return migratedDraft;
+  }
+  return null;
+}
+
+export async function persistDocumentDraftToIDB(draft: DocumentEditDraft, userId: string): Promise<void> {
+  await saveLocalDraft({
+    draftKey: buildDocumentDraftKey(draft.documentId, draft.docType),
+    userId,
+    docType: draft.docType,
+    documentId: draft.documentId,
+    payload: draft,
+  });
+}
+
+export async function clearDocumentDraftFromIDB(
+  documentId: string,
+  docType: ReviewDocumentType,
+): Promise<void> {
+  await deleteLocalDraft(buildDocumentDraftKey(documentId, docType));
 }
 
 function resolvePersistedDraftSubtotal(

--- a/frontend/src/features/quotes/hooks/quoteDraftPersistence.ts
+++ b/frontend/src/features/quotes/hooks/quoteDraftPersistence.ts
@@ -1,0 +1,141 @@
+import type { LineItemDraftWithFlags, QuoteSourceType } from "@/features/quotes/types/quote.types";
+import {
+  buildCaptureHandoffDraftKey,
+  CAPTURE_HANDOFF_DOCUMENT_ID,
+  getLocalDraft,
+  saveLocalDraft,
+} from "@/features/quotes/offline/draftRepository";
+import type { QuoteDraft } from "@/features/quotes/hooks/useQuoteDraft";
+
+const DRAFT_STORAGE_KEY = "stima_quote_draft";
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function parseDraftFromValue(value: unknown): QuoteDraft | null {
+  if (!isObject(value)) {
+    return null;
+  }
+
+  const {
+    customerId,
+    quoteId,
+    launchOrigin,
+    title,
+    transcript,
+    lineItems,
+    total,
+    taxRate,
+    discountType,
+    discountValue,
+    depositAmount,
+    notes,
+    sourceType,
+  } = value;
+
+  if (
+    typeof customerId !== "string" ||
+    (quoteId !== undefined && typeof quoteId !== "string") ||
+    (launchOrigin !== undefined && typeof launchOrigin !== "string") ||
+    (title !== undefined && typeof title !== "string") ||
+    typeof transcript !== "string" ||
+    !Array.isArray(lineItems) ||
+    typeof notes !== "string"
+  ) {
+    return null;
+  }
+
+  if (total !== null && typeof total !== "number") {
+    return null;
+  }
+  if (taxRate !== undefined && taxRate !== null && typeof taxRate !== "number") {
+    return null;
+  }
+  if (
+    discountType !== undefined
+    && discountType !== null
+    && discountType !== "fixed"
+    && discountType !== "percent"
+  ) {
+    return null;
+  }
+  if (discountValue !== undefined && discountValue !== null && typeof discountValue !== "number") {
+    return null;
+  }
+  if (depositAmount !== undefined && depositAmount !== null && typeof depositAmount !== "number") {
+    return null;
+  }
+
+  const parsedSourceType: QuoteSourceType =
+    sourceType === "voice" || sourceType === "text" ? sourceType : "text";
+
+  return {
+    customerId,
+    quoteId: typeof quoteId === "string" ? quoteId : undefined,
+    launchOrigin: typeof launchOrigin === "string" ? launchOrigin : "/",
+    title: typeof title === "string" ? title : "",
+    transcript,
+    lineItems: lineItems as LineItemDraftWithFlags[],
+    total,
+    taxRate: typeof taxRate === "number" ? taxRate : null,
+    discountType: discountType === "fixed" || discountType === "percent" ? discountType : null,
+    discountValue: typeof discountValue === "number" ? discountValue : null,
+    depositAmount: typeof depositAmount === "number" ? depositAmount : null,
+    notes,
+    sourceType: parsedSourceType,
+  };
+}
+
+function parseStoredDraft(raw: string | null): QuoteDraft | null {
+  if (!raw) {
+    return null;
+  }
+
+  try {
+    return parseDraftFromValue(JSON.parse(raw) as unknown);
+  } catch {
+    return null;
+  }
+}
+
+async function migrateSessionStorageDraftIfPresent(userId: string): Promise<QuoteDraft | null> {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  const rawDraft = window.sessionStorage.getItem(DRAFT_STORAGE_KEY);
+  if (!rawDraft) {
+    return null;
+  }
+
+  const parsedDraft = parseStoredDraft(rawDraft);
+  if (parsedDraft) {
+    await saveLocalDraft({
+      draftKey: buildCaptureHandoffDraftKey(userId),
+      userId,
+      docType: "capture_handoff",
+      documentId: CAPTURE_HANDOFF_DOCUMENT_ID,
+      payload: parsedDraft,
+    });
+  } else {
+    console.warn("Discarded malformed quote draft from sessionStorage migration.");
+  }
+
+  window.sessionStorage.removeItem(DRAFT_STORAGE_KEY);
+  return parsedDraft;
+}
+
+export async function readQuoteDraftFromIDB(userId: string): Promise<QuoteDraft | null> {
+  const persistedRecord = await getLocalDraft<unknown>(buildCaptureHandoffDraftKey(userId), userId);
+  if (persistedRecord) {
+    const parsedDraft = parseDraftFromValue(persistedRecord.payload);
+    if (!parsedDraft) {
+      console.warn("Discarded malformed quote draft from IndexedDB.");
+      return null;
+    }
+    return parsedDraft;
+  }
+
+  return migrateSessionStorageDraftIfPresent(userId);
+}

--- a/frontend/src/features/quotes/hooks/usePersistedReview.ts
+++ b/frontend/src/features/quotes/hooks/usePersistedReview.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import { invoiceService } from "@/features/invoices/services/invoiceService";
 import { isInvoiceEditableStatus } from "@/features/invoices/utils/invoiceStatus";
@@ -22,6 +22,8 @@ export {
   type DocumentEditDraft,
   type PersistedEditableDocument,
 };
+
+const DOCUMENT_DRAFT_PERSIST_DEBOUNCE_MS = 250;
 
 async function fetchEditableDocument(documentId: string): Promise<PersistedEditableDocument> {
   try {
@@ -66,6 +68,39 @@ export function usePersistedReview(
   const [isLoadingDocumentState, setIsLoadingDocumentState] = useState(true);
   const [isLoadingDraft, setIsLoadingDraft] = useState(true);
   const [loadError, setLoadError] = useState<string | null>(null);
+  const persistTimerRef = useRef<number | null>(null);
+
+  const scheduleDraftPersist = useCallback((nextDraft: DocumentEditDraft) => {
+    if (!userId || typeof window === "undefined") {
+      return;
+    }
+
+    if (persistTimerRef.current !== null) {
+      window.clearTimeout(persistTimerRef.current);
+    }
+
+    persistTimerRef.current = window.setTimeout(() => {
+      persistTimerRef.current = null;
+      void persistDocumentDraftToIDB(nextDraft, userId).catch((error) => {
+        console.warn("Unable to persist document edit draft locally.", error);
+      });
+    }, DOCUMENT_DRAFT_PERSIST_DEBOUNCE_MS);
+  }, [userId]);
+
+  useEffect(() => {
+    return () => {
+      if (persistTimerRef.current !== null && typeof window !== "undefined") {
+        window.clearTimeout(persistTimerRef.current);
+      }
+    };
+  }, []);
+
+  useEffect(() => {
+    if (persistTimerRef.current !== null && typeof window !== "undefined") {
+      window.clearTimeout(persistTimerRef.current);
+      persistTimerRef.current = null;
+    }
+  }, [userId]);
 
   const setDraft = useCallback((
     nextDraft: DocumentEditDraft | ((current: DocumentEditDraft) => DocumentEditDraft),
@@ -80,14 +115,10 @@ export function usePersistedReview(
         return currentDraft;
       }
 
-      if (userId) {
-        void persistDocumentDraftToIDB(resolvedDraft, userId).catch((error) => {
-          console.warn("Unable to persist document edit draft locally.", error);
-        });
-      }
+      scheduleDraftPersist(resolvedDraft);
       return resolvedDraft;
     });
-  }, [userId]);
+  }, [scheduleDraftPersist]);
 
   const clearDraft = useCallback(() => {
     setDraftState((currentDraft) => {

--- a/frontend/src/features/quotes/hooks/usePersistedReview.ts
+++ b/frontend/src/features/quotes/hooks/usePersistedReview.ts
@@ -6,12 +6,12 @@ import { quoteService } from "@/features/quotes/services/quoteService";
 import { isQuoteEditableStatus } from "@/features/quotes/utils/quoteStatus";
 import { isHttpRequestError } from "@/shared/lib/http";
 import {
-  clearDocumentDraftFromStorage,
+  clearDocumentDraftFromIDB,
   mapDocumentToEditDraft,
   mapInvoiceToEditDraft,
   mapQuoteToEditDraft,
-  persistDocumentDraftToStorage,
-  readDocumentDraftFromStorage,
+  persistDocumentDraftToIDB,
+  readDocumentDraftFromIDB,
   type DocumentEditDraft,
   type PersistedEditableDocument,
 } from "@/features/quotes/hooks/persistedDocumentDraft";
@@ -57,10 +57,14 @@ interface UsePersistedReviewResult {
   refreshDocument: (options?: { reseedDraft?: boolean }) => Promise<PersistedEditableDocument>;
 }
 
-export function usePersistedReview(documentId: string | undefined): UsePersistedReviewResult {
-  const [draft, setDraftState] = useState<DocumentEditDraft | null>(() => readDocumentDraftFromStorage());
+export function usePersistedReview(
+  documentId: string | undefined,
+  userId: string | undefined,
+): UsePersistedReviewResult {
+  const [draft, setDraftState] = useState<DocumentEditDraft | null>(null);
   const [document, setDocument] = useState<PersistedEditableDocument | null>(null);
-  const [isLoadingDocument, setIsLoadingDocument] = useState(true);
+  const [isLoadingDocumentState, setIsLoadingDocumentState] = useState(true);
+  const [isLoadingDraft, setIsLoadingDraft] = useState(true);
   const [loadError, setLoadError] = useState<string | null>(null);
 
   const setDraft = useCallback((
@@ -76,14 +80,24 @@ export function usePersistedReview(documentId: string | undefined): UsePersisted
         return currentDraft;
       }
 
-      persistDocumentDraftToStorage(resolvedDraft);
+      if (userId) {
+        void persistDocumentDraftToIDB(resolvedDraft, userId).catch((error) => {
+          console.warn("Unable to persist document edit draft locally.", error);
+        });
+      }
       return resolvedDraft;
     });
-  }, []);
+  }, [userId]);
 
   const clearDraft = useCallback(() => {
-    clearDocumentDraftFromStorage();
-    setDraftState(null);
+    setDraftState((currentDraft) => {
+      if (currentDraft) {
+        void clearDocumentDraftFromIDB(currentDraft.documentId, currentDraft.docType).catch((error) => {
+          console.warn("Unable to clear document edit draft.", error);
+        });
+      }
+      return null;
+    });
   }, []);
 
   const refreshDocument = useCallback(async (
@@ -107,11 +121,14 @@ export function usePersistedReview(documentId: string | undefined): UsePersisted
     async function fetchDocument(): Promise<void> {
       if (!documentId) {
         setLoadError("Missing document id.");
-        setIsLoadingDocument(false);
+        setDraftState(null);
+        setIsLoadingDraft(false);
+        setIsLoadingDocumentState(false);
         return;
       }
 
-      setIsLoadingDocument(true);
+      setIsLoadingDocumentState(true);
+      setIsLoadingDraft(true);
       setLoadError(null);
 
       try {
@@ -121,6 +138,18 @@ export function usePersistedReview(documentId: string | undefined): UsePersisted
         }
 
         setDocument(fetchedDocument);
+        if (!userId) {
+          setDraftState(mapDocumentToEditDraft(fetchedDocument));
+          return;
+        }
+
+        const docType = "customer" in fetchedDocument ? "invoice" : "quote";
+        const hydratedDraft = await readDocumentDraftFromIDB(fetchedDocument.id, docType, userId);
+        if (!isActive) {
+          return;
+        }
+
+        setDraftState(hydratedDraft ?? mapDocumentToEditDraft(fetchedDocument));
       } catch (error) {
         if (!isActive) {
           return;
@@ -130,7 +159,8 @@ export function usePersistedReview(documentId: string | undefined): UsePersisted
         setLoadError(message);
       } finally {
         if (isActive) {
-          setIsLoadingDocument(false);
+          setIsLoadingDocumentState(false);
+          setIsLoadingDraft(false);
         }
       }
     }
@@ -140,19 +170,10 @@ export function usePersistedReview(documentId: string | undefined): UsePersisted
     return () => {
       isActive = false;
     };
-  }, [documentId]);
-
-  useEffect(() => {
-    if (!document) {
-      return;
-    }
-
-    if (!draft || draft.documentId !== document.id) {
-      setDraft(mapDocumentToEditDraft(document));
-    }
-  }, [document, draft, setDraft]);
+  }, [documentId, userId]);
 
   const currentDraft = draft && document && draft.documentId === document.id ? draft : null;
+  const isLoadingDocument = isLoadingDocumentState || isLoadingDraft;
 
   return {
     document,

--- a/frontend/src/features/quotes/hooks/useQuoteDraft.ts
+++ b/frontend/src/features/quotes/hooks/useQuoteDraft.ts
@@ -84,6 +84,13 @@ export function useQuoteDraft(userId: string | undefined): UseQuoteDraftResult {
   }, []);
 
   useEffect(() => {
+    if (persistTimerRef.current !== null && typeof window !== "undefined") {
+      window.clearTimeout(persistTimerRef.current);
+      persistTimerRef.current = null;
+    }
+  }, [userId]);
+
+  useEffect(() => {
     let isActive = true;
 
     void Promise.resolve()
@@ -185,7 +192,7 @@ export function useQuoteDraft(userId: string | undefined): UseQuoteDraftResult {
     });
   }, [scheduleDraftPersist]);
 
-  const scopedDraft = userId ? draft : null;
+  const scopedDraft = userId && hydratedUserId === userId ? draft : null;
 
   return {
     draft: scopedDraft,

--- a/frontend/src/features/quotes/hooks/useQuoteDraft.ts
+++ b/frontend/src/features/quotes/hooks/useQuoteDraft.ts
@@ -1,9 +1,16 @@
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import type { LineItemDraftWithFlags, QuoteSourceType } from "@/features/quotes/types/quote.types";
+import {
+  buildCaptureHandoffDraftKey,
+  CAPTURE_HANDOFF_DOCUMENT_ID,
+  deleteLocalDraft,
+  saveLocalDraft,
+} from "@/features/quotes/offline/draftRepository";
+import { readQuoteDraftFromIDB } from "@/features/quotes/hooks/quoteDraftPersistence";
 import type { DiscountType } from "@/shared/lib/pricing";
 
-const DRAFT_STORAGE_KEY = "stima_quote_draft";
+const DRAFT_PERSIST_DEBOUNCE_MS = 200;
 
 export interface QuoteDraft {
   quoteId?: string;
@@ -25,125 +32,97 @@ type QuoteDraftUpdater = QuoteDraft | ((current: QuoteDraft) => QuoteDraft);
 
 interface UseQuoteDraftResult {
   draft: QuoteDraft | null;
+  isLoading: boolean;
   setDraft: (nextDraft: QuoteDraftUpdater) => void;
   updateLineItem: (index: number, item: LineItemDraftWithFlags) => void;
   removeLineItem: (index: number) => void;
   clearDraft: () => void;
 }
 
-function isObject(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null;
-}
+export function useQuoteDraft(userId: string | undefined): UseQuoteDraftResult {
+  const [draft, setDraftState] = useState<QuoteDraft | null>(null);
+  const [hydratedUserId, setHydratedUserId] = useState<string | null>(null);
+  const persistTimerRef = useRef<number | null>(null);
 
-function parseStoredDraft(raw: string | null): QuoteDraft | null {
-  if (!raw) {
-    return null;
-  }
-
-  try {
-    const parsed = JSON.parse(raw) as unknown;
-    if (!isObject(parsed)) {
-      return null;
+  const persistDraft = useCallback((nextDraft: QuoteDraft) => {
+    if (!userId) {
+      return;
     }
 
-    const {
-      customerId,
-      quoteId,
-      launchOrigin,
-      title,
-      transcript,
-      lineItems,
-      total,
-      taxRate,
-      discountType,
-      discountValue,
-      depositAmount,
-      notes,
-      sourceType,
-    } = parsed;
+    void saveLocalDraft({
+      draftKey: buildCaptureHandoffDraftKey(userId),
+      userId,
+      docType: "capture_handoff",
+      documentId: CAPTURE_HANDOFF_DOCUMENT_ID,
+      payload: nextDraft,
+    }).catch((error) => {
+      console.warn("Unable to persist quote draft locally.", error);
+    });
+  }, [userId]);
 
-    if (
-      typeof customerId !== "string" ||
-      (quoteId !== undefined && typeof quoteId !== "string") ||
-      (launchOrigin !== undefined && typeof launchOrigin !== "string") ||
-      (title !== undefined && typeof title !== "string") ||
-      typeof transcript !== "string" ||
-      !Array.isArray(lineItems) ||
-      typeof notes !== "string"
-    ) {
-      return null;
+  const scheduleDraftPersist = useCallback((nextDraft: QuoteDraft) => {
+    if (!userId || typeof window === "undefined") {
+      return;
     }
 
-    if (total !== null && typeof total !== "number") {
-      return null;
-    }
-    if (taxRate !== undefined && taxRate !== null && typeof taxRate !== "number") {
-      return null;
-    }
-    if (
-      discountType !== undefined
-      && discountType !== null
-      && discountType !== "fixed"
-      && discountType !== "percent"
-    ) {
-      return null;
-    }
-    if (discountValue !== undefined && discountValue !== null && typeof discountValue !== "number") {
-      return null;
-    }
-    if (depositAmount !== undefined && depositAmount !== null && typeof depositAmount !== "number") {
-      return null;
+    if (persistTimerRef.current !== null) {
+      window.clearTimeout(persistTimerRef.current);
     }
 
-    const parsedSourceType: QuoteSourceType =
-      sourceType === "voice" || sourceType === "text" ? sourceType : "text";
+    persistTimerRef.current = window.setTimeout(() => {
+      persistTimerRef.current = null;
+      persistDraft(nextDraft);
+    }, DRAFT_PERSIST_DEBOUNCE_MS);
+  }, [persistDraft, userId]);
 
-    return {
-      customerId,
-      quoteId: typeof quoteId === "string" ? quoteId : undefined,
-      launchOrigin: typeof launchOrigin === "string" ? launchOrigin : "/",
-      title: typeof title === "string" ? title : "",
-      transcript,
-      lineItems: lineItems as LineItemDraftWithFlags[],
-      total,
-      taxRate: typeof taxRate === "number" ? taxRate : null,
-      discountType: discountType === "fixed" || discountType === "percent" ? discountType : null,
-      discountValue: typeof discountValue === "number" ? discountValue : null,
-      depositAmount: typeof depositAmount === "number" ? depositAmount : null,
-      notes,
-      sourceType: parsedSourceType,
+  useEffect(() => {
+    return () => {
+      if (persistTimerRef.current !== null && typeof window !== "undefined") {
+        window.clearTimeout(persistTimerRef.current);
+      }
     };
-  } catch {
-    return null;
-  }
-}
+  }, []);
 
-function readDraftFromStorage(): QuoteDraft | null {
-  if (typeof window === "undefined") {
-    return null;
-  }
+  useEffect(() => {
+    let isActive = true;
 
-  return parseStoredDraft(window.sessionStorage.getItem(DRAFT_STORAGE_KEY));
-}
+    void Promise.resolve()
+      .then(async () => {
+        if (!userId) {
+          return {
+            nextDraft: null as QuoteDraft | null,
+            nextHydratedUserId: null as string | null,
+          };
+        }
 
-function persistDraftToStorage(draft: QuoteDraft): void {
-  if (typeof window === "undefined") {
-    return;
-  }
+        try {
+          const persistedDraft = await readQuoteDraftFromIDB(userId);
+          return {
+            nextDraft: persistedDraft,
+            nextHydratedUserId: userId,
+          };
+        } catch (error) {
+          console.warn("Unable to hydrate quote draft from local storage.", error);
+          return {
+            nextDraft: null as QuoteDraft | null,
+            nextHydratedUserId: userId,
+          };
+        }
+      })
+      .then(({ nextDraft, nextHydratedUserId }) => {
+        if (!isActive) {
+          return;
+        }
+        setDraftState(nextDraft);
+        setHydratedUserId(nextHydratedUserId);
+      });
 
-  window.sessionStorage.setItem(DRAFT_STORAGE_KEY, JSON.stringify(draft));
-}
+    return () => {
+      isActive = false;
+    };
+  }, [userId]);
 
-function removeDraftFromStorage(): void {
-  if (typeof window === "undefined") {
-    return;
-  }
-
-  window.sessionStorage.removeItem(DRAFT_STORAGE_KEY);
-}
-
-export function useQuoteDraft(): UseQuoteDraftResult {
-  const [draft, setDraftState] = useState<QuoteDraft | null>(() => readDraftFromStorage());
+  const isLoading = typeof userId === "string" && hydratedUserId !== userId;
 
   const setDraft = useCallback((nextDraft: QuoteDraftUpdater) => {
     setDraftState((currentDraft) => {
@@ -156,15 +135,23 @@ export function useQuoteDraft(): UseQuoteDraftResult {
         return currentDraft;
       }
 
-      persistDraftToStorage(resolvedDraft);
+      scheduleDraftPersist(resolvedDraft);
       return resolvedDraft;
     });
-  }, []);
+  }, [scheduleDraftPersist]);
 
   const clearDraft = useCallback(() => {
-    removeDraftFromStorage();
+    if (persistTimerRef.current !== null && typeof window !== "undefined") {
+      window.clearTimeout(persistTimerRef.current);
+      persistTimerRef.current = null;
+    }
+    if (userId) {
+      void deleteLocalDraft(buildCaptureHandoffDraftKey(userId)).catch((error) => {
+        console.warn("Unable to clear quote draft.", error);
+      });
+    }
     setDraftState(null);
-  }, []);
+  }, [userId]);
 
   const updateLineItem = useCallback((index: number, item: LineItemDraftWithFlags) => {
     setDraftState((currentDraft) => {
@@ -178,10 +165,10 @@ export function useQuoteDraft(): UseQuoteDraftResult {
           currentIndex === index ? item : existingItem,
         ),
       };
-      persistDraftToStorage(nextDraft);
+      scheduleDraftPersist(nextDraft);
       return nextDraft;
     });
-  }, []);
+  }, [scheduleDraftPersist]);
 
   const removeLineItem = useCallback((index: number) => {
     setDraftState((currentDraft) => {
@@ -193,13 +180,16 @@ export function useQuoteDraft(): UseQuoteDraftResult {
         ...currentDraft,
         lineItems: currentDraft.lineItems.filter((_, currentIndex) => currentIndex !== index),
       };
-      persistDraftToStorage(nextDraft);
+      scheduleDraftPersist(nextDraft);
       return nextDraft;
     });
-  }, []);
+  }, [scheduleDraftPersist]);
+
+  const scopedDraft = userId ? draft : null;
 
   return {
-    draft,
+    draft: scopedDraft,
+    isLoading,
     setDraft,
     updateLineItem,
     removeLineItem,

--- a/frontend/src/features/quotes/offline/draftRepository.test.ts
+++ b/frontend/src/features/quotes/offline/draftRepository.test.ts
@@ -1,0 +1,198 @@
+import "fake-indexeddb/auto";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { CAPTURE_STORE_NAMES, getDb, resetCaptureDbForTests } from "@/features/quotes/offline/captureDb";
+import {
+  buildDocumentDraftKey,
+  clearDraftsForUser,
+  deleteLocalDraft,
+  deleteStaleLocalDrafts,
+  getLocalDraft,
+  listDraftsForUser,
+  saveLocalDraft,
+  type LocalDraft,
+} from "@/features/quotes/offline/draftRepository";
+
+describe("draftRepository", () => {
+  beforeEach(async () => {
+    await resetCaptureDbForTests();
+  });
+
+  afterEach(async () => {
+    await resetCaptureDbForTests();
+  });
+
+  it("saves and loads drafts by key + user", async () => {
+    await saveLocalDraft({
+      draftKey: buildDocumentDraftKey("doc-1", "quote"),
+      userId: "user-a",
+      docType: "quote",
+      documentId: "doc-1",
+      payload: { title: "Quote Draft" },
+    });
+
+    await expect(getLocalDraft(buildDocumentDraftKey("doc-1", "quote"), "user-a")).resolves.toEqual(
+      expect.objectContaining({
+        draftKey: "doc-1:quote",
+        userId: "user-a",
+        docType: "quote",
+        documentId: "doc-1",
+        payload: { title: "Quote Draft" },
+      }),
+    );
+  });
+
+  it("returns null for unknown keys and wrong users", async () => {
+    await saveLocalDraft({
+      draftKey: buildDocumentDraftKey("doc-1", "invoice"),
+      userId: "user-a",
+      docType: "invoice",
+      documentId: "doc-1",
+      payload: { title: "Invoice Draft" },
+    });
+
+    await expect(getLocalDraft("missing-key", "user-a")).resolves.toBeNull();
+    await expect(getLocalDraft(buildDocumentDraftKey("doc-1", "invoice"), "user-b")).resolves.toBeNull();
+  });
+
+  it("deletes drafts by key", async () => {
+    const draftKey = buildDocumentDraftKey("doc-delete", "quote");
+    await saveLocalDraft({
+      draftKey,
+      userId: "user-a",
+      docType: "quote",
+      documentId: "doc-delete",
+      payload: { title: "Delete me" },
+    });
+
+    await deleteLocalDraft(draftKey);
+
+    await expect(getLocalDraft(draftKey, "user-a")).resolves.toBeNull();
+  });
+
+  it("lists drafts for user in updatedAt descending order", async () => {
+    await putRawDraftRecord({
+      draftKey: "older",
+      userId: "user-a",
+      docType: "quote",
+      documentId: "doc-1",
+      payload: { title: "older" },
+      createdAt: "2026-04-01T00:00:00.000Z",
+      updatedAt: "2026-04-01T00:00:00.000Z",
+    });
+    await putRawDraftRecord({
+      draftKey: "newer",
+      userId: "user-a",
+      docType: "invoice",
+      documentId: "doc-2",
+      payload: { title: "newer" },
+      createdAt: "2026-04-10T00:00:00.000Z",
+      updatedAt: "2026-04-20T00:00:00.000Z",
+    });
+
+    await expect(listDraftsForUser("user-a")).resolves.toEqual([
+      {
+        draftKey: "newer",
+        docType: "invoice",
+        documentId: "doc-2",
+        updatedAt: "2026-04-20T00:00:00.000Z",
+      },
+      {
+        draftKey: "older",
+        docType: "quote",
+        documentId: "doc-1",
+        updatedAt: "2026-04-01T00:00:00.000Z",
+      },
+    ]);
+  });
+
+  it("deletes stale drafts older than the threshold and keeps recent ones", async () => {
+    const nowMs = Date.now();
+    const staleUpdatedAt = new Date(nowMs - 10 * 24 * 60 * 60 * 1000).toISOString();
+    const freshUpdatedAt = new Date(nowMs - 24 * 60 * 60 * 1000).toISOString();
+
+    await putRawDraftRecord({
+      draftKey: "stale-draft",
+      userId: "user-a",
+      docType: "quote",
+      documentId: "doc-1",
+      payload: { title: "stale" },
+      createdAt: staleUpdatedAt,
+      updatedAt: staleUpdatedAt,
+    });
+    await putRawDraftRecord({
+      draftKey: "fresh-draft",
+      userId: "user-a",
+      docType: "invoice",
+      documentId: "doc-2",
+      payload: { title: "fresh" },
+      createdAt: freshUpdatedAt,
+      updatedAt: freshUpdatedAt,
+    });
+
+    await deleteStaleLocalDrafts("user-a", 7);
+
+    await expect(getLocalDraft("stale-draft", "user-a")).resolves.toBeNull();
+    await expect(getLocalDraft("fresh-draft", "user-a")).resolves.not.toBeNull();
+  });
+
+  it("clears all drafts for one user without touching other users", async () => {
+    await saveLocalDraft({
+      draftKey: "user-a-draft-1",
+      userId: "user-a",
+      docType: "quote",
+      documentId: "doc-a1",
+      payload: {},
+    });
+    await saveLocalDraft({
+      draftKey: "user-a-draft-2",
+      userId: "user-a",
+      docType: "invoice",
+      documentId: "doc-a2",
+      payload: {},
+    });
+    await saveLocalDraft({
+      draftKey: "user-b-draft",
+      userId: "user-b",
+      docType: "quote",
+      documentId: "doc-b1",
+      payload: {},
+    });
+
+    await clearDraftsForUser("user-a");
+
+    await expect(getLocalDraft("user-a-draft-1", "user-a")).resolves.toBeNull();
+    await expect(getLocalDraft("user-a-draft-2", "user-a")).resolves.toBeNull();
+    await expect(getLocalDraft("user-b-draft", "user-b")).resolves.not.toBeNull();
+  });
+
+  it("returns null safely for corrupt records", async () => {
+    await putRawDraftRecord({
+      draftKey: "corrupt",
+      userId: "user-a",
+      docType: "quote",
+      documentId: "doc-1",
+      payload: undefined,
+      createdAt: "2026-04-01T00:00:00.000Z",
+      updatedAt: "2026-04-01T00:00:00.000Z",
+    } as unknown as LocalDraft);
+
+    await expect(getLocalDraft("corrupt", "user-a")).resolves.toBeNull();
+  });
+});
+
+async function putRawDraftRecord(record: LocalDraft): Promise<void> {
+  const db = await getDb();
+  const transaction = db.transaction(CAPTURE_STORE_NAMES.localDrafts, "readwrite");
+  transaction.objectStore(CAPTURE_STORE_NAMES.localDrafts).put(record);
+  await transactionDone(transaction);
+}
+
+function transactionDone(transaction: IDBTransaction): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    transaction.oncomplete = () => resolve();
+    transaction.onerror = () => reject(transaction.error ?? new Error("IndexedDB transaction failed."));
+    transaction.onabort = () => reject(transaction.error ?? new Error("IndexedDB transaction aborted."));
+  });
+}

--- a/frontend/src/features/quotes/offline/draftRepository.ts
+++ b/frontend/src/features/quotes/offline/draftRepository.ts
@@ -1,0 +1,197 @@
+import { CAPTURE_STORE_NAMES, getDb } from "@/features/quotes/offline/captureDb";
+
+export type DraftDocType = "quote" | "invoice" | "capture_handoff";
+
+export const CAPTURE_HANDOFF_DOCUMENT_ID = "capture_handoff";
+
+export interface LocalDraft<TPayload = unknown> {
+  draftKey: string;
+  userId: string;
+  docType: DraftDocType;
+  documentId: string;
+  payload: TPayload;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface SaveLocalDraftInput<TPayload = unknown> {
+  draftKey: string;
+  userId: string;
+  docType: DraftDocType;
+  documentId: string;
+  payload: TPayload;
+}
+
+export type LocalDraftSummary = Pick<
+  LocalDraft,
+  "draftKey" | "docType" | "documentId" | "updatedAt"
+>;
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+export function buildCaptureHandoffDraftKey(userId: string): string {
+  return `capture_handoff:${userId}`;
+}
+
+export function buildDocumentDraftKey(documentId: string, docType: "quote" | "invoice"): string {
+  return `${documentId}:${docType}`;
+}
+
+export async function saveLocalDraft<TPayload>(input: SaveLocalDraftInput<TPayload>): Promise<void> {
+  const db = await getDb();
+  const transaction = db.transaction(CAPTURE_STORE_NAMES.localDrafts, "readwrite");
+  const store = transaction.objectStore(CAPTURE_STORE_NAMES.localDrafts);
+  const existingRawRecord = await requestToPromise(store.get(input.draftKey));
+  const existingDraft = parseStoredDraftRecord(existingRawRecord);
+  const now = new Date().toISOString();
+  const nextRecord: LocalDraft<TPayload> = {
+    draftKey: input.draftKey,
+    userId: input.userId,
+    docType: input.docType,
+    documentId: input.documentId,
+    payload: input.payload,
+    createdAt: existingDraft?.createdAt ?? now,
+    updatedAt: now,
+  };
+  store.put(nextRecord);
+  await transactionDone(transaction);
+}
+
+export async function getLocalDraft<TPayload = unknown>(
+  draftKey: string,
+  userId: string,
+): Promise<LocalDraft<TPayload> | null> {
+  const db = await getDb();
+  const transaction = db.transaction(CAPTURE_STORE_NAMES.localDrafts, "readonly");
+  const store = transaction.objectStore(CAPTURE_STORE_NAMES.localDrafts);
+  const rawRecord = await requestToPromise(store.get(draftKey));
+  await transactionDone(transaction);
+
+  const record = parseStoredDraftRecord(rawRecord);
+  if (!record || record.userId !== userId) {
+    return null;
+  }
+
+  return record as LocalDraft<TPayload>;
+}
+
+export async function deleteLocalDraft(draftKey: string): Promise<void> {
+  const db = await getDb();
+  const transaction = db.transaction(CAPTURE_STORE_NAMES.localDrafts, "readwrite");
+  const store = transaction.objectStore(CAPTURE_STORE_NAMES.localDrafts);
+  store.delete(draftKey);
+  await transactionDone(transaction);
+}
+
+export async function listDraftsForUser(userId: string): Promise<LocalDraftSummary[]> {
+  const db = await getDb();
+  const transaction = db.transaction(CAPTURE_STORE_NAMES.localDrafts, "readonly");
+  const store = transaction.objectStore(CAPTURE_STORE_NAMES.localDrafts);
+  const userIndex = store.index("userId");
+  const rawRecords = await requestToPromise(userIndex.getAll(IDBKeyRange.only(userId)));
+  await transactionDone(transaction);
+
+  return rawRecords
+    .map(parseStoredDraftRecord)
+    .filter((record): record is LocalDraft => record !== null && record.userId === userId)
+    .sort((left, right) => right.updatedAt.localeCompare(left.updatedAt))
+    .map((record) => ({
+      draftKey: record.draftKey,
+      docType: record.docType,
+      documentId: record.documentId,
+      updatedAt: record.updatedAt,
+    }));
+}
+
+export async function deleteStaleLocalDrafts(userId: string, olderThanDays = 7): Promise<void> {
+  const db = await getDb();
+  const transaction = db.transaction(CAPTURE_STORE_NAMES.localDrafts, "readwrite");
+  const store = transaction.objectStore(CAPTURE_STORE_NAMES.localDrafts);
+  const userIndex = store.index("userId");
+  const rawRecords = await requestToPromise(userIndex.getAll(IDBKeyRange.only(userId)));
+  const staleThresholdMs = Date.now() - Math.max(olderThanDays, 0) * MS_PER_DAY;
+
+  for (const rawRecord of rawRecords) {
+    const record = parseStoredDraftRecord(rawRecord);
+    if (!record) {
+      continue;
+    }
+
+    const updatedAtMs = Date.parse(record.updatedAt);
+    const isStale = Number.isNaN(updatedAtMs) || updatedAtMs < staleThresholdMs;
+    if (isStale) {
+      store.delete(record.draftKey);
+    }
+  }
+
+  await transactionDone(transaction);
+}
+
+export async function clearDraftsForUser(userId: string): Promise<void> {
+  const db = await getDb();
+  const transaction = db.transaction(CAPTURE_STORE_NAMES.localDrafts, "readwrite");
+  const store = transaction.objectStore(CAPTURE_STORE_NAMES.localDrafts);
+  const userIndex = store.index("userId");
+  const draftKeys = await requestToPromise(userIndex.getAllKeys(IDBKeyRange.only(userId)));
+
+  for (const draftKey of draftKeys) {
+    store.delete(draftKey);
+  }
+
+  await transactionDone(transaction);
+}
+
+function parseStoredDraftRecord(value: unknown): LocalDraft | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  const draftKey = value.draftKey;
+  const userId = value.userId;
+  const docType = value.docType;
+  const documentId = value.documentId;
+  const createdAt = value.createdAt;
+  const updatedAt = value.updatedAt;
+  const payload = value.payload;
+
+  if (
+    typeof draftKey !== "string" ||
+    typeof userId !== "string" ||
+    (docType !== "quote" && docType !== "invoice" && docType !== "capture_handoff") ||
+    typeof documentId !== "string" ||
+    typeof createdAt !== "string" ||
+    typeof updatedAt !== "string" ||
+    payload === undefined
+  ) {
+    return null;
+  }
+
+  return {
+    draftKey,
+    userId,
+    docType,
+    documentId,
+    payload,
+    createdAt,
+    updatedAt,
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function requestToPromise<T>(request: IDBRequest<T>): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error ?? new Error("IndexedDB request failed."));
+  });
+}
+
+function transactionDone(transaction: IDBTransaction): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    transaction.oncomplete = () => resolve();
+    transaction.onerror = () => reject(transaction.error ?? new Error("IndexedDB transaction failed."));
+    transaction.onabort = () => reject(transaction.error ?? new Error("IndexedDB transaction aborted."));
+  });
+}

--- a/frontend/src/features/quotes/tests/CaptureScreen.test.tsx
+++ b/frontend/src/features/quotes/tests/CaptureScreen.test.tsx
@@ -319,6 +319,7 @@ beforeEach(() => {
   });
   mockedUseQuoteDraft.mockReturnValue({
     draft: null,
+    isLoading: false,
     setDraft: setDraftMock,
     updateLineItem: vi.fn(),
     removeLineItem: vi.fn(),

--- a/frontend/src/features/quotes/tests/LineItemCatalogInsert.test.tsx
+++ b/frontend/src/features/quotes/tests/LineItemCatalogInsert.test.tsx
@@ -66,6 +66,24 @@ vi.mock("@/features/profile/services/profileService", () => ({
   },
 }));
 
+vi.mock("@/features/auth/hooks/useAuth", () => ({
+  useAuth: () => ({
+    user: {
+      id: "user-1",
+      email: "user@example.com",
+      is_active: true,
+      is_onboarded: true,
+      timezone: null,
+    },
+    isLoading: false,
+    isOnboarded: true,
+    refreshUser: async () => undefined,
+    login: async () => undefined,
+    register: async () => undefined,
+    logout: async () => undefined,
+  }),
+}));
+
 const mockedUsePersistedReview = vi.mocked(usePersistedReview);
 const mockedLineItemCatalogService = vi.mocked(lineItemCatalogService);
 const mockedQuoteService = vi.mocked(quoteService);

--- a/frontend/src/features/quotes/tests/ReviewScreen.test.tsx
+++ b/frontend/src/features/quotes/tests/ReviewScreen.test.tsx
@@ -58,6 +58,24 @@ vi.mock("@/features/profile/services/profileService", () => ({
   },
 }));
 
+vi.mock("@/features/auth/hooks/useAuth", () => ({
+  useAuth: () => ({
+    user: {
+      id: "user-1",
+      email: "user@example.com",
+      is_active: true,
+      is_onboarded: true,
+      timezone: null,
+    },
+    isLoading: false,
+    isOnboarded: true,
+    refreshUser: async () => undefined,
+    login: async () => undefined,
+    register: async () => undefined,
+    logout: async () => undefined,
+  }),
+}));
+
 const mockedUsePersistedReview = vi.mocked(usePersistedReview);
 const mockedQuoteService = vi.mocked(quoteService);
 const mockedInvoiceService = vi.mocked(invoiceService);

--- a/frontend/src/features/quotes/tests/persistedDocumentDraft.test.ts
+++ b/frontend/src/features/quotes/tests/persistedDocumentDraft.test.ts
@@ -1,0 +1,84 @@
+import "fake-indexeddb/auto";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { resetCaptureDbForTests } from "@/features/quotes/offline/captureDb";
+import {
+  clearDocumentDraftFromIDB,
+  persistDocumentDraftToIDB,
+  readDocumentDraftFromIDB,
+  type DocumentEditDraft,
+} from "@/features/quotes/hooks/persistedDocumentDraft";
+
+const EDIT_STORAGE_KEY = "stima_document_edit";
+
+const draftFixture: DocumentEditDraft = {
+  documentId: "doc-1",
+  docType: "quote",
+  title: "Spring cleanup",
+  transcript: "Mulch and edging",
+  lineItems: [
+    {
+      description: "Mulch",
+      details: "5 yards",
+      price: 120,
+      flagged: false,
+      flagReason: null,
+    },
+  ],
+  total: 120,
+  taxRate: null,
+  discountType: null,
+  discountValue: null,
+  depositAmount: null,
+  notes: "Thanks",
+  dueDate: "",
+};
+
+describe("persistedDocumentDraft", () => {
+  beforeEach(async () => {
+    window.sessionStorage.clear();
+    await resetCaptureDbForTests();
+  });
+
+  afterEach(async () => {
+    window.sessionStorage.clear();
+    await resetCaptureDbForTests();
+  });
+
+  it("round-trips drafts through IndexedDB", async () => {
+    await persistDocumentDraftToIDB(draftFixture, "user-a");
+
+    await expect(readDocumentDraftFromIDB("doc-1", "quote", "user-a")).resolves.toEqual(draftFixture);
+  });
+
+  it("returns null for missing drafts or wrong users", async () => {
+    await persistDocumentDraftToIDB(draftFixture, "user-a");
+
+    await expect(readDocumentDraftFromIDB("missing", "quote", "user-a")).resolves.toBeNull();
+    await expect(readDocumentDraftFromIDB("doc-1", "quote", "user-b")).resolves.toBeNull();
+  });
+
+  it("migrates a legacy sessionStorage draft once and clears the old key", async () => {
+    window.sessionStorage.setItem(EDIT_STORAGE_KEY, JSON.stringify(draftFixture));
+
+    await expect(readDocumentDraftFromIDB("doc-1", "quote", "user-a")).resolves.toEqual(draftFixture);
+    expect(window.sessionStorage.getItem(EDIT_STORAGE_KEY)).toBeNull();
+
+    await expect(readDocumentDraftFromIDB("doc-1", "quote", "user-a")).resolves.toEqual(draftFixture);
+  });
+
+  it("handles corrupt migration payloads safely", async () => {
+    window.sessionStorage.setItem(EDIT_STORAGE_KEY, "{bad json");
+
+    await expect(readDocumentDraftFromIDB("doc-1", "quote", "user-a")).resolves.toBeNull();
+    expect(window.sessionStorage.getItem(EDIT_STORAGE_KEY)).toBeNull();
+  });
+
+  it("clears drafts by document id + type key", async () => {
+    await persistDocumentDraftToIDB(draftFixture, "user-a");
+    await clearDocumentDraftFromIDB("doc-1", "quote");
+
+    await expect(readDocumentDraftFromIDB("doc-1", "quote", "user-a")).resolves.toBeNull();
+  });
+});

--- a/frontend/src/features/quotes/tests/usePersistedReview.test.tsx
+++ b/frontend/src/features/quotes/tests/usePersistedReview.test.tsx
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { usePersistedReview } from "@/features/quotes/hooks/usePersistedReview";
 import { invoiceService } from "@/features/invoices/services/invoiceService";
 import { resetCaptureDbForTests } from "@/features/quotes/offline/captureDb";
+import * as persistedDraftModule from "@/features/quotes/hooks/persistedDocumentDraft";
 import { quoteService } from "@/features/quotes/services/quoteService";
 import type { InvoiceDetail } from "@/features/invoices/types/invoice.types";
 import type { QuoteDetail } from "@/features/quotes/types/quote.types";
@@ -226,5 +227,42 @@ describe("usePersistedReview", () => {
 
     expect(result.current.loadError).toBeTruthy();
     expect(mockedInvoiceService.getInvoice).not.toHaveBeenCalled();
+  });
+
+  it("debounces document draft persistence to one write for rapid updates", async () => {
+    const persistDraftSpy = vi.spyOn(persistedDraftModule, "persistDocumentDraftToIDB");
+    mockedQuoteService.getQuote.mockResolvedValueOnce(makeQuote());
+
+    const { result } = renderHook(() => usePersistedReview("doc-1", "user-a"));
+
+    await waitFor(() => {
+      expect(result.current.isLoadingDocument).toBe(false);
+    });
+    persistDraftSpy.mockClear();
+
+    vi.useFakeTimers();
+    try {
+      act(() => {
+        result.current.setDraft((currentDraft) => ({ ...currentDraft, title: "Edit 1" }));
+        result.current.setDraft((currentDraft) => ({ ...currentDraft, title: "Edit 2" }));
+        result.current.setDraft((currentDraft) => ({ ...currentDraft, title: "Edit 3" }));
+      });
+      expect(persistDraftSpy).not.toHaveBeenCalled();
+
+      await act(async () => {
+        vi.advanceTimersByTime(249);
+        await Promise.resolve();
+      });
+      expect(persistDraftSpy).not.toHaveBeenCalled();
+
+      await act(async () => {
+        vi.advanceTimersByTime(1);
+        await Promise.resolve();
+      });
+      expect(persistDraftSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+      persistDraftSpy.mockRestore();
+    }
   });
 });

--- a/frontend/src/features/quotes/tests/usePersistedReview.test.tsx
+++ b/frontend/src/features/quotes/tests/usePersistedReview.test.tsx
@@ -1,8 +1,11 @@
+import "fake-indexeddb/auto";
+
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { usePersistedReview } from "@/features/quotes/hooks/usePersistedReview";
 import { invoiceService } from "@/features/invoices/services/invoiceService";
+import { resetCaptureDbForTests } from "@/features/quotes/offline/captureDb";
 import { quoteService } from "@/features/quotes/services/quoteService";
 import type { InvoiceDetail } from "@/features/invoices/types/invoice.types";
 import type { QuoteDetail } from "@/features/quotes/types/quote.types";
@@ -124,8 +127,13 @@ beforeEach(() => {
   mockedInvoiceService.getInvoice.mockReset();
 });
 
-afterEach(() => {
+beforeEach(async () => {
+  await resetCaptureDbForTests();
+});
+
+afterEach(async () => {
   window.sessionStorage.clear();
+  await resetCaptureDbForTests();
 });
 
 describe("usePersistedReview", () => {
@@ -137,7 +145,7 @@ describe("usePersistedReview", () => {
       .mockResolvedValueOnce(initialQuote)
       .mockResolvedValueOnce(refreshedQuote);
 
-    const { result } = renderHook(() => usePersistedReview("doc-1"));
+    const { result } = renderHook(() => usePersistedReview("doc-1", "user-a"));
 
     await waitFor(() => {
       expect(result.current.isLoadingDocument).toBe(false);
@@ -169,7 +177,7 @@ describe("usePersistedReview", () => {
       .mockResolvedValueOnce(initialQuote)
       .mockResolvedValueOnce(refreshedQuote);
 
-    const { result } = renderHook(() => usePersistedReview("doc-1"));
+    const { result } = renderHook(() => usePersistedReview("doc-1", "user-a"));
 
     await waitFor(() => {
       expect(result.current.isLoadingDocument).toBe(false);
@@ -195,7 +203,7 @@ describe("usePersistedReview", () => {
     mockedQuoteService.getQuote.mockRejectedValueOnce(new HttpRequestError("Not found", 404, null));
     mockedInvoiceService.getInvoice.mockResolvedValueOnce(makeInvoice());
 
-    const { result } = renderHook(() => usePersistedReview("doc-1"));
+    const { result } = renderHook(() => usePersistedReview("doc-1", "user-a"));
 
     await waitFor(() => {
       expect(result.current.isLoadingDocument).toBe(false);
@@ -210,7 +218,7 @@ describe("usePersistedReview", () => {
       new HttpRequestError("Internal Server Error", 500, null),
     );
 
-    const { result } = renderHook(() => usePersistedReview("doc-1"));
+    const { result } = renderHook(() => usePersistedReview("doc-1", "user-a"));
 
     await waitFor(() => {
       expect(result.current.isLoadingDocument).toBe(false);

--- a/frontend/src/features/quotes/tests/useQuoteDraft.test.tsx
+++ b/frontend/src/features/quotes/tests/useQuoteDraft.test.tsx
@@ -1,9 +1,19 @@
-import { act, fireEvent, render, screen } from "@testing-library/react";
+import "fake-indexeddb/auto";
+
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { useQuoteDraft, type QuoteDraft } from "@/features/quotes/hooks/useQuoteDraft";
+import {
+  buildCaptureHandoffDraftKey,
+  CAPTURE_HANDOFF_DOCUMENT_ID,
+  getLocalDraft,
+  saveLocalDraft,
+} from "@/features/quotes/offline/draftRepository";
+import { resetCaptureDbForTests } from "@/features/quotes/offline/captureDb";
 
 const DRAFT_STORAGE_KEY = "stima_quote_draft";
+const TEST_USER_ID = "user-a";
 
 const draftFixture: QuoteDraft = {
   customerId: "cust-1",
@@ -28,8 +38,8 @@ const draftFixture: QuoteDraft = {
   sourceType: "text",
 };
 
-function HookHarness(): React.ReactElement {
-  const { draft, setDraft, updateLineItem, removeLineItem, clearDraft } = useQuoteDraft();
+function HookHarness({ userId = TEST_USER_ID }: { userId?: string }): React.ReactElement {
+  const { draft, isLoading, setDraft, updateLineItem, removeLineItem, clearDraft } = useQuoteDraft(userId);
 
   return (
     <div>
@@ -54,43 +64,60 @@ function HookHarness(): React.ReactElement {
       <button type="button" onClick={clearDraft}>
         Clear Draft
       </button>
+      <output data-testid="draft-loading">{isLoading ? "loading" : "ready"}</output>
       <output data-testid="draft-state">{draft ? JSON.stringify(draft) : "null"}</output>
     </div>
   );
 }
 
-beforeEach(() => {
+async function readPersistedDraft(userId = TEST_USER_ID): Promise<QuoteDraft | null> {
+  const record = await getLocalDraft<QuoteDraft>(buildCaptureHandoffDraftKey(userId), userId);
+  return record?.payload ?? null;
+}
+
+beforeEach(async () => {
   window.sessionStorage.clear();
+  await resetCaptureDbForTests();
 });
 
-afterEach(() => {
+afterEach(async () => {
   window.sessionStorage.clear();
+  await resetCaptureDbForTests();
 });
 
 describe("useQuoteDraft", () => {
-  it("rehydrates draft state from sessionStorage on mount", () => {
+  it("hydrates from sessionStorage once, migrates to IndexedDB, and clears the legacy key", async () => {
     window.sessionStorage.setItem(DRAFT_STORAGE_KEY, JSON.stringify(draftFixture));
 
     render(<HookHarness />);
 
-    expect(screen.getByTestId("draft-state")).toHaveTextContent(JSON.stringify(draftFixture));
+    await waitFor(() => {
+      expect(screen.getByTestId("draft-loading")).toHaveTextContent("ready");
+      expect(screen.getByTestId("draft-state")).toHaveTextContent(JSON.stringify(draftFixture));
+    });
+    expect(window.sessionStorage.getItem(DRAFT_STORAGE_KEY)).toBeNull();
+    await expect(readPersistedDraft()).resolves.toEqual(draftFixture);
   });
 
-  it("writes draft to sessionStorage synchronously when setDraft is called", () => {
+  it("writes draft to IndexedDB when setDraft is called", async () => {
     render(<HookHarness />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("draft-loading")).toHaveTextContent("ready");
+    });
 
     act(() => {
       fireEvent.click(screen.getByRole("button", { name: "Set Draft" }));
+    });
 
-      const rawStoredDraft = window.sessionStorage.getItem(DRAFT_STORAGE_KEY);
-      expect(rawStoredDraft).not.toBeNull();
-      expect(JSON.parse(rawStoredDraft ?? "")).toEqual(draftFixture);
+    await waitFor(async () => {
+      await expect(readPersistedDraft()).resolves.toEqual(draftFixture);
     });
   });
 
-  it("supports functional draft updates against the latest stored state", () => {
+  it("supports functional draft updates against the latest state", async () => {
     function FunctionalHarness(): React.ReactElement {
-      const { draft, setDraft } = useQuoteDraft();
+      const { draft, isLoading, setDraft } = useQuoteDraft(TEST_USER_ID);
 
       return (
         <div>
@@ -109,12 +136,16 @@ describe("useQuoteDraft", () => {
           >
             Clear Discount
           </button>
+          <output data-testid="functional-loading">{isLoading ? "loading" : "ready"}</output>
           <output data-testid="functional-draft-state">{draft ? JSON.stringify(draft) : "null"}</output>
         </div>
       );
     }
 
     render(<FunctionalHarness />);
+    await waitFor(() => {
+      expect(screen.getByTestId("functional-loading")).toHaveTextContent("ready");
+    });
 
     act(() => {
       fireEvent.click(screen.getByRole("button", { name: "Seed Draft" }));
@@ -130,8 +161,12 @@ describe("useQuoteDraft", () => {
     );
   });
 
-  it("removes draft from state and storage when clearDraft is called", () => {
+  it("removes draft from state and IndexedDB when clearDraft is called", async () => {
     render(<HookHarness />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("draft-loading")).toHaveTextContent("ready");
+    });
 
     act(() => {
       fireEvent.click(screen.getByRole("button", { name: "Set Draft" }));
@@ -139,10 +174,10 @@ describe("useQuoteDraft", () => {
     });
 
     expect(screen.getByTestId("draft-state")).toHaveTextContent("null");
-    expect(window.sessionStorage.getItem(DRAFT_STORAGE_KEY)).toBeNull();
+    await expect(readPersistedDraft()).resolves.toBeNull();
   });
 
-  it("rehydrates older drafts that do not include flag metadata", () => {
+  it("rehydrates older drafts from migration payloads without flag metadata", async () => {
     const legacyDraft = {
       customerId: draftFixture.customerId,
       transcript: draftFixture.transcript,
@@ -155,53 +190,74 @@ describe("useQuoteDraft", () => {
 
     render(<HookHarness />);
 
-    expect(screen.getByTestId("draft-state")).toHaveTextContent(
-      JSON.stringify({
-        ...draftFixture,
-        title: "",
-        launchOrigin: "/",
-        lineItems: [{ description: "Brown mulch", details: "5 yards", price: 120 }],
-      }),
-    );
+    const expectedDraft = {
+      ...draftFixture,
+      title: "",
+      launchOrigin: "/",
+      lineItems: [{ description: "Brown mulch", details: "5 yards", price: 120 }],
+    };
+    await waitFor(() => {
+      expect(screen.getByTestId("draft-state")).toHaveTextContent(JSON.stringify(expectedDraft));
+    });
+    await expect(readPersistedDraft()).resolves.toEqual(expectedDraft);
   });
 
-  it("updates one line item and persists it to sessionStorage", () => {
+  it("updates one line item and persists it to IndexedDB", async () => {
     render(<HookHarness />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("draft-loading")).toHaveTextContent("ready");
+    });
 
     act(() => {
       fireEvent.click(screen.getByRole("button", { name: "Set Draft" }));
       fireEvent.click(screen.getByRole("button", { name: "Update Line Item" }));
     });
 
-    expect(screen.getByTestId("draft-state")).toHaveTextContent(
-      JSON.stringify({
-        ...draftFixture,
-        lineItems: [{ description: "Updated mulch", details: "6 yards", price: 150 }],
-      }),
-    );
-    expect(JSON.parse(window.sessionStorage.getItem(DRAFT_STORAGE_KEY) ?? "")).toEqual({
+    const expectedDraft = {
       ...draftFixture,
       lineItems: [{ description: "Updated mulch", details: "6 yards", price: 150 }],
+    };
+    await waitFor(async () => {
+      await expect(readPersistedDraft()).resolves.toEqual(expectedDraft);
     });
   });
 
-  it("removes one line item and persists it to sessionStorage", () => {
+  it("removes one line item and persists it to IndexedDB", async () => {
     render(<HookHarness />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("draft-loading")).toHaveTextContent("ready");
+    });
 
     act(() => {
       fireEvent.click(screen.getByRole("button", { name: "Set Draft" }));
       fireEvent.click(screen.getByRole("button", { name: "Remove Line Item" }));
     });
 
-    expect(screen.getByTestId("draft-state")).toHaveTextContent(
-      JSON.stringify({
-        ...draftFixture,
-        lineItems: [],
-      }),
-    );
-    expect(JSON.parse(window.sessionStorage.getItem(DRAFT_STORAGE_KEY) ?? "")).toEqual({
+    const expectedDraft = {
       ...draftFixture,
       lineItems: [],
+    };
+    await waitFor(async () => {
+      await expect(readPersistedDraft()).resolves.toEqual(expectedDraft);
+    });
+  });
+
+  it("returns null when a draft exists for a different user", async () => {
+    await saveLocalDraft({
+      draftKey: buildCaptureHandoffDraftKey("user-a"),
+      userId: "user-a",
+      docType: "capture_handoff",
+      documentId: CAPTURE_HANDOFF_DOCUMENT_ID,
+      payload: draftFixture,
+    });
+
+    render(<HookHarness userId="user-b" />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("draft-loading")).toHaveTextContent("ready");
+      expect(screen.getByTestId("draft-state")).toHaveTextContent("null");
     });
   });
 });

--- a/frontend/src/features/quotes/tests/useQuoteDraft.test.tsx
+++ b/frontend/src/features/quotes/tests/useQuoteDraft.test.tsx
@@ -1,9 +1,10 @@
 import "fake-indexeddb/auto";
 
 import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { useQuoteDraft, type QuoteDraft } from "@/features/quotes/hooks/useQuoteDraft";
+import * as draftRepositoryModule from "@/features/quotes/offline/draftRepository";
 import {
   buildCaptureHandoffDraftKey,
   CAPTURE_HANDOFF_DOCUMENT_ID,
@@ -259,5 +260,31 @@ describe("useQuoteDraft", () => {
       expect(screen.getByTestId("draft-loading")).toHaveTextContent("ready");
       expect(screen.getByTestId("draft-state")).toHaveTextContent("null");
     });
+  });
+
+  it("cancels pending persist when user changes before debounce fires", async () => {
+    const persistSpy = vi.spyOn(draftRepositoryModule, "saveLocalDraft").mockResolvedValue(undefined);
+    try {
+      const { rerender } = render(<HookHarness userId="user-a" />);
+      await waitFor(() => {
+        expect(screen.getByTestId("draft-loading")).toHaveTextContent("ready");
+      });
+
+      vi.useFakeTimers();
+      act(() => {
+        fireEvent.click(screen.getByRole("button", { name: "Set Draft" }));
+      });
+      rerender(<HookHarness userId="user-b" />);
+
+      await act(async () => {
+        vi.advanceTimersByTime(200);
+        await Promise.resolve();
+      });
+
+      expect(persistSpy).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+      persistSpy.mockRestore();
+    }
   });
 });


### PR DESCRIPTION
## Summary
- add draftRepository over the local_drafts IndexedDB store with user-scoped CRUD and stale cleanup
- migrate useQuoteDraft and document draft persistence from sessionStorage to async IndexedDB with a one-time sessionStorage migration shim
- update usePersistedReview and ReviewScreen for async draft hydration guards and user-scoped reads/writes
- clear user drafts on logout and prune stale drafts on auth bootstrap/refresh
- add unit/component coverage for repository behavior, migration, user isolation, and hook behavior

## Verification
- cd frontend && npm exec vitest run src/features/quotes/offline/draftRepository.test.ts src/features/quotes/tests/persistedDocumentDraft.test.ts src/features/quotes/tests/useQuoteDraft.test.tsx src/features/quotes/tests/usePersistedReview.test.tsx src/features/auth/tests/useAuth.test.tsx src/features/quotes/tests/ReviewScreen.test.tsx src/features/quotes/tests/LineItemCatalogInsert.test.tsx
- make frontend-verify

Closes #557