### PR TITLE
Task #559: implement outbox sync engine for offline extraction

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -15,6 +15,7 @@ import { ResetPasswordPage } from "@/features/auth/components/ResetPasswordPage"
 import { useAuth } from "@/features/auth/hooks/useAuth";
 import { LandingPage } from "@/features/marketing/components/LandingPage";
 import { QuoteList } from "@/features/quotes/components/QuoteList";
+import { OutboxSyncCoordinator } from "@/features/quotes/offline/OutboxSyncCoordinator";
 import { PageTransition } from "@/ui/PageTransition";
 import { ToastProvider } from "@/ui/Toast";
 
@@ -121,6 +122,7 @@ function withRouteSuspense(node: React.ReactNode): React.ReactElement {
 export default function App(): React.ReactElement {
   return (
     <ToastProvider>
+      <OutboxSyncCoordinator />
       <Routes>
         <Route element={<PageTransition />}>
           <Route

--- a/frontend/src/features/quotes/components/CaptureScreen.tsx
+++ b/frontend/src/features/quotes/components/CaptureScreen.tsx
@@ -9,10 +9,13 @@ import {
   isInFlightIdempotencyConflict,
   resolveExtractionRequestIdempotencyKey,
 } from "@/features/quotes/components/captureScreenIdempotency";
+import { hydrateCaptureDraftFromQuote } from "@/features/quotes/components/captureScreenDraftHydration";
+import { markOutboxJobSucceeded, queueOutboxRetryJob } from "@/features/quotes/components/captureScreenOutbox";
+import { createManualDraftForCapture } from "@/features/quotes/components/captureScreenStartBlank";
+import { CaptureScreenBody } from "@/features/quotes/components/CaptureScreenBody";
+import { CaptureScreenFooter } from "@/features/quotes/components/CaptureScreenFooter";
 import { useCaptureExtractionKeyReset } from "@/features/quotes/components/useCaptureExtractionKeyReset";
-import { buildDraftFromQuoteDetail } from "@/features/quotes/components/captureScreenDraft";
 import { pollExtractionJobUntilQuote } from "@/features/quotes/components/captureScreenPolling";
-import { CaptureInputPanel } from "@/features/quotes/components/CaptureInputPanel";
 import { classifySubmitFailure } from "@/features/quotes/offline/classifySubmitFailure";
 import { getLocalCaptureStatusCopy } from "@/features/quotes/offline/localCaptureStatusCopy";
 import { useLocalCaptureSession } from "@/features/quotes/offline/useLocalCaptureSession";
@@ -20,15 +23,12 @@ import { resolveCaptureLaunchOrigin } from "@/features/quotes/utils/workflowNavi
 import { MAX_VOICE_CLIPS_PER_CAPTURE, useVoiceCapture } from "@/features/quotes/hooks/useVoiceCapture";
 import { quoteService } from "@/features/quotes/services/quoteService";
 import type { QuoteSourceType } from "@/features/quotes/types/quote.types";
-import { Button } from "@/shared/components/Button";
 import { ConfirmModal } from "@/shared/components/ConfirmModal";
-import { ScreenFooter } from "@/shared/components/ScreenFooter";
 import { WorkflowScreenHeader } from "@/shared/components/WorkflowScreenHeader";
 import { formatByteLimit } from "@/shared/lib/formatters";
 import { MAX_AUDIO_CLIPS_PER_REQUEST, MAX_AUDIO_TOTAL_BYTES } from "@/shared/lib/inputLimits";
 import { perfMark, perfMeasure, perfMeasureSincePageLoad } from "@/shared/perf";
 import { useToast } from "@/ui/Toast";
-
 const START_BLANK_GUARD_TARGET = "__start_blank__";
 
 export function CaptureScreen(): React.ReactElement {
@@ -158,27 +158,27 @@ export function CaptureScreen(): React.ReactElement {
     });
   }, [displayedError, show]);
 
-  async function hydrateFromPersistedQuote(
-    quoteId: string,
-    sourceType: QuoteSourceType,
-  ): Promise<void> {
-    perfMark("capture:draft:hydrate_start");
-    const persistedQuote = await quoteService.getQuote(quoteId);
-    setDraft(buildDraftFromQuoteDetail({
-      sourceType,
-      quoteDetail: persistedQuote,
-      quoteId,
-      customerId,
-      launchOrigin,
-    }));
-    perfMark("capture:draft:ready");
-    perfMeasure("capture:draft:hydrate_ms", "capture:draft:hydrate_start", "capture:draft:ready");
-  }
-
   async function onExtract(): Promise<void> {
     // TODO(spec1): perfMark("capture:local:save_start") / perfMark("capture:local:save_done")
     clearActionErrors();
+    let idempotencyKey = "";
+    let extractionSessionId: string | null = null;
     if (typeof navigator !== "undefined" && navigator.onLine === false) {
+      ({
+        idempotencyKey,
+        sessionId: extractionSessionId,
+      } = await resolveExtractionRequestIdempotencyKey({
+        localSessionId,
+        ensureLocalCaptureSession,
+        extractionIdempotencyKeyRef,
+      }));
+      if (extractionSessionId && user?.id) {
+        await queueOutboxRetryJob({
+          userId: user.id,
+          sessionId: extractionSessionId,
+          idempotencyKey,
+        });
+      }
       await markLocalCaptureStatus("ready_to_extract", {
         failureKind: "offline",
       });
@@ -220,14 +220,14 @@ export function CaptureScreen(): React.ReactElement {
     });
 
     try {
-      const {
+      ({
         idempotencyKey,
         sessionId: extractionSessionId,
       } = await resolveExtractionRequestIdempotencyKey({
         localSessionId,
         ensureLocalCaptureSession,
         extractionIdempotencyKeyRef,
-      });
+      }));
       const extraction = await quoteService.extract({
         clipIds: clips.map((clip) => clip.id),
         notes,
@@ -246,11 +246,22 @@ export function CaptureScreen(): React.ReactElement {
       }
       const sourceType: QuoteSourceType = clips.length > 0 ? "voice" : "text";
       if (extraction.type === "sync") {
+        await markOutboxJobSucceeded({
+          sessionId: extractionSessionId,
+          quoteId: extraction.quoteId,
+          extractJobId: null,
+        });
         await markLocalCaptureStatus("synced", {
           serverQuoteId: extraction.quoteId,
           extractJobId: null,
         });
-        await hydrateFromPersistedQuote(extraction.quoteId, sourceType);
+        await hydrateCaptureDraftFromQuote({
+          quoteId: extraction.quoteId,
+          sourceType,
+          customerId,
+          launchOrigin,
+          setDraft,
+        });
         navigate(`/documents/${extraction.quoteId}/edit`);
         return;
       }
@@ -258,7 +269,34 @@ export function CaptureScreen(): React.ReactElement {
       void markLocalCaptureStatus("submitting", {
         extractJobId: extraction.jobId,
       });
-      await pollExtractionJob(extraction.jobId, sourceType);
+      await pollExtractionJobUntilQuote({
+        jobId: extraction.jobId,
+        isMounted: () => isMountedRef.current,
+        onQuoteReady: async (job) => {
+          if (!job.quote_id || !job.extraction_result) {
+            throw new Error(
+              "Extraction completed without a result. Please try again.",
+            );
+          }
+          await markLocalCaptureStatus("synced", {
+            serverQuoteId: job.quote_id,
+            extractJobId: job.id,
+          });
+          await hydrateCaptureDraftFromQuote({
+            quoteId: job.quote_id,
+            sourceType,
+            customerId,
+            launchOrigin,
+            setDraft,
+          });
+          navigate(`/documents/${job.quote_id}/edit`);
+        },
+      });
+      await markOutboxJobSucceeded({
+        sessionId: extractionSessionId,
+        quoteId: null,
+        extractJobId: extraction.jobId,
+      });
     } catch (submitError) {
       if (!isMountedRef.current) {
         return;
@@ -274,6 +312,20 @@ export function CaptureScreen(): React.ReactElement {
         failureKind,
         error: message,
       });
+      if (
+        extractionSessionId
+        && user?.id
+        && (failureKind === "offline"
+          || failureKind === "timeout"
+          || failureKind === "server_retryable"
+          || failureKind === "auth_required")
+      ) {
+        await queueOutboxRetryJob({
+          userId: user.id,
+          sessionId: extractionSessionId,
+          idempotencyKey,
+        });
+      }
       if (isIdempotencyInFlightConflict) {
         setIsRetryLockedByInFlightExtraction(true);
       }
@@ -290,11 +342,11 @@ export function CaptureScreen(): React.ReactElement {
     clearActionErrors();
     setIsStartingBlank(true);
     try {
-      const manualDraft = await quoteService.createManualDraft({ customerId });
+      const manualDraftId = await createManualDraftForCapture(customerId);
       if (!isMountedRef.current) {
         return;
       }
-      navigate(`/documents/${manualDraft.id}/edit`);
+      navigate(`/documents/${manualDraftId}/edit`);
     } catch (startBlankError) {
       if (!isMountedRef.current) {
         return;
@@ -310,37 +362,11 @@ export function CaptureScreen(): React.ReactElement {
       }
     }
   }
-  async function pollExtractionJob(
-    jobId: string,
-    sourceType: QuoteSourceType,
-  ): Promise<void> {
-    await pollExtractionJobUntilQuote({
-      jobId,
-      isMounted: () => isMountedRef.current,
-      onQuoteReady: async (job) => {
-        if (!job.quote_id || !job.extraction_result) {
-          throw new Error(
-            "Extraction completed without a result. Please try again.",
-          );
-        }
-        await markLocalCaptureStatus("synced", {
-          serverQuoteId: job.quote_id,
-          extractJobId: job.id,
-        });
-        await hydrateFromPersistedQuote(job.quote_id, sourceType);
-        navigate(`/documents/${job.quote_id}/edit`);
-      },
-    });
-  }
 
   const hasReachedClipLimit = clips.length >= MAX_VOICE_CLIPS_PER_CAPTURE;
-  const hasUnsavedWork = clips.length > 0
-    || (notes.trim().length > 0
-      && (localSessionId === null || localSaveState === "saving" || localSaveState === "error"));
-  const canExtract = (hasClips || hasNotes)
-    && !isExtracting
-    && !isRecording
-    && !isRetryLockedByInFlightExtraction;
+  const hasUnsavedWork = clips.length > 0 || (notes.trim().length > 0
+    && (localSessionId === null || localSaveState === "saving" || localSaveState === "error"));
+  const canExtract = (hasClips || hasNotes) && !isExtracting && !isRecording && !isRetryLockedByInFlightExtraction;
   const localStatusCopy = localSaveState === "saving"
     ? "Saving on this device..."
     : localSaveState === "error"
@@ -355,7 +381,8 @@ export function CaptureScreen(): React.ReactElement {
     }
     setHasAttemptedAutoExtract(true);
     void onExtract();
-  }, [autoExtractOnLoad, canExtract, hasAttemptedAutoExtract, isHydratingLocalSession, onExtract]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- onExtract identity changes each render.
+  }, [autoExtractOnLoad, canExtract, hasAttemptedAutoExtract, isHydratingLocalSession]);
   return (
     <main className="min-h-dvh bg-background">
       <WorkflowScreenHeader
@@ -367,63 +394,38 @@ export function CaptureScreen(): React.ReactElement {
           : navigate(launchOrigin, { replace: true }))}
       />
 
-      <section className="mx-auto flex min-h-dvh w-full max-w-2xl flex-col px-4 pb-36 pt-20">
-        {!isSupported ? (
-          <p className="ghost-shadow mb-4 rounded-[var(--radius-document)] border-l-4 border-warning-accent bg-warning-container p-4 text-sm text-warning">
-            Voice capture is not supported in this browser. You can still type
-            notes and extract line items.
-          </p>
-        ) : null}
+      <CaptureScreenBody
+        isSupported={isSupported}
+        isExtracting={isExtracting}
+        clips={clips}
+        removeClip={removeClip}
+        notes={notes}
+        onNotesChange={handleNotesChange}
+        isRecording={isRecording}
+        elapsedSeconds={elapsedSeconds}
+        hasReachedClipLimit={hasReachedClipLimit}
+        onStartRecording={() => {
+          void (async () => {
+            const ensuredSessionId = await ensureLocalCaptureSession();
+            await startRecording(ensuredSessionId);
+          })();
+        }}
+        onStopRecording={stopRecording}
+        onStartBlank={() => (hasUnsavedWork
+          ? setPendingExitTarget(START_BLANK_GUARD_TARGET)
+          : void onStartBlank())}
+        isStartBlankDisabled={isExtracting || isRecording || isStartingBlank}
+      />
 
-        <div className="flex min-h-0 flex-1 flex-col">
-          <CaptureInputPanel
-            clips={clips}
-            isExtracting={isExtracting}
-            removeClip={removeClip}
-            notes={notes}
-            onNotesChange={handleNotesChange}
-            isRecording={isRecording}
-            elapsedSeconds={elapsedSeconds}
-            hasReachedClipLimit={hasReachedClipLimit}
-            isSupported={isSupported}
-            onStartRecording={() => {
-              void (async () => {
-                const ensuredSessionId = await ensureLocalCaptureSession();
-                await startRecording(ensuredSessionId);
-              })();
-            }}
-            onStopRecording={stopRecording}
-            onStartBlank={() => (hasUnsavedWork
-              ? setPendingExitTarget(START_BLANK_GUARD_TARGET)
-              : void onStartBlank())}
-            isStartBlankDisabled={isExtracting || isRecording || isStartingBlank}
-          />
-        </div>
-      </section>
-
-      <ScreenFooter>
-        <div className="mx-auto w-full max-w-2xl">
-          {!extractionStage && localStatusCopy ? (
-            <p className="mb-2 text-center text-sm font-medium text-on-surface-variant">
-              {localStatusCopy}
-            </p>
-          ) : null}
-          {extractionStage ? (
-            <p className="mb-2 text-center text-sm font-medium text-on-surface-variant">
-              {extractionStage}
-            </p>
-          ) : null}
-          <Button
-            variant="primary"
-            className="w-full"
-            disabled={!canExtract}
-            isLoading={isExtracting}
-            onClick={() => void onExtract()}
-          >
-            Extract Line Items
-          </Button>
-        </div>
-      </ScreenFooter>
+      <CaptureScreenFooter
+        extractionStage={extractionStage}
+        localStatusCopy={localStatusCopy}
+        canExtract={canExtract}
+        isExtracting={isExtracting}
+        onExtract={() => {
+          void onExtract();
+        }}
+      />
 
       {pendingExitTarget ? (
         <ConfirmModal

--- a/frontend/src/features/quotes/components/CaptureScreenBody.tsx
+++ b/frontend/src/features/quotes/components/CaptureScreenBody.tsx
@@ -1,0 +1,49 @@
+import { CaptureInputPanel } from "@/features/quotes/components/CaptureInputPanel";
+import type { VoiceClip } from "@/features/quotes/hooks/useVoiceCapture";
+
+interface CaptureScreenBodyProps {
+  isSupported: boolean;
+  isExtracting: boolean;
+  clips: VoiceClip[];
+  removeClip: (clipId: string) => void;
+  notes: string;
+  onNotesChange: (value: string) => void;
+  isRecording: boolean;
+  elapsedSeconds: number;
+  hasReachedClipLimit: boolean;
+  onStartRecording: () => void;
+  onStopRecording: () => void;
+  onStartBlank: () => void;
+  isStartBlankDisabled: boolean;
+}
+
+export function CaptureScreenBody(props: CaptureScreenBodyProps): React.ReactElement {
+  return (
+    <section className="mx-auto flex min-h-dvh w-full max-w-2xl flex-col px-4 pb-36 pt-20">
+      {!props.isSupported ? (
+        <p className="ghost-shadow mb-4 rounded-[var(--radius-document)] border-l-4 border-warning-accent bg-warning-container p-4 text-sm text-warning">
+          Voice capture is not supported in this browser. You can still type
+          notes and extract line items.
+        </p>
+      ) : null}
+
+      <div className="flex min-h-0 flex-1 flex-col">
+        <CaptureInputPanel
+          clips={props.clips}
+          isExtracting={props.isExtracting}
+          removeClip={props.removeClip}
+          notes={props.notes}
+          onNotesChange={props.onNotesChange}
+          isRecording={props.isRecording}
+          elapsedSeconds={props.elapsedSeconds}
+          hasReachedClipLimit={props.hasReachedClipLimit}
+          isSupported={props.isSupported}
+          onStartRecording={props.onStartRecording}
+          onStopRecording={props.onStopRecording}
+          onStartBlank={props.onStartBlank}
+          isStartBlankDisabled={props.isStartBlankDisabled}
+        />
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/features/quotes/components/CaptureScreenFooter.tsx
+++ b/frontend/src/features/quotes/components/CaptureScreenFooter.tsx
@@ -1,0 +1,38 @@
+import { Button } from "@/shared/components/Button";
+import { ScreenFooter } from "@/shared/components/ScreenFooter";
+
+interface CaptureScreenFooterProps {
+  extractionStage: string | null;
+  localStatusCopy: string | null;
+  canExtract: boolean;
+  isExtracting: boolean;
+  onExtract: () => void;
+}
+
+export function CaptureScreenFooter(props: CaptureScreenFooterProps): React.ReactElement {
+  return (
+    <ScreenFooter>
+      <div className="mx-auto w-full max-w-2xl">
+        {!props.extractionStage && props.localStatusCopy ? (
+          <p className="mb-2 text-center text-sm font-medium text-on-surface-variant">
+            {props.localStatusCopy}
+          </p>
+        ) : null}
+        {props.extractionStage ? (
+          <p className="mb-2 text-center text-sm font-medium text-on-surface-variant">
+            {props.extractionStage}
+          </p>
+        ) : null}
+        <Button
+          variant="primary"
+          className="w-full"
+          disabled={!props.canExtract}
+          isLoading={props.isExtracting}
+          onClick={props.onExtract}
+        >
+          Extract Line Items
+        </Button>
+      </div>
+    </ScreenFooter>
+  );
+}

--- a/frontend/src/features/quotes/components/PendingCapturesSection.tsx
+++ b/frontend/src/features/quotes/components/PendingCapturesSection.tsx
@@ -13,6 +13,7 @@ interface PendingCapturesSectionProps {
   error: string | null;
   onResume: (sessionId: string) => void;
   onExtract: (sessionId: string) => void;
+  onRetry: (sessionId: string) => void;
   onDelete: (sessionId: string) => void;
 }
 
@@ -26,6 +27,26 @@ function buildCaptureSummaryLabel(notes: string): string {
   return firstLine.length > 60 ? `${firstLine.slice(0, 57)}...` : firstLine;
 }
 
+function buildPendingCaptureStatusCopy(capture: LocalCaptureSummary): string {
+  if (capture.outboxStatus === "running") {
+    const attemptCount = Math.max(capture.outboxAttemptCount ?? 1, 1);
+    const maxAttempts = Math.max(capture.outboxMaxAttempts ?? 5, 1);
+    return `Retrying... (attempt ${attemptCount} of ${maxAttempts})`;
+  }
+
+  if (capture.outboxStatus === "failed_retryable") {
+    const attemptCount = Math.max(capture.outboxAttemptCount ?? 1, 1);
+    const maxAttempts = Math.max(capture.outboxMaxAttempts ?? 5, 1);
+    return `Could not sync. Tap Retry. (tried ${attemptCount} of ${maxAttempts})`;
+  }
+
+  if (capture.outboxStatus === "failed_terminal") {
+    return "Could not sync permanently. Open to edit or delete.";
+  }
+
+  return getLocalCaptureStatusCopy(capture.status) ?? "Saved on this device";
+}
+
 export function PendingCapturesSection({
   captures,
   isLoading,
@@ -34,6 +55,7 @@ export function PendingCapturesSection({
   error,
   onResume,
   onExtract,
+  onRetry,
   onDelete,
 }: PendingCapturesSectionProps): React.ReactElement {
   return (
@@ -70,7 +92,7 @@ export function PendingCapturesSection({
                   {buildCaptureSummaryLabel(capture.notes)}
                 </p>
                 <p className="mt-1 text-xs text-on-surface-variant">
-                  {getLocalCaptureStatusCopy(capture.status) ?? "Saved on this device"}
+                  {buildPendingCaptureStatusCopy(capture)}
                 </p>
                 <p className="mt-1 text-xs text-outline">
                   Updated {formatDate(capture.updatedAt, timezone)}
@@ -88,10 +110,18 @@ export function PendingCapturesSection({
                     type="button"
                     size="sm"
                     variant="secondary"
-                    disabled={!isOnline}
-                    onClick={() => onExtract(capture.sessionId)}
+                    disabled={!isOnline || capture.outboxStatus === "running"}
+                    onClick={() => (
+                      capture.outboxStatus === "failed_retryable"
+                        ? onRetry(capture.sessionId)
+                        : onExtract(capture.sessionId)
+                    )}
                   >
-                    Extract
+                    {capture.outboxStatus === "running"
+                      ? "Retrying..."
+                      : capture.outboxStatus === "failed_retryable"
+                        ? "Retry"
+                        : "Extract"}
                   </Button>
                   <Button
                     type="button"

--- a/frontend/src/features/quotes/components/QuoteList.tsx
+++ b/frontend/src/features/quotes/components/QuoteList.tsx
@@ -7,6 +7,8 @@ import type { InvoiceListItem } from "@/features/invoices/types/invoice.types";
 import { PendingCapturesSection } from "@/features/quotes/components/PendingCapturesSection";
 import { useQuoteCreateFlow } from "@/features/quotes/hooks/useQuoteCreateFlow";
 import { useRecoverableCaptures } from "@/features/quotes/offline/useRecoverableCaptures";
+import { runOutboxPass } from "@/features/quotes/offline/outboxEngine";
+import { getJobForSession, updateJobStatus } from "@/features/quotes/offline/outboxRepository";
 import { quoteService } from "@/features/quotes/services/quoteService";
 import type { QuoteListItem } from "@/features/quotes/types/quote.types";
 import { BottomNav } from "@/shared/components/BottomNav";
@@ -41,6 +43,7 @@ export function QuoteList(): React.ReactElement {
     captures: recoverableCaptures,
     isLoading: isLoadingRecoverableCaptures,
     error: recoverableCapturesError,
+    refresh: refreshRecoverableCaptures,
     deleteCapture,
   } = useRecoverableCaptures(user?.id);
 
@@ -247,6 +250,32 @@ export function QuoteList(): React.ReactElement {
     }
   }
 
+  async function onRetryCapture(sessionId: string): Promise<void> {
+    if (!user?.id) {
+      return;
+    }
+
+    setPendingCaptureActionError(null);
+    try {
+      const outboxJob = await getJobForSession(sessionId);
+      if (!outboxJob || outboxJob.status === "running") {
+        return;
+      }
+
+      await updateJobStatus(outboxJob.jobId, {
+        status: "queued",
+        nextRetryAt: null,
+      });
+      await runOutboxPass(user.id);
+      await refreshRecoverableCaptures();
+    } catch (retryError) {
+      const message = retryError instanceof Error
+        ? retryError.message
+        : "Unable to retry pending capture";
+      setPendingCaptureActionError(message);
+    }
+  }
+
   return (
     <main className="min-h-screen bg-background pb-24">
       <ScreenHeader title={headerTitle} subtitle={headerSubtitle} layout="top-level" />
@@ -331,6 +360,9 @@ export function QuoteList(): React.ReactElement {
             error={recoverableCapturesError ?? pendingCaptureActionError}
             onResume={(sessionId) => navigateToLocalCapture(sessionId)}
             onExtract={(sessionId) => navigateToLocalCapture(sessionId, { autoExtract: true })}
+            onRetry={(sessionId) => {
+              void onRetryCapture(sessionId);
+            }}
             onDelete={(sessionId) => {
               void onDeleteCapture(sessionId);
             }}

--- a/frontend/src/features/quotes/components/captureScreenDraftHydration.ts
+++ b/frontend/src/features/quotes/components/captureScreenDraftHydration.ts
@@ -1,0 +1,32 @@
+import { buildDraftFromQuoteDetail } from "@/features/quotes/components/captureScreenDraft";
+import { quoteService } from "@/features/quotes/services/quoteService";
+import type { QuoteSourceType } from "@/features/quotes/types/quote.types";
+import { perfMark, perfMeasure } from "@/shared/perf";
+
+interface HydrateDraftParams {
+  quoteId: string;
+  sourceType: QuoteSourceType;
+  customerId: string | undefined;
+  launchOrigin: string;
+  setDraft: (draft: ReturnType<typeof buildDraftFromQuoteDetail>) => void;
+}
+
+export async function hydrateCaptureDraftFromQuote({
+  quoteId,
+  sourceType,
+  customerId,
+  launchOrigin,
+  setDraft,
+}: HydrateDraftParams): Promise<void> {
+  perfMark("capture:draft:hydrate_start");
+  const persistedQuote = await quoteService.getQuote(quoteId);
+  setDraft(buildDraftFromQuoteDetail({
+    sourceType,
+    quoteDetail: persistedQuote,
+    quoteId,
+    customerId,
+    launchOrigin,
+  }));
+  perfMark("capture:draft:ready");
+  perfMeasure("capture:draft:hydrate_ms", "capture:draft:hydrate_start", "capture:draft:ready");
+}

--- a/frontend/src/features/quotes/components/captureScreenOutbox.ts
+++ b/frontend/src/features/quotes/components/captureScreenOutbox.ts
@@ -1,0 +1,44 @@
+import { updateCaptureField } from "@/features/quotes/offline/captureRepository";
+import { enqueueJob, getJobForSession, updateJobStatus } from "@/features/quotes/offline/outboxRepository";
+
+interface QueueOutboxRetryParams {
+  userId: string;
+  sessionId: string;
+  idempotencyKey: string;
+}
+
+interface MarkOutboxSuccessParams {
+  sessionId: string | null;
+  quoteId: string | null;
+  extractJobId: string | null;
+}
+
+export async function queueOutboxRetryJob(params: QueueOutboxRetryParams): Promise<void> {
+  const queuedJob = await enqueueJob({
+    userId: params.userId,
+    sessionId: params.sessionId,
+    idempotencyKey: params.idempotencyKey,
+  });
+
+  await updateCaptureField(params.sessionId, { outboxJobId: queuedJob.jobId });
+}
+
+export async function markOutboxJobSucceeded(params: MarkOutboxSuccessParams): Promise<void> {
+  if (!params.sessionId) {
+    return;
+  }
+
+  const outboxJob = await getJobForSession(params.sessionId);
+  if (!outboxJob) {
+    return;
+  }
+
+  await updateJobStatus(outboxJob.jobId, {
+    status: "succeeded",
+    serverQuoteId: params.quoteId,
+    serverJobId: params.extractJobId,
+    lastFailureKind: null,
+    lastError: null,
+    nextRetryAt: null,
+  });
+}

--- a/frontend/src/features/quotes/components/captureScreenStartBlank.ts
+++ b/frontend/src/features/quotes/components/captureScreenStartBlank.ts
@@ -1,0 +1,6 @@
+import { quoteService } from "@/features/quotes/services/quoteService";
+
+export async function createManualDraftForCapture(customerId: string | undefined): Promise<string> {
+  const manualDraft = await quoteService.createManualDraft({ customerId });
+  return manualDraft.id;
+}

--- a/frontend/src/features/quotes/offline/OutboxSyncCoordinator.tsx
+++ b/frontend/src/features/quotes/offline/OutboxSyncCoordinator.tsx
@@ -1,7 +1,8 @@
-import { useCallback, useEffect } from "react";
+import { useCallback, useEffect, useRef } from "react";
 
 import { useAuth } from "@/features/auth/hooks/useAuth";
 import {
+  clearOutboxEngineStateForUser,
   registerOnlineTrigger,
   runOutboxPass,
   type OutboxEngineEvent,
@@ -11,6 +12,7 @@ import { useToast } from "@/ui/Toast";
 export function OutboxSyncCoordinator(): React.ReactElement | null {
   const { user } = useAuth();
   const { show } = useToast();
+  const previousUserIdRef = useRef<string | null>(null);
 
   const onEvent = useCallback((event: OutboxEngineEvent) => {
     if (event.kind === "sync_success") {
@@ -38,13 +40,22 @@ export function OutboxSyncCoordinator(): React.ReactElement | null {
   }, [show]);
 
   useEffect(() => {
+    const previousUserId = previousUserIdRef.current;
+    if (previousUserId && previousUserId !== user?.id) {
+      clearOutboxEngineStateForUser(previousUserId);
+    }
+    previousUserIdRef.current = user?.id ?? null;
+
     if (!user?.id) {
       return;
     }
 
     void runOutboxPass(user.id, { onEvent, forceAfterAuth: true });
     const cleanup = registerOnlineTrigger(user.id, { onEvent });
-    return cleanup;
+    return () => {
+      cleanup();
+      clearOutboxEngineStateForUser(user.id);
+    };
   }, [onEvent, user?.id]);
 
   return null;

--- a/frontend/src/features/quotes/offline/OutboxSyncCoordinator.tsx
+++ b/frontend/src/features/quotes/offline/OutboxSyncCoordinator.tsx
@@ -1,0 +1,51 @@
+import { useCallback, useEffect } from "react";
+
+import { useAuth } from "@/features/auth/hooks/useAuth";
+import {
+  registerOnlineTrigger,
+  runOutboxPass,
+  type OutboxEngineEvent,
+} from "@/features/quotes/offline/outboxEngine";
+import { useToast } from "@/ui/Toast";
+
+export function OutboxSyncCoordinator(): React.ReactElement | null {
+  const { user } = useAuth();
+  const { show } = useToast();
+
+  const onEvent = useCallback((event: OutboxEngineEvent) => {
+    if (event.kind === "sync_success") {
+      show({
+        message: "A pending capture synced to your quote draft.",
+        variant: "success",
+      });
+      return;
+    }
+
+    if (event.kind === "sync_terminal_failure") {
+      show({
+        message: "A pending capture could not sync. Open it to retry or delete.",
+        variant: "warning",
+        durationMs: null,
+      });
+      return;
+    }
+
+    show({
+      message: "Sign in again to resume syncing pending captures.",
+      variant: "warning",
+      durationMs: null,
+    });
+  }, [show]);
+
+  useEffect(() => {
+    if (!user?.id) {
+      return;
+    }
+
+    void runOutboxPass(user.id, { onEvent, forceAfterAuth: true });
+    const cleanup = registerOnlineTrigger(user.id, { onEvent });
+    return cleanup;
+  }, [onEvent, user?.id]);
+
+  return null;
+}

--- a/frontend/src/features/quotes/offline/captureRepository.ts
+++ b/frontend/src/features/quotes/offline/captureRepository.ts
@@ -1,5 +1,6 @@
 import { CAPTURE_STORE_NAMES, getDb } from "@/features/quotes/offline/captureDb";
 import { deleteAllClipsForSession } from "@/features/quotes/offline/audioRepository";
+import { deleteJobForSession } from "@/features/quotes/offline/outboxRepository";
 import type {
   CreateLocalCaptureInput,
   CreateLocalSyncEventInput,
@@ -176,6 +177,7 @@ export async function markCaptureStatus(
 
 export async function deleteCaptureSession(sessionId: string): Promise<void> {
   await deleteAllClipsForSession(sessionId);
+  await deleteJobForSession(sessionId);
   const db = await getDb();
   const transaction = db.transaction(CAPTURE_STORE_NAMES.captureSessions, "readwrite");
   const store = transaction.objectStore(CAPTURE_STORE_NAMES.captureSessions);

--- a/frontend/src/features/quotes/offline/captureTypes.ts
+++ b/frontend/src/features/quotes/offline/captureTypes.ts
@@ -51,7 +51,11 @@ export interface CreateLocalCaptureInput {
 export type LocalCaptureSummary = Pick<
   LocalCaptureSession,
   "sessionId" | "status" | "notes" | "updatedAt" | "lastFailureKind" | "lastError"
->;
+> & {
+  outboxStatus?: OutboxJobStatus | null;
+  outboxAttemptCount?: number;
+  outboxMaxAttempts?: number;
+};
 
 export interface LocalSyncEvent {
   eventId: string;
@@ -98,14 +102,33 @@ export interface LocalDraftRecord {
   updatedAt: string;
 }
 
-export type LocalOutboxStatus = "pending" | "processing" | "failed" | "succeeded";
+export type OutboxJobStatus =
+  | "queued"
+  | "running"
+  | "succeeded"
+  | "failed_retryable"
+  | "failed_terminal";
 
-export interface LocalOutboxJob {
+export interface OutboxJob {
   jobId: string;
-  sessionId: string;
   userId: string;
-  status: LocalOutboxStatus;
-  attempts: number;
+  sessionId: string;
+  idempotencyKey: string;
+  status: OutboxJobStatus;
+  attemptCount: number;
+  maxAttempts: number;
+  nextRetryAt: string | null;
+  lastFailureKind: SubmitFailureKind | null;
+  lastError: string | null;
+  serverQuoteId: string | null;
+  serverJobId: string | null;
   createdAt: string;
   updatedAt: string;
+}
+
+export interface EnqueueJobInput {
+  userId: string;
+  sessionId: string;
+  idempotencyKey: string;
+  maxAttempts?: number;
 }

--- a/frontend/src/features/quotes/offline/outboxEngine.test.ts
+++ b/frontend/src/features/quotes/offline/outboxEngine.test.ts
@@ -9,11 +9,14 @@ import {
   updateCaptureField,
 } from "@/features/quotes/offline/captureRepository";
 import { resetCaptureDbForTests } from "@/features/quotes/offline/captureDb";
-import { registerOnlineTrigger, runOutboxPass } from "@/features/quotes/offline/outboxEngine";
+import {
+  clearOutboxEngineStateForUser,
+  registerOnlineTrigger,
+  runOutboxPass,
+} from "@/features/quotes/offline/outboxEngine";
 import {
   enqueueJob,
   getJob,
-  getJobForSession,
   updateJobStatus,
 } from "@/features/quotes/offline/outboxRepository";
 import { quoteService } from "@/features/quotes/services/quoteService";
@@ -35,7 +38,10 @@ describe("outboxEngine", () => {
 
   afterEach(async () => {
     await resetCaptureDbForTests();
+    clearOutboxEngineStateForUser("user-1");
+    clearOutboxEngineStateForUser("user-2");
     vi.restoreAllMocks();
+    vi.useRealTimers();
   });
 
   it("marks queued jobs as succeeded and syncs capture sessions", async () => {
@@ -202,17 +208,75 @@ describe("outboxEngine", () => {
       },
     });
 
-    const resumedJob = await getJobForSession(session.sessionId);
-    if (!resumedJob) {
-      throw new Error("Expected resumed job");
-    }
-    await updateJobStatus(resumedJob.jobId, {
+    await runOutboxPass("user-1", { forceAfterAuth: true });
+
+    const completedJob = await getJob(queuedJob.jobId);
+    expect(completedJob?.status).toBe("succeeded");
+  });
+
+  it("marks retryable timeout when extraction call hangs", async () => {
+    const session = await createCaptureSession({
+      userId: "user-1",
+      notes: "Install sod",
+      customerId: "customer-1",
+    });
+
+    const queuedJob = await enqueueJob({
+      userId: "user-1",
+      sessionId: session.sessionId,
+      idempotencyKey: "idem-1",
+    });
+
+    mockedQuoteService.extract.mockReturnValueOnce(new Promise(() => undefined));
+    await runOutboxPass("user-1", { extractionTimeoutMs: 1 });
+
+    const updatedJob = await getJob(queuedJob.jobId);
+    expect(updatedJob?.status).toBe("failed_retryable");
+    expect(updatedJob?.lastFailureKind).toBe("timeout");
+  });
+
+  it("clears per-user paused state via cleanup helper", async () => {
+    const session = await createCaptureSession({
+      userId: "user-1",
+      notes: "Install sod",
+      customerId: "customer-1",
+    });
+    const queuedJob = await enqueueJob({
+      userId: "user-1",
+      sessionId: session.sessionId,
+      idempotencyKey: "idem-1",
+    });
+
+    mockedQuoteService.extract.mockRejectedValueOnce(
+      new HttpRequestError("Unauthorized", 401, { detail: "Unauthorized" }),
+    );
+    await runOutboxPass("user-1");
+
+    clearOutboxEngineStateForUser("user-1");
+    await updateJobStatus(queuedJob.jobId, {
       status: "queued",
       nextRetryAt: null,
     });
+    mockedQuoteService.extract.mockResolvedValueOnce({
+      type: "sync",
+      quoteId: "quote-cleared-state",
+      result: {
+        transcript: "Install sod",
+        line_items: [],
+        pricing_hints: {
+          explicit_total: null,
+          deposit_amount: null,
+          tax_rate: null,
+          discount_type: null,
+          discount_value: null,
+        },
+        customer_notes_suggestion: null,
+        extraction_tier: "primary",
+        extraction_degraded_reason_code: null,
+      },
+    });
 
-    await runOutboxPass("user-1", { forceAfterAuth: true });
-
+    await runOutboxPass("user-1");
     const completedJob = await getJob(queuedJob.jobId);
     expect(completedJob?.status).toBe("succeeded");
   });

--- a/frontend/src/features/quotes/offline/outboxEngine.test.ts
+++ b/frontend/src/features/quotes/offline/outboxEngine.test.ts
@@ -1,0 +1,219 @@
+import "fake-indexeddb/auto";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  createCaptureSession,
+  getCaptureSession,
+  listSyncEvents,
+  updateCaptureField,
+} from "@/features/quotes/offline/captureRepository";
+import { resetCaptureDbForTests } from "@/features/quotes/offline/captureDb";
+import { registerOnlineTrigger, runOutboxPass } from "@/features/quotes/offline/outboxEngine";
+import {
+  enqueueJob,
+  getJob,
+  getJobForSession,
+  updateJobStatus,
+} from "@/features/quotes/offline/outboxRepository";
+import { quoteService } from "@/features/quotes/services/quoteService";
+import { HttpRequestError } from "@/shared/lib/http";
+
+vi.mock("@/features/quotes/services/quoteService", () => ({
+  quoteService: {
+    extract: vi.fn(),
+  },
+}));
+
+const mockedQuoteService = vi.mocked(quoteService);
+
+describe("outboxEngine", () => {
+  beforeEach(async () => {
+    await resetCaptureDbForTests();
+    mockedQuoteService.extract.mockReset();
+  });
+
+  afterEach(async () => {
+    await resetCaptureDbForTests();
+    vi.restoreAllMocks();
+  });
+
+  it("marks queued jobs as succeeded and syncs capture sessions", async () => {
+    const session = await createCaptureSession({
+      userId: "user-1",
+      notes: "Install sod",
+      customerId: "customer-1",
+    });
+
+    const queuedJob = await enqueueJob({
+      userId: "user-1",
+      sessionId: session.sessionId,
+      idempotencyKey: "idem-1",
+    });
+
+    mockedQuoteService.extract.mockResolvedValueOnce({
+      type: "sync",
+      quoteId: "quote-1",
+      result: {
+        transcript: "Install sod",
+        line_items: [],
+        pricing_hints: {
+          explicit_total: null,
+          deposit_amount: null,
+          tax_rate: null,
+          discount_type: null,
+          discount_value: null,
+        },
+        customer_notes_suggestion: null,
+        extraction_tier: "primary",
+        extraction_degraded_reason_code: null,
+      },
+    });
+
+    await runOutboxPass("user-1");
+
+    const updatedJob = await getJob(queuedJob.jobId);
+    const updatedSession = await getCaptureSession(session.sessionId);
+    const syncEvents = await listSyncEvents(session.sessionId);
+
+    expect(updatedJob?.status).toBe("succeeded");
+    expect(updatedJob?.serverQuoteId).toBe("quote-1");
+    expect(updatedSession?.status).toBe("synced");
+    expect(updatedSession?.serverQuoteId).toBe("quote-1");
+    expect(syncEvents.some((event) => event.message.includes("synced"))).toBe(true);
+  });
+
+  it("marks retryable failures with backoff and incremented attempts", async () => {
+    const session = await createCaptureSession({
+      userId: "user-1",
+      notes: "Install sod",
+      customerId: "customer-1",
+    });
+
+    const queuedJob = await enqueueJob({
+      userId: "user-1",
+      sessionId: session.sessionId,
+      idempotencyKey: "idem-1",
+    });
+
+    mockedQuoteService.extract.mockRejectedValueOnce(new Error("Request timed out"));
+
+    await runOutboxPass("user-1");
+
+    const updatedJob = await getJob(queuedJob.jobId);
+    const updatedSession = await getCaptureSession(session.sessionId);
+
+    expect(updatedJob?.status).toBe("failed_retryable");
+    expect(updatedJob?.attemptCount).toBe(1);
+    expect(updatedJob?.lastFailureKind).toBe("timeout");
+    expect(updatedJob?.nextRetryAt).not.toBeNull();
+    expect(updatedSession?.status).toBe("local_only");
+  });
+
+  it("escalates to terminal failure after max attempts", async () => {
+    const session = await createCaptureSession({
+      userId: "user-1",
+      notes: "Install sod",
+      customerId: "customer-1",
+    });
+
+    const queuedJob = await enqueueJob({
+      userId: "user-1",
+      sessionId: session.sessionId,
+      idempotencyKey: "idem-1",
+      maxAttempts: 2,
+    });
+    await updateJobStatus(queuedJob.jobId, {
+      status: "failed_retryable",
+      attemptCount: 1,
+      nextRetryAt: new Date(Date.now() - 1_000).toISOString(),
+      lastFailureKind: "timeout",
+    });
+    await updateCaptureField(session.sessionId, { outboxJobId: queuedJob.jobId });
+
+    mockedQuoteService.extract.mockRejectedValueOnce(
+      new HttpRequestError("Validation failed", 422, { detail: "Validation failed" }),
+    );
+
+    await runOutboxPass("user-1");
+
+    const updatedJob = await getJob(queuedJob.jobId);
+    const updatedSession = await getCaptureSession(session.sessionId);
+
+    expect(updatedJob?.status).toBe("failed_terminal");
+    expect(updatedSession?.status).toBe("extract_failed");
+    expect(updatedSession?.lastFailureKind).toBe("validation_failed");
+  });
+
+  it("registers and cleans up online event handlers", () => {
+    const addEventListenerSpy = vi.spyOn(window, "addEventListener");
+    const removeEventListenerSpy = vi.spyOn(window, "removeEventListener");
+
+    const cleanup = registerOnlineTrigger("user-1");
+
+    const addCall = addEventListenerSpy.mock.calls.find((call) => call[0] === "online");
+    expect(addCall).toBeDefined();
+
+    cleanup();
+
+    const removeCall = removeEventListenerSpy.mock.calls.find((call) => call[0] === "online");
+    expect(removeCall).toBeDefined();
+    expect(removeCall?.[1]).toBe(addCall?.[1]);
+  });
+
+  it("skips auth-required jobs until forceAfterAuth run", async () => {
+    const session = await createCaptureSession({
+      userId: "user-1",
+      notes: "Install sod",
+      customerId: "customer-1",
+    });
+
+    const queuedJob = await enqueueJob({
+      userId: "user-1",
+      sessionId: session.sessionId,
+      idempotencyKey: "idem-1",
+    });
+
+    mockedQuoteService.extract.mockRejectedValueOnce(
+      new HttpRequestError("Unauthorized", 401, { detail: "Unauthorized" }),
+    );
+
+    await runOutboxPass("user-1");
+    const pausedJob = await getJob(queuedJob.jobId);
+    expect(pausedJob?.status).toBe("failed_retryable");
+    expect(pausedJob?.lastFailureKind).toBe("auth_required");
+
+    mockedQuoteService.extract.mockResolvedValueOnce({
+      type: "sync",
+      quoteId: "quote-after-auth",
+      result: {
+        transcript: "Install sod",
+        line_items: [],
+        pricing_hints: {
+          explicit_total: null,
+          deposit_amount: null,
+          tax_rate: null,
+          discount_type: null,
+          discount_value: null,
+        },
+        customer_notes_suggestion: null,
+        extraction_tier: "primary",
+        extraction_degraded_reason_code: null,
+      },
+    });
+
+    const resumedJob = await getJobForSession(session.sessionId);
+    if (!resumedJob) {
+      throw new Error("Expected resumed job");
+    }
+    await updateJobStatus(resumedJob.jobId, {
+      status: "queued",
+      nextRetryAt: null,
+    });
+
+    await runOutboxPass("user-1", { forceAfterAuth: true });
+
+    const completedJob = await getJob(queuedJob.jobId);
+    expect(completedJob?.status).toBe("succeeded");
+  });
+});

--- a/frontend/src/features/quotes/offline/outboxEngine.ts
+++ b/frontend/src/features/quotes/offline/outboxEngine.ts
@@ -5,10 +5,11 @@ import {
   markCaptureStatus,
   updateCaptureField,
 } from "@/features/quotes/offline/captureRepository";
-import type { OutboxJob, SubmitFailureKind } from "@/features/quotes/offline/captureTypes";
+import type { LocalCaptureSession, OutboxJob, SubmitFailureKind } from "@/features/quotes/offline/captureTypes";
 import { classifySubmitFailure } from "@/features/quotes/offline/classifySubmitFailure";
 import {
   listPendingJobs,
+  unpauseAuthRequiredJobs,
   updateJobStatus,
 } from "@/features/quotes/offline/outboxRepository";
 import { quoteService } from "@/features/quotes/services/quoteService";
@@ -26,6 +27,7 @@ const TERMINAL_FAILURE_KINDS = new Set<SubmitFailureKind>([
 ]);
 const BACKOFF_BASE_MS = 2_000;
 const BACKOFF_MAX_MS = 120_000;
+const EXTRACTION_REQUEST_TIMEOUT_MS = 30_000;
 
 const inFlightPasses = new Map<string, Promise<void>>();
 const authPausedUsers = new Set<string>();
@@ -38,6 +40,7 @@ export type OutboxEngineEvent =
 interface OutboxPassOptions {
   onEvent?: (event: OutboxEngineEvent) => void;
   forceAfterAuth?: boolean;
+  extractionTimeoutMs?: number;
 }
 
 export async function runOutboxPass(userId: string, opts?: OutboxPassOptions): Promise<void> {
@@ -76,9 +79,15 @@ export function registerOnlineTrigger(userId: string, opts?: OutboxPassOptions):
   };
 }
 
+export function clearOutboxEngineStateForUser(userId: string): void {
+  authPausedUsers.delete(userId);
+  inFlightPasses.delete(userId);
+}
+
 async function runOutboxPassInternal(userId: string, opts?: OutboxPassOptions): Promise<void> {
   if (opts?.forceAfterAuth) {
     authPausedUsers.delete(userId);
+    await unpauseAuthRequiredJobs(userId);
   }
 
   if (authPausedUsers.has(userId)) {
@@ -108,12 +117,7 @@ async function processJob(job: OutboxJob, opts?: OutboxPassOptions): Promise<voi
   }
 
   try {
-    const extraction = await quoteService.extract({
-      clipIds: session.clipIds,
-      notes: session.notes,
-      customerId: session.customerId ?? undefined,
-      idempotencyKey: job.idempotencyKey,
-    });
+    const extraction = await extractWithTimeout(job, session, opts?.extractionTimeoutMs);
 
     if (extraction.type === "sync") {
       await markSuccess(job, {
@@ -275,4 +279,33 @@ async function pollForPersistedQuote(jobId: string): Promise<{ quote_id: string 
 function computeNextRetryAt(attemptCount: number): string {
   const delayMs = Math.min(BACKOFF_BASE_MS * (2 ** Math.max(attemptCount - 1, 0)), BACKOFF_MAX_MS);
   return new Date(Date.now() + delayMs).toISOString();
+}
+
+async function extractWithTimeout(
+  job: OutboxJob,
+  session: LocalCaptureSession,
+  timeoutMs = EXTRACTION_REQUEST_TIMEOUT_MS,
+) {
+  let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timeoutHandle = globalThis.setTimeout(() => {
+      reject(new Error("Outbox extraction timed out."));
+    }, timeoutMs);
+  });
+
+  try {
+    return await Promise.race([
+      quoteService.extract({
+        clipIds: session.clipIds,
+        notes: session.notes,
+        customerId: session.customerId ?? undefined,
+        idempotencyKey: job.idempotencyKey,
+      }),
+      timeoutPromise,
+    ]);
+  } finally {
+    if (timeoutHandle !== undefined) {
+      globalThis.clearTimeout(timeoutHandle);
+    }
+  }
 }

--- a/frontend/src/features/quotes/offline/outboxEngine.ts
+++ b/frontend/src/features/quotes/offline/outboxEngine.ts
@@ -1,0 +1,278 @@
+import { EXTRACTION_MAX_POLLS, EXTRACTION_POLL_INTERVAL_MS } from "@/features/quotes/components/captureScreenHelpers";
+import {
+  appendSyncEvent,
+  getCaptureSession,
+  markCaptureStatus,
+  updateCaptureField,
+} from "@/features/quotes/offline/captureRepository";
+import type { OutboxJob, SubmitFailureKind } from "@/features/quotes/offline/captureTypes";
+import { classifySubmitFailure } from "@/features/quotes/offline/classifySubmitFailure";
+import {
+  listPendingJobs,
+  updateJobStatus,
+} from "@/features/quotes/offline/outboxRepository";
+import { quoteService } from "@/features/quotes/services/quoteService";
+import { jobService } from "@/shared/lib/jobService";
+
+const RETRYABLE_FAILURE_KINDS = new Set<SubmitFailureKind>([
+  "offline",
+  "timeout",
+  "server_retryable",
+  "auth_required",
+]);
+const TERMINAL_FAILURE_KINDS = new Set<SubmitFailureKind>([
+  "validation_failed",
+  "server_terminal",
+]);
+const BACKOFF_BASE_MS = 2_000;
+const BACKOFF_MAX_MS = 120_000;
+
+const inFlightPasses = new Map<string, Promise<void>>();
+const authPausedUsers = new Set<string>();
+
+export type OutboxEngineEvent =
+  | { kind: "sync_success"; sessionId: string; quoteId: string | null }
+  | { kind: "sync_terminal_failure"; sessionId: string; failureKind: SubmitFailureKind }
+  | { kind: "auth_required"; sessionId: string };
+
+interface OutboxPassOptions {
+  onEvent?: (event: OutboxEngineEvent) => void;
+  forceAfterAuth?: boolean;
+}
+
+export async function runOutboxPass(userId: string, opts?: OutboxPassOptions): Promise<void> {
+  if (!userId) {
+    return;
+  }
+
+  const existingPass = inFlightPasses.get(userId);
+  if (existingPass) {
+    return existingPass;
+  }
+
+  const pass = runOutboxPassInternal(userId, opts)
+    .catch((error) => {
+      console.warn("Outbox pass failed.", error);
+    })
+    .finally(() => {
+      inFlightPasses.delete(userId);
+    });
+  inFlightPasses.set(userId, pass);
+  return pass;
+}
+
+export function registerOnlineTrigger(userId: string, opts?: OutboxPassOptions): () => void {
+  if (typeof window === "undefined") {
+    return () => undefined;
+  }
+
+  const handler = () => {
+    void runOutboxPass(userId, opts);
+  };
+
+  window.addEventListener("online", handler);
+  return () => {
+    window.removeEventListener("online", handler);
+  };
+}
+
+async function runOutboxPassInternal(userId: string, opts?: OutboxPassOptions): Promise<void> {
+  if (opts?.forceAfterAuth) {
+    authPausedUsers.delete(userId);
+  }
+
+  if (authPausedUsers.has(userId)) {
+    return;
+  }
+
+  const pendingJobs = await listPendingJobs(userId);
+  for (const job of pendingJobs) {
+    if (authPausedUsers.has(userId)) {
+      return;
+    }
+
+    await processJob(job, opts);
+  }
+}
+
+async function processJob(job: OutboxJob, opts?: OutboxPassOptions): Promise<void> {
+  await updateJobStatus(job.jobId, {
+    status: "running",
+    nextRetryAt: null,
+  });
+
+  const session = await getCaptureSession(job.sessionId);
+  if (!session) {
+    await markTerminalFailure(job, "server_terminal", "Capture session was missing on this device.", opts);
+    return;
+  }
+
+  try {
+    const extraction = await quoteService.extract({
+      clipIds: session.clipIds,
+      notes: session.notes,
+      customerId: session.customerId ?? undefined,
+      idempotencyKey: job.idempotencyKey,
+    });
+
+    if (extraction.type === "sync") {
+      await markSuccess(job, {
+        quoteId: extraction.quoteId,
+        serverJobId: null,
+      }, opts);
+      return;
+    }
+
+    const jobResult = await pollForPersistedQuote(extraction.jobId);
+    await markSuccess(job, {
+      quoteId: jobResult.quote_id,
+      serverJobId: extraction.jobId,
+    }, opts);
+  } catch (error) {
+    const failureKind = classifySubmitFailure(error);
+    const message = error instanceof Error ? error.message : "Unable to sync capture.";
+
+    if (TERMINAL_FAILURE_KINDS.has(failureKind)) {
+      await markTerminalFailure(job, failureKind, message, opts);
+      return;
+    }
+
+    if (failureKind === "auth_required") {
+      authPausedUsers.add(job.userId);
+      opts?.onEvent?.({ kind: "auth_required", sessionId: job.sessionId });
+    }
+
+    if (RETRYABLE_FAILURE_KINDS.has(failureKind)) {
+      await markRetryableFailure(job, failureKind, message, opts);
+      return;
+    }
+
+    await markTerminalFailure(job, "server_terminal", message, opts);
+  }
+}
+
+async function markSuccess(
+  job: OutboxJob,
+  params: { quoteId: string | null; serverJobId: string | null },
+  opts?: OutboxPassOptions,
+): Promise<void> {
+  await updateJobStatus(job.jobId, {
+    status: "succeeded",
+    serverQuoteId: params.quoteId,
+    serverJobId: params.serverJobId,
+    lastFailureKind: null,
+    lastError: null,
+    nextRetryAt: null,
+  });
+  await markCaptureStatus(job.sessionId, "synced");
+  await updateCaptureField(job.sessionId, {
+    serverQuoteId: params.quoteId,
+    extractJobId: params.serverJobId,
+  });
+  await appendSyncEvent({
+    sessionId: job.sessionId,
+    userId: job.userId,
+    level: "info",
+    message: "Extraction synced to server.",
+  });
+
+  opts?.onEvent?.({
+    kind: "sync_success",
+    sessionId: job.sessionId,
+    quoteId: params.quoteId,
+  });
+}
+
+async function markRetryableFailure(
+  job: OutboxJob,
+  failureKind: SubmitFailureKind,
+  message: string,
+  opts?: OutboxPassOptions,
+): Promise<void> {
+  const nextAttemptCount = job.attemptCount + 1;
+  if (nextAttemptCount >= job.maxAttempts) {
+    await markTerminalFailure(job, failureKind, message, opts);
+    return;
+  }
+
+  const nextRetryAt = computeNextRetryAt(nextAttemptCount);
+  await updateJobStatus(job.jobId, {
+    status: "failed_retryable",
+    lastFailureKind: failureKind,
+    lastError: message,
+    attemptCount: nextAttemptCount,
+    nextRetryAt,
+  });
+
+  await appendSyncEvent({
+    sessionId: job.sessionId,
+    userId: job.userId,
+    level: "warning",
+    message: `Retry ${nextAttemptCount} failed: ${failureKind}`,
+  });
+}
+
+async function markTerminalFailure(
+  job: OutboxJob,
+  failureKind: SubmitFailureKind,
+  message: string,
+  opts?: OutboxPassOptions,
+): Promise<void> {
+  const nextAttemptCount = Math.min(job.attemptCount + 1, job.maxAttempts);
+  await updateJobStatus(job.jobId, {
+    status: "failed_terminal",
+    lastFailureKind: failureKind,
+    lastError: message,
+    attemptCount: nextAttemptCount,
+    nextRetryAt: null,
+  });
+  await markCaptureStatus(job.sessionId, "extract_failed", {
+    failureKind,
+    error: message,
+  });
+  await appendSyncEvent({
+    sessionId: job.sessionId,
+    userId: job.userId,
+    level: "error",
+    message: `Extraction failed permanently: ${failureKind}`,
+  });
+
+  opts?.onEvent?.({
+    kind: "sync_terminal_failure",
+    sessionId: job.sessionId,
+    failureKind,
+  });
+}
+
+async function pollForPersistedQuote(jobId: string): Promise<{ quote_id: string }> {
+  for (let pollCount = 0; pollCount < EXTRACTION_MAX_POLLS; pollCount += 1) {
+    const job = await jobService.getJobStatus(jobId);
+
+    if (job.quote_id) {
+      return { quote_id: job.quote_id };
+    }
+
+    if (job.status === "success") {
+      throw new Error("Extraction completed without a persisted draft. Please try again.");
+    }
+
+    if (job.status === "terminal") {
+      throw new Error("Extraction failed. Please try again.");
+    }
+
+    if (pollCount === EXTRACTION_MAX_POLLS - 1) {
+      break;
+    }
+
+    await new Promise((resolve) => {
+      window.setTimeout(resolve, EXTRACTION_POLL_INTERVAL_MS);
+    });
+  }
+
+  throw new Error("Extraction is taking longer than expected. Please try again.");
+}
+
+function computeNextRetryAt(attemptCount: number): string {
+  const delayMs = Math.min(BACKOFF_BASE_MS * (2 ** Math.max(attemptCount - 1, 0)), BACKOFF_MAX_MS);
+  return new Date(Date.now() + delayMs).toISOString();
+}

--- a/frontend/src/features/quotes/offline/outboxRepository.test.ts
+++ b/frontend/src/features/quotes/offline/outboxRepository.test.ts
@@ -46,7 +46,7 @@ describe("outboxRepository", () => {
     });
 
     expect(secondJob.jobId).toBe(firstJob.jobId);
-    expect(secondJob.idempotencyKey).toBe("idem-2");
+    expect(secondJob.idempotencyKey).toBe("idem-1");
   });
 
   it("lists only pending queued and due retryable jobs", async () => {

--- a/frontend/src/features/quotes/offline/outboxRepository.test.ts
+++ b/frontend/src/features/quotes/offline/outboxRepository.test.ts
@@ -1,0 +1,121 @@
+import "fake-indexeddb/auto";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { resetCaptureDbForTests } from "@/features/quotes/offline/captureDb";
+import {
+  enqueueJob,
+  getJob,
+  listPendingJobs,
+  updateJobStatus,
+} from "@/features/quotes/offline/outboxRepository";
+
+describe("outboxRepository", () => {
+  beforeEach(async () => {
+    await resetCaptureDbForTests();
+  });
+
+  afterEach(async () => {
+    await resetCaptureDbForTests();
+  });
+
+  it("creates outbox jobs with queued defaults", async () => {
+    const job = await enqueueJob({
+      userId: "user-1",
+      sessionId: "session-1",
+      idempotencyKey: "idem-1",
+    });
+
+    expect(job.status).toBe("queued");
+    expect(job.attemptCount).toBe(0);
+    expect(job.maxAttempts).toBe(5);
+    expect(job.nextRetryAt).toBeNull();
+  });
+
+  it("reuses an active session job instead of creating duplicates", async () => {
+    const firstJob = await enqueueJob({
+      userId: "user-1",
+      sessionId: "session-1",
+      idempotencyKey: "idem-1",
+    });
+
+    const secondJob = await enqueueJob({
+      userId: "user-1",
+      sessionId: "session-1",
+      idempotencyKey: "idem-2",
+    });
+
+    expect(secondJob.jobId).toBe(firstJob.jobId);
+    expect(secondJob.idempotencyKey).toBe("idem-2");
+  });
+
+  it("lists only pending queued and due retryable jobs", async () => {
+    const queuedJob = await enqueueJob({
+      userId: "user-1",
+      sessionId: "session-queued",
+      idempotencyKey: "idem-queued",
+    });
+    const dueRetryableJob = await enqueueJob({
+      userId: "user-1",
+      sessionId: "session-retryable",
+      idempotencyKey: "idem-retryable",
+    });
+    const authPausedJob = await enqueueJob({
+      userId: "user-1",
+      sessionId: "session-auth",
+      idempotencyKey: "idem-auth",
+    });
+    const succeededJob = await enqueueJob({
+      userId: "user-1",
+      sessionId: "session-done",
+      idempotencyKey: "idem-done",
+    });
+
+    await updateJobStatus(dueRetryableJob.jobId, {
+      status: "failed_retryable",
+      lastFailureKind: "timeout",
+      nextRetryAt: new Date(Date.now() - 5_000).toISOString(),
+      attemptCount: 1,
+    });
+    await updateJobStatus(authPausedJob.jobId, {
+      status: "failed_retryable",
+      lastFailureKind: "auth_required",
+      nextRetryAt: new Date(Date.now() - 5_000).toISOString(),
+      attemptCount: 1,
+    });
+    await updateJobStatus(succeededJob.jobId, {
+      status: "succeeded",
+      nextRetryAt: null,
+    });
+
+    const pending = await listPendingJobs("user-1");
+    const pendingIds = new Set(pending.map((job) => job.jobId));
+
+    expect(pendingIds.has(queuedJob.jobId)).toBe(true);
+    expect(pendingIds.has(dueRetryableJob.jobId)).toBe(true);
+    expect(pendingIds.has(authPausedJob.jobId)).toBe(false);
+    expect(pendingIds.has(succeededJob.jobId)).toBe(false);
+  });
+
+  it("persists outbox status updates", async () => {
+    const job = await enqueueJob({
+      userId: "user-1",
+      sessionId: "session-1",
+      idempotencyKey: "idem-1",
+    });
+
+    await updateJobStatus(job.jobId, {
+      status: "failed_retryable",
+      attemptCount: 2,
+      lastFailureKind: "timeout",
+      lastError: "Timed out",
+      nextRetryAt: new Date().toISOString(),
+    });
+
+    const updatedJob = await getJob(job.jobId);
+    expect(updatedJob?.status).toBe("failed_retryable");
+    expect(updatedJob?.attemptCount).toBe(2);
+    expect(updatedJob?.lastFailureKind).toBe("timeout");
+    expect(updatedJob?.lastError).toBe("Timed out");
+  });
+});

--- a/frontend/src/features/quotes/offline/outboxRepository.ts
+++ b/frontend/src/features/quotes/offline/outboxRepository.ts
@@ -35,7 +35,6 @@ export async function enqueueJob(input: EnqueueJobInput): Promise<OutboxJob> {
   const existingForSession = await listJobsForSessionFromStore(store, input.sessionId);
   const activeJob = existingForSession.find((job) => ACTIVE_STATUSES.has(job.status));
   if (activeJob) {
-    activeJob.idempotencyKey = input.idempotencyKey;
     activeJob.maxAttempts = normalizeMaxAttempts(input.maxAttempts ?? activeJob.maxAttempts);
     activeJob.updatedAt = new Date().toISOString();
     store.put(activeJob);
@@ -178,6 +177,31 @@ export async function listPendingJobs(userId: string): Promise<OutboxJob[]> {
       return Number.isFinite(nextRetryAtMs) && nextRetryAtMs <= nowMs;
     })
     .sort((left, right) => left.updatedAt.localeCompare(right.updatedAt));
+}
+
+export async function unpauseAuthRequiredJobs(userId: string): Promise<void> {
+  const db = await getDb();
+  const transaction = db.transaction(CAPTURE_STORE_NAMES.outboxJobs, "readwrite");
+  const store = transaction.objectStore(CAPTURE_STORE_NAMES.outboxJobs);
+  const userIndex = store.index("userId");
+  const records = await requestToPromise(userIndex.getAll(IDBKeyRange.only(userId)));
+
+  for (const rawRecord of records) {
+    const job = parseStoredOutboxJob(rawRecord);
+    if (!job || job.userId !== userId) {
+      continue;
+    }
+    if (job.status !== "failed_retryable" || job.lastFailureKind !== "auth_required") {
+      continue;
+    }
+
+    job.status = "queued";
+    job.nextRetryAt = null;
+    job.updatedAt = new Date().toISOString();
+    store.put(job);
+  }
+
+  await transactionDone(transaction);
 }
 
 export async function listAllJobsForUser(userId: string): Promise<OutboxJob[]> {

--- a/frontend/src/features/quotes/offline/outboxRepository.ts
+++ b/frontend/src/features/quotes/offline/outboxRepository.ts
@@ -1,0 +1,385 @@
+import { CAPTURE_STORE_NAMES, getDb } from "@/features/quotes/offline/captureDb";
+import type {
+  EnqueueJobInput,
+  OutboxJob,
+  OutboxJobStatus,
+  SubmitFailureKind,
+} from "@/features/quotes/offline/captureTypes";
+
+const DEFAULT_MAX_ATTEMPTS = 5;
+const ACTIVE_STATUSES = new Set<OutboxJobStatus>(["queued", "running", "failed_retryable"]);
+const OUTBOX_STATUSES = new Set<OutboxJobStatus>([
+  "queued",
+  "running",
+  "succeeded",
+  "failed_retryable",
+  "failed_terminal",
+]);
+const SUBMIT_FAILURE_KINDS = new Set<SubmitFailureKind>([
+  "offline",
+  "timeout",
+  "auth_required",
+  "csrf_failed",
+  "validation_failed",
+  "server_retryable",
+  "server_terminal",
+]);
+
+type UnknownRecord = Record<string, unknown>;
+
+export async function enqueueJob(input: EnqueueJobInput): Promise<OutboxJob> {
+  const db = await getDb();
+  const transaction = db.transaction(CAPTURE_STORE_NAMES.outboxJobs, "readwrite");
+  const store = transaction.objectStore(CAPTURE_STORE_NAMES.outboxJobs);
+
+  const existingForSession = await listJobsForSessionFromStore(store, input.sessionId);
+  const activeJob = existingForSession.find((job) => ACTIVE_STATUSES.has(job.status));
+  if (activeJob) {
+    activeJob.idempotencyKey = input.idempotencyKey;
+    activeJob.maxAttempts = normalizeMaxAttempts(input.maxAttempts ?? activeJob.maxAttempts);
+    activeJob.updatedAt = new Date().toISOString();
+    store.put(activeJob);
+    await transactionDone(transaction);
+    return activeJob;
+  }
+
+  const now = new Date().toISOString();
+  const createdJob: OutboxJob = {
+    jobId: buildLocalId(),
+    userId: input.userId,
+    sessionId: input.sessionId,
+    idempotencyKey: input.idempotencyKey,
+    status: "queued",
+    attemptCount: 0,
+    maxAttempts: normalizeMaxAttempts(input.maxAttempts),
+    nextRetryAt: null,
+    lastFailureKind: null,
+    lastError: null,
+    serverQuoteId: null,
+    serverJobId: null,
+    createdAt: now,
+    updatedAt: now,
+  };
+
+  store.put(createdJob);
+  await transactionDone(transaction);
+  return createdJob;
+}
+
+export async function getJob(jobId: string): Promise<OutboxJob | null> {
+  const db = await getDb();
+  const transaction = db.transaction(CAPTURE_STORE_NAMES.outboxJobs, "readonly");
+  const store = transaction.objectStore(CAPTURE_STORE_NAMES.outboxJobs);
+  const rawRecord = await requestToPromise(store.get(jobId));
+  await transactionDone(transaction);
+  return parseStoredOutboxJob(rawRecord);
+}
+
+export async function getJobForSession(sessionId: string): Promise<OutboxJob | null> {
+  const db = await getDb();
+  const transaction = db.transaction(CAPTURE_STORE_NAMES.outboxJobs, "readonly");
+  const store = transaction.objectStore(CAPTURE_STORE_NAMES.outboxJobs);
+  const records = await listJobsForSessionFromStore(store, sessionId);
+  await transactionDone(transaction);
+
+  if (records.length === 0) {
+    return null;
+  }
+
+  const activeJob = records.find((job) => ACTIVE_STATUSES.has(job.status));
+  if (activeJob) {
+    return activeJob;
+  }
+
+  return records[0] ?? null;
+}
+
+export async function updateJobStatus(jobId: string, patch: Partial<OutboxJob>): Promise<void> {
+  validateOutboxPatch(patch);
+
+  const db = await getDb();
+  const transaction = db.transaction(CAPTURE_STORE_NAMES.outboxJobs, "readwrite");
+  const store = transaction.objectStore(CAPTURE_STORE_NAMES.outboxJobs);
+  const job = await getWritableOutboxJob(store, jobId);
+
+  if (patch.userId !== undefined) {
+    job.userId = patch.userId;
+  }
+  if (patch.sessionId !== undefined) {
+    job.sessionId = patch.sessionId;
+  }
+  if (patch.idempotencyKey !== undefined) {
+    job.idempotencyKey = patch.idempotencyKey;
+  }
+  if (patch.status !== undefined) {
+    job.status = patch.status;
+  }
+  if (patch.attemptCount !== undefined) {
+    job.attemptCount = patch.attemptCount;
+  }
+  if (patch.maxAttempts !== undefined) {
+    job.maxAttempts = normalizeMaxAttempts(patch.maxAttempts);
+  }
+  if (patch.nextRetryAt !== undefined) {
+    job.nextRetryAt = patch.nextRetryAt;
+  }
+  if (patch.lastFailureKind !== undefined) {
+    job.lastFailureKind = patch.lastFailureKind;
+  }
+  if (patch.lastError !== undefined) {
+    job.lastError = patch.lastError;
+  }
+  if (patch.serverQuoteId !== undefined) {
+    job.serverQuoteId = patch.serverQuoteId;
+  }
+  if (patch.serverJobId !== undefined) {
+    job.serverJobId = patch.serverJobId;
+  }
+
+  job.updatedAt = new Date().toISOString();
+  store.put(job);
+  await transactionDone(transaction);
+}
+
+export async function listPendingJobs(userId: string): Promise<OutboxJob[]> {
+  const db = await getDb();
+  const transaction = db.transaction(CAPTURE_STORE_NAMES.outboxJobs, "readonly");
+  const store = transaction.objectStore(CAPTURE_STORE_NAMES.outboxJobs);
+  const userIndex = store.index("userId");
+  const records = await requestToPromise(userIndex.getAll(IDBKeyRange.only(userId)));
+  await transactionDone(transaction);
+
+  const nowMs = Date.now();
+  return records
+    .map(parseStoredOutboxJob)
+    .filter((record): record is OutboxJob => record !== null)
+    .filter((record) => {
+      if (record.userId !== userId) {
+        return false;
+      }
+
+      if (record.status === "queued") {
+        return true;
+      }
+
+      if (record.status !== "failed_retryable") {
+        return false;
+      }
+
+      if (record.lastFailureKind === "auth_required") {
+        return false;
+      }
+
+      if (!record.nextRetryAt) {
+        return true;
+      }
+
+      const nextRetryAtMs = Date.parse(record.nextRetryAt);
+      return Number.isFinite(nextRetryAtMs) && nextRetryAtMs <= nowMs;
+    })
+    .sort((left, right) => left.updatedAt.localeCompare(right.updatedAt));
+}
+
+export async function listAllJobsForUser(userId: string): Promise<OutboxJob[]> {
+  const db = await getDb();
+  const transaction = db.transaction(CAPTURE_STORE_NAMES.outboxJobs, "readonly");
+  const store = transaction.objectStore(CAPTURE_STORE_NAMES.outboxJobs);
+  const userIndex = store.index("userId");
+  const records = await requestToPromise(userIndex.getAll(IDBKeyRange.only(userId)));
+  await transactionDone(transaction);
+
+  return records
+    .map(parseStoredOutboxJob)
+    .filter((record): record is OutboxJob => record !== null)
+    .filter((record) => record.userId === userId)
+    .sort((left, right) => right.updatedAt.localeCompare(left.updatedAt));
+}
+
+export async function deleteJob(jobId: string): Promise<void> {
+  const db = await getDb();
+  const transaction = db.transaction(CAPTURE_STORE_NAMES.outboxJobs, "readwrite");
+  const store = transaction.objectStore(CAPTURE_STORE_NAMES.outboxJobs);
+  store.delete(jobId);
+  await transactionDone(transaction);
+}
+
+export async function deleteJobForSession(sessionId: string): Promise<void> {
+  const db = await getDb();
+  const transaction = db.transaction(CAPTURE_STORE_NAMES.outboxJobs, "readwrite");
+  const store = transaction.objectStore(CAPTURE_STORE_NAMES.outboxJobs);
+
+  const jobs = await listJobsForSessionFromStore(store, sessionId);
+  for (const job of jobs) {
+    store.delete(job.jobId);
+  }
+
+  await transactionDone(transaction);
+}
+
+async function listJobsForSessionFromStore(
+  store: IDBObjectStore,
+  sessionId: string,
+): Promise<OutboxJob[]> {
+  const sessionIndex = store.index("sessionId");
+  const records = await requestToPromise(sessionIndex.getAll(IDBKeyRange.only(sessionId)));
+
+  return records
+    .map(parseStoredOutboxJob)
+    .filter((record): record is OutboxJob => record !== null)
+    .sort((left, right) => right.updatedAt.localeCompare(left.updatedAt));
+}
+
+function validateOutboxPatch(patch: Partial<OutboxJob>): void {
+  if (
+    patch.status !== undefined
+    && (typeof patch.status !== "string" || !OUTBOX_STATUSES.has(patch.status as OutboxJobStatus))
+  ) {
+    throw new Error(`Invalid outbox status patch: ${String(patch.status)}`);
+  }
+
+  if (
+    patch.lastFailureKind !== undefined
+    && patch.lastFailureKind !== null
+    && (typeof patch.lastFailureKind !== "string"
+      || !SUBMIT_FAILURE_KINDS.has(patch.lastFailureKind as SubmitFailureKind))
+  ) {
+    throw new Error(`Invalid outbox failure kind patch: ${String(patch.lastFailureKind)}`);
+  }
+
+  if (patch.maxAttempts !== undefined && (!Number.isFinite(patch.maxAttempts) || patch.maxAttempts < 1)) {
+    throw new Error(`Invalid outbox maxAttempts patch: ${String(patch.maxAttempts)}`);
+  }
+
+  if (patch.attemptCount !== undefined && (!Number.isFinite(patch.attemptCount) || patch.attemptCount < 0)) {
+    throw new Error(`Invalid outbox attemptCount patch: ${String(patch.attemptCount)}`);
+  }
+
+  if (
+    patch.nextRetryAt !== undefined
+    && patch.nextRetryAt !== null
+    && (typeof patch.nextRetryAt !== "string" || Number.isNaN(Date.parse(patch.nextRetryAt)))
+  ) {
+    throw new Error(`Invalid outbox nextRetryAt patch: ${String(patch.nextRetryAt)}`);
+  }
+}
+
+async function getWritableOutboxJob(store: IDBObjectStore, jobId: string): Promise<OutboxJob> {
+  const rawRecord = await requestToPromise(store.get(jobId));
+  if (rawRecord === undefined) {
+    throw new Error(`Outbox job not found: ${jobId}`);
+  }
+
+  const parsedRecord = parseStoredOutboxJob(rawRecord);
+  if (!parsedRecord) {
+    throw new Error(`Stored outbox job is invalid: ${jobId}`);
+  }
+
+  return parsedRecord;
+}
+
+function parseStoredOutboxJob(value: unknown): OutboxJob | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  const jobId = value.jobId;
+  const userId = value.userId;
+  const sessionId = value.sessionId;
+  const idempotencyKey = value.idempotencyKey;
+  const status = value.status;
+  const attemptCount = value.attemptCount;
+  const maxAttempts = value.maxAttempts;
+  const nextRetryAt = value.nextRetryAt;
+  const lastFailureKind = value.lastFailureKind;
+  const lastError = value.lastError;
+  const serverQuoteId = value.serverQuoteId;
+  const serverJobId = value.serverJobId;
+  const createdAt = value.createdAt;
+  const updatedAt = value.updatedAt;
+
+  if (
+    typeof jobId !== "string"
+    || typeof userId !== "string"
+    || typeof sessionId !== "string"
+    || typeof idempotencyKey !== "string"
+    || typeof status !== "string"
+    || !OUTBOX_STATUSES.has(status as OutboxJobStatus)
+    || !Number.isFinite(attemptCount)
+    || !Number.isFinite(maxAttempts)
+    || !isOptionalNullableString(nextRetryAt)
+    || !isOptionalNullableString(lastError)
+    || !isOptionalNullableString(serverQuoteId)
+    || !isOptionalNullableString(serverJobId)
+    || typeof createdAt !== "string"
+    || typeof updatedAt !== "string"
+  ) {
+    return null;
+  }
+
+  if (
+    lastFailureKind !== undefined
+    && lastFailureKind !== null
+    && (typeof lastFailureKind !== "string"
+      || !SUBMIT_FAILURE_KINDS.has(lastFailureKind as SubmitFailureKind))
+  ) {
+    return null;
+  }
+
+  if (nextRetryAt !== undefined && nextRetryAt !== null && Number.isNaN(Date.parse(nextRetryAt as string))) {
+    return null;
+  }
+
+  return {
+    jobId,
+    userId,
+    sessionId,
+    idempotencyKey,
+    status: status as OutboxJobStatus,
+    attemptCount: attemptCount as number,
+    maxAttempts: maxAttempts as number,
+    nextRetryAt: (nextRetryAt as string | null | undefined) ?? null,
+    lastFailureKind: (lastFailureKind as SubmitFailureKind | null | undefined) ?? null,
+    lastError: (lastError as string | null | undefined) ?? null,
+    serverQuoteId: (serverQuoteId as string | null | undefined) ?? null,
+    serverJobId: (serverJobId as string | null | undefined) ?? null,
+    createdAt,
+    updatedAt,
+  };
+}
+
+function normalizeMaxAttempts(maxAttempts: number | undefined): number {
+  if (!Number.isFinite(maxAttempts) || (maxAttempts ?? 0) < 1) {
+    return DEFAULT_MAX_ATTEMPTS;
+  }
+  return maxAttempts as number;
+}
+
+function isOptionalNullableString(value: unknown): boolean {
+  return value === undefined || value === null || typeof value === "string";
+}
+
+function isRecord(value: unknown): value is UnknownRecord {
+  return typeof value === "object" && value !== null;
+}
+
+function buildLocalId(): string {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID();
+  }
+  return `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+}
+
+function requestToPromise<T>(request: IDBRequest<T>): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error ?? new Error("IndexedDB request failed."));
+  });
+}
+
+function transactionDone(transaction: IDBTransaction): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    transaction.oncomplete = () => resolve();
+    transaction.onerror = () => reject(transaction.error ?? new Error("IndexedDB transaction failed."));
+    transaction.onabort = () => reject(transaction.error ?? new Error("IndexedDB transaction aborted."));
+  });
+}

--- a/frontend/src/features/quotes/offline/useRecoverableCaptures.ts
+++ b/frontend/src/features/quotes/offline/useRecoverableCaptures.ts
@@ -6,6 +6,7 @@ import {
   listRecoverableCaptures,
 } from "@/features/quotes/offline/captureRepository";
 import type { LocalCaptureSummary } from "@/features/quotes/offline/captureTypes";
+import { listAllJobsForUser } from "@/features/quotes/offline/outboxRepository";
 
 const MAX_RECOVERABLE_CAPTURES = 20;
 
@@ -39,8 +40,36 @@ export function useRecoverableCaptures(userId: string | undefined): UseRecoverab
 
     try {
       await deleteEmptyAbandonedSessions(userId);
-      const nextCaptures = await listRecoverableCaptures(userId);
-      setCaptures(nextCaptures.slice(0, MAX_RECOVERABLE_CAPTURES));
+      const [nextCaptures, outboxJobs] = await Promise.all([
+        listRecoverableCaptures(userId),
+        listAllJobsForUser(userId),
+      ]);
+      const nextCaptureBySessionId = new Map(nextCaptures.map((capture) => [capture.sessionId, capture]));
+      const latestJobBySessionId = new Map<string, (typeof outboxJobs)[number]>();
+      for (const outboxJob of outboxJobs) {
+        if (!nextCaptureBySessionId.has(outboxJob.sessionId)) {
+          continue;
+        }
+        if (!latestJobBySessionId.has(outboxJob.sessionId)) {
+          latestJobBySessionId.set(outboxJob.sessionId, outboxJob);
+        }
+      }
+
+      const captureSummaries = nextCaptures.map((capture) => {
+        const outboxJob = latestJobBySessionId.get(capture.sessionId);
+        if (!outboxJob) {
+          return capture;
+        }
+
+        return {
+          ...capture,
+          outboxStatus: outboxJob.status,
+          outboxAttemptCount: outboxJob.attemptCount,
+          outboxMaxAttempts: outboxJob.maxAttempts,
+        } satisfies LocalCaptureSummary;
+      });
+
+      setCaptures(captureSummaries.slice(0, MAX_RECOVERABLE_CAPTURES));
     } catch (loadError) {
       setError(getErrorMessage(loadError));
     } finally {

--- a/frontend/src/features/quotes/tests/CaptureScreen.test.tsx
+++ b/frontend/src/features/quotes/tests/CaptureScreen.test.tsx
@@ -6,6 +6,7 @@ import { useAuth } from "@/features/auth/hooks/useAuth";
 import { CaptureScreen } from "@/features/quotes/components/CaptureScreen";
 import { useQuoteDraft } from "@/features/quotes/hooks/useQuoteDraft";
 import { getCaptureSession, updateCaptureField } from "@/features/quotes/offline/captureRepository";
+import { enqueueJob, getJobForSession, updateJobStatus } from "@/features/quotes/offline/outboxRepository";
 import { HOME_ROUTE } from "@/features/quotes/utils/workflowNavigation";
 import { MAX_VOICE_CLIPS_PER_CAPTURE, useVoiceCapture, type VoiceClip } from "@/features/quotes/hooks/useVoiceCapture";
 import { quoteService } from "@/features/quotes/services/quoteService";
@@ -125,6 +126,27 @@ vi.mock("@/features/quotes/offline/captureRepository", () => ({
   updateCaptureField: vi.fn(async () => undefined),
 }));
 
+vi.mock("@/features/quotes/offline/outboxRepository", () => ({
+  enqueueJob: vi.fn(async ({ sessionId }: { sessionId: string }) => ({
+    jobId: "job-1",
+    userId: "user-1",
+    sessionId,
+    idempotencyKey: "idem-1",
+    status: "queued",
+    attemptCount: 0,
+    maxAttempts: 5,
+    nextRetryAt: null,
+    lastFailureKind: null,
+    lastError: null,
+    serverQuoteId: null,
+    serverJobId: null,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  })),
+  getJobForSession: vi.fn(async () => null),
+  updateJobStatus: vi.fn(async () => undefined),
+}));
+
 vi.mock("@/shared/lib/jobService", () => ({
   jobService: {
     getJobStatus: vi.fn(),
@@ -138,6 +160,9 @@ const mockedQuoteService = vi.mocked(quoteService);
 const mockedJobService = vi.mocked(jobService);
 const mockedGetCaptureSession = vi.mocked(getCaptureSession);
 const mockedUpdateCaptureField = vi.mocked(updateCaptureField);
+const mockedEnqueueJob = vi.mocked(enqueueJob);
+const mockedGetJobForSession = vi.mocked(getJobForSession);
+const mockedUpdateJobStatus = vi.mocked(updateJobStatus);
 
 const extractionFixture: ExtractionResult = {
   transcript: "5 yards brown mulch",
@@ -359,6 +384,9 @@ beforeEach(() => {
   mockedJobService.getJobStatus.mockReset();
   mockedGetCaptureSession.mockResolvedValue(null);
   mockedUpdateCaptureField.mockResolvedValue(undefined);
+  mockedEnqueueJob.mockClear();
+  mockedGetJobForSession.mockResolvedValue(null);
+  mockedUpdateJobStatus.mockResolvedValue(undefined);
   useParamsMock.mockReturnValue({ customerId: "cust-1" });
 });
 
@@ -609,6 +637,11 @@ describe("CaptureScreen", () => {
     expect(
       await screen.findByText("Ready to extract when online. Your notes are still saved on this device."),
     ).toBeInTheDocument();
+    expect(mockedEnqueueJob).toHaveBeenCalledWith(expect.objectContaining({
+      userId: "user-1",
+      sessionId: "local-session-1",
+      idempotencyKey: expect.any(String),
+    }));
     expect(screen.getByText("Ready to extract when online")).toBeInTheDocument();
   });
 

--- a/frontend/src/features/quotes/tests/QuoteList.test.tsx
+++ b/frontend/src/features/quotes/tests/QuoteList.test.tsx
@@ -7,6 +7,8 @@ import { invoiceService } from "@/features/invoices/services/invoiceService";
 import type { InvoiceListItem } from "@/features/invoices/types/invoice.types";
 import { QuoteList } from "@/features/quotes/components/QuoteList";
 import { useRecoverableCaptures } from "@/features/quotes/offline/useRecoverableCaptures";
+import { runOutboxPass } from "@/features/quotes/offline/outboxEngine";
+import { getJobForSession, updateJobStatus } from "@/features/quotes/offline/outboxRepository";
 import { quoteService } from "@/features/quotes/services/quoteService";
 import type { QuoteListItem } from "@/features/quotes/types/quote.types";
 
@@ -57,10 +59,22 @@ vi.mock("@/features/quotes/offline/useRecoverableCaptures", () => ({
   useRecoverableCaptures: vi.fn(),
 }));
 
+vi.mock("@/features/quotes/offline/outboxRepository", () => ({
+  getJobForSession: vi.fn(async () => null),
+  updateJobStatus: vi.fn(async () => undefined),
+}));
+
+vi.mock("@/features/quotes/offline/outboxEngine", () => ({
+  runOutboxPass: vi.fn(async () => undefined),
+}));
+
 const mockedQuoteService = vi.mocked(quoteService);
 const mockedInvoiceService = vi.mocked(invoiceService);
 const mockedUseAuth = vi.mocked(useAuth);
 const mockedUseRecoverableCaptures = vi.mocked(useRecoverableCaptures);
+const mockedGetJobForSession = vi.mocked(getJobForSession);
+const mockedUpdateJobStatus = vi.mocked(updateJobStatus);
+const mockedRunOutboxPass = vi.mocked(runOutboxPass);
 const ORIGINAL_NAVIGATOR_ONLINE_DESCRIPTOR = Object.getOwnPropertyDescriptor(window.navigator, "onLine");
 
 function makeQuoteListItem(overrides: Partial<QuoteListItem> = {}): QuoteListItem {
@@ -303,6 +317,60 @@ describe("QuoteList", () => {
     await screen.findByText(/Q-001/);
 
     expect(screen.getByRole("button", { name: "Extract" })).toBeDisabled();
+  });
+
+  it("shows Retry action for failed retryable outbox jobs and runs sync pass", async () => {
+    const refreshRecoverableCaptures = vi.fn(async () => undefined);
+    setNavigatorOnline(true);
+    mockedGetJobForSession.mockResolvedValueOnce({
+      jobId: "job-1",
+      userId: "user-1",
+      sessionId: "session-1",
+      idempotencyKey: "idem-1",
+      status: "failed_retryable",
+      attemptCount: 2,
+      maxAttempts: 5,
+      nextRetryAt: new Date().toISOString(),
+      lastFailureKind: "timeout",
+      lastError: "Request timed out",
+      serverQuoteId: null,
+      serverJobId: null,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+    mockedUseRecoverableCaptures.mockReturnValue({
+      captures: [
+        {
+          sessionId: "session-1",
+          status: "extract_failed",
+          notes: "Patio estimate",
+          updatedAt: "2026-03-20T00:00:00.000Z",
+          lastFailureKind: "timeout",
+          lastError: "Request timed out",
+          outboxStatus: "failed_retryable",
+          outboxAttemptCount: 2,
+          outboxMaxAttempts: 5,
+        },
+      ],
+      isLoading: false,
+      error: null,
+      refresh: refreshRecoverableCaptures,
+      deleteCapture: vi.fn(async () => undefined),
+    });
+    mockedQuoteService.listQuotes.mockResolvedValueOnce([makeQuoteListItem()]);
+
+    renderScreen();
+    await screen.findByText(/Q-001/);
+
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+
+    await waitFor(() => {
+      expect(mockedUpdateJobStatus).toHaveBeenCalledWith("job-1", expect.objectContaining({
+        status: "queued",
+      }));
+      expect(mockedRunOutboxPass).toHaveBeenCalledWith("user-1");
+      expect(refreshRecoverableCaptures).toHaveBeenCalled();
+    });
   });
 
   it("renders quote cards from listQuotes response", async () => {


### PR DESCRIPTION
## Summary
- add IndexedDB-backed outbox repository and foreground outbox engine with retry/backoff, auth pause, and online trigger
- wire capture/quote flows to enqueue retryable extraction failures and support manual retry from pending captures
- add app-level outbox sync coordinator with toast events
- expand tests for outbox repository/engine and capture/list integrations

## Verification
- `cd frontend && ./node_modules/.bin/vitest run src/features/quotes/offline/outboxRepository.test.ts src/features/quotes/offline/outboxEngine.test.ts src/features/quotes/tests/CaptureScreen.test.tsx src/features/quotes/tests/QuoteList.test.tsx`
- `make frontend-verify`

Closes #559