### PR TITLE
Task #577: local recovery events and live list refresh

### DIFF
--- a/frontend/src/features/quotes/components/QuoteList.tsx
+++ b/frontend/src/features/quotes/components/QuoteList.tsx
@@ -5,6 +5,7 @@ import { DocumentRowsSection, type DocumentRow } from "@/features/quotes/compone
 import { invoiceService } from "@/features/invoices/services/invoiceService";
 import type { InvoiceListItem } from "@/features/invoices/types/invoice.types";
 import { PendingCapturesSection } from "@/features/quotes/components/PendingCapturesSection";
+import { useOutboxSuccessQuoteRefresh } from "@/features/quotes/components/useOutboxSuccessQuoteRefresh";
 import { useQuoteCreateFlow } from "@/features/quotes/hooks/useQuoteCreateFlow";
 import { useRecoverableCaptures } from "@/features/quotes/offline/useRecoverableCaptures";
 import { runOutboxPass } from "@/features/quotes/offline/outboxEngine";
@@ -47,7 +48,11 @@ export function QuoteList(): React.ReactElement {
     refresh: refreshRecoverableCaptures,
     deleteCapture,
   } = useRecoverableCaptures(user?.id);
-
+  useOutboxSuccessQuoteRefresh({
+    userId: user?.id,
+    onQuotesLoaded: setQuotes,
+    onLoadError: setQuoteLoadError,
+  });
   useEffect(() => {
     let isActive = true;
 
@@ -125,7 +130,6 @@ export function QuoteList(): React.ReactElement {
       window.removeEventListener("offline", onOnlineChange);
     };
   }, []);
