### PR TITLE
Task #587: Move document action success feedback to toasts

### DIFF
--- a/frontend/src/features/invoices/components/InvoiceDetailScreen.tsx
+++ b/frontend/src/features/invoices/components/InvoiceDetailScreen.tsx
@@ -14,7 +14,6 @@ import {
   DocumentActionHint,
   DocumentActionManualCopyField,
   DocumentActionStatus,
-  DocumentActionSuccessMessage,
   DocumentActionSurface,
   documentActionPrimaryLinkClassName,
 } from "@/shared/components/DocumentActionSurface";
@@ -24,9 +23,11 @@ import { ScreenHeader } from "@/shared/components/ScreenHeader";
 import { DocumentHeroCard } from "@/ui/DocumentHeroCard";
 import { Eyebrow } from "@/ui/Eyebrow";
 import { canNavigateBack } from "@/shared/lib/navigation";
+import { useToast } from "@/ui/Toast";
 
 export function InvoiceDetailScreen(): React.ReactElement {
   const navigate = useNavigate();
+  const { show } = useToast();
   const { id } = useParams<{ id: string }>();
   const [showRevokeShareConfirm, setShowRevokeShareConfirm] = useState(false);
   const {
@@ -42,14 +43,12 @@ export function InvoiceDetailScreen(): React.ReactElement {
     isSharing,
     isRevokingShare,
     shareError,
-    shareMessage,
     manualCopyUrl,
     showSendEmailConfirm,
     isSendingEmail,
     isMarkingPaid,
     isMarkingVoid,
     emailError,
-    emailMessage,
     outcomeError,
     setShowSendEmailConfirm,
     onGeneratePdf,
@@ -64,6 +63,9 @@ export function InvoiceDetailScreen(): React.ReactElement {
     invoice,
     setInvoice,
     loadInvoiceDetail,
+    onSuccess: (message) => {
+      show({ message, variant: "success" });
+    },
   });
   const openPdfUrl = invoice?.pdf_artifact.download_url ?? null;
   const hasSourceQuote = Boolean(invoice?.source_document_id && invoice.source_quote_number);
@@ -120,18 +122,6 @@ export function InvoiceDetailScreen(): React.ReactElement {
     },
   });
 
