### PR TITLE
Task #561: Redis degraded mode runtime fallback

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -63,6 +63,14 @@ class Settings(BaseSettings):
 
     environment: str = Field(default="development", validation_alias="ENVIRONMENT")
     redis_url: str | None = Field(default=None, validation_alias="REDIS_URL")
+    allow_redis_degraded_mode: bool = Field(
+        default=False,
+        validation_alias="ALLOW_REDIS_DEGRADED_MODE",
+    )
+    redis_startup_probe_timeout_seconds: float = Field(
+        default=2.0,
+        validation_alias="REDIS_STARTUP_PROBE_TIMEOUT_SECONDS",
+    )
     redis_key_prefix: str = Field(
         default="stima",
         validation_alias="REDIS_KEY_PREFIX",
@@ -368,6 +376,14 @@ class Settings(BaseSettings):
             raise ValueError("PROVIDER_REQUEST_TIMEOUT_SECONDS must be greater than 0")
         return value
 
+    @field_validator("redis_startup_probe_timeout_seconds")
+    @classmethod
+    def validate_redis_startup_probe_timeout_seconds(cls, value: float) -> float:
+        """Require a positive startup probe timeout."""
+        if value <= 0:
+            raise ValueError("REDIS_STARTUP_PROBE_TIMEOUT_SECONDS must be greater than 0")
+        return value
+
     @field_validator("provider_max_retries")
     @classmethod
     def validate_provider_max_retries(cls, value: int) -> int:
@@ -426,7 +442,7 @@ class Settings(BaseSettings):
         parsed_frontend_url = urlparse(self.frontend_url)
         if parsed_frontend_url.hostname in LOCALHOST_HOSTS:
             raise ValueError("FRONTEND_URL must not use localhost when ENVIRONMENT is 'production'")
-        if self.redis_url is None:
+        if self.redis_url is None and not self.allow_redis_degraded_mode:
             raise ValueError("REDIS_URL must be set when ENVIRONMENT is 'production'")
 
         return self

--- a/backend/app/core/tests/test_config.py
+++ b/backend/app/core/tests/test_config.py
@@ -265,3 +265,17 @@ def test_production_requires_redis_url(monkeypatch) -> None:
 
     with pytest.raises(ValidationError, match="REDIS_URL must be set"):
         get_settings()
+
+
+def test_production_allows_missing_redis_url_when_degraded_mode_enabled(monkeypatch) -> None:
+    monkeypatch.setenv("ENVIRONMENT", "production")
+    monkeypatch.setenv("COOKIE_SECURE", "true")
+    monkeypatch.setenv("FRONTEND_URL", "https://app.stima.dev")
+    monkeypatch.setenv("ALLOWED_HOSTS", "api.stima.dev")
+    monkeypatch.setenv("ALLOW_REDIS_DEGRADED_MODE", "true")
+    monkeypatch.setenv("REDIS_URL", "")
+
+    settings = get_settings()
+
+    assert settings.redis_url is None
+    assert settings.allow_redis_degraded_mode is True

--- a/backend/app/core/tests/test_main.py
+++ b/backend/app/core/tests/test_main.py
@@ -4,13 +4,15 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import AsyncGenerator, Iterator
-from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
 import pytest_asyncio
 from app.core.config import get_settings
 from app.main import create_app
+from app.shared.idempotency import IdempotencyStore, InMemoryIdempotencyStateStore
+from app.shared.rate_limit import ExtractionControlManager, InMemoryExtractionStateStore
+from app.shared.redis_runtime import RedisRuntimeState
 from httpx import ASGITransport, AsyncClient
 
 
@@ -21,6 +23,11 @@ def _required_settings(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
     monkeypatch.delenv("ALLOWED_HOSTS", raising=False)
     monkeypatch.delenv("ENABLE_HTTPS_REDIRECT", raising=False)
     monkeypatch.delenv("TRUSTED_PROXY_IPS", raising=False)
+    monkeypatch.delenv("ENVIRONMENT", raising=False)
+    monkeypatch.delenv("REDIS_URL", raising=False)
+    monkeypatch.delenv("COOKIE_SECURE", raising=False)
+    monkeypatch.delenv("FRONTEND_URL", raising=False)
+    monkeypatch.delenv("ALLOW_REDIS_DEGRADED_MODE", raising=False)
     get_settings.cache_clear()
     yield
     get_settings.cache_clear()
@@ -63,6 +70,7 @@ async def test_trusted_proxy_headers_prevent_https_redirect_loops(
     monkeypatch.setenv("COOKIE_SECURE", "true")
     monkeypatch.setenv("FRONTEND_URL", "https://stima.odysian.dev")
     monkeypatch.setenv("REDIS_URL", "redis://localhost:6379/0")
+    monkeypatch.setenv("ALLOW_REDIS_DEGRADED_MODE", "true")
     monkeypatch.setenv("ALLOWED_HOSTS", "api.stima.odysian.dev,127.0.0.1")
     monkeypatch.setenv("ENABLE_HTTPS_REDIRECT", "true")
     monkeypatch.setenv("TRUSTED_PROXY_IPS", "127.0.0.1")
@@ -170,18 +178,31 @@ async def test_missing_or_invalid_ingress_correlation_id_generates_new_value(
 async def test_app_lifespan_closes_extraction_controls(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    aclose = AsyncMock()
+    extraction_controls = ExtractionControlManager(InMemoryExtractionStateStore())
+    extraction_controls_aclose = AsyncMock()
+    monkeypatch.setattr(extraction_controls, "aclose", extraction_controls_aclose)
+
+    idempotency_store = IdempotencyStore(InMemoryIdempotencyStateStore())
     idempotency_aclose = AsyncMock()
+    monkeypatch.setattr(idempotency_store, "aclose", idempotency_aclose)
 
-    class _CachedStoreFactory:
-        def __call__(self) -> object:
-            return SimpleNamespace(aclose=idempotency_aclose)
-
-        def cache_info(self) -> SimpleNamespace:
-            return SimpleNamespace(currsize=1)
-
-    monkeypatch.setattr("app.main.get_idempotency_store", _CachedStoreFactory())
-    monkeypatch.setattr("app.main.extraction_controls.aclose", aclose)
+    monkeypatch.setattr(
+        "app.main.resolve_redis_runtime_state",
+        AsyncMock(
+            return_value=RedisRuntimeState(
+                mode="degraded_memory",
+                degraded_reason="redis_missing",
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        "app.main.configure_runtime_rate_limit_state",
+        lambda **_: extraction_controls,
+    )
+    monkeypatch.setattr(
+        "app.main.build_idempotency_store",
+        lambda *_args, **_kwargs: idempotency_store,
+    )
 
     app = create_app()
 
@@ -189,15 +210,20 @@ async def test_app_lifespan_closes_extraction_controls(
         pass
 
     idempotency_aclose.assert_awaited_once()
-    aclose.assert_awaited_once()
+    extraction_controls_aclose.assert_awaited_once()
 
 
 @pytest.mark.asyncio
 async def test_app_lifespan_degrades_when_arq_pool_startup_fails(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    monkeypatch.setenv("ALLOW_REDIS_DEGRADED_MODE", "true")
     monkeypatch.setenv("REDIS_URL", "redis://localhost:6379/0")
     get_settings.cache_clear()
+    monkeypatch.setattr(
+        "app.main.resolve_redis_runtime_state",
+        AsyncMock(return_value=RedisRuntimeState(mode="redis")),
+    )
     monkeypatch.setattr(
         "app.main.create_pool",
         AsyncMock(side_effect=RuntimeError("redis unavailable")),
@@ -207,6 +233,8 @@ async def test_app_lifespan_degrades_when_arq_pool_startup_fails(
 
     async with app.router.lifespan_context(app):
         assert app.state.arq_pool is None
+        assert app.state.redis_runtime_mode == "degraded_memory"
+        assert app.state.queue_available is False
 
 
 @pytest.mark.asyncio

--- a/backend/app/features/quotes/api.py
+++ b/backend/app/features/quotes/api.py
@@ -165,8 +165,7 @@ async def convert_notes(
     extraction_service: Annotated[ExtractionService, Depends(get_extraction_service)],
 ) -> ExtractionResponse:
     """Convert notes into extraction output without creating a persisted draft."""
-    del request
-    async with extraction_capacity_guard(user.id):
+    async with extraction_capacity_guard(request, user.id):
         try:
             extraction = await extraction_service.convert_notes(payload.notes)
             return ExtractionResponse.from_internal_result(extraction)
@@ -277,7 +276,6 @@ async def extract_combined(
     idempotency_key: Annotated[str | None, Header(alias="Idempotency-Key")] = None,
 ) -> PersistedExtractionResponse | JobRecordResponse:
     """Extract quote data, persist the draft, and return a quote id or extraction job."""
-    del request
     clip_inputs = await _parse_upload_clips(clips or [])
     clip_hashes = [sha256(clip.content).hexdigest() for clip in clip_inputs]
     capture_detail = _resolve_capture_detail(clip_inputs, notes)
@@ -330,7 +328,7 @@ async def extract_combined(
 
     if arq_pool is None:
         try:
-            async with extraction_capacity_guard(user.id):
+            async with extraction_capacity_guard(request, user.id):
                 try:
                     extraction = await extraction_service.extract_combined(
                         clip_inputs,

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -6,6 +6,7 @@ import asyncio
 import logging
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
+from typing import Literal
 
 from arq.connections import ArqRedis, create_pool
 from fastapi import Depends, FastAPI
@@ -30,9 +31,9 @@ from app.features.line_item_catalog.api import router as line_item_catalog_route
 from app.features.profile.api import router as profile_router
 from app.features.quotes.api import public_router as quote_public_router
 from app.features.quotes.api import router as quote_router
-from app.shared.dependencies import get_idempotency_store
 from app.shared.event_logger import configure_event_logging
 from app.shared.extraction_logger import configure_extraction_logging
+from app.shared.idempotency import IdempotencyStore, build_idempotency_store
 from app.shared.observability import (
     RequestObservabilityMiddleware,
     bind_request_context,
@@ -40,7 +41,17 @@ from app.shared.observability import (
     security_rate_limit_handler,
 )
 from app.shared.proxy_headers import TrustedProxyHeadersMiddleware
-from app.shared.rate_limit import extraction_controls, limiter
+from app.shared.rate_limit import (
+    ExtractionControlManager,
+    close_limiter_storage,
+    configure_runtime_rate_limit_state,
+    limiter,
+)
+from app.shared.redis_runtime import (
+    RedisRuntimeResolutionError,
+    RedisRuntimeState,
+    resolve_redis_runtime_state,
+)
 from app.worker.runtime import build_arq_redis_settings
 
 LOGGER = logging.getLogger(__name__)
@@ -83,6 +94,34 @@ def _resolve_allowed_hosts(allowed_hosts: list[str]) -> list[str]:
 @asynccontextmanager
 async def _lifespan(app: FastAPI) -> AsyncIterator[None]:
     settings = get_settings()
+    runtime_state = await resolve_redis_runtime_state(settings)
+    runtime_limiter_mode: Literal["redis", "memory"] = (
+        "redis" if runtime_state.mode == "redis" else "memory"
+    )
+    extraction_controls = configure_runtime_rate_limit_state(
+        settings=settings,
+        runtime_mode=runtime_limiter_mode,
+        degraded_reason=runtime_state.degraded_reason,
+    )
+    idempotency_store = build_idempotency_store(
+        settings,
+        runtime_mode=runtime_limiter_mode,
+    )
+    _bind_runtime_state(
+        app=app,
+        runtime_state=runtime_state,
+        extraction_controls=extraction_controls,
+        idempotency_store=idempotency_store,
+    )
+
+    if runtime_state.mode == "degraded_memory":
+        LOGGER.warning(
+            "Redis degraded mode active at startup: reason=%s; "
+            "rate_limiter=memory extraction_controls=memory "
+            "idempotency=memory queue_available=false",
+            runtime_state.degraded_reason or "redis_probe_failed",
+        )
+
     arq_pool: ArqRedis | None = None
     stale_job_reaper_task = asyncio.create_task(
         run_stale_extraction_job_reaper(
@@ -92,16 +131,41 @@ async def _lifespan(app: FastAPI) -> AsyncIterator[None]:
         )
     )
     app.state.stale_job_reaper_task = stale_job_reaper_task
-    if settings.redis_url is not None:
+    if runtime_state.mode == "redis":
         try:
             arq_pool = await create_pool(build_arq_redis_settings(settings))
         except Exception:
-            LOGGER.warning(
-                "ARQ Redis unavailable at startup; async jobs disabled "
-                "and sync extraction fallback remains enabled.",
-                exc_info=True,
-            )
+            if settings.allow_redis_degraded_mode:
+                runtime_state = RedisRuntimeState(
+                    mode="degraded_memory",
+                    degraded_reason="redis_probe_failed",
+                )
+                extraction_controls = configure_runtime_rate_limit_state(
+                    settings=settings,
+                    runtime_mode="memory",
+                    degraded_reason=runtime_state.degraded_reason,
+                )
+                await idempotency_store.aclose()
+                idempotency_store = build_idempotency_store(settings, runtime_mode="memory")
+                _bind_runtime_state(
+                    app=app,
+                    runtime_state=runtime_state,
+                    extraction_controls=extraction_controls,
+                    idempotency_store=idempotency_store,
+                )
+                LOGGER.warning(
+                    "Redis degraded mode active at startup after ARQ init failure: "
+                    "reason=%s; rate_limiter=memory extraction_controls=memory "
+                    "idempotency=memory queue_available=false",
+                    runtime_state.degraded_reason,
+                    exc_info=True,
+                )
+            else:
+                raise RedisRuntimeResolutionError(
+                    "ARQ Redis unavailable at startup and degraded mode disabled"
+                ) from None
     app.state.arq_pool = arq_pool
+    app.state.queue_available = arq_pool is not None
     yield
     stale_job_reaper_task.cancel()
     try:
@@ -110,9 +174,30 @@ async def _lifespan(app: FastAPI) -> AsyncIterator[None]:
         pass
     if arq_pool is not None:
         await arq_pool.aclose()
-    if get_idempotency_store.cache_info().currsize:
-        await get_idempotency_store().aclose()
-    await extraction_controls.aclose()
+    app.state.queue_available = False
+
+    runtime_idempotency_store = getattr(app.state, "idempotency_store", None)
+    if isinstance(runtime_idempotency_store, IdempotencyStore):
+        await runtime_idempotency_store.aclose()
+
+    runtime_extraction_controls = getattr(app.state, "extraction_controls", None)
+    if isinstance(runtime_extraction_controls, ExtractionControlManager):
+        await runtime_extraction_controls.aclose()
+
+    close_limiter_storage(limiter)
+
+
+def _bind_runtime_state(
+    *,
+    app: FastAPI,
+    runtime_state: RedisRuntimeState,
+    extraction_controls: ExtractionControlManager,
+    idempotency_store: IdempotencyStore,
+) -> None:
+    app.state.redis_runtime_mode = runtime_state.mode
+    app.state.redis_degraded_reason = runtime_state.degraded_reason
+    app.state.extraction_controls = extraction_controls
+    app.state.idempotency_store = idempotency_store
 
 
 def create_app() -> FastAPI:
@@ -129,6 +214,11 @@ def create_app() -> FastAPI:
     app.state.limiter = limiter
     app.state.arq_pool = None
     app.state.stale_job_reaper_task = None
+    app.state.redis_runtime_mode = "pending"
+    app.state.redis_degraded_reason = None
+    app.state.extraction_controls = None
+    app.state.idempotency_store = None
+    app.state.queue_available = False
     app.add_exception_handler(RateLimitExceeded, security_rate_limit_handler)  # type: ignore[arg-type]
     app.add_middleware(
         CORSMiddleware,
@@ -177,7 +267,15 @@ def create_app() -> FastAPI:
 
     @app.get("/health", include_in_schema=False)
     async def health() -> JSONResponse:
-        return JSONResponse({"status": "ok"})
+        payload = {
+            "status": "ok",
+            "runtime_mode": str(getattr(app.state, "redis_runtime_mode", "unknown")),
+            "queue_available": bool(getattr(app.state, "queue_available", False)),
+        }
+        degraded_reason = getattr(app.state, "redis_degraded_reason", None)
+        if degraded_reason:
+            payload["degraded_reason"] = degraded_reason
+        return JSONResponse(payload)
 
     return app
 

--- a/backend/app/shared/dependencies.py
+++ b/backend/app/shared/dependencies.py
@@ -46,7 +46,11 @@ from app.integrations.storage import StorageService
 from app.integrations.transcription import TranscriptionIntegration
 from app.shared.idempotency import IdempotencyStore, build_idempotency_store
 from app.shared.pdf_artifact_repository import PdfArtifactRepository
-from app.shared.rate_limit import limiter, reserve_extraction_capacity
+from app.shared.rate_limit import (
+    ExtractionControlManager,
+    extraction_controls,
+    reserve_extraction_capacity,
+)
 
 
 @lru_cache(maxsize=1)
@@ -105,10 +109,26 @@ def get_transcription_integration() -> TranscriptionIntegration:
     )
 
 
+def get_idempotency_store(request: Request) -> IdempotencyStore:
+    """Return the runtime-resolved idempotency store from app state."""
+    state_store = getattr(request.app.state, "idempotency_store", None)
+    if isinstance(state_store, IdempotencyStore):
+        return state_store
+    return _get_fallback_idempotency_store()
+
+
 @lru_cache(maxsize=1)
-def get_idempotency_store() -> IdempotencyStore:
-    """Return the configured idempotency store singleton."""
+def _get_fallback_idempotency_store() -> IdempotencyStore:
+    """Compatibility fallback for contexts that bypass lifespan startup."""
     return build_idempotency_store()
+
+
+def get_extraction_control_manager(request: Request) -> ExtractionControlManager:
+    """Return runtime extraction control manager from app state."""
+    manager = getattr(request.app.state, "extraction_controls", None)
+    if isinstance(manager, ExtractionControlManager):
+        return manager
+    return extraction_controls
 
 
 def get_auth_service(
@@ -273,7 +293,7 @@ def require_csrf(
 
 
 @asynccontextmanager
-async def extraction_capacity_guard(user_id: UUID) -> AsyncIterator[None]:
+async def extraction_capacity_guard(request: Request, user_id: UUID) -> AsyncIterator[None]:
     """Hold extraction quota/concurrency for the wrapped block (no-op when limiter disabled).
 
     Use inside route handlers after SlowAPI's per-route limit check so 429s from the
@@ -285,11 +305,13 @@ async def extraction_capacity_guard(user_id: UUID) -> AsyncIterator[None]:
     SlowAPI decorators independently of extraction guards, introduce a dedicated
     ``EXTRACTION_GUARDS_ENABLED`` setting rather than removing this check.
     """
-    if not limiter.enabled:
+    limiter = getattr(request.app.state, "limiter", None)
+    if limiter is not None and not limiter.enabled:
         yield
         return
 
-    async with reserve_extraction_capacity(user_id) as capacity_available:
+    manager = get_extraction_control_manager(request)
+    async with reserve_extraction_capacity(user_id, manager=manager) as capacity_available:
         if not capacity_available:
             raise HTTPException(
                 status_code=status.HTTP_429_TOO_MANY_REQUESTS,

--- a/backend/app/shared/idempotency.py
+++ b/backend/app/shared/idempotency.py
@@ -17,6 +17,7 @@ from app.core.config import Settings, get_settings
 
 LOGGER = logging.getLogger(__name__)
 _IDEMPOTENCY_TTL_SECONDS = 24 * 60 * 60
+RuntimeIdempotencyMode = Literal["redis", "memory"]
 
 
 @dataclass(frozen=True, slots=True)
@@ -356,15 +357,29 @@ class IdempotencyStore:
         return self._settings if self._settings is not None else get_settings()
 
 
-def build_idempotency_store(settings: Settings | None = None) -> IdempotencyStore:
+def build_idempotency_store(
+    settings: Settings | None = None,
+    *,
+    runtime_mode: RuntimeIdempotencyMode | None = None,
+) -> IdempotencyStore:
     """Build a settings-backed idempotency store."""
     resolved_settings = settings if settings is not None else get_settings()
+    if runtime_mode == "redis":
+        if not resolved_settings.redis_url:
+            raise ValueError("REDIS_URL must be set when idempotency runtime mode is redis")
+        return IdempotencyStore(
+            RedisIdempotencyStateStore(resolved_settings.redis_url),
+            settings=resolved_settings,
+        )
+    if runtime_mode == "memory":
+        return IdempotencyStore(InMemoryIdempotencyStateStore(), settings=resolved_settings)
+
     if resolved_settings.redis_url:
         return IdempotencyStore(
             RedisIdempotencyStateStore(resolved_settings.redis_url),
-            settings=settings,
+            settings=resolved_settings,
         )
-    return IdempotencyStore(InMemoryIdempotencyStateStore(), settings=settings)
+    return IdempotencyStore(InMemoryIdempotencyStateStore(), settings=resolved_settings)
 
 
 def reset_local_idempotency_state(store: IdempotencyStore) -> None:

--- a/backend/app/shared/rate_limit.py
+++ b/backend/app/shared/rate_limit.py
@@ -9,12 +9,14 @@ import time
 from collections.abc import AsyncIterator, Awaitable
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
-from typing import Any, cast
+from typing import Any, Literal, cast
 from urllib.parse import urlsplit, urlunsplit
 from uuid import UUID
 
 from fastapi import Request
 from jwt import InvalidTokenError
+from limits.storage import storage_from_string
+from limits.strategies import STRATEGIES
 from redis.asyncio import Redis
 from slowapi import Limiter
 
@@ -31,6 +33,7 @@ from app.shared.proxy_headers import (
 
 LOGGER = logging.getLogger(__name__)
 _MEMORY_STORAGE_URI = "memory://"
+RuntimeLimiterMode = Literal["redis", "memory"]
 
 
 def get_ip_key(request: Request) -> str:
@@ -69,7 +72,7 @@ def get_user_key(request: Request) -> str:
 @dataclass(frozen=True)
 class LimiterBackendConfig:
     storage_uri: str
-    mode: str
+    mode: RuntimeLimiterMode
     fallback_reason: str | None = None
 
 
@@ -324,6 +327,13 @@ def build_limiter(settings: Settings | None = None) -> Limiter:
     """Build a settings-backed SlowAPI limiter."""
     resolved_settings = settings if settings is not None else get_settings()
     backend = resolve_limiter_backend(resolved_settings)
+    return _build_limiter_from_backend(resolved_settings, backend)
+
+
+def _build_limiter_from_backend(
+    settings: Settings,
+    backend: LimiterBackendConfig,
+) -> Limiter:
     if backend.mode == "redis":
         LOGGER.info(
             "Redis rate limiting enabled with backend %s",
@@ -331,14 +341,14 @@ def build_limiter(settings: Settings | None = None) -> Limiter:
         )
         rate_limiter = Limiter(
             key_func=get_ip_key,
-            headers_enabled=resolved_settings.rate_limit_headers_enabled,
+            headers_enabled=settings.rate_limit_headers_enabled,
             storage_uri=backend.storage_uri,
-            storage_options={"key_prefix": resolved_settings.redis_key_prefix},
+            storage_options={"key_prefix": settings.redis_key_prefix},
         )
     else:
         rate_limiter = Limiter(
             key_func=get_ip_key,
-            headers_enabled=resolved_settings.rate_limit_headers_enabled,
+            headers_enabled=settings.rate_limit_headers_enabled,
             storage_uri=backend.storage_uri,
         )
     rate_limiter._stima_storage_mode = backend.mode  # type: ignore[attr-defined]
@@ -348,10 +358,15 @@ def build_limiter(settings: Settings | None = None) -> Limiter:
 
 def build_extraction_control_manager(
     settings: Settings | None = None,
+    *,
+    runtime_mode: RuntimeLimiterMode | None = None,
 ) -> ExtractionControlManager:
     """Build extraction quota/concurrency controls from the current settings."""
     resolved_settings = settings if settings is not None else get_settings()
-    backend = resolve_limiter_backend(resolved_settings)
+    backend = resolve_limiter_backend_for_runtime_mode(
+        resolved_settings,
+        runtime_mode=runtime_mode,
+    )
     if backend.mode == "redis" and resolved_settings.redis_url is not None:
         return ExtractionControlManager(
             RedisExtractionStateStore(resolved_settings.redis_url),
@@ -371,11 +386,34 @@ def configure_active_limiter_key_prefix(prefix: str) -> None:
 def resolve_limiter_backend(settings: Settings | None = None) -> LimiterBackendConfig:
     """Resolve whether the app should use Redis or degraded in-memory storage."""
     resolved_settings = settings if settings is not None else get_settings()
-    environment = resolved_settings.environment.lower()
-    if resolved_settings.redis_url:
-        return LimiterBackendConfig(storage_uri=resolved_settings.redis_url, mode="redis")
+    return resolve_limiter_backend_for_runtime_mode(
+        resolved_settings,
+        runtime_mode="redis" if resolved_settings.redis_url else None,
+    )
 
-    if environment == "production":
+
+def resolve_limiter_backend_for_runtime_mode(
+    settings: Settings,
+    *,
+    runtime_mode: RuntimeLimiterMode | None,
+    degraded_reason: str | None = None,
+) -> LimiterBackendConfig:
+    """Resolve limiter backend from explicit runtime mode when available."""
+    if runtime_mode == "redis":
+        if not settings.redis_url:
+            raise ValueError("REDIS_URL must be set when limiter runtime mode is redis")
+        return LimiterBackendConfig(storage_uri=settings.redis_url, mode="redis")
+    if runtime_mode == "memory":
+        return LimiterBackendConfig(
+            storage_uri=_MEMORY_STORAGE_URI,
+            mode="memory",
+            fallback_reason=degraded_reason,
+        )
+
+    if settings.redis_url:
+        return LimiterBackendConfig(storage_uri=settings.redis_url, mode="redis")
+
+    if settings.environment.lower() == "production" and not settings.allow_redis_degraded_mode:
         raise ValueError("REDIS_URL must be set when ENVIRONMENT is 'production'")
 
     fallback_reason = (
@@ -389,6 +427,64 @@ def resolve_limiter_backend(settings: Settings | None = None) -> LimiterBackendC
     )
 
 
+def configure_runtime_rate_limit_state(
+    *,
+    settings: Settings,
+    runtime_mode: RuntimeLimiterMode,
+    degraded_reason: str | None = None,
+) -> ExtractionControlManager:
+    """Rebind global limiter + extraction controls to runtime-resolved mode."""
+    backend = resolve_limiter_backend_for_runtime_mode(
+        settings,
+        runtime_mode=runtime_mode,
+        degraded_reason=degraded_reason,
+    )
+    _reconfigure_limiter_backend(limiter, backend=backend, settings=settings)
+
+    global extraction_controls
+    extraction_controls = build_extraction_control_manager(
+        settings,
+        runtime_mode=runtime_mode,
+    )
+    return extraction_controls
+
+
+def _reconfigure_limiter_backend(
+    rate_limiter: Limiter,
+    *,
+    backend: LimiterBackendConfig,
+    settings: Settings,
+) -> None:
+    old_storage = getattr(rate_limiter, "_storage", None)
+    strategy_name = getattr(rate_limiter, "_strategy", None) or "fixed-window"
+    storage_options = {"key_prefix": settings.redis_key_prefix} if backend.mode == "redis" else {}
+    storage = storage_from_string(backend.storage_uri, **storage_options)
+
+    rate_limiter._storage_uri = backend.storage_uri  # type: ignore[attr-defined]
+    rate_limiter._storage_options = storage_options  # type: ignore[attr-defined]
+    rate_limiter._storage = storage  # type: ignore[attr-defined]
+    rate_limiter._limiter = STRATEGIES[strategy_name](storage)  # type: ignore[attr-defined]
+    rate_limiter._stima_storage_mode = backend.mode  # type: ignore[attr-defined]
+    rate_limiter._stima_fallback_reason = backend.fallback_reason  # type: ignore[attr-defined]
+    _close_limiter_storage(old_storage)
+
+
+def _close_limiter_storage(storage: Any) -> None:
+    if storage is None:
+        return
+    storage_client = getattr(storage, "storage", None)
+    if storage_client is None:
+        return
+    close_sync = getattr(storage_client, "close", None)
+    if callable(close_sync):
+        close_sync()
+
+
+def close_limiter_storage(rate_limiter: Limiter) -> None:
+    """Release active limiter storage client resources when supported."""
+    _close_limiter_storage(getattr(rate_limiter, "_storage", None))
+
+
 limiter = build_limiter()
 extraction_controls = build_extraction_control_manager()
 
@@ -400,7 +496,11 @@ def reset_local_rate_limit_state() -> None:
 
 
 @asynccontextmanager
-async def reserve_extraction_capacity(user_id: UUID) -> AsyncIterator[bool]:
+async def reserve_extraction_capacity(
+    user_id: UUID,
+    *,
+    manager: ExtractionControlManager | None = None,
+) -> AsyncIterator[bool]:
     """Acquire extraction concurrency and daily quota before provider-backed work starts.
 
     Ordering: concurrency is acquired first so a provider slot is confirmed before
@@ -413,12 +513,13 @@ async def reserve_extraction_capacity(user_id: UUID) -> AsyncIterator[bool]:
     quota slot. Decide there whether retries should bypass this guard or consume
     quota per attempt.
     """
-    lease = await extraction_controls.acquire_concurrency(user_id)
+    active_manager = manager if manager is not None else extraction_controls
+    lease = await active_manager.acquire_concurrency(user_id)
     if lease is None:
         yield False
         return
 
-    quota_reserved = await extraction_controls.reserve_daily_quota(user_id)
+    quota_reserved = await active_manager.reserve_daily_quota(user_id)
     if not quota_reserved:
         await lease.release()
         yield False

--- a/backend/app/shared/redis_runtime.py
+++ b/backend/app/shared/redis_runtime.py
@@ -39,7 +39,10 @@ async def probe_redis(
     except Exception:
         return False, "redis_probe_failed"
     finally:
-        await client.aclose()
+        try:
+            await client.aclose()
+        except Exception:
+            pass
     return True, None
 
 

--- a/backend/app/shared/redis_runtime.py
+++ b/backend/app/shared/redis_runtime.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from dataclasses import dataclass
 from typing import Literal
 
@@ -11,6 +12,7 @@ from redis.asyncio import Redis
 from app.core.config import Settings
 
 RedisRuntimeMode = Literal["redis", "degraded_memory"]
+LOGGER = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True, slots=True)
@@ -42,13 +44,18 @@ async def probe_redis(
         try:
             await client.aclose()
         except Exception:
-            pass
+            LOGGER.warning(
+                "Redis probe client close failed; continuing startup resolution",
+                exc_info=True,
+            )
     return True, None
 
 
 async def resolve_redis_runtime_state(settings: Settings) -> RedisRuntimeState:
     """Resolve startup Redis mode from policy and runtime availability."""
     if settings.redis_url is None:
+        if settings.environment.lower() != "production":
+            return RedisRuntimeState(mode="degraded_memory", degraded_reason="redis_missing")
         if settings.allow_redis_degraded_mode:
             return RedisRuntimeState(mode="degraded_memory", degraded_reason="redis_missing")
         raise RedisRuntimeResolutionError("REDIS_URL is required in production")

--- a/backend/app/shared/redis_runtime.py
+++ b/backend/app/shared/redis_runtime.py
@@ -1,0 +1,65 @@
+"""Redis runtime mode resolution for startup degraded-mode behavior."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from typing import Literal
+
+from redis.asyncio import Redis
+
+from app.core.config import Settings
+
+RedisRuntimeMode = Literal["redis", "degraded_memory"]
+
+
+@dataclass(frozen=True, slots=True)
+class RedisRuntimeState:
+    """Resolved Redis runtime mode and optional degraded reason."""
+
+    mode: RedisRuntimeMode
+    degraded_reason: str | None = None
+
+
+class RedisRuntimeResolutionError(RuntimeError):
+    """Raised when startup policy forbids running without healthy Redis."""
+
+
+async def probe_redis(
+    redis_url: str,
+    *,
+    timeout_seconds: float = 2.0,
+) -> tuple[bool, str | None]:
+    """Return probe success and failure reason category for startup logging."""
+    client = Redis.from_url(redis_url, encoding="utf-8", decode_responses=True)
+    try:
+        await asyncio.wait_for(client.ping(), timeout=timeout_seconds)
+    except TimeoutError:
+        return False, "redis_startup_timeout"
+    except Exception:
+        return False, "redis_probe_failed"
+    finally:
+        await client.aclose()
+    return True, None
+
+
+async def resolve_redis_runtime_state(settings: Settings) -> RedisRuntimeState:
+    """Resolve startup Redis mode from policy and runtime availability."""
+    if settings.redis_url is None:
+        if settings.allow_redis_degraded_mode:
+            return RedisRuntimeState(mode="degraded_memory", degraded_reason="redis_missing")
+        raise RedisRuntimeResolutionError("REDIS_URL is required in production")
+
+    is_healthy, reason = await probe_redis(
+        settings.redis_url,
+        timeout_seconds=settings.redis_startup_probe_timeout_seconds,
+    )
+    if is_healthy:
+        return RedisRuntimeState(mode="redis")
+    if settings.allow_redis_degraded_mode:
+        return RedisRuntimeState(mode="degraded_memory", degraded_reason=reason)
+
+    degraded_reason = reason or "redis_probe_failed"
+    raise RedisRuntimeResolutionError(
+        f"Redis unavailable at startup and degraded mode disabled: {degraded_reason}"
+    )

--- a/backend/app/shared/tests/test_rate_limit.py
+++ b/backend/app/shared/tests/test_rate_limit.py
@@ -19,6 +19,7 @@ from app.shared.rate_limit import (
     get_ip_key,
     get_user_key,
     resolve_limiter_backend,
+    resolve_limiter_backend_for_runtime_mode,
 )
 from limits.storage.memory import MemoryStorage
 from limits.storage.redis import RedisStorage
@@ -254,6 +255,35 @@ def test_resolve_limiter_backend_rejects_production_without_redis_url() -> None:
     settings = Settings.model_construct(environment="production", redis_url=None)
     with pytest.raises(ValueError, match="REDIS_URL must be set"):
         resolve_limiter_backend(settings)
+
+
+def test_resolve_limiter_backend_allows_production_memory_when_degraded_enabled() -> None:
+    settings = Settings.model_construct(
+        environment="production",
+        redis_url=None,
+        allow_redis_degraded_mode=True,
+    )
+
+    backend = resolve_limiter_backend(settings)
+
+    assert backend.mode == "memory"
+    assert backend.storage_uri == "memory://"
+
+
+def test_resolve_limiter_backend_for_runtime_mode_forces_memory() -> None:
+    settings = Settings.model_construct(
+        environment="production",
+        redis_url="redis://localhost:6379/0",
+    )
+
+    backend = resolve_limiter_backend_for_runtime_mode(
+        settings,
+        runtime_mode="memory",
+        degraded_reason="redis_probe_failed",
+    )
+
+    assert backend.mode == "memory"
+    assert backend.fallback_reason == "redis_probe_failed"
 
 
 @pytest.mark.asyncio

--- a/backend/app/shared/tests/test_redis_runtime.py
+++ b/backend/app/shared/tests/test_redis_runtime.py
@@ -93,3 +93,13 @@ async def test_resolve_runtime_state_rejects_unhealthy_redis_when_degraded_disab
 
     with pytest.raises(RedisRuntimeResolutionError):
         await resolve_redis_runtime_state(get_settings())
+
+
+@pytest.mark.asyncio
+async def test_resolve_runtime_state_allows_missing_redis_in_development_default() -> None:
+    settings = get_settings()
+
+    runtime_state = await resolve_redis_runtime_state(settings)
+
+    assert runtime_state.mode == "degraded_memory"
+    assert runtime_state.degraded_reason == "redis_missing"

--- a/backend/app/shared/tests/test_redis_runtime.py
+++ b/backend/app/shared/tests/test_redis_runtime.py
@@ -96,7 +96,14 @@ async def test_resolve_runtime_state_rejects_unhealthy_redis_when_degraded_disab
 
 
 @pytest.mark.asyncio
-async def test_resolve_runtime_state_allows_missing_redis_in_development_default() -> None:
+async def test_resolve_runtime_state_allows_missing_redis_in_development_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("TEST_REDIS_URL", raising=False)
+    monkeypatch.setenv("REDIS_URL", "")
+    monkeypatch.setenv("ENVIRONMENT", "development")
+    get_settings.cache_clear()
+
     settings = get_settings()
 
     runtime_state = await resolve_redis_runtime_state(settings)

--- a/backend/app/shared/tests/test_redis_runtime.py
+++ b/backend/app/shared/tests/test_redis_runtime.py
@@ -1,0 +1,95 @@
+"""Redis runtime degraded-mode resolution tests."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Iterator
+from unittest.mock import AsyncMock
+
+import pytest
+from app.core.config import get_settings
+from app.shared.redis_runtime import (
+    RedisRuntimeResolutionError,
+    probe_redis,
+    resolve_redis_runtime_state,
+)
+
+
+@pytest.fixture(autouse=True)
+def _required_settings(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    monkeypatch.setenv("SECRET_KEY", "test-secret-key-that-is-at-least-32-bytes")
+    monkeypatch.setenv("GCS_BUCKET_NAME", "stima-test-logos")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.mark.asyncio
+async def test_probe_redis_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _FakeRedis:
+        async def ping(self) -> bool:
+            return True
+
+        async def aclose(self) -> None:
+            return None
+
+    monkeypatch.setattr("app.shared.redis_runtime.Redis.from_url", lambda *_a, **_k: _FakeRedis())
+
+    ok, reason = await probe_redis("redis://localhost:6379/0", timeout_seconds=0.1)
+
+    assert ok is True
+    assert reason is None
+
+
+@pytest.mark.asyncio
+async def test_probe_redis_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _FakeRedis:
+        async def ping(self) -> bool:
+            await asyncio.sleep(0.2)
+            return True
+
+        async def aclose(self) -> None:
+            return None
+
+    monkeypatch.setattr("app.shared.redis_runtime.Redis.from_url", lambda *_a, **_k: _FakeRedis())
+
+    ok, reason = await probe_redis("redis://localhost:6379/0", timeout_seconds=0.01)
+
+    assert ok is False
+    assert reason == "redis_startup_timeout"
+
+
+@pytest.mark.asyncio
+async def test_resolve_runtime_state_uses_degraded_memory_when_missing_redis_and_allowed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("ENVIRONMENT", "production")
+    monkeypatch.setenv("COOKIE_SECURE", "true")
+    monkeypatch.setenv("FRONTEND_URL", "https://app.stima.dev")
+    monkeypatch.setenv("ALLOWED_HOSTS", "api.stima.dev")
+    monkeypatch.setenv("ALLOW_REDIS_DEGRADED_MODE", "true")
+    monkeypatch.setenv("REDIS_URL", "")
+
+    runtime_state = await resolve_redis_runtime_state(get_settings())
+
+    assert runtime_state.mode == "degraded_memory"
+    assert runtime_state.degraded_reason == "redis_missing"
+
+
+@pytest.mark.asyncio
+async def test_resolve_runtime_state_rejects_unhealthy_redis_when_degraded_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("ENVIRONMENT", "production")
+    monkeypatch.setenv("COOKIE_SECURE", "true")
+    monkeypatch.setenv("FRONTEND_URL", "https://app.stima.dev")
+    monkeypatch.setenv("ALLOWED_HOSTS", "api.stima.dev")
+    monkeypatch.setenv("ALLOW_REDIS_DEGRADED_MODE", "false")
+    monkeypatch.setenv("REDIS_URL", "redis://localhost:6379/0")
+    monkeypatch.setattr(
+        "app.shared.redis_runtime.probe_redis",
+        AsyncMock(return_value=(False, "redis_probe_failed")),
+    )
+
+    with pytest.raises(RedisRuntimeResolutionError):
+        await resolve_redis_runtime_state(get_settings())

--- a/backend/app/worker/tests/test_runtime.py
+++ b/backend/app/worker/tests/test_runtime.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from uuid import UUID, uuid4
 
 import pytest
+from app.core.config import get_settings
 from app.features.auth.models import User
 from app.features.jobs.models import JobRecord, JobStatus, JobType
 from app.features.jobs.repository import JobRepository
@@ -148,6 +149,7 @@ async def test_worker_startup_raises_when_redis_is_unreachable(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setenv("REDIS_URL", "redis://cache.example:6379/0")
+    get_settings.cache_clear()
 
     class _BrokenRedisClient:
         async def ping(self) -> None:
@@ -163,6 +165,8 @@ async def test_worker_startup_raises_when_redis_is_unreachable(
 
     with pytest.raises(ConnectionError, match="cannot reach redis"):
         await on_worker_startup({})
+
+    get_settings.cache_clear()
 
 
 async def _successful_handler() -> None:

--- a/backend/conftest.py
+++ b/backend/conftest.py
@@ -24,15 +24,19 @@ os.environ["REDIS_URL"] = os.environ.get("TEST_REDIS_URL", "")
 from app.core.database import Base, get_db
 from app.features import registry as feature_registry  # noqa: F401
 from app.main import app
+from app.shared import dependencies as shared_dependencies
 from app.shared import event_logger
 from app.shared.dependencies import (
     get_extraction_integration,
-    get_idempotency_store,
     get_transcription_integration,
 )
 from app.shared.idempotency import reset_local_idempotency_state
 from app.shared.observability import reset_observability_state
-from app.shared.rate_limit import configure_active_limiter_key_prefix, reset_local_rate_limit_state
+from app.shared.rate_limit import (
+    configure_active_limiter_key_prefix,
+    configure_runtime_rate_limit_state,
+    reset_local_rate_limit_state,
+)
 
 TEST_SCHEMA = "stima_test"
 TEST_DATABASE_URL = os.getenv(
@@ -105,16 +109,25 @@ def _isolate_rate_limit_state(
     get_settings.cache_clear()
     get_extraction_integration.cache_clear()
     get_transcription_integration.cache_clear()
+    settings = get_settings()
+    configure_runtime_rate_limit_state(
+        settings=settings,
+        runtime_mode="redis" if settings.redis_url else "memory",
+    )
     configure_active_limiter_key_prefix(prefix)
     reset_local_rate_limit_state()
     reset_observability_state()
-    if get_idempotency_store.cache_info().currsize:
-        reset_local_idempotency_state(get_idempotency_store())
+    shared_dependencies._get_fallback_idempotency_store.cache_clear()
+    idempotency_store = getattr(app.state, "idempotency_store", None)
+    if idempotency_store is not None:
+        reset_local_idempotency_state(idempotency_store)
     yield
     reset_local_rate_limit_state()
     reset_observability_state()
-    if get_idempotency_store.cache_info().currsize:
-        reset_local_idempotency_state(get_idempotency_store())
+    idempotency_store = getattr(app.state, "idempotency_store", None)
+    if idempotency_store is not None:
+        reset_local_idempotency_state(idempotency_store)
+    shared_dependencies._get_fallback_idempotency_store.cache_clear()
     get_extraction_integration.cache_clear()
     get_transcription_integration.cache_clear()
     get_settings.cache_clear()


### PR DESCRIPTION
## Summary
- add intentional Redis degraded mode policy with ALLOW_REDIS_DEGRADED_MODE and runtime Redis probe
- resolve runtime mode at app startup (redis vs degraded_memory), wire limiter/extraction/idempotency to resolved mode, and expose runtime status in /health
- preserve queue fallback contract (arq_pool is None) and add explicit degraded startup warnings
- move idempotency/extraction dependencies to app-state runtime stores with compatibility fallbacks for non-lifespan test contexts
- add coverage for config/runtime resolution and update lifecycle/conftest/worker tests for new startup contract

## Verification
- cd backend && .venv/bin/pytest app/core/tests/test_config.py app/core/tests/test_main.py app/shared/tests/test_rate_limit.py app/shared/tests/test_redis_runtime.py -x --tb=short
- cd backend && .venv/bin/pytest app/features/invoices/tests/test_invoice_email.py app/features/quotes/tests/test_quote_email.py app/features/quotes/tests/test_quote_extraction.py -x --tb=short
- make backend-static-verify
- make backend-verify

Closes #561
