### PR TITLE
Task #558: Idempotent extraction submit

### DIFF
--- a/backend/app/features/quotes/api.py
+++ b/backend/app/features/quotes/api.py
@@ -279,7 +279,7 @@ async def extract_combined(
     """Extract quote data, persist the draft, and return a quote id or extraction job."""
     del request
     clip_inputs = await _parse_upload_clips(clips or [])
-    clip_sizes = [len(clip.content) for clip in clip_inputs]
+    clip_hashes = [sha256(clip.content).hexdigest() for clip in clip_inputs]
     capture_detail = _resolve_capture_detail(clip_inputs, notes)
     source_type = _resolve_source_type(clip_inputs)
 
@@ -302,7 +302,7 @@ async def extract_combined(
         idempotency_resource_id = _build_extraction_resource_id(
             user_id=user.id,
             notes=notes,
-            clip_sizes=clip_sizes,
+            clip_hashes=clip_hashes,
             customer_id=customer_id,
         )
         replay = await idempotency_store.begin(
@@ -488,13 +488,13 @@ def _build_extraction_resource_id(
     *,
     user_id: UUID,
     notes: str,
-    clip_sizes: list[int],
+    clip_hashes: list[str],
     customer_id: UUID | None,
 ) -> UUID:
     fingerprint = _build_extraction_fingerprint(
         user_id=user_id,
         notes=notes,
-        clip_sizes=clip_sizes,
+        clip_hashes=clip_hashes,
         customer_id=customer_id,
     )
     return uuid5(NAMESPACE_URL, f"extract:{fingerprint}")
@@ -504,14 +504,14 @@ def _build_extraction_fingerprint(
     *,
     user_id: UUID,
     notes: str,
-    clip_sizes: list[int],
+    clip_hashes: list[str],
     customer_id: UUID | None,
 ) -> str:
     normalized_parts = [
         str(user_id),
         notes.strip(),
-        str(len(clip_sizes)),
-        ",".join(str(size) for size in sorted(clip_sizes)),
+        str(len(clip_hashes)),
+        ",".join(sorted(clip_hashes)),
         str(customer_id) if customer_id is not None else "",
     ]
     return sha256("|".join(normalized_parts).encode()).hexdigest()

--- a/backend/app/features/quotes/api.py
+++ b/backend/app/features/quotes/api.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 import logging
 from datetime import UTC, datetime
+from hashlib import sha256
 from typing import Annotated, Literal, Protocol, cast
-from uuid import UUID
+from uuid import NAMESPACE_URL, UUID, uuid5
 
 from arq.connections import ArqRedis
 from fastapi import (
@@ -268,14 +269,17 @@ async def extract_combined(
     db: Annotated[AsyncSession, Depends(get_db)],
     arq_pool: Annotated[ArqRedis | None, Depends(get_arq_pool)],
     job_service: Annotated[JobService, Depends(get_job_service)],
+    idempotency_store: Annotated[IdempotencyStore, Depends(get_idempotency_store)],
     response: Response,
     clips: Annotated[list[UploadFile] | None, File()] = None,
     notes: Annotated[str, Form(max_length=NOTE_INPUT_MAX_CHARS)] = "",
     customer_id: Annotated[UUID | None, Form()] = None,
+    idempotency_key: Annotated[str | None, Header(alias="Idempotency-Key")] = None,
 ) -> PersistedExtractionResponse | JobRecordResponse:
     """Extract quote data, persist the draft, and return a quote id or extraction job."""
     del request
     clip_inputs = await _parse_upload_clips(clips or [])
+    clip_sizes = [len(clip.content) for clip in clip_inputs]
     capture_detail = _resolve_capture_detail(clip_inputs, notes)
     source_type = _resolve_source_type(clip_inputs)
 
@@ -287,96 +291,230 @@ async def extract_combined(
     except QuoteServiceError as exc:
         raise HTTPException(status_code=exc.status_code, detail=exc.detail) from exc
 
+    normalized_idempotency_key: str | None = None
+    idempotency_resource_id: UUID | None = None
+    if idempotency_key is not None:
+        try:
+            normalized_idempotency_key = validate_idempotency_key(idempotency_key)
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+        idempotency_resource_id = _build_extraction_resource_id(
+            user_id=user.id,
+            notes=notes,
+            clip_sizes=clip_sizes,
+            customer_id=customer_id,
+        )
+        replay = await idempotency_store.begin(
+            endpoint_slug="quote-extract",
+            user_id=user.id,
+            resource_id=idempotency_resource_id,
+            idempotency_key=normalized_idempotency_key,
+        )
+        if replay.kind == "replay" and replay.response is not None:
+            response.headers["Idempotency-Replayed"] = "true"
+            response.status_code = replay.response.status_code
+            if replay.response.status_code == status.HTTP_202_ACCEPTED:
+                return JobRecordResponse.model_validate(replay.response.payload)
+            return PersistedExtractionResponse.model_validate(replay.response.payload)
+        if replay.kind == "in_progress":
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="Extraction already in progress for this key",
+            )
+        if replay.kind == "conflict":
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail="Idempotency key reused with different content",
+            )
+
     if arq_pool is None:
-        async with extraction_capacity_guard(user.id):
-            try:
-                extraction = await extraction_service.extract_combined(
-                    clip_inputs,
-                    notes,
-                    mode="initial",
-                    user_id=user.id,
-                    allow_degraded_persist_on_retryable_failure=True,
-                )
-            except QuoteServiceError as exc:
-                raise HTTPException(status_code=exc.status_code, detail=exc.detail) from exc
-
-            try:
-                quote = await quote_service.create_extracted_draft(
-                    user_id=user.id,
-                    customer_id=customer_id,
-                    extraction_result=extraction,
-                    source_type=source_type,
-                )
-            except QuoteServiceError as exc:
-                if exc.status_code == status.HTTP_503_SERVICE_UNAVAILABLE:
-                    log_draft_generation_failed_event(
+        try:
+            async with extraction_capacity_guard(user.id):
+                try:
+                    extraction = await extraction_service.extract_combined(
+                        clip_inputs,
+                        notes,
+                        mode="initial",
                         user_id=user.id,
-                        capture_detail=capture_detail,
+                        allow_degraded_persist_on_retryable_failure=True,
                     )
-                raise HTTPException(status_code=exc.status_code, detail=exc.detail) from exc
-        log_event(
-            "quote.created",
-            user_id=user.id,
-            quote_id=quote.id,
-            customer_id=quote.customer_id,
-        )
-        log_draft_generated_event(
-            user_id=user.id,
-            quote_id=quote.id,
-            customer_id=quote.customer_id,
-            capture_detail=capture_detail,
-            extraction_result=extraction,
-        )
-        return PersistedExtractionResponse.from_internal_persisted_result(
-            quote_id=quote.id,
-            result=extraction,
-        )
+                except QuoteServiceError as exc:
+                    raise HTTPException(status_code=exc.status_code, detail=exc.detail) from exc
+
+                try:
+                    quote = await quote_service.create_extracted_draft(
+                        user_id=user.id,
+                        customer_id=customer_id,
+                        extraction_result=extraction,
+                        source_type=source_type,
+                    )
+                except QuoteServiceError as exc:
+                    if exc.status_code == status.HTTP_503_SERVICE_UNAVAILABLE:
+                        log_draft_generation_failed_event(
+                            user_id=user.id,
+                            capture_detail=capture_detail,
+                        )
+                    raise HTTPException(status_code=exc.status_code, detail=exc.detail) from exc
+            log_event(
+                "quote.created",
+                user_id=user.id,
+                quote_id=quote.id,
+                customer_id=quote.customer_id,
+            )
+            log_draft_generated_event(
+                user_id=user.id,
+                quote_id=quote.id,
+                customer_id=quote.customer_id,
+                capture_detail=capture_detail,
+                extraction_result=extraction,
+            )
+            persisted_response = PersistedExtractionResponse.from_internal_persisted_result(
+                quote_id=quote.id,
+                result=extraction,
+            )
+            if normalized_idempotency_key and idempotency_resource_id:
+                try:
+                    await idempotency_store.complete(
+                        endpoint_slug="quote-extract",
+                        user_id=user.id,
+                        resource_id=idempotency_resource_id,
+                        idempotency_key=normalized_idempotency_key,
+                        status_code=status.HTTP_200_OK,
+                        payload=persisted_response.model_dump(mode="json"),
+                    )
+                except Exception:  # pragma: no cover - degraded Redis persistence path
+                    LOGGER.warning(
+                        "quote extraction completed without persisted idempotency replay state",
+                        extra={"user_id": str(user.id)},
+                    )
+            return persisted_response
+        except Exception:
+            if normalized_idempotency_key and idempotency_resource_id:
+                try:
+                    await idempotency_store.abort(
+                        endpoint_slug="quote-extract",
+                        user_id=user.id,
+                        resource_id=idempotency_resource_id,
+                        idempotency_key=normalized_idempotency_key,
+                    )
+                except Exception:  # pragma: no cover - degraded Redis persistence path
+                    LOGGER.warning(
+                        "quote extraction idempotency abort failed after sync failure",
+                        extra={"user_id": str(user.id)},
+                    )
+            raise
 
     try:
-        prepared_capture_input = await extraction_service.prepare_capture_input(
-            clip_inputs,
-            notes,
-            user_id=user.id,
-        )
-    except QuoteServiceError as exc:
-        raise HTTPException(status_code=exc.status_code, detail=exc.detail) from exc
+        try:
+            prepared_capture_input = await extraction_service.prepare_capture_input(
+                clip_inputs,
+                notes,
+                user_id=user.id,
+            )
+        except QuoteServiceError as exc:
+            raise HTTPException(status_code=exc.status_code, detail=exc.detail) from exc
 
-    settings = get_settings()
-    job = await job_service.create_extraction_job_if_capacity_available(
-        user_id=user.id,
-        concurrency_limit=settings.extraction_concurrency_limit,
-    )
-    if job is None:
-        raise HTTPException(
-            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
-            detail="Extraction quota or concurrency exhausted. Please retry later.",
+        settings = get_settings()
+        job = await job_service.create_extraction_job_if_capacity_available(
+            user_id=user.id,
+            concurrency_limit=settings.extraction_concurrency_limit,
         )
-    try:
-        queued_job = await arq_pool.enqueue_job(
-            EXTRACTION_JOB_NAME,
-            str(job.id),
-            _job_id=str(job.id),
-            correlation_id=current_correlation_id(),
-            prepared_capture_input=prepared_capture_input.model_dump(mode="json"),
-            extraction_mode="initial",
-            source_type=source_type,
-            capture_detail=capture_detail,
-            customer_id=str(customer_id) if customer_id is not None else None,
-        )
-        if queued_job is None:
-            raise RuntimeError("ARQ did not accept the extraction job")
-    except Exception as exc:
-        LOGGER.warning("Failed to enqueue extraction job %s", job.id, exc_info=True)
-        await job_service.mark_enqueue_failed(job.id, job_type=JobType.EXTRACTION)
+        if job is None:
+            raise HTTPException(
+                status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+                detail="Extraction quota or concurrency exhausted. Please retry later.",
+            )
+        try:
+            queued_job = await arq_pool.enqueue_job(
+                EXTRACTION_JOB_NAME,
+                str(job.id),
+                _job_id=str(job.id),
+                correlation_id=current_correlation_id(),
+                prepared_capture_input=prepared_capture_input.model_dump(mode="json"),
+                extraction_mode="initial",
+                source_type=source_type,
+                capture_detail=capture_detail,
+                customer_id=str(customer_id) if customer_id is not None else None,
+            )
+            if queued_job is None:
+                raise RuntimeError("ARQ did not accept the extraction job")
+        except Exception as exc:
+            LOGGER.warning("Failed to enqueue extraction job %s", job.id, exc_info=True)
+            await job_service.mark_enqueue_failed(job.id, job_type=JobType.EXTRACTION)
+            await db.commit()
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail=_QUEUE_FAILURE_DETAIL,
+            ) from exc
+
         await db.commit()
-        raise HTTPException(
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail=_QUEUE_FAILURE_DETAIL,
-        ) from exc
+        response.status_code = status.HTTP_202_ACCEPTED
+        job_response = job_record_to_response(job)
+        if normalized_idempotency_key and idempotency_resource_id:
+            try:
+                await idempotency_store.complete(
+                    endpoint_slug="quote-extract",
+                    user_id=user.id,
+                    resource_id=idempotency_resource_id,
+                    idempotency_key=normalized_idempotency_key,
+                    status_code=status.HTTP_202_ACCEPTED,
+                    payload=job_response.model_dump(mode="json"),
+                )
+            except Exception:  # pragma: no cover - degraded Redis persistence path
+                LOGGER.warning(
+                    "quote extraction queued without persisted idempotency replay state",
+                    extra={"user_id": str(user.id)},
+                )
+        return job_response
+    except Exception:
+        if normalized_idempotency_key and idempotency_resource_id:
+            try:
+                await idempotency_store.abort(
+                    endpoint_slug="quote-extract",
+                    user_id=user.id,
+                    resource_id=idempotency_resource_id,
+                    idempotency_key=normalized_idempotency_key,
+                )
+            except Exception:  # pragma: no cover - degraded Redis persistence path
+                LOGGER.warning(
+                    "quote extraction idempotency abort failed after async failure",
+                    extra={"user_id": str(user.id)},
+                )
+        raise
 
-    await db.commit()
-    response.status_code = status.HTTP_202_ACCEPTED
-    return job_record_to_response(job)
+
+def _build_extraction_resource_id(
+    *,
+    user_id: UUID,
+    notes: str,
+    clip_sizes: list[int],
+    customer_id: UUID | None,
+) -> UUID:
+    fingerprint = _build_extraction_fingerprint(
+        user_id=user_id,
+        notes=notes,
+        clip_sizes=clip_sizes,
+        customer_id=customer_id,
+    )
+    return uuid5(NAMESPACE_URL, f"extract:{fingerprint}")
+
+
+def _build_extraction_fingerprint(
+    *,
+    user_id: UUID,
+    notes: str,
+    clip_sizes: list[int],
+    customer_id: UUID | None,
+) -> str:
+    normalized_parts = [
+        str(user_id),
+        notes.strip(),
+        str(len(clip_sizes)),
+        ",".join(str(size) for size in sorted(clip_sizes)),
+        str(customer_id) if customer_id is not None else "",
+    ]
+    return sha256("|".join(normalized_parts).encode()).hexdigest()
 
 
 def _resolve_source_type(clips: list[CaptureAudioClip]) -> Literal["text", "voice"]:

--- a/backend/app/features/quotes/tests/test_quote_extraction.py
+++ b/backend/app/features/quotes/tests/test_quote_extraction.py
@@ -68,6 +68,13 @@ def _assert_public_extraction_contract(payload: dict[str, object]) -> None:
         assert "confidence" not in line_item
 
 
+def _extract_headers(csrf_token: str, *, idempotency_key: str | None = None) -> dict[str, str]:
+    headers = {"X-CSRF-Token": csrf_token}
+    if idempotency_key is not None:
+        headers["Idempotency-Key"] = idempotency_key
+    return headers
+
+
 async def test_convert_notes_returns_422_for_extraction_errors(
     client: AsyncClient,
 ) -> None:
@@ -186,6 +193,143 @@ async def test_extract_combined_notes_only_success(client: AsyncClient) -> None:
     assert payload["quote_id"]
     assert payload["transcript"] == "add 10 percent travel surcharge"
     assert payload["line_items"]
+
+
+async def test_extract_combined_replays_same_idempotency_key_without_second_quote(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    csrf_token = await _register_and_login(client, _credentials())
+    app.state.arq_pool = None
+
+    first_response = await client.post(
+        "/api/quotes/extract",
+        files=[("notes", (None, "mulch and edging"))],
+        headers=_extract_headers(csrf_token, idempotency_key="extract-replay-key"),
+    )
+    second_response = await client.post(
+        "/api/quotes/extract",
+        files=[("notes", (None, "mulch and edging"))],
+        headers=_extract_headers(csrf_token, idempotency_key="extract-replay-key"),
+    )
+
+    assert first_response.status_code == 200
+    assert second_response.status_code == 200
+    assert second_response.headers["Idempotency-Replayed"] == "true"
+    assert second_response.json()["quote_id"] == first_response.json()["quote_id"]
+
+    quote_count = await db_session.scalar(select(func.count(Document.id)))
+    assert quote_count == 1
+
+
+async def test_extract_combined_same_idempotency_key_with_different_content_returns_422(
+    client: AsyncClient,
+) -> None:
+    csrf_token = await _register_and_login(client, _credentials())
+    app.state.arq_pool = None
+
+    first_response = await client.post(
+        "/api/quotes/extract",
+        files=[("notes", (None, "mulch and edging"))],
+        headers=_extract_headers(csrf_token, idempotency_key="extract-conflict-key"),
+    )
+    second_response = await client.post(
+        "/api/quotes/extract",
+        files=[("notes", (None, "different capture content"))],
+        headers=_extract_headers(csrf_token, idempotency_key="extract-conflict-key"),
+    )
+
+    assert first_response.status_code == 200
+    assert second_response.status_code == 422
+    assert second_response.json() == {"detail": "Idempotency key reused with different content"}
+
+
+async def test_extract_combined_duplicate_in_progress_idempotency_key_returns_409(
+    client: AsyncClient,
+) -> None:
+    class _BlockingExtractionIntegration:
+        def __init__(self) -> None:
+            self.started = asyncio.Event()
+            self.release = asyncio.Event()
+
+        async def extract(
+            self,
+            notes: PreparedCaptureInput,
+            *,
+            mode: ExtractionMode = "initial",
+        ) -> ExtractionResult:
+            del mode
+            self.started.set()
+            await self.release.wait()
+            return ExtractionResult(
+                transcript=notes.transcript,
+                line_items=[],
+                pricing_hints=PricingHints(),
+            )
+
+    blocking_integration = _BlockingExtractionIntegration()
+
+    async def _override_get_extraction_service() -> ExtractionService:
+        return ExtractionService(
+            extraction_integration=blocking_integration,
+            audio_integration=_MockAudioIntegration(),
+            transcription_integration=_MockTranscriptionIntegration(),
+        )
+
+    app.dependency_overrides[get_extraction_service] = _override_get_extraction_service
+    app.state.arq_pool = None
+    csrf_token = await _register_and_login(client, _credentials())
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://testserver") as second_client:
+        second_client.cookies.update(client.cookies)
+        first_request = asyncio.create_task(
+            client.post(
+                "/api/quotes/extract",
+                files=[("notes", (None, "mulch and edging"))],
+                headers=_extract_headers(csrf_token, idempotency_key="extract-inflight-key"),
+            )
+        )
+        await blocking_integration.started.wait()
+
+        blocked_response = await second_client.post(
+            "/api/quotes/extract",
+            files=[("notes", (None, "mulch and edging"))],
+            headers=_extract_headers(csrf_token, idempotency_key="extract-inflight-key"),
+        )
+
+        blocking_integration.release.set()
+        first_response = await first_request
+
+    assert first_response.status_code == 200
+    assert blocked_response.status_code == 409
+    assert blocked_response.json() == {"detail": "Extraction already in progress for this key"}
+
+
+async def test_extract_combined_without_idempotency_key_creates_new_quotes(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    csrf_token = await _register_and_login(client, _credentials())
+    app.state.arq_pool = None
+
+    first_response = await client.post(
+        "/api/quotes/extract",
+        files=[("notes", (None, "mulch and edging"))],
+        headers=_extract_headers(csrf_token),
+    )
+    second_response = await client.post(
+        "/api/quotes/extract",
+        files=[("notes", (None, "mulch and edging"))],
+        headers=_extract_headers(csrf_token),
+    )
+
+    assert first_response.status_code == 200
+    assert second_response.status_code == 200
+    assert first_response.json()["quote_id"] != second_response.json()["quote_id"]
+
+    quote_count = await db_session.scalar(select(func.count(Document.id)))
+    assert quote_count == 2
 
 
 async def test_extract_combined_keeps_null_price_rows_without_price_status_contract(

--- a/backend/app/features/quotes/tests/test_quote_extraction.py
+++ b/backend/app/features/quotes/tests/test_quote_extraction.py
@@ -244,6 +244,34 @@ async def test_extract_combined_same_idempotency_key_with_different_content_retu
     assert second_response.json() == {"detail": "Idempotency key reused with different content"}
 
 
+async def test_extract_combined_same_idempotency_key_with_same_size_different_clips_returns_422(
+    client: AsyncClient,
+) -> None:
+    csrf_token = await _register_and_login(client, _credentials())
+    app.state.arq_pool = None
+
+    first_response = await client.post(
+        "/api/quotes/extract",
+        files=[
+            ("clips", ("clip-1.webm", b"aaaa", "audio/webm")),
+            ("notes", (None, "mulch and edging")),
+        ],
+        headers=_extract_headers(csrf_token, idempotency_key="extract-clip-conflict-key"),
+    )
+    second_response = await client.post(
+        "/api/quotes/extract",
+        files=[
+            ("clips", ("clip-1.webm", b"bbbb", "audio/webm")),
+            ("notes", (None, "mulch and edging")),
+        ],
+        headers=_extract_headers(csrf_token, idempotency_key="extract-clip-conflict-key"),
+    )
+
+    assert first_response.status_code == 200
+    assert second_response.status_code == 422
+    assert second_response.json() == {"detail": "Idempotency key reused with different content"}
+
+
 async def test_extract_combined_duplicate_in_progress_idempotency_key_returns_409(
     client: AsyncClient,
 ) -> None:

--- a/frontend/src/features/quotes/components/CaptureScreen.tsx
+++ b/frontend/src/features/quotes/components/CaptureScreen.tsx
@@ -4,6 +4,11 @@ import { useLocation, useNavigate, useParams } from "react-router-dom";
 import { useAuth } from "@/features/auth/hooks/useAuth";
 import { useQuoteDraft } from "@/features/quotes/hooks/useQuoteDraft";
 import { EXTRACTION_STAGE_DELAY_MS, getExtractionStages } from "@/features/quotes/components/captureScreenHelpers";
+import {
+  clearExtractionRequestIdempotencyKey,
+  isInFlightIdempotencyConflict,
+  resolveExtractionRequestIdempotencyKey,
+} from "@/features/quotes/components/captureScreenIdempotency";
 import { buildDraftFromQuoteDetail } from "@/features/quotes/components/captureScreenDraft";
 import { pollExtractionJobUntilQuote } from "@/features/quotes/components/captureScreenPolling";
 import { CaptureInputPanel } from "@/features/quotes/components/CaptureInputPanel";
@@ -13,7 +18,7 @@ import { useLocalCaptureSession } from "@/features/quotes/offline/useLocalCaptur
 import { resolveCaptureLaunchOrigin } from "@/features/quotes/utils/workflowNavigation";
 import { MAX_VOICE_CLIPS_PER_CAPTURE, useVoiceCapture } from "@/features/quotes/hooks/useVoiceCapture";
 import { quoteService } from "@/features/quotes/services/quoteService";
-import type { QuoteDetail, QuoteSourceType } from "@/features/quotes/types/quote.types";
+import type { QuoteSourceType } from "@/features/quotes/types/quote.types";
 import { Button } from "@/shared/components/Button";
 import { ConfirmModal } from "@/shared/components/ConfirmModal";
 import { ScreenFooter } from "@/shared/components/ScreenFooter";
@@ -70,7 +75,9 @@ export function CaptureScreen(): React.ReactElement {
   const [pendingExitTarget, setPendingExitTarget] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [isStartingBlank, setIsStartingBlank] = useState(false);
+  const [isRetryLockedByInFlightExtraction, setIsRetryLockedByInFlightExtraction] = useState(false);
   const [hasAttemptedAutoExtract, setHasAttemptedAutoExtract] = useState(false);
+  const extractionIdempotencyKeyRef = useRef<string | null>(null);
   const isExtracting = extractionStage !== null;
   const hasClips = clips.length > 0;
   const hasNotes = notes.trim().length > 0;
@@ -89,6 +96,7 @@ export function CaptureScreen(): React.ReactElement {
   function clearActionErrors(): void {
     setError(null);
     clearError();
+    setIsRetryLockedByInFlightExtraction(false);
   }
 
   const dismissActiveErrorRef = useRef<() => void>(() => {});
@@ -128,6 +136,10 @@ export function CaptureScreen(): React.ReactElement {
   }, [clips, setLocalCaptureClipIds]);
 
   useEffect(() => {
+    setIsRetryLockedByInFlightExtraction(false);
+  }, [clips, notes]);
+
+  useEffect(() => {
     if (!displayedError) {
       return;
     }
@@ -139,43 +151,21 @@ export function CaptureScreen(): React.ReactElement {
     });
   }, [displayedError, show]);
 
-  function applyDraftFromQuoteDetail(
-    sourceType: QuoteSourceType,
-    quoteDetail: QuoteDetail,
-    quoteId: string,
-  ): void {
-    setDraft(buildDraftFromQuoteDetail({
-      sourceType,
-      quoteDetail,
-      quoteId,
-      customerId,
-      launchOrigin,
-    }));
-  }
-
-  async function markSyncedLocalCaptureStatus(
-    quoteId: string,
-    extractJobId?: string | null,
-  ): Promise<void> {
-    await markLocalCaptureStatus("synced", {
-      serverQuoteId: quoteId,
-      extractJobId: extractJobId ?? null,
-    });
-  }
-
   async function hydrateFromPersistedQuote(
     quoteId: string,
     sourceType: QuoteSourceType,
   ): Promise<void> {
     perfMark("capture:draft:hydrate_start");
     const persistedQuote = await quoteService.getQuote(quoteId);
-    applyDraftFromQuoteDetail(sourceType, persistedQuote, quoteId);
+    setDraft(buildDraftFromQuoteDetail({
+      sourceType,
+      quoteDetail: persistedQuote,
+      quoteId,
+      customerId,
+      launchOrigin,
+    }));
     perfMark("capture:draft:ready");
     perfMeasure("capture:draft:hydrate_ms", "capture:draft:hydrate_start", "capture:draft:ready");
-  }
-
-  function navigateToReview(quoteId: string): void {
-    navigate(`/documents/${quoteId}/edit`);
   }
 
   async function onExtract(): Promise<void> {
@@ -223,11 +213,21 @@ export function CaptureScreen(): React.ReactElement {
     });
 
     try {
+      const {
+        idempotencyKey,
+        sessionId: extractionSessionId,
+      } = await resolveExtractionRequestIdempotencyKey({
+        localSessionId,
+        ensureLocalCaptureSession,
+        extractionIdempotencyKeyRef,
+      });
       const extraction = await quoteService.extract({
         clipIds: clips.map((clip) => clip.id),
         notes,
         customerId,
+        idempotencyKey,
       });
+      await clearExtractionRequestIdempotencyKey(extractionSessionId, extractionIdempotencyKeyRef);
       perfMark("capture:extract:response");
       perfMeasure(
         "capture:extract:submit_to_response_ms",
@@ -239,9 +239,12 @@ export function CaptureScreen(): React.ReactElement {
       }
       const sourceType: QuoteSourceType = clips.length > 0 ? "voice" : "text";
       if (extraction.type === "sync") {
-        await markSyncedLocalCaptureStatus(extraction.quoteId, null);
+        await markLocalCaptureStatus("synced", {
+          serverQuoteId: extraction.quoteId,
+          extractJobId: null,
+        });
         await hydrateFromPersistedQuote(extraction.quoteId, sourceType);
-        navigateToReview(extraction.quoteId);
+        navigate(`/documents/${extraction.quoteId}/edit`);
         return;
       }
 
@@ -254,14 +257,19 @@ export function CaptureScreen(): React.ReactElement {
         return;
       }
       const failureKind = classifySubmitFailure(submitError);
-      const message =
-        submitError instanceof Error
+      const isIdempotencyInFlightConflict = isInFlightIdempotencyConflict(submitError);
+      const message = isIdempotencyInFlightConflict
+        ? "Extraction already in progress"
+        : submitError instanceof Error
           ? submitError.message
           : "Unable to extract line items";
       await markLocalCaptureStatus("extract_failed", {
         failureKind,
         error: message,
       });
+      if (isIdempotencyInFlightConflict) {
+        setIsRetryLockedByInFlightExtraction(true);
+      }
       setError(message);
     } finally {
       const shouldResetExtractionStage = isMountedRef.current;
@@ -308,41 +316,24 @@ export function CaptureScreen(): React.ReactElement {
             "Extraction completed without a result. Please try again.",
           );
         }
-        await markSyncedLocalCaptureStatus(job.quote_id, job.id);
+        await markLocalCaptureStatus("synced", {
+          serverQuoteId: job.quote_id,
+          extractJobId: job.id,
+        });
         await hydrateFromPersistedQuote(job.quote_id, sourceType);
-        navigateToReview(job.quote_id);
+        navigate(`/documents/${job.quote_id}/edit`);
       },
     });
   }
 
-  function hasUnsavedWork(): boolean {
-    const hasPotentiallyUnsavedNotes = notes.trim().length > 0
-      && (localSessionId === null || localSaveState === "saving" || localSaveState === "error");
-    return clips.length > 0 || hasPotentiallyUnsavedNotes;
-  }
-  function requestExit(target: string): void {
-    if (hasUnsavedWork()) {
-      setPendingExitTarget(target);
-      return;
-    }
-
-    navigate(target, { replace: true });
-  }
-
-  function onBack(): void {
-    requestExit(launchOrigin);
-  }
-
-  function onStartBlankClick(): void {
-    if (hasUnsavedWork()) {
-      setPendingExitTarget(START_BLANK_GUARD_TARGET);
-      return;
-    }
-    void onStartBlank();
-  }
-
   const hasReachedClipLimit = clips.length >= MAX_VOICE_CLIPS_PER_CAPTURE;
-  const canExtract = (hasClips || hasNotes) && !isExtracting && !isRecording;
+  const hasUnsavedWork = clips.length > 0
+    || (notes.trim().length > 0
+      && (localSessionId === null || localSaveState === "saving" || localSaveState === "error"));
+  const canExtract = (hasClips || hasNotes)
+    && !isExtracting
+    && !isRecording
+    && !isRetryLockedByInFlightExtraction;
   const localStatusCopy = localSaveState === "saving"
     ? "Saving on this device..."
     : localSaveState === "error"
@@ -368,7 +359,9 @@ export function CaptureScreen(): React.ReactElement {
         title="Capture Job Notes"
         subtitle="Describe the job and we'll extract the line items"
         backLabel="Go back"
-        onBack={onBack}
+        onBack={() => (hasUnsavedWork
+          ? setPendingExitTarget(launchOrigin)
+          : navigate(launchOrigin, { replace: true }))}
       />
 
       <section className="mx-auto flex min-h-dvh w-full max-w-2xl flex-col px-4 pb-36 pt-20">
@@ -397,7 +390,9 @@ export function CaptureScreen(): React.ReactElement {
               })();
             }}
             onStopRecording={stopRecording}
-            onStartBlank={onStartBlankClick}
+            onStartBlank={() => (hasUnsavedWork
+              ? setPendingExitTarget(START_BLANK_GUARD_TARGET)
+              : void onStartBlank())}
             isStartBlankDisabled={isExtracting || isRecording || isStartingBlank}
           />
         </div>

--- a/frontend/src/features/quotes/components/CaptureScreen.tsx
+++ b/frontend/src/features/quotes/components/CaptureScreen.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useLocation, useNavigate, useParams } from "react-router-dom";
 
 import { useAuth } from "@/features/auth/hooks/useAuth";
@@ -9,6 +9,7 @@ import {
   isInFlightIdempotencyConflict,
   resolveExtractionRequestIdempotencyKey,
 } from "@/features/quotes/components/captureScreenIdempotency";
+import { useCaptureExtractionKeyReset } from "@/features/quotes/components/useCaptureExtractionKeyReset";
 import { buildDraftFromQuoteDetail } from "@/features/quotes/components/captureScreenDraft";
 import { pollExtractionJobUntilQuote } from "@/features/quotes/components/captureScreenPolling";
 import { CaptureInputPanel } from "@/features/quotes/components/CaptureInputPanel";
@@ -78,7 +79,6 @@ export function CaptureScreen(): React.ReactElement {
   const [isRetryLockedByInFlightExtraction, setIsRetryLockedByInFlightExtraction] = useState(false);
   const [hasAttemptedAutoExtract, setHasAttemptedAutoExtract] = useState(false);
   const extractionIdempotencyKeyRef = useRef<string | null>(null);
-  const previousClipSignatureRef = useRef("");
   const isExtracting = extractionStage !== null;
   const hasClips = clips.length > 0;
   const hasNotes = notes.trim().length > 0;
@@ -136,35 +136,15 @@ export function CaptureScreen(): React.ReactElement {
     void setLocalCaptureClipIds(clips.map((clip) => clip.id));
   }, [clips, setLocalCaptureClipIds]);
 
-  useEffect(() => {
-    const currentClipSignature = clips
-      .map((clip) => `${clip.id}:${clip.sizeBytes}`)
-      .join("|");
-    const hasChanged = previousClipSignatureRef.current !== currentClipSignature;
-    previousClipSignatureRef.current = currentClipSignature;
-    if (!hasChanged) {
-      return;
-    }
-    if (!isRetryLockedByInFlightExtraction && extractionIdempotencyKeyRef.current === null) {
-      return;
-    }
-    setIsRetryLockedByInFlightExtraction(false);
-    void clearExtractionRequestIdempotencyKey(localSessionId, extractionIdempotencyKeyRef);
-  }, [clips, isRetryLockedByInFlightExtraction, localSessionId]);
-
-  useEffect(() => {
-    setIsRetryLockedByInFlightExtraction(false);
-  }, [notes]);
-
-  const handleNotesChange = useCallback((value: string): void => {
-    if (value !== notes) {
-      if (isRetryLockedByInFlightExtraction || extractionIdempotencyKeyRef.current !== null) {
-        setIsRetryLockedByInFlightExtraction(false);
-        void clearExtractionRequestIdempotencyKey(localSessionId, extractionIdempotencyKeyRef);
-      }
-    }
-    setNotes(value);
-  }, [isRetryLockedByInFlightExtraction, localSessionId, notes, setNotes]);
+  const handleNotesChange = useCaptureExtractionKeyReset({
+    clips,
+    notes,
+    localSessionId,
+    isRetryLockedByInFlightExtraction,
+    setIsRetryLockedByInFlightExtraction,
+    extractionIdempotencyKeyRef,
+    setNotes,
+  });
 
   useEffect(() => {
     if (!displayedError) {
@@ -366,20 +346,16 @@ export function CaptureScreen(): React.ReactElement {
     : localSaveState === "error"
       ? "Stima could not save this capture on your device. Copy your notes before leaving this screen."
       : getLocalCaptureStatusCopy(sessionStatus);
-
   useEffect(() => {
     setHasAttemptedAutoExtract(false);
   }, [autoExtractOnLoad, localSessionQueryParam]);
-
   useEffect(() => {
     if (!autoExtractOnLoad || hasAttemptedAutoExtract || isHydratingLocalSession || !canExtract) {
       return;
     }
-
     setHasAttemptedAutoExtract(true);
     void onExtract();
   }, [autoExtractOnLoad, canExtract, hasAttemptedAutoExtract, isHydratingLocalSession, onExtract]);
-
   return (
     <main className="min-h-dvh bg-background">
       <WorkflowScreenHeader

--- a/frontend/src/features/quotes/components/CaptureScreen.tsx
+++ b/frontend/src/features/quotes/components/CaptureScreen.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useLocation, useNavigate, useParams } from "react-router-dom";
 
 import { useAuth } from "@/features/auth/hooks/useAuth";
@@ -78,6 +78,7 @@ export function CaptureScreen(): React.ReactElement {
   const [isRetryLockedByInFlightExtraction, setIsRetryLockedByInFlightExtraction] = useState(false);
   const [hasAttemptedAutoExtract, setHasAttemptedAutoExtract] = useState(false);
   const extractionIdempotencyKeyRef = useRef<string | null>(null);
+  const previousClipSignatureRef = useRef("");
   const isExtracting = extractionStage !== null;
   const hasClips = clips.length > 0;
   const hasNotes = notes.trim().length > 0;
@@ -136,8 +137,34 @@ export function CaptureScreen(): React.ReactElement {
   }, [clips, setLocalCaptureClipIds]);
 
   useEffect(() => {
+    const currentClipSignature = clips
+      .map((clip) => `${clip.id}:${clip.sizeBytes}`)
+      .join("|");
+    const hasChanged = previousClipSignatureRef.current !== currentClipSignature;
+    previousClipSignatureRef.current = currentClipSignature;
+    if (!hasChanged) {
+      return;
+    }
+    if (!isRetryLockedByInFlightExtraction && extractionIdempotencyKeyRef.current === null) {
+      return;
+    }
     setIsRetryLockedByInFlightExtraction(false);
-  }, [clips, notes]);
+    void clearExtractionRequestIdempotencyKey(localSessionId, extractionIdempotencyKeyRef);
+  }, [clips, isRetryLockedByInFlightExtraction, localSessionId]);
+
+  useEffect(() => {
+    setIsRetryLockedByInFlightExtraction(false);
+  }, [notes]);
+
+  const handleNotesChange = useCallback((value: string): void => {
+    if (value !== notes) {
+      if (isRetryLockedByInFlightExtraction || extractionIdempotencyKeyRef.current !== null) {
+        setIsRetryLockedByInFlightExtraction(false);
+        void clearExtractionRequestIdempotencyKey(localSessionId, extractionIdempotencyKeyRef);
+      }
+    }
+    setNotes(value);
+  }, [isRetryLockedByInFlightExtraction, localSessionId, notes, setNotes]);
 
   useEffect(() => {
     if (!displayedError) {
@@ -378,7 +405,7 @@ export function CaptureScreen(): React.ReactElement {
             isExtracting={isExtracting}
             removeClip={removeClip}
             notes={notes}
-            onNotesChange={setNotes}
+            onNotesChange={handleNotesChange}
             isRecording={isRecording}
             elapsedSeconds={elapsedSeconds}
             hasReachedClipLimit={hasReachedClipLimit}

--- a/frontend/src/features/quotes/components/captureScreenIdempotency.ts
+++ b/frontend/src/features/quotes/components/captureScreenIdempotency.ts
@@ -1,0 +1,56 @@
+import { getCaptureSession, updateCaptureField } from "@/features/quotes/offline/captureRepository";
+import { buildIdempotencyKey } from "@/shared/lib/idempotency";
+import { HttpRequestError } from "@/shared/lib/http";
+
+interface ResolveIdempotencyKeyParams {
+  localSessionId: string | null;
+  ensureLocalCaptureSession: () => Promise<string | null>;
+  extractionIdempotencyKeyRef: { current: string | null };
+}
+
+export async function resolveExtractionRequestIdempotencyKey({
+  localSessionId,
+  ensureLocalCaptureSession,
+  extractionIdempotencyKeyRef,
+}: ResolveIdempotencyKeyParams): Promise<{ idempotencyKey: string; sessionId: string | null }> {
+  const sessionId = localSessionId ?? await ensureLocalCaptureSession();
+  if (!extractionIdempotencyKeyRef.current && sessionId) {
+    const session = await getCaptureSession(sessionId);
+    const storedIdempotencyKey = session?.idempotencyKey?.trim() ?? "";
+    if (storedIdempotencyKey.length > 0) {
+      extractionIdempotencyKeyRef.current = storedIdempotencyKey;
+    }
+  }
+
+  if (!extractionIdempotencyKeyRef.current) {
+    extractionIdempotencyKeyRef.current = buildIdempotencyKey();
+  }
+
+  if (sessionId) {
+    await updateCaptureField(sessionId, {
+      idempotencyKey: extractionIdempotencyKeyRef.current,
+    });
+  }
+
+  return {
+    idempotencyKey: extractionIdempotencyKeyRef.current,
+    sessionId,
+  };
+}
+
+export async function clearExtractionRequestIdempotencyKey(
+  sessionId: string | null,
+  extractionIdempotencyKeyRef: { current: string | null },
+): Promise<void> {
+  extractionIdempotencyKeyRef.current = null;
+  if (!sessionId) {
+    return;
+  }
+  await updateCaptureField(sessionId, { idempotencyKey: null });
+}
+
+export function isInFlightIdempotencyConflict(error: unknown): boolean {
+  return error instanceof HttpRequestError
+    && error.status === 409
+    && error.message.includes("already in progress for this key");
+}

--- a/frontend/src/features/quotes/components/useCaptureExtractionKeyReset.ts
+++ b/frontend/src/features/quotes/components/useCaptureExtractionKeyReset.ts
@@ -1,0 +1,66 @@
+import { useCallback, useEffect, useRef } from "react";
+
+import { clearExtractionRequestIdempotencyKey } from "@/features/quotes/components/captureScreenIdempotency";
+
+interface UseCaptureExtractionKeyResetParams {
+  clips: { id: string; sizeBytes: number }[];
+  notes: string;
+  localSessionId: string | null;
+  isRetryLockedByInFlightExtraction: boolean;
+  setIsRetryLockedByInFlightExtraction: (value: boolean) => void;
+  extractionIdempotencyKeyRef: { current: string | null };
+  setNotes: (value: string) => void;
+}
+
+export function useCaptureExtractionKeyReset({
+  clips,
+  notes,
+  localSessionId,
+  isRetryLockedByInFlightExtraction,
+  setIsRetryLockedByInFlightExtraction,
+  extractionIdempotencyKeyRef,
+  setNotes,
+}: UseCaptureExtractionKeyResetParams): (value: string) => void {
+  const previousClipSignatureRef = useRef("");
+
+  useEffect(() => {
+    const currentClipSignature = clips.map((clip) => `${clip.id}:${clip.sizeBytes}`).join("|");
+    const hasChanged = previousClipSignatureRef.current !== currentClipSignature;
+    previousClipSignatureRef.current = currentClipSignature;
+    if (!hasChanged) {
+      return;
+    }
+    if (!isRetryLockedByInFlightExtraction && extractionIdempotencyKeyRef.current === null) {
+      return;
+    }
+    setIsRetryLockedByInFlightExtraction(false);
+    void clearExtractionRequestIdempotencyKey(localSessionId, extractionIdempotencyKeyRef);
+  }, [
+    clips,
+    extractionIdempotencyKeyRef,
+    isRetryLockedByInFlightExtraction,
+    localSessionId,
+    setIsRetryLockedByInFlightExtraction,
+  ]);
+
+  useEffect(() => {
+    setIsRetryLockedByInFlightExtraction(false);
+  }, [notes, setIsRetryLockedByInFlightExtraction]);
+
+  return useCallback((value: string): void => {
+    if (value !== notes) {
+      if (isRetryLockedByInFlightExtraction || extractionIdempotencyKeyRef.current !== null) {
+        setIsRetryLockedByInFlightExtraction(false);
+        void clearExtractionRequestIdempotencyKey(localSessionId, extractionIdempotencyKeyRef);
+      }
+    }
+    setNotes(value);
+  }, [
+    extractionIdempotencyKeyRef,
+    isRetryLockedByInFlightExtraction,
+    localSessionId,
+    notes,
+    setIsRetryLockedByInFlightExtraction,
+    setNotes,
+  ]);
+}

--- a/frontend/src/features/quotes/services/quoteService.ts
+++ b/frontend/src/features/quotes/services/quoteService.ts
@@ -81,13 +81,18 @@ async function buildExtractionFormDataFromIds(params: {
 
 async function submitExtraction(
   path: string,
-  params: { clipIds?: string[]; notes?: string; customerId?: string },
+  params: { clipIds?: string[]; notes?: string; customerId?: string; idempotencyKey?: string },
 ): Promise<QuoteExtractResponse> {
   const formData = await buildExtractionFormDataFromIds(params);
+  const headers: HeadersInit = {};
+  if (params.idempotencyKey) {
+    headers["Idempotency-Key"] = params.idempotencyKey;
+  }
 
   const response = await requestWithMetadata<PersistedExtractionPayload | JobStatusResponse>(path, {
     method: "POST",
     body: formData,
+    headers,
   });
 
   if (response.status === 202) {
@@ -106,8 +111,17 @@ async function submitExtraction(
   };
 }
 
-async function extract(params: { clipIds?: string[]; notes?: string; customerId?: string }): Promise<QuoteExtractResponse> {
-  return submitExtraction("/api/quotes/extract", params);
+async function extract(params: {
+  clipIds?: string[];
+  notes?: string;
+  customerId?: string;
+  idempotencyKey?: string;
+}): Promise<QuoteExtractResponse> {
+  const idempotencyKey = params.idempotencyKey ?? buildIdempotencyKey();
+  return submitExtraction("/api/quotes/extract", {
+    ...params,
+    idempotencyKey,
+  });
 }
 
 function createManualDraft(params?: { customerId?: string }): Promise<Quote> {

--- a/frontend/src/features/quotes/tests/CaptureScreen.test.tsx
+++ b/frontend/src/features/quotes/tests/CaptureScreen.test.tsx
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useAuth } from "@/features/auth/hooks/useAuth";
 import { CaptureScreen } from "@/features/quotes/components/CaptureScreen";
 import { useQuoteDraft } from "@/features/quotes/hooks/useQuoteDraft";
+import { getCaptureSession, updateCaptureField } from "@/features/quotes/offline/captureRepository";
 import { HOME_ROUTE } from "@/features/quotes/utils/workflowNavigation";
 import { MAX_VOICE_CLIPS_PER_CAPTURE, useVoiceCapture, type VoiceClip } from "@/features/quotes/hooks/useVoiceCapture";
 import { quoteService } from "@/features/quotes/services/quoteService";
@@ -13,6 +14,7 @@ import type {
   JobStatusResponse,
   QuoteDetail,
 } from "@/features/quotes/types/quote.types";
+import { HttpRequestError } from "@/shared/lib/http";
 import { jobService } from "@/shared/lib/jobService";
 import {
   MAX_AUDIO_TOTAL_BYTES,
@@ -118,6 +120,10 @@ vi.mock("@/features/quotes/services/quoteService", () => ({
     shareQuote: vi.fn(),
   },
 }));
+vi.mock("@/features/quotes/offline/captureRepository", () => ({
+  getCaptureSession: vi.fn(async () => null),
+  updateCaptureField: vi.fn(async () => undefined),
+}));
 
 vi.mock("@/shared/lib/jobService", () => ({
   jobService: {
@@ -130,6 +136,8 @@ const mockedUseQuoteDraft = vi.mocked(useQuoteDraft);
 const mockedUseAuth = vi.mocked(useAuth);
 const mockedQuoteService = vi.mocked(quoteService);
 const mockedJobService = vi.mocked(jobService);
+const mockedGetCaptureSession = vi.mocked(getCaptureSession);
+const mockedUpdateCaptureField = vi.mocked(updateCaptureField);
 
 const extractionFixture: ExtractionResult = {
   transcript: "5 yards brown mulch",
@@ -349,6 +357,8 @@ beforeEach(() => {
     updated_at: "2026-03-20T00:00:00.000Z",
   });
   mockedJobService.getJobStatus.mockReset();
+  mockedGetCaptureSession.mockResolvedValue(null);
+  mockedUpdateCaptureField.mockResolvedValue(undefined);
   useParamsMock.mockReturnValue({ customerId: "cust-1" });
 });
 
@@ -573,6 +583,7 @@ describe("CaptureScreen", () => {
         clipIds: [clipFixture.id],
         notes: "  add travel surcharge  ",
         customerId: "cust-1",
+        idempotencyKey: expect.any(String),
       });
     });
     expect(navigateMock).toHaveBeenCalledWith("/documents/quote-1/edit");
@@ -708,6 +719,7 @@ describe("CaptureScreen", () => {
         clipIds: [],
         notes: "Install sod in backyard",
         customerId: undefined,
+        idempotencyKey: expect.any(String),
       });
     });
     expect(mockedJobService.getJobStatus).toHaveBeenCalledWith("job-home");
@@ -742,6 +754,47 @@ describe("CaptureScreen", () => {
     );
   });
 
+  it("reuses the same idempotency key when retrying after a failed extraction", async () => {
+    mockedQuoteService.extract
+      .mockRejectedValueOnce(new Error("Temporary extraction failure"))
+      .mockResolvedValueOnce({
+        type: "sync",
+        quoteId: "quote-after-retry",
+        result: extractionFixture,
+      });
+    renderScreen();
+
+    fireEvent.change(screen.getByLabelText(/written description/i), {
+      target: { value: "Install sod in backyard" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /extract line items/i }));
+
+    await screen.findByRole("alert");
+    fireEvent.click(screen.getByRole("button", { name: /extract line items/i }));
+
+    await waitFor(() => expect(mockedQuoteService.extract).toHaveBeenCalledTimes(2));
+    const firstCall = mockedQuoteService.extract.mock.calls[0]?.[0];
+    const secondCall = mockedQuoteService.extract.mock.calls[1]?.[0];
+    expect(firstCall?.idempotencyKey).toBeDefined();
+    expect(secondCall?.idempotencyKey).toBe(firstCall?.idempotencyKey);
+  });
+
+  it("clears persisted idempotency key after extraction submission succeeds", async () => {
+    renderScreen();
+
+    fireEvent.change(screen.getByLabelText(/written description/i), {
+      target: { value: "Install sod in backyard" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /extract line items/i }));
+
+    await waitFor(() => {
+      expect(mockedUpdateCaptureField).toHaveBeenCalledWith(
+        "local-session-1",
+        expect.objectContaining({ idempotencyKey: null }),
+      );
+    });
+  });
+
   it("shows persistent error toast and does not navigate when extraction fails", async () => {
     mockedQuoteService.extract.mockRejectedValueOnce(new Error("Extraction failed"));
     renderScreen();
@@ -753,6 +806,26 @@ describe("CaptureScreen", () => {
 
     expect(await screen.findByRole("alert")).toHaveTextContent("Extraction failed");
     expect(navigateMock).not.toHaveBeenCalledWith("/documents/quote-1/edit");
+  });
+
+  it("shows in-progress idempotency conflict message and disables retry", async () => {
+    mockedQuoteService.extract.mockRejectedValueOnce(
+      new HttpRequestError(
+        "Extraction already in progress for this key",
+        409,
+        { detail: "Extraction already in progress for this key" },
+      ),
+    );
+    renderScreen();
+
+    fireEvent.change(screen.getByLabelText(/written description/i), {
+      target: { value: "Install sod in backyard" },
+    });
+    const extractButton = screen.getByRole("button", { name: /extract line items/i });
+    fireEvent.click(extractButton);
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("Extraction already in progress");
+    expect(extractButton).toBeDisabled();
   });
 
   it("dismisses submission errors via local error state without clearing voice capture", async () => {

--- a/frontend/src/features/quotes/tests/CaptureScreen.test.tsx
+++ b/frontend/src/features/quotes/tests/CaptureScreen.test.tsx
@@ -779,6 +779,35 @@ describe("CaptureScreen", () => {
     expect(secondCall?.idempotencyKey).toBe(firstCall?.idempotencyKey);
   });
 
+  it("generates a new idempotency key when notes change before retry", async () => {
+    mockedQuoteService.extract
+      .mockRejectedValueOnce(new Error("Temporary extraction failure"))
+      .mockResolvedValueOnce({
+        type: "sync",
+        quoteId: "quote-after-edit-retry",
+        result: extractionFixture,
+      });
+    renderScreen();
+
+    fireEvent.change(screen.getByLabelText(/written description/i), {
+      target: { value: "Install sod in backyard" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /extract line items/i }));
+    await screen.findByRole("alert");
+
+    fireEvent.change(screen.getByLabelText(/written description/i), {
+      target: { value: "Install sod in backyard and add mulch" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /extract line items/i }));
+
+    await waitFor(() => expect(mockedQuoteService.extract).toHaveBeenCalledTimes(2));
+    const firstCall = mockedQuoteService.extract.mock.calls[0]?.[0];
+    const secondCall = mockedQuoteService.extract.mock.calls[1]?.[0];
+    expect(firstCall?.idempotencyKey).toBeDefined();
+    expect(secondCall?.idempotencyKey).toBeDefined();
+    expect(secondCall?.idempotencyKey).not.toBe(firstCall?.idempotencyKey);
+  });
+
   it("clears persisted idempotency key after extraction submission succeeds", async () => {
     renderScreen();
 

--- a/frontend/src/features/quotes/tests/quoteService.extract.test.ts
+++ b/frontend/src/features/quotes/tests/quoteService.extract.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { AudioClipMissingError } from "@/features/quotes/offline/captureTypes";
 import { getAudioClip } from "@/features/quotes/offline/audioRepository";
 import { quoteService } from "@/features/quotes/services/quoteService";
+import { buildIdempotencyKey } from "@/shared/lib/idempotency";
 import { request, requestWithMetadata } from "@/shared/lib/http";
 
 vi.mock("@/shared/lib/http", () => ({
@@ -13,10 +14,14 @@ vi.mock("@/shared/lib/http", () => ({
 vi.mock("@/features/quotes/offline/audioRepository", () => ({
   getAudioClip: vi.fn(),
 }));
+vi.mock("@/shared/lib/idempotency", () => ({
+  buildIdempotencyKey: vi.fn(() => "generated-idempotency-key"),
+}));
 
 const mockedRequestWithMetadata = vi.mocked(requestWithMetadata);
 const mockedRequest = vi.mocked(request);
 const mockedGetAudioClip = vi.mocked(getAudioClip);
+const mockedBuildIdempotencyKey = vi.mocked(buildIdempotencyKey);
 
 describe("quoteService.extract", () => {
   const extractionPayload = {
@@ -38,6 +43,7 @@ describe("quoteService.extract", () => {
     mockedRequestWithMetadata.mockReset();
     mockedRequest.mockReset();
     mockedGetAudioClip.mockReset();
+    mockedBuildIdempotencyKey.mockClear();
   });
 
   it("builds multipart form data with clip IDs and trimmed notes for async extraction", async () => {
@@ -115,6 +121,7 @@ describe("quoteService.extract", () => {
     const formData = options?.body as FormData;
     expect(formData.getAll("clips")).toHaveLength(0);
     expect(formData.get("notes")).toBe("typed note only");
+    expect(options?.headers).toEqual({ "Idempotency-Key": "generated-idempotency-key" });
   });
 
   it("omits notes field for clips-only extraction", async () => {
@@ -148,6 +155,26 @@ describe("quoteService.extract", () => {
     expect((formData.getAll("clips")[0] as File).name).toBe("clip-1.webm");
     expect(formData.get("notes")).toBeNull();
     expect(formData.get("customer_id")).toBeNull();
+    expect(options?.headers).toEqual({ "Idempotency-Key": "generated-idempotency-key" });
+  });
+
+  it("uses provided idempotency key header when extract params include one", async () => {
+    mockedRequestWithMetadata.mockResolvedValue({
+      status: 200,
+      data: {
+        quote_id: "quote-31",
+        ...extractionPayload,
+      },
+    });
+
+    await quoteService.extract({
+      notes: "typed note only",
+      idempotencyKey: "provided-idempotency-key",
+    });
+
+    const [, options] = mockedRequestWithMetadata.mock.calls[0] ?? [];
+    expect(options?.headers).toEqual({ "Idempotency-Key": "provided-idempotency-key" });
+    expect(mockedBuildIdempotencyKey).not.toHaveBeenCalled();
   });
 
   it("throws AudioClipMissingError and skips submit when a clip ID is missing from IndexedDB", async () => {

--- a/frontend/src/features/quotes/tests/quoteService.integration.test.ts
+++ b/frontend/src/features/quotes/tests/quoteService.integration.test.ts
@@ -79,10 +79,12 @@ describe("quoteService integration (MSW)", () => {
   it("extract returns async job metadata when the backend responds with 202", async () => {
     setCsrfToken("integration-csrf-token");
     let capturedCsrfHeader: string | null = null;
+    let capturedIdempotencyHeader: string | null = null;
 
     server.use(
       http.post("/api/quotes/extract", ({ request }) => {
         capturedCsrfHeader = request.headers.get("X-CSRF-Token");
+        capturedIdempotencyHeader = request.headers.get("Idempotency-Key");
         return HttpResponse.json(
           {
             id: "job-1",
@@ -106,7 +108,35 @@ describe("quoteService integration (MSW)", () => {
     const result = await quoteService.extract({ notes: "Mulch and edging" });
 
     expect(capturedCsrfHeader).toBe("integration-csrf-token");
+    expect(capturedIdempotencyHeader).toBeTruthy();
     expect(result).toEqual({ type: "async", jobId: "job-1" });
+  });
+
+  it("extract sends provided Idempotency-Key header", async () => {
+    setCsrfToken("integration-csrf-token");
+    let capturedIdempotencyHeader: string | null = null;
+
+    server.use(
+      http.post("/api/quotes/extract", ({ request }) => {
+        capturedIdempotencyHeader = request.headers.get("Idempotency-Key");
+        return HttpResponse.json(
+          {
+            quote_id: "quote-provided-key",
+            transcript: "Mulch and edging",
+            line_items: [],
+            total: null,
+          },
+          { status: 200 },
+        );
+      }),
+    );
+
+    await quoteService.extract({
+      notes: "Mulch and edging",
+      idempotencyKey: "provided-key",
+    });
+
+    expect(capturedIdempotencyHeader).toBe("provided-key");
   });
 
   it("extract returns persisted quote id and extraction result when the backend responds with 200", async () => {


### PR DESCRIPTION
Closes #558

## Summary
- wire Idempotency-Key handling into POST /api/quotes/extract with replay/conflict/in-progress behavior
- add extraction fingerprint/resource-id logic + idempotency complete/abort paths for sync and async extraction
- wire frontend extraction idempotency key lifecycle through quoteService.extract and CaptureScreen
- add backend/frontend tests for replay, in-progress conflict, mismatch, no-key fallback, and capture key lifecycle

## Verification
- cd backend && .venv/bin/pytest app/features/quotes/tests/test_quote_extraction.py -k "idempotency or without_idempotency" -x --tb=short
- cd frontend && npx vitest run src/features/quotes/tests/quoteService.extract.test.ts src/features/quotes/tests/quoteService.integration.test.ts src/features/quotes/tests/CaptureScreen.test.tsx
- make backend-static-verify
- make backend-verify
- make frontend-verify
