### PR TITLE
Task #588: Home search persistent toggle and clear-only X

### DIFF
--- a/frontend/src/features/quotes/components/QuoteList.tsx
+++ b/frontend/src/features/quotes/components/QuoteList.tsx
@@ -170,9 +170,7 @@ export function QuoteList(): React.ReactElement {
   const headerTitle = documentMode === "quotes" ? "Quotes" : "Invoices";
   const headerSubtitle = documentMode === "quotes" ? quoteSubtitle : invoiceSubtitle;
   const searchLabel = documentMode === "quotes" ? "Search quotes" : "Search invoices";
-  const searchPlaceholder = documentMode === "quotes"
-    ? "Search customer, title, or quote ID..."
-    : "Search customer, title, or invoice ID...";
+  const searchPlaceholder = documentMode === "quotes" ? "Search customer, title, or quote ID..." : "Search customer, title, or invoice ID...";
   const emptyStateMessage = totalRows === 0
     ? documentMode === "quotes"
       ? "No quotes yet. Tap New Quote to create your first."
@@ -205,7 +203,6 @@ export function QuoteList(): React.ReactElement {
     })),
     [nonDraftQuotes, timezone],
   );
-
   const invoiceRows = useMemo<DocumentRow[]>(
     () => filteredInvoices.map((invoice) => ({
       id: invoice.id,
@@ -305,18 +302,23 @@ export function QuoteList(): React.ReactElement {
                 Invoices
               </button>
             </div>
-            {!isSearchOpen ? (
-              <Button
-                type="button"
-                variant="iconButton"
-                size="sm"
-                aria-label="Open search"
-                className="border border-outline-variant/30 bg-surface-container-lowest text-on-surface ghost-shadow"
-                onClick={() => setIsSearchOpen(true)}
-              >
-                <span className="material-symbols-outlined block text-[1.125rem] leading-none">search</span>
-              </Button>
-            ) : null}
+            <Button
+              type="button"
+              variant="iconButton"
+              size="sm"
+              aria-label={isSearchOpen ? "Close search" : "Open search"}
+              className={isSearchOpen
+                ? "border border-primary/70 bg-primary text-on-primary ghost-shadow hover:bg-primary/90"
+                : "border border-outline-variant/30 bg-surface-container-lowest text-on-surface ghost-shadow"}
+              onClick={() => {
+                if (isSearchOpen) {
+                  setSearchQuery("");
+                }
+                setIsSearchOpen((open) => !open);
+              }}
+            >
+              <span className="material-symbols-outlined block text-[1.125rem] leading-none">search</span>
+            </Button>
           </div>
           {isSearchOpen ? (
             <Input
@@ -331,12 +333,9 @@ export function QuoteList(): React.ReactElement {
                   type="button"
                   variant="iconButton"
                   size="xs"
-                  aria-label="Close search"
+                  aria-label="Clear search text"
                   className="text-outline"
-                  onClick={() => {
-                    setSearchQuery("");
-                    setIsSearchOpen(false);
-                  }}
+                  onClick={() => setSearchQuery("")}
                 >
                   <span className="material-symbols-outlined block text-base leading-none">close</span>
                 </Button>

--- a/frontend/src/features/quotes/tests/QuoteList.test.tsx
+++ b/frontend/src/features/quotes/tests/QuoteList.test.tsx
@@ -184,7 +184,7 @@ describe("QuoteList", () => {
     expect(screen.getByRole("button", { name: "Open search" })).toBeInTheDocument();
   });
 
-  it("opens search, focuses the input, and hides the open-search button", async () => {
+  it("opens search, focuses the input, and keeps the search toggle visible as active", async () => {
     mockedQuoteService.listQuotes.mockResolvedValueOnce([makeQuoteListItem()]);
 
     renderScreen();
@@ -195,7 +195,7 @@ describe("QuoteList", () => {
       expect(searchInput).toHaveFocus();
     });
     expect(screen.queryByRole("button", { name: "Open search" })).not.toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Close search" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Close search" })).toHaveClass("bg-primary", "text-on-primary");
   });
 
   it("closes search and clears the query, and reopening starts empty", async () => {
@@ -214,6 +214,23 @@ describe("QuoteList", () => {
 
     const reopenedSearchInput = await openSearch();
     expect(reopenedSearchInput).toHaveValue("");
+  });
+
+  it("clears the query from input-end control and keeps search open", async () => {
+    mockedQuoteService.listQuotes.mockResolvedValueOnce([makeQuoteListItem()]);
+
+    renderScreen();
+    await screen.findByText(/Q-001/);
+
+    const searchInput = await openSearch();
+    fireEvent.change(searchInput, { target: { value: "alice" } });
+    expect(searchInput).toHaveValue("alice");
+
+    fireEvent.click(screen.getByRole("button", { name: "Clear search text" }));
+
+    expect(screen.getByLabelText("Search quotes")).toBeInTheDocument();
+    expect(screen.getByLabelText("Search quotes")).toHaveValue("");
+    expect(screen.getByRole("button", { name: "Close search" })).toBeInTheDocument();
   });
 
   it("preserves open search state and query when switching tabs", async () => {


### PR DESCRIPTION
## Summary
- keep the home search button mounted in both closed/open states
- style the open state as active/filled and let the same button toggle search off
- change the input-end X action to clear text only while keeping search open
- update QuoteList tests for persistent toggle and clear-only behavior

## Verification
- cd frontend && ./node_modules/.bin/vitest run src/features/quotes/tests/QuoteList.test.tsx
- make frontend-verify

Closes #588