### PR TITLE
Task #589: Line item sheet tab ergonomics

### DIFF
--- a/frontend/src/features/quotes/components/LineItemCatalogTabPanel.tsx
+++ b/frontend/src/features/quotes/components/LineItemCatalogTabPanel.tsx
@@ -10,6 +10,7 @@ interface LineItemCatalogTabPanelProps {
   items: LineItemCatalogItem[];
   onRetry: () => void;
   onInsertItem: (item: LineItemCatalogItem) => void;
+  panelClassName?: string;
 }
 
 function formatCatalogPrice(value: number | null): string {
@@ -25,9 +26,11 @@ export function LineItemCatalogTabPanel({
   items,
   onRetry,
   onInsertItem,
+  panelClassName,
 }: LineItemCatalogTabPanelProps): React.ReactElement {
+  const className = ["space-y-3", panelClassName].filter(Boolean).join(" ");
   return (
-    <div id="line-item-tabpanel-catalog" role="tabpanel" className="space-y-3">
+    <div id="line-item-tabpanel-catalog" role="tabpanel" className={className}>
       {loadState === "loading" ? (
         <p role="status" className="text-sm text-on-surface-variant">Loading catalog items...</p>
       ) : null}

--- a/frontend/src/features/quotes/components/LineItemEditSheet.tsx
+++ b/frontend/src/features/quotes/components/LineItemEditSheet.tsx
@@ -353,7 +353,11 @@ export function LineItemEditSheet({
                 </div>
               ) : null}
               {showManualFields ? (
-                <div id="line-item-tabpanel-manual" role={mode === "add" ? "tabpanel" : undefined} className="space-y-4">
+                <div
+                  id="line-item-tabpanel-manual"
+                  role={mode === "add" ? "tabpanel" : undefined}
+                  className={`space-y-4 ${mode === "add" ? "min-h-72" : ""}`.trim()}
+                >
                   <section className="space-y-2">
                     <div className="flex items-end justify-between">
                       <label htmlFor="line-item-sheet-description" className="font-headline text-sm font-bold text-on-surface">
@@ -419,7 +423,7 @@ export function LineItemEditSheet({
                           setFormError(null);
                         }
                       }}
-                      className="w-full rounded-[var(--radius-document)] border border-outline-variant/30 bg-surface-container-high p-4 text-sm text-on-surface placeholder:text-outline/70 outline-none transition-all focus:border-primary focus:bg-surface-container-lowest focus:ring-2 focus:ring-primary/20"
+                      className="w-full resize-none rounded-[var(--radius-document)] border border-outline-variant/30 bg-surface-container-high p-4 text-sm text-on-surface placeholder:text-outline/70 outline-none transition-all focus:border-primary focus:bg-surface-container-lowest focus:ring-2 focus:ring-primary/20"
                     />
                   </section>
                 </div>
@@ -428,6 +432,7 @@ export function LineItemEditSheet({
                   loadState={catalogLoadState}
                   loadError={catalogLoadError}
                   items={catalogItems}
+                  panelClassName={mode === "add" ? "min-h-72" : undefined}
                   onRetry={() => {
                     setCatalogLoadState("idle");
                     void loadCatalogItems();

--- a/frontend/src/features/quotes/tests/LineItemEditSheet.test.tsx
+++ b/frontend/src/features/quotes/tests/LineItemEditSheet.test.tsx
@@ -359,6 +359,31 @@ describe("LineItemEditSheet", () => {
 
     expect(screen.getByLabelText(/price/i)).toHaveAttribute("inputmode", "decimal");
     expect(screen.getByLabelText(/details/i)).toHaveAttribute("rows", "2");
+    expect(screen.getByLabelText(/details/i)).toHaveClass("resize-none");
+  });
+
+  it("keeps a shared minimum tabpanel height in add mode across Manual and Catalog", async () => {
+    const user = userEvent.setup();
+    const onLoadCatalogItems = vi.fn().mockResolvedValue([]);
+
+    render(
+      <LineItemEditSheet
+        open
+        mode="add"
+        initialLineItem={makeLineItem({ description: "", details: null, price: null })}
+        onClose={vi.fn()}
+        onSave={vi.fn()}
+        onLoadCatalogItems={onLoadCatalogItems}
+      />,
+    );
+
+    expect(screen.getByRole("tabpanel")).toHaveClass("min-h-72");
+
+    await user.click(screen.getByRole("tab", { name: /catalog/i }));
+    await waitFor(() => {
+      expect(onLoadCatalogItems).toHaveBeenCalledTimes(1);
+    });
+    expect(screen.getByRole("tabpanel")).toHaveClass("min-h-72");
   });
 
   it("fires delete callback from top-right trash action", () => {

--- a/frontend/src/ui/Toast.tsx
+++ b/frontend/src/ui/Toast.tsx
@@ -216,7 +216,7 @@ export function ToastProvider({ children }: { children: React.ReactNode }): Reac
       <section
         aria-live="polite"
         aria-atomic="false"
-        className="pointer-events-none fixed bottom-[calc(env(safe-area-inset-bottom)+var(--bottom-nav-offset,0px))] left-0 right-0 z-50 flex flex-col items-center gap-2 px-4"
+        className="pointer-events-none fixed bottom-[calc(env(safe-area-inset-bottom)+var(--bottom-nav-offset,0px))] left-0 right-0 z-[60] flex flex-col items-center gap-2 px-4"
       >
         {toasts.map((toast) => (
           <Toast key={toast.id} toast={toast} onDismiss={() => dismiss(toast.id)} />


### PR DESCRIPTION
## Summary
- add a shared min-height contract for add-mode Manual and Catalog tab panels to reduce tab-switch jumpiness
- keep catalog lazy-load behavior unchanged on first Catalog activation
- make manual Details textarea non-resizable with `resize-none`
- add tests for non-resizable details field and shared tabpanel min-height contract

## Verification
- cd frontend && ./node_modules/.bin/vitest run src/features/quotes/tests/LineItemEditSheet.test.tsx src/features/quotes/tests/LineItemCatalogInsert.test.tsx
- make frontend-verify

Closes #589