### PR TITLE
Task #576: Offline auth continuity for local recovery

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -57,10 +57,10 @@ const SettingsScreen = lazy(() =>
 );
 
 function ProtectedRoute(): React.ReactElement {
-  const { user, isOnboarded } = useAuth();
+  const { authMode, isOnboarded } = useAuth();
   const location = useLocation();
 
-  if (!user) {
+  if (authMode === "signed_out") {
     return <Navigate to="/login" state={{ from: location }} replace />;
   }
   if (!isOnboarded) {
@@ -71,9 +71,9 @@ function ProtectedRoute(): React.ReactElement {
 }
 
 function PublicRoute({ children }: { children: React.ReactNode }): React.ReactElement {
-  const { user } = useAuth();
+  const { authMode } = useAuth();
 
-  if (user) {
+  if (authMode !== "signed_out") {
     return <Navigate to="/" replace />;
   }
 
@@ -81,9 +81,9 @@ function PublicRoute({ children }: { children: React.ReactNode }): React.ReactEl
 }
 
 function OnboardingRoute(): React.ReactElement {
-  const { user, isOnboarded } = useAuth();
+  const { authMode, isOnboarded } = useAuth();
 
-  if (!user) {
+  if (authMode === "signed_out") {
     return <Navigate to="/login" replace />;
   }
   if (isOnboarded) {
@@ -94,9 +94,9 @@ function OnboardingRoute(): React.ReactElement {
 }
 
 function RootHome(): React.ReactElement {
-  const { user, isOnboarded } = useAuth();
+  const { authMode, isOnboarded } = useAuth();
 
-  if (!user) {
+  if (authMode === "signed_out") {
     return <LandingPage />;
   }
   if (!isOnboarded) {

--- a/frontend/src/features/auth/hooks/useAuth.ts
+++ b/frontend/src/features/auth/hooks/useAuth.ts
@@ -8,14 +8,25 @@ import {
   useState,
 } from "react";
 
+import {
+  isExplicitAuthFailure,
+  isOfflineOrNetworkFailure,
+} from "@/features/auth/offline/authBootstrapErrors";
+import {
+  clearOfflineUserSnapshot,
+  readOfflineUserSnapshot,
+  writeOfflineUserSnapshot,
+} from "@/features/auth/offline/offlineUserSnapshot";
 import { authService } from "@/features/auth/services/authService";
+import type { AuthMode, LoginRequest, RegisterRequest, User } from "@/features/auth/types/auth.types";
 import { clearDraftsForUser, deleteStaleLocalDrafts } from "@/features/quotes/offline/draftRepository";
-import type { LoginRequest, RegisterRequest, User } from "@/features/auth/types/auth.types";
+import { runOutboxPass } from "@/features/quotes/offline/outboxEngine";
 import { LoadingScreen } from "@/shared/components/LoadingScreen";
 import { hydrateCsrfTokenFromCookie } from "@/shared/lib/http";
 
 interface AuthContextValue {
   user: User | null;
+  authMode: AuthMode;
   isLoading: boolean;
   isOnboarded: boolean;
   refreshUser: () => Promise<void>;
@@ -28,15 +39,27 @@ const AuthContext = createContext<AuthContextValue | undefined>(undefined);
 
 export function AuthProvider({ children }: { children: React.ReactNode }): React.ReactElement {
   const [user, setUser] = useState<User | null>(null);
+  const [authMode, setAuthMode] = useState<AuthMode>("signed_out");
   const [isLoading, setIsLoading] = useState(true);
+
+  const setVerifiedUser = useCallback((currentUser: User) => {
+    setUser(currentUser);
+    setAuthMode("verified");
+    writeOfflineUserSnapshot({
+      userId: currentUser.id,
+      isOnboarded: currentUser.is_onboarded,
+      timezone: currentUser.timezone,
+      lastVerifiedAt: new Date().toISOString(),
+    });
+  }, []);
 
   const refreshUser = useCallback(async () => {
     const currentUser = await authService.me();
-    setUser(currentUser);
+    setVerifiedUser(currentUser);
     void deleteStaleLocalDrafts(currentUser.id, 7).catch((error) => {
       console.warn("Unable to clean stale local drafts during auth refresh.", error);
     });
-  }, []);
+  }, [setVerifiedUser]);
 
   useEffect(() => {
     let active = true;
@@ -46,15 +69,40 @@ export function AuthProvider({ children }: { children: React.ReactNode }): React
         hydrateCsrfTokenFromCookie();
         const currentUser = await authService.me();
         if (active) {
-          setUser(currentUser);
+          setVerifiedUser(currentUser);
           void deleteStaleLocalDrafts(currentUser.id, 7).catch((error) => {
             console.warn("Unable to clean stale local drafts during auth bootstrap.", error);
           });
         }
-      } catch {
-        if (active) {
-          setUser(null);
+      } catch (bootstrapError) {
+        if (!active) {
+          return;
         }
+
+        if (isExplicitAuthFailure(bootstrapError)) {
+          clearOfflineUserSnapshot();
+          setUser(null);
+          setAuthMode("signed_out");
+          return;
+        }
+
+        if (isOfflineOrNetworkFailure(bootstrapError)) {
+          const snapshot = readOfflineUserSnapshot();
+          if (snapshot) {
+            setUser({
+              id: snapshot.userId,
+              email: "",
+              is_active: true,
+              is_onboarded: snapshot.isOnboarded,
+              timezone: snapshot.timezone,
+            });
+            setAuthMode("offline_recovered");
+            return;
+          }
+        }
+
+        setUser(null);
+        setAuthMode("signed_out");
       } finally {
         if (active) {
           setIsLoading(false);
@@ -67,7 +115,49 @@ export function AuthProvider({ children }: { children: React.ReactNode }): React
     return () => {
       active = false;
     };
-  }, []);
+  }, [setVerifiedUser]);
+
+  const reverifyOfflineRecoveredUser = useCallback(async () => {
+    if (authMode !== "offline_recovered" || !user?.id) {
+      return;
+    }
+
+    try {
+      await refreshUser();
+      await runOutboxPass(user.id, { forceAfterAuth: true });
+    } catch (error) {
+      if (isExplicitAuthFailure(error)) {
+        clearOfflineUserSnapshot();
+        setUser(null);
+        setAuthMode("signed_out");
+        return;
+      }
+
+      if (isOfflineOrNetworkFailure(error)) {
+        return;
+      }
+
+      console.warn("Unable to reverify offline-recovered auth state.", error);
+    }
+  }, [authMode, refreshUser, user?.id]);
+
+  useEffect(() => {
+    if (typeof window === "undefined" || authMode !== "offline_recovered") {
+      return;
+    }
+
+    const onOnline = () => {
+      if (!window.navigator.onLine) {
+        return;
+      }
+      void reverifyOfflineRecoveredUser();
+    };
+
+    window.addEventListener("online", onOnline);
+    return () => {
+      window.removeEventListener("online", onOnline);
+    };
+  }, [authMode, reverifyOfflineRecoveredUser]);
 
   const login = useCallback(async (credentials: LoginRequest) => {
     await authService.login(credentials);
@@ -83,17 +173,20 @@ export function AuthProvider({ children }: { children: React.ReactNode }): React
   const logout = useCallback(async () => {
     const userId = user?.id;
     await authService.logout();
+    clearOfflineUserSnapshot();
     if (userId) {
       await clearDraftsForUser(userId).catch((error) => {
         console.warn("Unable to clear local drafts during logout.", error);
       });
     }
     setUser(null);
+    setAuthMode("signed_out");
   }, [user]);
 
   const value = useMemo<AuthContextValue>(
     () => ({
       user,
+      authMode,
       isLoading,
       isOnboarded: user?.is_onboarded ?? false,
       refreshUser,
@@ -101,7 +194,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }): React
       register,
       logout,
     }),
-    [isLoading, login, logout, refreshUser, register, user],
+    [authMode, isLoading, login, logout, refreshUser, register, user],
   );
 
   if (isLoading) {

--- a/frontend/src/features/auth/offline/authBootstrapErrors.ts
+++ b/frontend/src/features/auth/offline/authBootstrapErrors.ts
@@ -1,0 +1,25 @@
+import { isHttpRequestError } from "@/shared/lib/http";
+
+export function isExplicitAuthFailure(error: unknown): boolean {
+  return isHttpRequestError(error) && (error.status === 401 || error.status === 403);
+}
+
+export function isOfflineOrNetworkFailure(error: unknown): boolean {
+  if (typeof navigator !== "undefined" && navigator.onLine === false) {
+    return true;
+  }
+
+  if (isHttpRequestError(error)) {
+    return false;
+  }
+
+  if (!(error instanceof TypeError)) {
+    return false;
+  }
+
+  if (error.name === "AbortError") {
+    return false;
+  }
+
+  return /failed to fetch/i.test(error.message);
+}

--- a/frontend/src/features/auth/offline/offlineUserSnapshot.ts
+++ b/frontend/src/features/auth/offline/offlineUserSnapshot.ts
@@ -1,0 +1,101 @@
+export interface OfflineUserSnapshot {
+  userId: string;
+  isOnboarded: boolean;
+  timezone: string | null;
+  lastVerifiedAt: string;
+}
+
+const SNAPSHOT_STORAGE_KEY = "stima.offlineUserSnapshot.v1";
+const SNAPSHOT_MAX_AGE_MS = 14 * 24 * 60 * 60 * 1000;
+
+function canUseStorage(): boolean {
+  return typeof window !== "undefined" && typeof window.localStorage !== "undefined";
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function parseSnapshot(value: unknown): OfflineUserSnapshot | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  const userId = value.userId;
+  const isOnboarded = value.isOnboarded;
+  const timezone = value.timezone;
+  const lastVerifiedAt = value.lastVerifiedAt;
+
+  if (
+    typeof userId !== "string"
+    || userId.length === 0
+    || typeof isOnboarded !== "boolean"
+    || (timezone !== null && typeof timezone !== "string")
+    || typeof lastVerifiedAt !== "string"
+  ) {
+    return null;
+  }
+
+  return {
+    userId,
+    isOnboarded,
+    timezone,
+    lastVerifiedAt,
+  };
+}
+
+function isExpired(lastVerifiedAt: string): boolean {
+  const verifiedAtMs = Date.parse(lastVerifiedAt);
+  if (Number.isNaN(verifiedAtMs)) {
+    return true;
+  }
+  return Date.now() - verifiedAtMs > SNAPSHOT_MAX_AGE_MS;
+}
+
+export function writeOfflineUserSnapshot(snapshot: OfflineUserSnapshot): void {
+  if (!canUseStorage()) {
+    return;
+  }
+
+  try {
+    window.localStorage.setItem(SNAPSHOT_STORAGE_KEY, JSON.stringify(snapshot));
+  } catch (error) {
+    console.warn("Unable to persist offline user snapshot.", error);
+  }
+}
+
+export function readOfflineUserSnapshot(): OfflineUserSnapshot | null {
+  if (!canUseStorage()) {
+    return null;
+  }
+
+  try {
+    const rawValue = window.localStorage.getItem(SNAPSHOT_STORAGE_KEY);
+    if (!rawValue) {
+      return null;
+    }
+
+    const snapshot = parseSnapshot(JSON.parse(rawValue) as unknown);
+    if (!snapshot || isExpired(snapshot.lastVerifiedAt)) {
+      window.localStorage.removeItem(SNAPSHOT_STORAGE_KEY);
+      return null;
+    }
+
+    return snapshot;
+  } catch (error) {
+    console.warn("Unable to read offline user snapshot.", error);
+    return null;
+  }
+}
+
+export function clearOfflineUserSnapshot(): void {
+  if (!canUseStorage()) {
+    return;
+  }
+
+  try {
+    window.localStorage.removeItem(SNAPSHOT_STORAGE_KEY);
+  } catch (error) {
+    console.warn("Unable to clear offline user snapshot.", error);
+  }
+}

--- a/frontend/src/features/auth/tests/App.routes.test.tsx
+++ b/frontend/src/features/auth/tests/App.routes.test.tsx
@@ -4,6 +4,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import App from "@/App";
 import { AuthProvider } from "@/features/auth/hooks/useAuth";
+import { clearOfflineUserSnapshot, writeOfflineUserSnapshot } from "@/features/auth/offline/offlineUserSnapshot";
 import { authService } from "@/features/auth/services/authService";
 import { ThemeProvider } from "@/shared/components/ThemeProvider";
 
@@ -64,6 +65,7 @@ function renderApp(path: string): void {
 }
 
 afterEach(() => {
+  clearOfflineUserSnapshot();
   vi.clearAllMocks();
 });
 
@@ -131,6 +133,21 @@ describe("App routes", () => {
 
     expect(await screen.findByRole("heading", { name: /settings/i })).toBeInTheDocument();
     expect(screen.queryByText(/settings coming soon/i)).not.toBeInTheDocument();
+  });
+
+  it("allows offline_recovered users through protected routes", async () => {
+    mockedAuthService.me.mockRejectedValueOnce(new TypeError("Failed to fetch"));
+    writeOfflineUserSnapshot({
+      userId: "user-offline",
+      isOnboarded: true,
+      timezone: "America/New_York",
+      lastVerifiedAt: new Date().toISOString(),
+    });
+
+    renderApp("/settings");
+
+    expect(await screen.findByRole("heading", { name: /settings/i })).toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: /welcome back/i })).not.toBeInTheDocument();
   });
 
   it("renders the landing page for unauthenticated users at root", async () => {

--- a/frontend/src/features/auth/tests/useAuth.test.tsx
+++ b/frontend/src/features/auth/tests/useAuth.test.tsx
@@ -2,9 +2,15 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { AuthProvider, useAuth } from "@/features/auth/hooks/useAuth";
+import {
+  clearOfflineUserSnapshot,
+  readOfflineUserSnapshot,
+  writeOfflineUserSnapshot,
+} from "@/features/auth/offline/offlineUserSnapshot";
 import { authService } from "@/features/auth/services/authService";
 import { clearDraftsForUser, deleteStaleLocalDrafts } from "@/features/quotes/offline/draftRepository";
-import { hydrateCsrfTokenFromCookie } from "@/shared/lib/http";
+import { runOutboxPass } from "@/features/quotes/offline/outboxEngine";
+import { HttpRequestError, hydrateCsrfTokenFromCookie } from "@/shared/lib/http";
 
 vi.mock("@/features/auth/services/authService", () => ({
   authService: {
@@ -20,6 +26,16 @@ vi.mock("@/features/quotes/offline/draftRepository", () => ({
   deleteStaleLocalDrafts: vi.fn(),
 }));
 
+vi.mock("@/features/auth/offline/offlineUserSnapshot", () => ({
+  clearOfflineUserSnapshot: vi.fn(),
+  readOfflineUserSnapshot: vi.fn(),
+  writeOfflineUserSnapshot: vi.fn(),
+}));
+
+vi.mock("@/features/quotes/offline/outboxEngine", () => ({
+  runOutboxPass: vi.fn(),
+}));
+
 vi.mock("@/shared/lib/http", async () => {
   const actual = await vi.importActual<typeof import("@/shared/lib/http")>("@/shared/lib/http");
 
@@ -33,13 +49,20 @@ const mockedAuthService = vi.mocked(authService);
 const mockedHydrateCsrf = vi.mocked(hydrateCsrfTokenFromCookie);
 const mockedClearDraftsForUser = vi.mocked(clearDraftsForUser);
 const mockedDeleteStaleLocalDrafts = vi.mocked(deleteStaleLocalDrafts);
+const mockedReadOfflineUserSnapshot = vi.mocked(readOfflineUserSnapshot);
+const mockedWriteOfflineUserSnapshot = vi.mocked(writeOfflineUserSnapshot);
+const mockedClearOfflineUserSnapshot = vi.mocked(clearOfflineUserSnapshot);
+const mockedRunOutboxPass = vi.mocked(runOutboxPass);
+const ORIGINAL_NAVIGATOR_ONLINE_DESCRIPTOR = Object.getOwnPropertyDescriptor(window.navigator, "onLine");
 
 function AuthHarness(): React.ReactElement {
-  const { user, register, logout } = useAuth();
+  const { authMode, user, register, logout } = useAuth();
 
   return (
     <div>
       <p data-testid="auth-state">{user ? user.email : "none"}</p>
+      <p data-testid="auth-mode">{authMode}</p>
+      <p data-testid="auth-user-id">{user?.id ?? "none"}</p>
       <button
         type="button"
         onClick={() =>
@@ -59,12 +82,23 @@ function AuthHarness(): React.ReactElement {
 }
 
 beforeEach(() => {
+  vi.resetAllMocks();
   mockedClearDraftsForUser.mockResolvedValue(undefined);
   mockedDeleteStaleLocalDrafts.mockResolvedValue(undefined);
+  mockedReadOfflineUserSnapshot.mockReturnValue(null);
+  mockedRunOutboxPass.mockResolvedValue(undefined);
+  Object.defineProperty(window.navigator, "onLine", {
+    configurable: true,
+    value: true,
+  });
 });
 
 afterEach(() => {
-  vi.clearAllMocks();
+  if (ORIGINAL_NAVIGATOR_ONLINE_DESCRIPTOR) {
+    Object.defineProperty(window.navigator, "onLine", ORIGINAL_NAVIGATOR_ONLINE_DESCRIPTOR);
+    return;
+  }
+  delete (window.navigator as { onLine?: boolean }).onLine;
 });
 
 describe("useAuth", () => {
@@ -86,6 +120,8 @@ describe("useAuth", () => {
     expect(await screen.findByText("user@example.com")).toBeInTheDocument();
     expect(mockedHydrateCsrf).toHaveBeenCalledTimes(1);
     expect(mockedDeleteStaleLocalDrafts).toHaveBeenCalledWith("user-1", 7);
+    expect(mockedWriteOfflineUserSnapshot).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId("auth-mode")).toHaveTextContent("verified");
   });
 
   it("registers, logs in, prunes stale drafts, and clears drafts on logout", async () => {
@@ -107,7 +143,9 @@ describe("useAuth", () => {
       </AuthProvider>,
     );
 
-    await screen.findByText("none");
+    await waitFor(() => {
+      expect(screen.getByTestId("auth-state")).toHaveTextContent("none");
+    });
 
     fireEvent.click(screen.getByRole("button", { name: "Register" }));
 
@@ -130,7 +168,135 @@ describe("useAuth", () => {
     await waitFor(() => {
       expect(mockedAuthService.logout).toHaveBeenCalledTimes(1);
       expect(mockedClearDraftsForUser).toHaveBeenCalledWith("user-2");
+      expect(mockedClearOfflineUserSnapshot).toHaveBeenCalledTimes(1);
       expect(screen.getByTestId("auth-state")).toHaveTextContent("none");
+      expect(screen.getByTestId("auth-mode")).toHaveTextContent("signed_out");
+    });
+  });
+
+  it("clears snapshot and stays signed out on explicit auth failure", async () => {
+    mockedAuthService.me.mockRejectedValueOnce(new HttpRequestError("Unauthorized", 401, null));
+    mockedReadOfflineUserSnapshot.mockReturnValue({
+      userId: "user-stale",
+      isOnboarded: true,
+      timezone: "UTC",
+      lastVerifiedAt: new Date().toISOString(),
+    });
+
+    render(
+      <AuthProvider>
+        <AuthHarness />
+      </AuthProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("auth-state")).toHaveTextContent("none");
+    });
+    expect(screen.getByTestId("auth-mode")).toHaveTextContent("signed_out");
+    expect(mockedClearOfflineUserSnapshot).toHaveBeenCalledTimes(1);
+    expect(mockedReadOfflineUserSnapshot).not.toHaveBeenCalled();
+  });
+
+  it("restores offline snapshot for failed-fetch bootstrap failures", async () => {
+    mockedAuthService.me.mockRejectedValueOnce(new TypeError("Failed to fetch"));
+    mockedReadOfflineUserSnapshot.mockReturnValue({
+      userId: "user-offline",
+      isOnboarded: true,
+      timezone: "America/New_York",
+      lastVerifiedAt: new Date().toISOString(),
+    });
+
+    render(
+      <AuthProvider>
+        <AuthHarness />
+      </AuthProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("auth-mode")).toHaveTextContent("offline_recovered");
+      expect(screen.getByTestId("auth-user-id")).toHaveTextContent("user-offline");
+    });
+  });
+
+  it("does not restore snapshot for unrelated TypeError failures", async () => {
+    mockedAuthService.me.mockRejectedValueOnce(new TypeError("Something unexpected happened"));
+    mockedReadOfflineUserSnapshot.mockReturnValue({
+      userId: "user-offline",
+      isOnboarded: true,
+      timezone: "America/New_York",
+      lastVerifiedAt: new Date().toISOString(),
+    });
+
+    render(
+      <AuthProvider>
+        <AuthHarness />
+      </AuthProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("auth-state")).toHaveTextContent("none");
+    });
+    expect(screen.getByTestId("auth-mode")).toHaveTextContent("signed_out");
+    expect(mockedReadOfflineUserSnapshot).not.toHaveBeenCalled();
+  });
+
+  it("does not restore snapshot for AbortError failures", async () => {
+    const abortError = new TypeError("Request was aborted");
+    abortError.name = "AbortError";
+    mockedAuthService.me.mockRejectedValueOnce(abortError);
+    mockedReadOfflineUserSnapshot.mockReturnValue({
+      userId: "user-offline",
+      isOnboarded: true,
+      timezone: "America/New_York",
+      lastVerifiedAt: new Date().toISOString(),
+    });
+
+    render(
+      <AuthProvider>
+        <AuthHarness />
+      </AuthProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("auth-state")).toHaveTextContent("none");
+    });
+    expect(screen.getByTestId("auth-mode")).toHaveTextContent("signed_out");
+    expect(mockedReadOfflineUserSnapshot).not.toHaveBeenCalled();
+  });
+
+  it("reverifies on online event from offline_recovered and unpauses auth-required jobs", async () => {
+    mockedAuthService.me
+      .mockRejectedValueOnce(new TypeError("Failed to fetch"))
+      .mockResolvedValueOnce({
+        id: "user-9",
+        email: "user9@example.com",
+        is_active: true,
+        is_onboarded: true,
+        timezone: "America/New_York",
+      });
+    mockedReadOfflineUserSnapshot.mockReturnValue({
+      userId: "user-9",
+      isOnboarded: true,
+      timezone: "America/New_York",
+      lastVerifiedAt: new Date().toISOString(),
+    });
+
+    render(
+      <AuthProvider>
+        <AuthHarness />
+      </AuthProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("auth-mode")).toHaveTextContent("offline_recovered");
+    });
+
+    window.dispatchEvent(new Event("online"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("auth-mode")).toHaveTextContent("verified");
+      expect(screen.getByTestId("auth-state")).toHaveTextContent("user9@example.com");
+      expect(mockedRunOutboxPass).toHaveBeenCalledWith("user-9", { forceAfterAuth: true });
     });
   });
 

--- a/frontend/src/features/auth/types/auth.types.ts
+++ b/frontend/src/features/auth/types/auth.types.ts
@@ -6,6 +6,8 @@ export interface User {
   timezone: string | null;
 }
 
+export type AuthMode = "verified" | "offline_recovered" | "signed_out";
+
 export interface LoginRequest {
   email: string;
   password: string;

--- a/frontend/src/features/customers/tests/CustomerDetailScreen.test.tsx
+++ b/frontend/src/features/customers/tests/CustomerDetailScreen.test.tsx
@@ -153,6 +153,7 @@ beforeEach(() => {
     }),
   ]);
   mockedUseAuth.mockReturnValue({
+    authMode: "verified",
     isLoading: false,
     isOnboarded: true,
     login: vi.fn(async () => undefined),

--- a/frontend/src/features/profile/tests/OnboardingForm.test.tsx
+++ b/frontend/src/features/profile/tests/OnboardingForm.test.tsx
@@ -57,6 +57,7 @@ function profileResponse(overrides: Partial<ProfileResponse> = {}): ProfileRespo
 
 beforeEach(() => {
   mockedUseAuth.mockReturnValue({
+    authMode: "signed_out",
     user: null,
     isLoading: false,
     isOnboarded: false,
@@ -92,6 +93,7 @@ describe("OnboardingForm", () => {
   it("submits profile updates and navigates to root on success", async () => {
     const refreshUser = vi.fn(async () => undefined);
     mockedUseAuth.mockReturnValue({
+      authMode: "signed_out",
       user: null,
       isLoading: false,
       isOnboarded: false,

--- a/frontend/src/features/quotes/components/QuoteList.tsx
+++ b/frontend/src/features/quotes/components/QuoteList.tsx
@@ -18,6 +18,7 @@ import { FeedbackMessage } from "@/shared/components/FeedbackMessage";
 import { Input } from "@/shared/components/Input";
 import { ScreenHeader } from "@/shared/components/ScreenHeader";
 import { formatDate } from "@/shared/lib/formatters";
+import { Banner } from "@/ui/Banner";
 import { EmptyState } from "@/ui/EmptyState";
 import { buildInvoiceSubtitle, buildQuoteSubtitle, matchesSearch } from "./QuoteList.helpers";
 
@@ -25,7 +26,7 @@ type DocumentMode = "quotes" | "invoices";
 
 export function QuoteList(): React.ReactElement {
   const navigate = useNavigate();
-  const { user } = useAuth();
+  const { authMode, user } = useAuth();
   const [documentMode, setDocumentMode] = useState<DocumentMode>("quotes");
   const [quotes, setQuotes] = useState<QuoteListItem[]>([]);
   const [invoices, setInvoices] = useState<InvoiceListItem[]>([]);
@@ -352,21 +353,24 @@ export function QuoteList(): React.ReactElement {
         </div>
 
         {documentMode === "quotes" ? (
-          <PendingCapturesSection
-            captures={recoverableCaptures}
-            isLoading={isLoadingRecoverableCaptures}
-            isOnline={isOnline}
-            timezone={timezone}
-            error={recoverableCapturesError ?? pendingCaptureActionError}
-            onResume={(sessionId) => navigateToLocalCapture(sessionId)}
-            onExtract={(sessionId) => navigateToLocalCapture(sessionId, { autoExtract: true })}
-            onRetry={(sessionId) => {
-              void onRetryCapture(sessionId);
-            }}
-            onDelete={(sessionId) => {
-              void onDeleteCapture(sessionId);
-            }}
-          />
+          <>
+            {authMode === "offline_recovered" ? (
+              <div className="mb-4 px-4">
+                <Banner kind="warn" title="Offline mode" message="Showing locally saved pending captures. Reconnect to verify your account and resume sync." />
+              </div>
+            ) : null}
+            <PendingCapturesSection
+              captures={recoverableCaptures}
+              isLoading={isLoadingRecoverableCaptures}
+              isOnline={isOnline}
+              timezone={timezone}
+              error={recoverableCapturesError ?? pendingCaptureActionError}
+              onResume={(sessionId) => navigateToLocalCapture(sessionId)}
+              onExtract={(sessionId) => navigateToLocalCapture(sessionId, { autoExtract: true })}
+              onRetry={(sessionId) => { void onRetryCapture(sessionId); }}
+              onDelete={(sessionId) => { void onDeleteCapture(sessionId); }}
+            />
+          </>
         ) : null}
 
         {isLoading ? (

--- a/frontend/src/features/quotes/offline/OutboxSyncCoordinator.tsx
+++ b/frontend/src/features/quotes/offline/OutboxSyncCoordinator.tsx
@@ -10,7 +10,7 @@ import {
 import { useToast } from "@/ui/Toast";
 
 export function OutboxSyncCoordinator(): React.ReactElement | null {
-  const { user } = useAuth();
+  const { authMode, user } = useAuth();
   const { show } = useToast();
   const previousUserIdRef = useRef<string | null>(null);
 
@@ -50,13 +50,16 @@ export function OutboxSyncCoordinator(): React.ReactElement | null {
       return;
     }
 
-    void runOutboxPass(user.id, { onEvent, forceAfterAuth: true });
+    void runOutboxPass(user.id, {
+      onEvent,
+      forceAfterAuth: authMode === "verified",
+    });
     const cleanup = registerOnlineTrigger(user.id, { onEvent });
     return () => {
       cleanup();
       clearOutboxEngineStateForUser(user.id);
     };
-  }, [onEvent, user?.id]);
+  }, [authMode, onEvent, user?.id]);
 
   return null;
 }

--- a/frontend/src/features/quotes/tests/CaptureScreen.test.tsx
+++ b/frontend/src/features/quotes/tests/CaptureScreen.test.tsx
@@ -336,6 +336,7 @@ function renderScreen({
 
 beforeEach(() => {
   mockedUseAuth.mockReturnValue({
+    authMode: "verified",
     isLoading: false,
     isOnboarded: true,
     login: vi.fn(async () => undefined),

--- a/frontend/src/features/quotes/tests/LineItemCatalogInsert.test.tsx
+++ b/frontend/src/features/quotes/tests/LineItemCatalogInsert.test.tsx
@@ -68,6 +68,7 @@ vi.mock("@/features/profile/services/profileService", () => ({
 
 vi.mock("@/features/auth/hooks/useAuth", () => ({
   useAuth: () => ({
+    authMode: "verified",
     user: {
       id: "user-1",
       email: "user@example.com",

--- a/frontend/src/features/quotes/tests/QuoteList.test.tsx
+++ b/frontend/src/features/quotes/tests/QuoteList.test.tsx
@@ -108,8 +108,9 @@ function makeInvoiceListItem(overrides: Partial<InvoiceListItem> = {}): InvoiceL
   };
 }
 
-function mockProfile(timezone: string | null = "UTC"): void {
+function mockProfile(timezone: string | null = "UTC", authMode: "verified" | "offline_recovered" = "verified"): void {
   mockedUseAuth.mockReturnValue({
+    authMode,
     isLoading: false,
     isOnboarded: true,
     login: vi.fn(async () => undefined),
@@ -251,6 +252,16 @@ describe("QuoteList", () => {
 
     expect(quotesButton).toHaveClass("ghost-shadow", "bg-surface-container-lowest", "text-primary");
     expect(createButton).toHaveClass("forest-gradient", "ghost-shadow", "text-on-primary");
+  });
+
+  it("shows an offline-mode banner for offline_recovered auth", async () => {
+    mockProfile("UTC", "offline_recovered");
+    mockedQuoteService.listQuotes.mockResolvedValueOnce([makeQuoteListItem()]);
+
+    renderScreen();
+
+    expect(await screen.findByText("Offline mode")).toBeInTheDocument();
+    expect(screen.getByText(/showing locally saved pending captures/i)).toBeInTheDocument();
   });
 
   it("renders pending captures with resume, extract, and delete actions", async () => {

--- a/frontend/src/features/quotes/tests/ReviewScreen.test.tsx
+++ b/frontend/src/features/quotes/tests/ReviewScreen.test.tsx
@@ -60,6 +60,7 @@ vi.mock("@/features/profile/services/profileService", () => ({
 
 vi.mock("@/features/auth/hooks/useAuth", () => ({
   useAuth: () => ({
+    authMode: "verified",
     user: {
       id: "user-1",
       email: "user@example.com",

--- a/frontend/src/features/settings/tests/SettingsScreen.test.tsx
+++ b/frontend/src/features/settings/tests/SettingsScreen.test.tsx
@@ -82,6 +82,7 @@ beforeEach(() => {
   });
   window.localStorage.clear();
   mockedUseAuth.mockReturnValue({
+    authMode: "verified",
     user: {
       id: "user-1",
       email: "test@example.com",
@@ -195,6 +196,7 @@ describe("SettingsScreen", () => {
   it("submits profile updates, refreshes auth user, and shows toast success feedback", async () => {
     const refreshUser = vi.fn(async () => undefined);
     mockedUseAuth.mockReturnValue({
+      authMode: "verified",
       user: {
         id: "user-1",
         email: "test@example.com",
@@ -320,6 +322,7 @@ describe("SettingsScreen", () => {
       throw new Error("Unable to refresh user");
     });
     mockedUseAuth.mockReturnValue({
+      authMode: "verified",
       user: {
         id: "user-1",
         email: "test@example.com",
@@ -388,6 +391,7 @@ describe("SettingsScreen", () => {
   it("requires confirmation before signing out", async () => {
     const logout = vi.fn(async () => undefined);
     mockedUseAuth.mockReturnValue({
+      authMode: "verified",
       user: {
         id: "user-1",
         email: "test@example.com",


### PR DESCRIPTION
## Summary
- add OfflineUserSnapshot persistence/read/clear with 14-day expiry and strict schema validation
- add auth bootstrap error classification and auth-mode state machine (verified | offline_recovered | signed_out)
- update route guards to allow offline_recovered, add quotes offline banner, and reverify on online with outbox unpause after verification
- add coverage for offline bootstrap, explicit auth failures, online reverify/unpause, route guard behavior, and quote banner

## Verification
- cd frontend && npx vitest run src/features/auth/tests/useAuth.test.tsx src/features/auth/tests/App.routes.test.tsx src/features/quotes/tests/QuoteList.test.tsx
- make frontend-verify

Closes #576