-
   const normalizedSearchQuery = searchQuery.trim().toLowerCase();
   const filteredQuotes = useMemo(
     () => quotes.filter((quote) => matchesSearch(quote, normalizedSearchQuery)),

--- a/frontend/src/features/quotes/components/useOutboxSuccessQuoteRefresh.ts
+++ b/frontend/src/features/quotes/components/useOutboxSuccessQuoteRefresh.ts
@@ -1,0 +1,51 @@
+import { useEffect } from "react";
+
+import { subscribeLocalRecoveryChanged } from "@/features/quotes/offline/localRecoveryEvents";
+import { quoteService } from "@/features/quotes/services/quoteService";
+import type { QuoteListItem } from "@/features/quotes/types/quote.types";
+
+interface UseOutboxSuccessQuoteRefreshParams {
+  userId: string | undefined;
+  onQuotesLoaded: (quotes: QuoteListItem[]) => void;
+  onLoadError: (error: string | null) => void;
+}
+
+export function useOutboxSuccessQuoteRefresh({
+  userId,
+  onQuotesLoaded,
+  onLoadError,
+}: UseOutboxSuccessQuoteRefreshParams): void {
+  useEffect(() => {
+    if (!userId) {
+      return;
+    }
+
+    let isActive = true;
+    const unsubscribe = subscribeLocalRecoveryChanged(userId, (event) => {
+      if (event.reason !== "outbox_succeeded") {
+        return;
+      }
+
+      void (async () => {
+        try {
+          const nextQuotes = await quoteService.listQuotes();
+          if (isActive) {
+            onLoadError(null);
+            onQuotesLoaded(nextQuotes);
+          }
+        } catch (error) {
+          if (!isActive) {
+            return;
+          }
+          const message = error instanceof Error ? error.message : "Unable to load quotes";
+          onLoadError(message);
+        }
+      })();
+    });
+
+    return () => {
+      isActive = false;
+      unsubscribe();
+    };
+  }, [onLoadError, onQuotesLoaded, userId]);
+}

--- a/frontend/src/features/quotes/offline/captureRepository.test.ts
+++ b/frontend/src/features/quotes/offline/captureRepository.test.ts
@@ -20,6 +20,10 @@ import {
   updateCaptureField,
   updateCaptureNotes,
 } from "@/features/quotes/offline/captureRepository";
+import {
+  LOCAL_RECOVERY_CHANGED_EVENT,
+  type LocalRecoveryChangedDetail,
+} from "@/features/quotes/offline/localRecoveryEvents";
 import { getAudioClip, saveAudioClip } from "@/features/quotes/offline/audioRepository";
 import type { LocalCaptureSession } from "@/features/quotes/offline/captureTypes";
 import { getStorageEstimate, isStoragePressured } from "@/features/quotes/offline/storageHealth";
@@ -213,6 +217,34 @@ describe("captureRepository", () => {
 
     expect(await getCaptureSession(session.sessionId)).toBeNull();
     expect(await getAudioClip("clip-1")).toBeNull();
+  });
+
+  it("emits local recovery events for capture save and delete", async () => {
+    const events: LocalRecoveryChangedDetail[] = [];
+    const eventListener = (event: Event): void => {
+      if (!(event instanceof CustomEvent)) {
+        return;
+      }
+      events.push(event.detail as LocalRecoveryChangedDetail);
+    };
+    window.addEventListener(LOCAL_RECOVERY_CHANGED_EVENT, eventListener);
+
+    const session = await createCaptureSession({
+      userId: "user-events",
+      notes: "pending",
+    });
+    await updateCaptureNotes(session.sessionId, "updated");
+    await updateCaptureField(session.sessionId, { status: "ready_to_extract" });
+    await deleteCaptureSession(session.sessionId);
+
+    window.removeEventListener(LOCAL_RECOVERY_CHANGED_EVENT, eventListener);
+
+    expect(events.map((event) => event.reason)).toContain("capture_saved");
+    expect(events[events.length - 1]).toMatchObject({
+      userId: "user-events",
+      sessionId: session.sessionId,
+      reason: "capture_deleted",
+    });
   });
 
   it("deletes only empty abandoned local-only sessions", async () => {

--- a/frontend/src/features/quotes/offline/captureRepository.ts
+++ b/frontend/src/features/quotes/offline/captureRepository.ts
@@ -1,5 +1,6 @@
 import { CAPTURE_STORE_NAMES, getDb } from "@/features/quotes/offline/captureDb";
 import { deleteAllClipsForSession } from "@/features/quotes/offline/audioRepository";
+import { dispatchLocalRecoveryChanged } from "@/features/quotes/offline/localRecoveryEvents";
 import { deleteJobForSession } from "@/features/quotes/offline/outboxRepository";
 import type {
   CreateLocalCaptureInput,
@@ -67,6 +68,11 @@ export async function createCaptureSession(
   const store = transaction.objectStore(CAPTURE_STORE_NAMES.captureSessions);
   store.put(session);
   await transactionDone(transaction);
+  dispatchLocalRecoveryChanged({
+    userId: session.userId,
+    sessionId: session.sessionId,
+    reason: "capture_saved",
+  });
   return session;
 }
 
@@ -88,6 +94,11 @@ export async function updateCaptureNotes(sessionId: string, notes: string): Prom
   session.updatedAt = new Date().toISOString();
   store.put(session);
   await transactionDone(transaction);
+  dispatchLocalRecoveryChanged({
+    userId: session.userId,
+    sessionId,
+    reason: "capture_saved",
+  });
 }
 
 export async function updateCaptureField(
@@ -111,6 +122,11 @@ export async function updateCaptureField(
   session.updatedAt = new Date().toISOString();
   store.put(session);
   await transactionDone(transaction);
+  dispatchLocalRecoveryChanged({
+    userId: session.userId,
+    sessionId,
+    reason: "capture_saved",
+  });
 }
 
 function validateCapturePatch(patch: Partial<LocalCaptureSession>): void {
@@ -173,9 +189,15 @@ export async function markCaptureStatus(
 
   store.put(session);
   await transactionDone(transaction);
+  dispatchLocalRecoveryChanged({
+    userId: session.userId,
+    sessionId,
+    reason: "capture_saved",
+  });
 }
 
 export async function deleteCaptureSession(sessionId: string): Promise<void> {
+  const session = await getCaptureSession(sessionId);
   await deleteAllClipsForSession(sessionId);
   await deleteJobForSession(sessionId);
   const db = await getDb();
@@ -183,6 +205,14 @@ export async function deleteCaptureSession(sessionId: string): Promise<void> {
   const store = transaction.objectStore(CAPTURE_STORE_NAMES.captureSessions);
   store.delete(sessionId);
   await transactionDone(transaction);
+  if (!session) {
+    return;
+  }
+  dispatchLocalRecoveryChanged({
+    userId: session.userId,
+    sessionId,
+    reason: "capture_deleted",
+  });
 }
 
 export async function deleteEmptyAbandonedSessions(userId: string): Promise<void> {

--- a/frontend/src/features/quotes/offline/localRecoveryEvents.test.ts
+++ b/frontend/src/features/quotes/offline/localRecoveryEvents.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  dispatchLocalRecoveryChanged,
+  LOCAL_RECOVERY_CHANGED_EVENT,
+  outboxStatusToLocalRecoveryReason,
+  subscribeLocalRecoveryChanged,
+  type LocalRecoveryChangedDetail,
+} from "@/features/quotes/offline/localRecoveryEvents";
+
+describe("localRecoveryEvents", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("maps outbox statuses to event reasons", () => {
+    expect(outboxStatusToLocalRecoveryReason("queued")).toBe("outbox_queued");
+    expect(outboxStatusToLocalRecoveryReason("running")).toBe("outbox_running");
+    expect(outboxStatusToLocalRecoveryReason("succeeded")).toBe("outbox_succeeded");
+    expect(outboxStatusToLocalRecoveryReason("failed_retryable")).toBe("outbox_failed_retryable");
+    expect(outboxStatusToLocalRecoveryReason("failed_terminal")).toBe("outbox_failed_terminal");
+  });
+
+  it("filters events by user id", () => {
+    const listener = vi.fn();
+    const unsubscribe = subscribeLocalRecoveryChanged("user-1", listener, { debounceMs: 1 });
+
+    dispatchLocalRecoveryChanged({
+      userId: "user-2",
+      sessionId: "session-2",
+      reason: "capture_saved",
+    });
+
+    expect(listener).not.toHaveBeenCalled();
+    unsubscribe();
+  });
+
+  it("uses leading-edge debounce with one trailing refresh", () => {
+    vi.useFakeTimers();
+    const received: LocalRecoveryChangedDetail[] = [];
+    const unsubscribe = subscribeLocalRecoveryChanged(
+      "user-1",
+      (detail) => {
+        received.push(detail);
+      },
+      { debounceMs: 250 },
+    );
+
+    dispatchLocalRecoveryChanged({
+      userId: "user-1",
+      sessionId: "session-1",
+      reason: "capture_saved",
+    });
+    expect(received.map((event) => event.reason)).toEqual(["capture_saved"]);
+
+    dispatchLocalRecoveryChanged({
+      userId: "user-1",
+      sessionId: "session-1",
+      reason: "outbox_running",
+    });
+    dispatchLocalRecoveryChanged({
+      userId: "user-1",
+      sessionId: "session-1",
+      reason: "outbox_succeeded",
+    });
+
+    vi.advanceTimersByTime(249);
+    expect(received.map((event) => event.reason)).toEqual(["capture_saved"]);
+
+    vi.advanceTimersByTime(1);
+    expect(received.map((event) => event.reason)).toEqual(["capture_saved", "outbox_succeeded"]);
+
+    vi.advanceTimersByTime(251);
+    dispatchLocalRecoveryChanged({
+      userId: "user-1",
+      sessionId: "session-1",
+      reason: "capture_deleted",
+    });
+    expect(received.map((event) => event.reason)).toEqual([
+      "capture_saved",
+      "outbox_succeeded",
+      "capture_deleted",
+    ]);
+
+    unsubscribe();
+  });
+
+  it("dispatches typed custom events", () => {
+    const listener = vi.fn();
+    window.addEventListener(LOCAL_RECOVERY_CHANGED_EVENT, listener);
+
+    dispatchLocalRecoveryChanged({
+      userId: "user-1",
+      sessionId: "session-1",
+      reason: "capture_saved",
+    });
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    window.removeEventListener(LOCAL_RECOVERY_CHANGED_EVENT, listener);
+  });
+});

--- a/frontend/src/features/quotes/offline/localRecoveryEvents.ts
+++ b/frontend/src/features/quotes/offline/localRecoveryEvents.ts
@@ -1,0 +1,156 @@
+import type { OutboxJobStatus } from "@/features/quotes/offline/captureTypes";
+
+export const LOCAL_RECOVERY_CHANGED_EVENT = "stima:local-recovery-changed";
+const DEFAULT_DEBOUNCE_MS = 250;
+
+export type LocalRecoveryChangedReason =
+  | "capture_saved"
+  | "capture_deleted"
+  | "outbox_queued"
+  | "outbox_running"
+  | "outbox_succeeded"
+  | "outbox_failed_retryable"
+  | "outbox_failed_terminal";
+
+export interface LocalRecoveryChangedDetail {
+  userId: string;
+  sessionId?: string;
+  reason: LocalRecoveryChangedReason;
+}
+
+export function outboxStatusToLocalRecoveryReason(status: OutboxJobStatus): LocalRecoveryChangedReason {
+  if (status === "queued") {
+    return "outbox_queued";
+  }
+  if (status === "running") {
+    return "outbox_running";
+  }
+  if (status === "succeeded") {
+    return "outbox_succeeded";
+  }
+  if (status === "failed_retryable") {
+    return "outbox_failed_retryable";
+  }
+  return "outbox_failed_terminal";
+}
+
+export function dispatchLocalRecoveryChanged(detail: LocalRecoveryChangedDetail): void {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  window.dispatchEvent(
+    new CustomEvent<LocalRecoveryChangedDetail>(LOCAL_RECOVERY_CHANGED_EVENT, {
+      detail,
+    }),
+  );
+}
+
+export function subscribeLocalRecoveryChanged(
+  userId: string,
+  listener: (detail: LocalRecoveryChangedDetail) => void,
+  options?: { debounceMs?: number },
+): () => void {
+  if (typeof window === "undefined") {
+    return () => undefined;
+  }
+
+  const debouncedListener = createLeadingEdgeDebouncedListener(
+    listener,
+    options?.debounceMs ?? DEFAULT_DEBOUNCE_MS,
+  );
+
+  const eventListener: EventListener = (event) => {
+    if (!(event instanceof CustomEvent)) {
+      return;
+    }
+
+    const detail = event.detail;
+    if (!isLocalRecoveryChangedDetail(detail) || detail.userId !== userId) {
+      return;
+    }
+
+    debouncedListener.enqueue(detail);
+  };
+
+  window.addEventListener(LOCAL_RECOVERY_CHANGED_EVENT, eventListener);
+
+  return () => {
+    window.removeEventListener(LOCAL_RECOVERY_CHANGED_EVENT, eventListener);
+    debouncedListener.cancel();
+  };
+}
+
+function createLeadingEdgeDebouncedListener(
+  listener: (detail: LocalRecoveryChangedDetail) => void,
+  debounceMs: number,
+): {
+  enqueue: (detail: LocalRecoveryChangedDetail) => void;
+  cancel: () => void;
+} {
+  let windowStartMs = 0;
+  let trailingTimer: number | null = null;
+  let queuedDetail: LocalRecoveryChangedDetail | null = null;
+
+  const runListener = (detail: LocalRecoveryChangedDetail): void => {
+    windowStartMs = Date.now();
+    listener(detail);
+  };
+
+  const cancelTimer = (): void => {
+    if (trailingTimer === null) {
+      return;
+    }
+
+    window.clearTimeout(trailingTimer);
+    trailingTimer = null;
+  };
+
+  return {
+    enqueue(detail: LocalRecoveryChangedDetail): void {
+      const nowMs = Date.now();
+      const outsideDebounceWindow = windowStartMs === 0 || nowMs - windowStartMs >= debounceMs;
+
+      if (outsideDebounceWindow) {
+        cancelTimer();
+        queuedDetail = null;
+        runListener(detail);
+        return;
+      }
+
+      queuedDetail = detail;
+      if (trailingTimer !== null) {
+        return;
+      }
+
+      const remainingMs = Math.max(debounceMs - (nowMs - windowStartMs), 0);
+      trailingTimer = window.setTimeout(() => {
+        trailingTimer = null;
+        if (!queuedDetail) {
+          return;
+        }
+
+        const nextDetail = queuedDetail;
+        queuedDetail = null;
+        runListener(nextDetail);
+      }, remainingMs);
+    },
+    cancel(): void {
+      cancelTimer();
+      queuedDetail = null;
+    },
+  };
+}
+
+function isLocalRecoveryChangedDetail(value: unknown): value is LocalRecoveryChangedDetail {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  const detail = value as Record<string, unknown>;
+  return (
+    typeof detail.userId === "string"
+    && typeof detail.reason === "string"
+    && (detail.sessionId === undefined || typeof detail.sessionId === "string")
+  );
+}

--- a/frontend/src/features/quotes/offline/outboxRepository.test.ts
+++ b/frontend/src/features/quotes/offline/outboxRepository.test.ts
@@ -4,6 +4,10 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { resetCaptureDbForTests } from "@/features/quotes/offline/captureDb";
 import {
+  LOCAL_RECOVERY_CHANGED_EVENT,
+  type LocalRecoveryChangedDetail,
+} from "@/features/quotes/offline/localRecoveryEvents";
+import {
   enqueueJob,
   getJob,
   listPendingJobs,
@@ -117,5 +121,34 @@ describe("outboxRepository", () => {
     expect(updatedJob?.attemptCount).toBe(2);
     expect(updatedJob?.lastFailureKind).toBe("timeout");
     expect(updatedJob?.lastError).toBe("Timed out");
+  });
+
+  it("emits outbox status change events", async () => {
+    const events: LocalRecoveryChangedDetail[] = [];
+    const eventListener = (event: Event): void => {
+      if (!(event instanceof CustomEvent)) {
+        return;
+      }
+      events.push(event.detail as LocalRecoveryChangedDetail);
+    };
+    window.addEventListener(LOCAL_RECOVERY_CHANGED_EVENT, eventListener);
+
+    const job = await enqueueJob({
+      userId: "user-1",
+      sessionId: "session-events",
+      idempotencyKey: "idem-events",
+    });
+    await updateJobStatus(job.jobId, { status: "running" });
+    await updateJobStatus(job.jobId, { status: "failed_retryable", attemptCount: 1 });
+    await updateJobStatus(job.jobId, { status: "failed_terminal", attemptCount: 2 });
+
+    window.removeEventListener(LOCAL_RECOVERY_CHANGED_EVENT, eventListener);
+
+    expect(events.map((event) => event.reason)).toEqual([
+      "outbox_queued",
+      "outbox_running",
+      "outbox_failed_retryable",
+      "outbox_failed_terminal",
+    ]);
   });
 });

--- a/frontend/src/features/quotes/offline/outboxRepository.ts
+++ b/frontend/src/features/quotes/offline/outboxRepository.ts
@@ -5,6 +5,10 @@ import type {
   OutboxJobStatus,
   SubmitFailureKind,
 } from "@/features/quotes/offline/captureTypes";
+import {
+  dispatchLocalRecoveryChanged,
+  outboxStatusToLocalRecoveryReason,
+} from "@/features/quotes/offline/localRecoveryEvents";
 
 const DEFAULT_MAX_ATTEMPTS = 5;
 const ACTIVE_STATUSES = new Set<OutboxJobStatus>(["queued", "running", "failed_retryable"]);
@@ -39,6 +43,13 @@ export async function enqueueJob(input: EnqueueJobInput): Promise<OutboxJob> {
     activeJob.updatedAt = new Date().toISOString();
     store.put(activeJob);
     await transactionDone(transaction);
+    if (activeJob.status === "queued") {
+      dispatchLocalRecoveryChanged({
+        userId: activeJob.userId,
+        sessionId: activeJob.sessionId,
+        reason: "outbox_queued",
+      });
+    }
     return activeJob;
   }
 
@@ -62,6 +73,11 @@ export async function enqueueJob(input: EnqueueJobInput): Promise<OutboxJob> {
 
   store.put(createdJob);
   await transactionDone(transaction);
+  dispatchLocalRecoveryChanged({
+    userId: createdJob.userId,
+    sessionId: createdJob.sessionId,
+    reason: "outbox_queued",
+  });
   return createdJob;
 }
 
@@ -138,6 +154,13 @@ export async function updateJobStatus(jobId: string, patch: Partial<OutboxJob>):
   job.updatedAt = new Date().toISOString();
   store.put(job);
   await transactionDone(transaction);
+  if (patch.status !== undefined) {
+    dispatchLocalRecoveryChanged({
+      userId: job.userId,
+      sessionId: job.sessionId,
+      reason: outboxStatusToLocalRecoveryReason(patch.status),
+    });
+  }
 }
 
 export async function listPendingJobs(userId: string): Promise<OutboxJob[]> {

--- a/frontend/src/features/quotes/offline/useRecoverableCaptures.ts
+++ b/frontend/src/features/quotes/offline/useRecoverableCaptures.ts
@@ -6,6 +6,7 @@ import {
   listRecoverableCaptures,
 } from "@/features/quotes/offline/captureRepository";
 import type { LocalCaptureSummary } from "@/features/quotes/offline/captureTypes";
+import { subscribeLocalRecoveryChanged } from "@/features/quotes/offline/localRecoveryEvents";
 import { listAllJobsForUser } from "@/features/quotes/offline/outboxRepository";
 
 const MAX_RECOVERABLE_CAPTURES = 20;
@@ -85,6 +86,16 @@ export function useRecoverableCaptures(userId: string | undefined): UseRecoverab
   useEffect(() => {
     void refresh();
   }, [refresh]);
+
+  useEffect(() => {
+    if (!userId) {
+      return;
+    }
+
+    return subscribeLocalRecoveryChanged(userId, () => {
+      void refresh();
+    });
+  }, [refresh, userId]);
 
   return {
     captures,

--- a/frontend/src/features/quotes/tests/QuoteList.test.tsx
+++ b/frontend/src/features/quotes/tests/QuoteList.test.tsx
@@ -6,6 +6,7 @@ import { useAuth } from "@/features/auth/hooks/useAuth";
 import { invoiceService } from "@/features/invoices/services/invoiceService";
 import type { InvoiceListItem } from "@/features/invoices/types/invoice.types";
 import { QuoteList } from "@/features/quotes/components/QuoteList";
+import { dispatchLocalRecoveryChanged } from "@/features/quotes/offline/localRecoveryEvents";
 import { useRecoverableCaptures } from "@/features/quotes/offline/useRecoverableCaptures";
 import { runOutboxPass } from "@/features/quotes/offline/outboxEngine";
 import { getJobForSession, updateJobStatus } from "@/features/quotes/offline/outboxRepository";
@@ -382,6 +383,32 @@ describe("QuoteList", () => {
       expect(mockedRunOutboxPass).toHaveBeenCalledWith("user-1");
       expect(refreshRecoverableCaptures).toHaveBeenCalled();
     });
+  });
+
+  it("refetches server quotes when an outbox sync succeeds", async () => {
+    mockedQuoteService.listQuotes
+      .mockResolvedValueOnce([makeQuoteListItem()])
+      .mockResolvedValueOnce([
+        makeQuoteListItem(),
+        makeQuoteListItem({
+          id: "quote-2",
+          doc_number: "Q-002",
+          customer_id: "cust-2",
+          customer_name: "Bob Brown",
+        }),
+      ]);
+
+    renderScreen();
+    await screen.findByText(/Q-001/);
+
+    dispatchLocalRecoveryChanged({
+      userId: "user-1",
+      sessionId: "session-1",
+      reason: "outbox_succeeded",
+    });
+
+    expect(await screen.findByText(/Q-002/)).toBeInTheDocument();
+    expect(mockedQuoteService.listQuotes).toHaveBeenCalledTimes(2);
   });
 
   it("renders quote cards from listQuotes response", async () => {

--- a/frontend/src/features/quotes/tests/useRecoverableCaptures.test.tsx
+++ b/frontend/src/features/quotes/tests/useRecoverableCaptures.test.tsx
@@ -4,6 +4,7 @@ import { act, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { createCaptureSession } from "@/features/quotes/offline/captureRepository";
+import { dispatchLocalRecoveryChanged } from "@/features/quotes/offline/localRecoveryEvents";
 import { resetCaptureDbForTests } from "@/features/quotes/offline/captureDb";
 import { useRecoverableCaptures } from "@/features/quotes/offline/useRecoverableCaptures";
 
@@ -51,5 +52,56 @@ describe("useRecoverableCaptures", () => {
     await waitFor(() => {
       expect(result.current.captures.some((capture) => capture.sessionId === session.sessionId)).toBe(false);
     });
+  });
+
+  it("refreshes captures when local recovery events are emitted for the same user", async () => {
+    const { result } = renderHook(() => useRecoverableCaptures("user-1"));
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.captures).toHaveLength(0);
+    });
+
+    let sessionId = "";
+    await act(async () => {
+      const session = await createCaptureSession({
+        userId: "user-1",
+        notes: "new local capture",
+      });
+      sessionId = session.sessionId;
+    });
+    await act(async () => {
+      dispatchLocalRecoveryChanged({
+        userId: "user-1",
+        sessionId,
+        reason: "capture_saved",
+      });
+    });
+
+    await waitFor(() => {
+      expect(result.current.captures.some((capture) => capture.sessionId === sessionId)).toBe(true);
+    });
+  });
+
+  it("ignores local recovery events for other users", async () => {
+    const { result } = renderHook(() => useRecoverableCaptures("user-1"));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.captures).toHaveLength(0);
+    });
+
+    await act(async () => {
+      dispatchLocalRecoveryChanged({
+        userId: "user-2",
+        sessionId: "session-other",
+        reason: "capture_saved",
+      });
+    });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(result.current.captures).toHaveLength(0);
   });
 });


### PR DESCRIPTION
## Summary
- add typed local recovery event bridge with user-scoped subscription and 250ms leading-edge debounce
- dispatch local recovery change events after capture/outbox IndexedDB mutations complete
- refresh pending captures hook on local recovery events and refetch quote list on outbox success
- add focused tests for event contract, repository dispatches, and live refresh behavior

## Verification
- make frontend-verify

Closes #577