-  const outcomeBanner = invoice?.status === "paid"
-    ? {
-      className: "mx-4 mt-4 rounded-[var(--radius-document)] border border-success/30 bg-success-container p-4 text-sm text-success",
-      message: "This invoice is marked as paid.",
-    }
-    : invoice?.status === "void"
-      ? {
-        className: "mx-4 mt-4 rounded-[var(--radius-document)] border border-outline/40 bg-surface-container-low p-4 text-sm text-on-surface-variant",
-        message: "This invoice is marked as void.",
-      }
-      : null;
-
   return (
     <main className="min-h-screen bg-background pb-24 pt-16">
       <ScreenHeader
@@ -171,12 +161,6 @@ export function InvoiceDetailScreen(): React.ReactElement {
 
         {!isLoadingInvoice && !loadError && invoice ? (
           <>
-            {outcomeBanner ? (
-              <div className={outcomeBanner.className}>
-                {outcomeBanner.message}
-              </div>
-            ) : null}
-
             <DocumentHeroCard
               documentLabel="INVOICE"
               status={invoice.status}
@@ -293,13 +277,10 @@ export function InvoiceDetailScreen(): React.ReactElement {
                   {outcomeError ? <DocumentActionError>{outcomeError}</DocumentActionError> : null}
                   {shareError ? <DocumentActionError>{shareError}</DocumentActionError> : null}
                   {manualCopyUrl ? (
-                    <DocumentActionManualCopyField url={manualCopyUrl} />
-                  ) : null}
-                  {emailMessage ? (
-                    <DocumentActionSuccessMessage>{emailMessage}</DocumentActionSuccessMessage>
-                  ) : null}
-                  {shareMessage ? (
-                    <DocumentActionSuccessMessage>{shareMessage}</DocumentActionSuccessMessage>
+                    <>
+                      <DocumentActionHint>Copy this share link manually.</DocumentActionHint>
+                      <DocumentActionManualCopyField url={manualCopyUrl} />
+                    </>
                   ) : null}
                 </>
               )}

--- a/frontend/src/features/invoices/hooks/useInvoiceDetailActions.ts
+++ b/frontend/src/features/invoices/hooks/useInvoiceDetailActions.ts
@@ -13,6 +13,7 @@ interface UseInvoiceDetailActionsArgs {
   invoice: InvoiceDetail | null;
   setInvoice: Dispatch<SetStateAction<InvoiceDetail | null>>;
   loadInvoiceDetail: (invoiceId: string) => Promise<void>;
+  onSuccess: (message: string) => void;
 }
 
 interface UseInvoiceDetailActionsResult {
@@ -21,14 +22,12 @@ interface UseInvoiceDetailActionsResult {
   isSharing: boolean;
   isRevokingShare: boolean;
   shareError: string | null;
-  shareMessage: string | null;
   manualCopyUrl: string | null;
   showSendEmailConfirm: boolean;
   isSendingEmail: boolean;
   isMarkingPaid: boolean;
   isMarkingVoid: boolean;
   emailError: string | null;
-  emailMessage: string | null;
   outcomeError: string | null;
   setShowSendEmailConfirm: Dispatch<SetStateAction<boolean>>;
   onGeneratePdf: () => Promise<void>;
@@ -49,20 +48,19 @@ export function useInvoiceDetailActions({
   invoice,
   setInvoice,
   loadInvoiceDetail,
+  onSuccess,
 }: UseInvoiceDetailActionsArgs): UseInvoiceDetailActionsResult {
   const [isGeneratingPdf, setIsGeneratingPdf] = useState(false);
   const [pdfError, setPdfError] = useState<string | null>(null);
   const [isSharing, setIsSharing] = useState(false);
   const [isRevokingShare, setIsRevokingShare] = useState(false);
   const [shareError, setShareError] = useState<string | null>(null);
-  const [shareMessage, setShareMessage] = useState<string | null>(null);
   const [manualCopyUrl, setManualCopyUrl] = useState<string | null>(null);
   const [showSendEmailConfirm, setShowSendEmailConfirm] = useState(false);
   const [isSendingEmail, setIsSendingEmail] = useState(false);
   const [isMarkingPaid, setIsMarkingPaid] = useState(false);
   const [isMarkingVoid, setIsMarkingVoid] = useState(false);
   const [emailError, setEmailError] = useState<string | null>(null);
-  const [emailMessage, setEmailMessage] = useState<string | null>(null);
   const [outcomeError, setOutcomeError] = useState<string | null>(null);
 
   function getErrorMessage(error: unknown, fallback: string): string {
@@ -74,10 +72,8 @@ export function useInvoiceDetailActions({
       setPdfError(null);
     }
     setEmailError(null);
-    setEmailMessage(null);
     setOutcomeError(null);
     setShareError(null);
-    setShareMessage(null);
     setManualCopyUrl(null);
   }
 
@@ -159,13 +155,12 @@ export function useInvoiceDetailActions({
       const nextShareUrl = `${apiBase}/share/${updatedInvoice.share_token}`;
       if (!navigator.clipboard || typeof navigator.clipboard.writeText !== "function") {
         setManualCopyUrl(nextShareUrl);
-        setShareMessage("Copy this share link manually.");
         return;
       }
 
       await navigator.clipboard.writeText(nextShareUrl);
       setManualCopyUrl(null);
-      setShareMessage("Invoice link copied to clipboard.");
+      onSuccess("Invoice link copied to clipboard.");
     } catch (error) {
       setManualCopyUrl(null);
       setShareError(getErrorMessage(error, "Unable to copy invoice link"));
@@ -183,7 +178,7 @@ export function useInvoiceDetailActions({
     try {
       await invoiceService.revokeShare(invoiceId);
       await loadInvoiceDetail(invoiceId);
-      setShareMessage("Share link revoked.");
+      onSuccess("Share link revoked.");
     } catch (error) {
       setShareError(getErrorMessage(error, "Unable to revoke share link"));
     } finally {
@@ -218,7 +213,6 @@ export function useInvoiceDetailActions({
     try {
       const job = await invoiceService.sendInvoiceEmail(invoiceId);
       await loadInvoiceDetail(invoiceId);
-      setEmailMessage("Invoice email is sending. We’ll update this status shortly.");
       await pollJobUntilSuccess({
         jobId: job.id,
         getJobStatus: jobService.getJobStatus,
@@ -226,7 +220,7 @@ export function useInvoiceDetailActions({
         timeoutErrorMessage: "Invoice email is taking longer than expected. Refresh to check delivery status.",
       });
       await loadInvoiceDetail(invoiceId);
-      setEmailMessage("Invoice sent by email.");
+      onSuccess("Invoice sent by email.");
     } catch (error) {
       setEmailError(getErrorMessage(error, "Unable to send invoice email"));
     } finally {
@@ -243,6 +237,7 @@ export function useInvoiceDetailActions({
     try {
       const updatedInvoice = await invoiceService.markInvoicePaid(invoiceId);
       applyInvoiceUpdate(updatedInvoice);
+      onSuccess("Invoice marked as paid.");
     } catch (error) {
       setOutcomeError(getErrorMessage(error, "Unable to mark invoice as paid"));
     } finally {
@@ -259,6 +254,7 @@ export function useInvoiceDetailActions({
     try {
       const updatedInvoice = await invoiceService.markInvoiceVoid(invoiceId);
       applyInvoiceUpdate(updatedInvoice);
+      onSuccess("Invoice marked as void.");
     } catch (error) {
       setOutcomeError(getErrorMessage(error, "Unable to mark invoice as void"));
     } finally {
@@ -272,14 +268,12 @@ export function useInvoiceDetailActions({
     isSharing,
     isRevokingShare,
     shareError,
-    shareMessage,
     manualCopyUrl,
     showSendEmailConfirm,
     isSendingEmail,
     isMarkingPaid,
     isMarkingVoid,
     emailError,
-    emailMessage,
     outcomeError,
     setShowSendEmailConfirm,
     onGeneratePdf,

--- a/frontend/src/features/invoices/tests/InvoiceDetailScreen.test.tsx
+++ b/frontend/src/features/invoices/tests/InvoiceDetailScreen.test.tsx
@@ -7,6 +7,7 @@ import { invoiceService } from "@/features/invoices/services/invoiceService";
 import type { JobStatusResponse } from "@/features/quotes/types/quote.types";
 import type { Invoice, InvoiceDetail } from "@/features/invoices/types/invoice.types";
 import { jobService } from "@/shared/lib/jobService";
+import { ToastProvider } from "@/ui/Toast";
 
 vi.mock("@/features/invoices/services/invoiceService", () => ({
   invoiceService: {
@@ -119,14 +120,16 @@ function makeInvoice(overrides: Partial<Invoice> = {}): Invoice {
 
 function renderScreen(path = "/invoices/invoice-1"): void {
   render(
-    <MemoryRouter initialEntries={[path]}>
-      <Routes>
-        <Route path="/invoices/:id" element={<InvoiceDetailScreen />} />
-        <Route path="/documents/:id/edit" element={<div>Document Edit Screen</div>} />
-        <Route path="/quotes/:id/preview" element={<div>Quote Preview Screen</div>} />
-        <Route path="/" element={<div>Quote List Screen</div>} />
-      </Routes>
-    </MemoryRouter>,
+    <ToastProvider>
+      <MemoryRouter initialEntries={[path]}>
+        <Routes>
+          <Route path="/invoices/:id" element={<InvoiceDetailScreen />} />
+          <Route path="/documents/:id/edit" element={<div>Document Edit Screen</div>} />
+          <Route path="/quotes/:id/preview" element={<div>Quote Preview Screen</div>} />
+          <Route path="/" element={<div>Quote List Screen</div>} />
+        </Routes>
+      </MemoryRouter>
+    </ToastProvider>,
   );
 }
 
@@ -344,7 +347,7 @@ describe("InvoiceDetailScreen", () => {
     expect(screen.getByRole("menuitem", { name: /mark as void/i })).toBeInTheDocument();
   });
 
-  it("shows paid banner and only Mark as Void in overflow for paid invoices", async () => {
+  it("keeps paid invoice overflow actions without showing a top paid banner", async () => {
     mockedInvoiceService.getInvoice.mockResolvedValueOnce(
       makeInvoiceDetail({
         status: "paid",
@@ -355,14 +358,15 @@ describe("InvoiceDetailScreen", () => {
 
     renderScreen();
 
-    expect(await screen.findByText("This invoice is marked as paid.")).toBeInTheDocument();
+    await screen.findByRole("heading", { name: "Invoice Preview" });
+    expect(screen.queryByText("This invoice is marked as paid.")).not.toBeInTheDocument();
     await openOverflowMenu();
 
     expect(screen.queryByRole("menuitem", { name: /mark as paid/i })).not.toBeInTheDocument();
     expect(screen.getByRole("menuitem", { name: /mark as void/i })).toBeInTheDocument();
   });
 
-  it("shows void banner and only Mark as Paid in overflow for void invoices", async () => {
+  it("keeps void invoice overflow actions without showing a top void banner", async () => {
     mockedInvoiceService.getInvoice.mockResolvedValueOnce(
       makeInvoiceDetail({
         status: "void",
@@ -373,7 +377,8 @@ describe("InvoiceDetailScreen", () => {
 
     renderScreen();
 
-    expect(await screen.findByText("This invoice is marked as void.")).toBeInTheDocument();
+    await screen.findByRole("heading", { name: "Invoice Preview" });
+    expect(screen.queryByText("This invoice is marked as void.")).not.toBeInTheDocument();
     await openOverflowMenu();
 
     expect(screen.getByRole("menuitem", { name: /mark as paid/i })).toBeInTheDocument();
@@ -422,7 +427,8 @@ describe("InvoiceDetailScreen", () => {
       expect(mockedInvoiceService.markInvoicePaid).toHaveBeenCalledWith("invoice-1");
     });
 
-    expect(await screen.findByText("This invoice is marked as paid.")).toBeInTheDocument();
+    expect(await screen.findByText("Invoice marked as paid.")).toBeInTheDocument();
+    expect(screen.queryByText("This invoice is marked as paid.")).not.toBeInTheDocument();
   });
 
   it("marks a paid invoice as void from overflow and updates visible state", async () => {
@@ -443,7 +449,8 @@ describe("InvoiceDetailScreen", () => {
       expect(mockedInvoiceService.markInvoiceVoid).toHaveBeenCalledWith("invoice-1");
     });
 
-    expect(await screen.findByText("This invoice is marked as void.")).toBeInTheDocument();
+    expect(await screen.findByText("Invoice marked as void.")).toBeInTheDocument();
+    expect(screen.queryByText("This invoice is marked as void.")).not.toBeInTheDocument();
   });
 
   it("hides the email action for draft invoices", async () => {

--- a/frontend/src/features/quotes/components/QuotePreview.tsx
+++ b/frontend/src/features/quotes/components/QuotePreview.tsx
@@ -24,9 +24,11 @@ import { FeedbackMessage } from "@/shared/components/FeedbackMessage";
 import { ScreenHeader } from "@/shared/components/ScreenHeader";
 import { canNavigateBack } from "@/shared/lib/navigation";
 import { DocumentHeroCard } from "@/ui/DocumentHeroCard";
+import { useToast } from "@/ui/Toast";
 
 export function QuotePreview(): React.ReactElement {
   const navigate = useNavigate();
+  const { show } = useToast();
   const { id } = useParams<{ id: string }>();
   const {
     setQuote,
@@ -74,7 +76,6 @@ export function QuotePreview(): React.ReactElement {
     isSharing,
     isRevokingShare,
     isSendingEmail,
-    shareMessage,
     shareError,
     manualCopyUrl,
     showSendEmailConfirm,
@@ -90,6 +91,9 @@ export function QuotePreview(): React.ReactElement {
     quote,
     setQuote,
     refetchQuote,
+    onSuccess: (message) => {
+      show({ message, variant: "success" });
+    },
   });
   const {
     isMarkingWon,
@@ -113,6 +117,9 @@ export function QuotePreview(): React.ReactElement {
     navigate,
     clearInvoiceError,
     clearShareFeedback,
+    onSuccess: (message) => {
+      show({ message, variant: "success" });
+    },
   });
   const resolvedPdfError = pdfError ?? (
     quote?.pdf_artifact.status === "failed"
@@ -241,7 +248,6 @@ export function QuotePreview(): React.ReactElement {
               pdfError={resolvedPdfError}
               shareError={shareError}
               outcomeError={outcomeError}
-              shareMessage={shareMessage}
             />
 
             {deleteError ? (

--- a/frontend/src/features/quotes/components/QuotePreviewActions.tsx
+++ b/frontend/src/features/quotes/components/QuotePreviewActions.tsx
@@ -4,7 +4,6 @@ import {
   DocumentActionHint,
   DocumentActionManualCopyField,
   DocumentActionStatus,
-  DocumentActionSuccessMessage,
   DocumentActionSurface,
   documentActionPrimaryLinkClassName,
 } from "@/shared/components/DocumentActionSurface";
@@ -27,7 +26,6 @@ interface QuotePreviewActionsProps {
   pdfError: string | null;
   shareError: string | null;
   outcomeError: string | null;
-  shareMessage: string | null;
 }
 
 export function QuotePreviewActions({
@@ -48,7 +46,6 @@ export function QuotePreviewActions({
   pdfError,
   shareError,
   outcomeError,
-  shareMessage,
 }: QuotePreviewActionsProps): React.ReactElement {
   let statusCopy: string | null = null;
   if (isGeneratingPdf) {
@@ -174,13 +171,13 @@ export function QuotePreviewActions({
           {shareError ? <DocumentActionError>{shareError}</DocumentActionError> : null}
           {outcomeError ? <DocumentActionError>{outcomeError}</DocumentActionError> : null}
           {manualCopyUrl ? (
-            <DocumentActionManualCopyField
-              url={manualCopyUrl}
-              label={shareUrl ? "Share URL" : "Generated share URL"}
-            />
-          ) : null}
-          {shareMessage ? (
-            <DocumentActionSuccessMessage>{shareMessage}</DocumentActionSuccessMessage>
+            <>
+              <DocumentActionHint>Copy this share link manually.</DocumentActionHint>
+              <DocumentActionManualCopyField
+                url={manualCopyUrl}
+                label={shareUrl ? "Share URL" : "Generated share URL"}
+              />
+            </>
           ) : null}
         </>
       )}

--- a/frontend/src/features/quotes/hooks/useQuoteDocumentActions.ts
+++ b/frontend/src/features/quotes/hooks/useQuoteDocumentActions.ts
@@ -16,6 +16,7 @@ interface UseQuoteDocumentActionsArgs {
   quote: QuoteDetail | null;
   setQuote: Dispatch<SetStateAction<QuoteDetail | null>>;
   refetchQuote: (quoteId: string) => Promise<void>;
+  onSuccess: (message: string) => void;
 }
 
 interface UseQuoteDocumentActionsResult {
@@ -24,7 +25,6 @@ interface UseQuoteDocumentActionsResult {
   isSharing: boolean;
   isRevokingShare: boolean;
   isSendingEmail: boolean;
-  shareMessage: string | null;
   shareError: string | null;
   manualCopyUrl: string | null;
   showSendEmailConfirm: boolean;
@@ -45,20 +45,19 @@ export function useQuoteDocumentActions({
   quote,
   setQuote,
   refetchQuote,
+  onSuccess,
 }: UseQuoteDocumentActionsArgs): UseQuoteDocumentActionsResult {
   const [isGeneratingPdf, setIsGeneratingPdf] = useState(false);
   const [pdfError, setPdfError] = useState<string | null>(null);
   const [isSharing, setIsSharing] = useState(false);
   const [isRevokingShare, setIsRevokingShare] = useState(false);
   const [isSendingEmail, setIsSendingEmail] = useState(false);
-  const [shareMessage, setShareMessage] = useState<string | null>(null);
   const [shareError, setShareError] = useState<string | null>(null);
   const [manualCopyUrl, setManualCopyUrl] = useState<string | null>(null);
   const [showSendEmailConfirm, setShowSendEmailConfirm] = useState(false);
 
   function clearShareFeedback(): void {
     setShareError(null);
-    setShareMessage(null);
     setManualCopyUrl(null);
   }
 
@@ -156,7 +155,7 @@ export function useQuoteDocumentActions({
             title: shareTitle,
             url: nextSharedUrl,
           });
-          setShareMessage("Quote link shared.");
+          onSuccess("Quote link shared.");
           setManualCopyUrl(null);
           return;
         } catch (error) {
@@ -169,13 +168,12 @@ export function useQuoteDocumentActions({
 
       if (!navigator.clipboard || typeof navigator.clipboard.writeText !== "function") {
         setManualCopyUrl(nextSharedUrl);
-        setShareMessage("Copy this share link manually.");
         return;
       }
 
       await navigator.clipboard.writeText(nextSharedUrl);
       setManualCopyUrl(null);
-      setShareMessage("Share link copied to clipboard.");
+      onSuccess("Share link copied to clipboard.");
     } catch (error) {
       setManualCopyUrl(null);
       const message = error instanceof Error ? error.message : "Unable to copy share link";
@@ -196,7 +194,7 @@ export function useQuoteDocumentActions({
     try {
       await quoteService.revokeShare(quoteId);
       await refetchQuote(quoteId);
-      setShareMessage("Share link revoked.");
+      onSuccess("Share link revoked.");
     } catch (error) {
       const message = error instanceof Error ? error.message : "Unable to revoke share link";
       setShareError(message);
@@ -231,7 +229,6 @@ export function useQuoteDocumentActions({
     try {
       const job = await quoteService.sendQuoteEmail(quoteId);
       await refetchQuote(quoteId);
-      setShareMessage("Quote email is sending. We’ll update this status shortly.");
       await pollJobUntilSuccess({
         jobId: job.id,
         getJobStatus: jobService.getJobStatus,
@@ -239,7 +236,7 @@ export function useQuoteDocumentActions({
         timeoutErrorMessage: "Quote email is taking longer than expected. Refresh to check delivery status.",
       });
       await refetchQuote(quoteId);
-      setShareMessage("Quote email sent.");
+      onSuccess("Quote email sent.");
     } catch (error) {
       setShareError(getSendEmailErrorMessage(error));
     } finally {
@@ -253,7 +250,6 @@ export function useQuoteDocumentActions({
     isSharing,
     isRevokingShare,
     isSendingEmail,
-    shareMessage,
     shareError,
     manualCopyUrl,
     showSendEmailConfirm,

--- a/frontend/src/features/quotes/hooks/useQuoteOutcomeActions.ts
+++ b/frontend/src/features/quotes/hooks/useQuoteOutcomeActions.ts
@@ -12,6 +12,7 @@ interface UseQuoteOutcomeActionsArgs {
   navigate: NavigateFunction;
   clearInvoiceError: () => void;
   clearShareFeedback: () => void;
+  onSuccess: (message: string) => void;
 }
 
 interface UseQuoteOutcomeActionsResult {
@@ -38,6 +39,7 @@ export function useQuoteOutcomeActions({
   navigate,
   clearInvoiceError,
   clearShareFeedback,
+  onSuccess,
 }: UseQuoteOutcomeActionsArgs): UseQuoteOutcomeActionsResult {
   const [isMarkingWon, setIsMarkingWon] = useState(false);
   const [isMarkingLost, setIsMarkingLost] = useState(false);
@@ -61,6 +63,7 @@ export function useQuoteOutcomeActions({
     try {
       await quoteService.markQuoteWon(quoteId);
       await refetchQuote(quoteId);
+      onSuccess("Quote marked as won.");
     } catch (error) {
       const message = error instanceof Error ? error.message : "Unable to mark quote as won";
       setOutcomeError(message);
@@ -82,6 +85,7 @@ export function useQuoteOutcomeActions({
     try {
       await quoteService.markQuoteLost(quoteId);
       await refetchQuote(quoteId);
+      onSuccess("Quote marked as lost.");
     } catch (error) {
       const message = error instanceof Error ? error.message : "Unable to mark quote as lost";
       setOutcomeError(message);

--- a/frontend/src/features/quotes/tests/QuotePreview.test.tsx
+++ b/frontend/src/features/quotes/tests/QuotePreview.test.tsx
@@ -7,6 +7,7 @@ import { quoteService } from "@/features/quotes/services/quoteService";
 import type { JobStatusResponse, Quote, QuoteDetail } from "@/features/quotes/types/quote.types";
 import { HttpRequestError } from "@/shared/lib/http";
 import { jobService } from "@/shared/lib/jobService";
+import { ToastProvider } from "@/ui/Toast";
 
 vi.mock("@/features/quotes/services/quoteService", () => ({
   quoteService: {
@@ -129,14 +130,16 @@ function renderScreen(
   },
 ): void {
   render(
-    <MemoryRouter initialEntries={options?.initialEntries ?? [path]} initialIndex={options?.initialIndex}>
-      <Routes>
-        <Route path="/quotes/:id/preview" element={<QuotePreview />} />
-        <Route path="/documents/:id/edit" element={<div>Document Edit Screen</div>} />
-        <Route path="/invoices/:id" element={<div>Invoice Detail Screen</div>} />
-        <Route path="/" element={<div>Quote List Screen</div>} />
-      </Routes>
-    </MemoryRouter>,
+    <ToastProvider>
+      <MemoryRouter initialEntries={options?.initialEntries ?? [path]} initialIndex={options?.initialIndex}>
+        <Routes>
+          <Route path="/quotes/:id/preview" element={<QuotePreview />} />
+          <Route path="/documents/:id/edit" element={<div>Document Edit Screen</div>} />
+          <Route path="/invoices/:id" element={<div>Invoice Detail Screen</div>} />
+          <Route path="/" element={<div>Quote List Screen</div>} />
+        </Routes>
+      </MemoryRouter>
+    </ToastProvider>,
   );
 }
 
@@ -608,6 +611,7 @@ describe("QuotePreview", () => {
     expect(screen.queryByLabelText(/quote status/i)).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: /more actions/i })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /edit quote/i })).toBeInTheDocument();
+    expect(await screen.findByText("Quote marked as won.")).toBeInTheDocument();
   });
 
   it("shows the lost confirmation modal and refetches the declined state after confirmation", async () => {
@@ -643,9 +647,10 @@ describe("QuotePreview", () => {
     expect(screen.queryByLabelText(/quote status/i)).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: /more actions/i })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /edit quote/i })).toBeInTheDocument();
+    expect(await screen.findByText("Quote marked as lost.")).toBeInTheDocument();
   });
 
-  it("clears existing share feedback before marking the quote won", async () => {
+  it("shows success toasts for copy-link and mark-won actions", async () => {
     const writeTextMock = vi.fn().mockResolvedValue(undefined);
     Object.defineProperty(navigator, "clipboard", {
       configurable: true,
@@ -679,7 +684,7 @@ describe("QuotePreview", () => {
     await waitFor(() => {
       expect(mockedQuoteService.markQuoteWon).toHaveBeenCalledWith("quote-1");
     });
-    expect(screen.queryByText("Share link copied to clipboard.")).not.toBeInTheDocument();
+    expect(await screen.findByText("Quote marked as won.")).toBeInTheDocument();
   });
 
   it("navigates to the canonical review route from the header action", async () => {

--- a/frontend/src/features/quotes/tests/QuotePreviewActions.test.tsx
+++ b/frontend/src/features/quotes/tests/QuotePreviewActions.test.tsx
@@ -23,7 +23,6 @@ function makeProps(overrides: Partial<ComponentProps<typeof QuotePreviewActions>
     pdfError: null,
     shareError: null,
     outcomeError: null,
-    shareMessage: null,
     ...overrides,
   };
 }


### PR DESCRIPTION
## Summary
- route quote and invoice action success outcomes through useToast at screen level
- remove inline DocumentActionSuccessMessage usage for copy/send/revoke and outcome mutations
- remove invoice paid/void top-of-page outcome banner while keeping hero status/state behavior intact
- keep inline errors, busy copy, and manual copy URL fallback behavior
- update quote/invoice screen tests to assert toast success feedback and no invoice outcome banner

## Verification
- cd frontend && ./node_modules/.bin/vitest run src/features/quotes/tests/QuotePreview.test.tsx src/features/quotes/tests/QuotePreviewActions.test.tsx src/features/invoices/tests/InvoiceDetailScreen.test.tsx src/ui/Toast.test.tsx
- make frontend-verify

Closes #587
