### PR TITLE
Task #590: Settings business profile display/edit mode

### DIFF
--- a/frontend/src/features/settings/components/SettingsBusinessProfileCard.tsx
+++ b/frontend/src/features/settings/components/SettingsBusinessProfileCard.tsx
@@ -83,7 +83,7 @@ export function SettingsBusinessProfileCard({
             type="button"
             variant="ghost"
             size="sm"
-            className="border border-outline-variant/30 px-3 text-xs text-on-surface"
+            className="min-h-0 border border-outline-variant/30 px-3 py-1 text-xs text-on-surface"
             onClick={onOpenEditor}
             aria-label="Edit business profile"
           >
@@ -92,43 +92,43 @@ export function SettingsBusinessProfileCard({
         ) : null}
       </div>
 
-      <div className="mt-4 flex flex-col gap-4">
-        <div
-          data-testid="settings-logo-block"
-          className="rounded-[var(--radius-document)] bg-surface-container-low p-4"
-        >
-          <div className="flex flex-col gap-3">
-            <Eyebrow>Logo</Eyebrow>
-            <div
-              data-testid="settings-logo-content-row"
-              className="flex flex-col gap-3 min-[360px]:grid min-[360px]:grid-cols-[128px_minmax(0,1fr)] min-[360px]:items-start min-[360px]:gap-4"
-            >
+      <div className="mt-2 flex flex-col gap-4">
+        {isEditingBusinessProfile ? (
+          <div
+            data-testid="settings-logo-block"
+            className="rounded-[var(--radius-document)] bg-surface-container-low p-4"
+          >
+            <div className="flex flex-col gap-3">
+              <Eyebrow>Logo</Eyebrow>
               <div
-                data-testid="settings-logo-preview-tile"
-                className="flex h-[128px] w-[128px] rounded-[var(--radius-document)] bg-surface-container-lowest p-2"
+                data-testid="settings-logo-content-row"
+                className="flex flex-col gap-3 min-[360px]:grid min-[360px]:grid-cols-[128px_minmax(0,1fr)] min-[360px]:items-start min-[360px]:gap-4"
               >
-                <div className="flex h-full w-full items-center justify-center rounded-[var(--radius-document)] bg-surface-container p-2">
-                  {hasLogo ? (
-                    <img
-                      key={logoPreviewVersion}
-                      src={logoPreviewSrc}
-                      alt="Business logo preview"
-                      className="max-h-full max-w-full object-contain"
-                    />
-                  ) : (
-                    <p className="text-xs text-on-surface-variant">No logo</p>
-                  )}
+                <div
+                  data-testid="settings-logo-preview-tile"
+                  className="flex h-[128px] w-[128px] rounded-[var(--radius-document)] bg-surface-container-lowest p-2"
+                >
+                  <div className="flex h-full w-full items-center justify-center rounded-[var(--radius-document)] bg-surface-container p-2">
+                    {hasLogo ? (
+                      <img
+                        key={logoPreviewVersion}
+                        src={logoPreviewSrc}
+                        alt="Business logo preview"
+                        className="max-h-full max-w-full object-contain"
+                      />
+                    ) : (
+                      <p className="text-xs text-on-surface-variant">No logo</p>
+                    )}
+                  </div>
                 </div>
-              </div>
 
-              <div
-                data-testid="settings-logo-actions"
-                className="flex min-w-0 flex-col gap-2"
-              >
-                <p className="text-xs text-on-surface-variant">
-                  {`JPEG or PNG, up to ${logoSizeLimitLabel}. Appears on quote PDFs.`}
-                </p>
-                {isEditingBusinessProfile ? (
+                <div
+                  data-testid="settings-logo-actions"
+                  className="flex min-w-0 flex-col gap-2"
+                >
+                  <p className="text-xs text-on-surface-variant">
+                    {`JPEG or PNG, up to ${logoSizeLimitLabel}. Appears on quote PDFs.`}
+                  </p>
                   <div className="flex flex-col items-start gap-2">
                     <Button
                       type="button"
@@ -163,14 +163,12 @@ export function SettingsBusinessProfileCard({
                       </Button>
                     ) : null}
                   </div>
-                ) : (
-                  <p className="text-xs text-on-surface-variant">Tap Edit to update logo.</p>
-                )}
-                {logoError ? <p role="alert" className="text-xs text-error">{logoError}</p> : null}
+                  {logoError ? <p role="alert" className="text-xs text-error">{logoError}</p> : null}
+                </div>
               </div>
             </div>
           </div>
-        </div>
+        ) : null}
 
         {isEditingBusinessProfile ? (
           <>
@@ -274,42 +272,42 @@ export function SettingsBusinessProfileCard({
             </div>
           </>
         ) : (
-          <div className="space-y-3" data-testid="settings-business-profile-display">
-            <div>
-              <Eyebrow>Business name</Eyebrow>
-              <p className="text-sm text-on-surface">{businessName || "Not set"}</p>
-            </div>
-            <div className="grid grid-cols-1 gap-3 min-[360px]:grid-cols-2">
-              <div>
-                <Eyebrow>First name</Eyebrow>
-                <p className="text-sm text-on-surface">{firstName || "Not set"}</p>
+          <div className="space-y-4" data-testid="settings-business-profile-display">
+            <div className="flex items-center gap-4">
+              <div className="flex h-16 w-16 shrink-0 items-center justify-center overflow-hidden rounded-[var(--radius-document)] bg-surface-container-low">
+                {hasLogo ? (
+                  <img
+                    key={logoPreviewVersion}
+                    src={logoPreviewSrc}
+                    alt="Business logo"
+                    className="h-full w-full object-contain"
+                  />
+                ) : (
+                  <span className="material-symbols-outlined text-2xl text-on-surface-variant">business</span>
+                )}
               </div>
-              <div>
-                <Eyebrow>Last name</Eyebrow>
-                <p className="text-sm text-on-surface">{lastName || "Not set"}</p>
-              </div>
-            </div>
-            <div className="grid grid-cols-1 gap-3 min-[360px]:grid-cols-2">
-              <div>
-                <Eyebrow>Trade type</Eyebrow>
-                <p className="text-sm text-on-surface">{tradeType}</p>
-              </div>
-              <div>
-                <Eyebrow>Tax rate (%)</Eyebrow>
-                <p className="text-sm text-on-surface">{defaultTaxRate || "Not set"}</p>
-              </div>
-            </div>
-            <div className="grid grid-cols-1 gap-3 min-[360px]:grid-cols-2">
-              <div>
-                <Eyebrow>Timezone</Eyebrow>
-                <p className="text-sm text-on-surface">{timezone}</p>
-              </div>
-              <div>
-                <Eyebrow>Theme</Eyebrow>
-                <p className="text-sm text-on-surface">
-                  {themeOptions.find((option) => option.value === themePreference)?.label ?? "System default"}
+              <div className="min-w-0 flex-1">
+                <p className="truncate text-base font-bold text-on-surface">{businessName || "Not set"}</p>
+                <p className="text-sm text-on-surface-variant">
+                  {firstName} {lastName}
                 </p>
               </div>
+            </div>
+
+            <div className="flex flex-wrap gap-x-4 gap-y-1 text-sm">
+              <span className="text-on-surface-variant">
+                <span className="text-on-surface">{tradeType}</span>
+                <span className="mx-1.5 text-outline">·</span>
+                {defaultTaxRate ? `${defaultTaxRate}% tax` : "No tax set"}
+              </span>
+            </div>
+
+            <div className="flex flex-wrap gap-x-4 gap-y-1 text-sm">
+              <span className="text-on-surface-variant">
+                {timezone}
+                <span className="mx-1.5 text-outline">·</span>
+                {themeOptions.find((option) => option.value === themePreference)?.label ?? "System default"}
+              </span>
             </div>
           </div>
         )}

--- a/frontend/src/features/settings/components/SettingsBusinessProfileCard.tsx
+++ b/frontend/src/features/settings/components/SettingsBusinessProfileCard.tsx
@@ -1,0 +1,319 @@
+import type { ChangeEvent } from "react";
+
+import type { TradeType } from "@/features/profile/types/profile.types";
+import { Button } from "@/shared/components/Button";
+import { Input } from "@/shared/components/Input";
+import type { ThemePreference } from "@/shared/lib/theme";
+import { NumericField } from "@/ui/NumericField";
+import { Select } from "@/ui/Select";
+import { Card } from "@/ui/Card";
+import { Eyebrow } from "@/ui/Eyebrow";
+
+interface SettingsBusinessProfileCardProps {
+  logoSizeLimitLabel: string;
+  hasLogo: boolean;
+  logoPreviewVersion: number;
+  logoPreviewSrc: string;
+  logoError: string | null;
+  isLogoSubmitting: boolean;
+  isEditingBusinessProfile: boolean;
+  businessName: string;
+  firstName: string;
+  lastName: string;
+  tradeType: TradeType;
+  timezone: string;
+  defaultTaxRate: string;
+  themePreference: ThemePreference;
+  tradeTypeOptions: readonly TradeType[];
+  timezoneOptions: string[];
+  themeOptions: ReadonlyArray<{ label: string; value: ThemePreference }>;
+  logoUploadInputRef: React.RefObject<HTMLInputElement | null>;
+  isSubmitting: boolean;
+  onOpenEditor: () => void;
+  onCancelEditor: () => void;
+  onOpenRemoveLogo: () => void;
+  onLogoUpload: (event: ChangeEvent<HTMLInputElement>) => void;
+  onBusinessNameChange: (value: string) => void;
+  onFirstNameChange: (value: string) => void;
+  onLastNameChange: (value: string) => void;
+  onTradeTypeChange: (value: TradeType) => void;
+  onTaxRateChange: (value: string) => void;
+  onTimezoneChange: (value: string) => void;
+  onThemeChange: (value: ThemePreference) => void;
+}
+
+export function SettingsBusinessProfileCard({
+  logoSizeLimitLabel,
+  hasLogo,
+  logoPreviewVersion,
+  logoPreviewSrc,
+  logoError,
+  isLogoSubmitting,
+  isEditingBusinessProfile,
+  businessName,
+  firstName,
+  lastName,
+  tradeType,
+  timezone,
+  defaultTaxRate,
+  themePreference,
+  tradeTypeOptions,
+  timezoneOptions,
+  themeOptions,
+  logoUploadInputRef,
+  isSubmitting,
+  onOpenEditor,
+  onCancelEditor,
+  onOpenRemoveLogo,
+  onLogoUpload,
+  onBusinessNameChange,
+  onFirstNameChange,
+  onLastNameChange,
+  onTradeTypeChange,
+  onTaxRateChange,
+  onTimezoneChange,
+  onThemeChange,
+}: SettingsBusinessProfileCardProps): React.ReactElement {
+  return (
+    <Card className="p-6">
+      <div className="flex items-start justify-between gap-3">
+        <Eyebrow>Business Profile</Eyebrow>
+        {!isEditingBusinessProfile ? (
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="border border-outline-variant/30 px-3 text-xs text-on-surface"
+            onClick={onOpenEditor}
+            aria-label="Edit business profile"
+          >
+            Edit
+          </Button>
+        ) : null}
+      </div>
+
+      <div className="mt-4 flex flex-col gap-4">
+        <div
+          data-testid="settings-logo-block"
+          className="rounded-[var(--radius-document)] bg-surface-container-low p-4"
+        >
+          <div className="flex flex-col gap-3">
+            <Eyebrow>Logo</Eyebrow>
+            <div
+              data-testid="settings-logo-content-row"
+              className="flex flex-col gap-3 min-[360px]:grid min-[360px]:grid-cols-[128px_minmax(0,1fr)] min-[360px]:items-start min-[360px]:gap-4"
+            >
+              <div
+                data-testid="settings-logo-preview-tile"
+                className="flex h-[128px] w-[128px] rounded-[var(--radius-document)] bg-surface-container-lowest p-2"
+              >
+                <div className="flex h-full w-full items-center justify-center rounded-[var(--radius-document)] bg-surface-container p-2">
+                  {hasLogo ? (
+                    <img
+                      key={logoPreviewVersion}
+                      src={logoPreviewSrc}
+                      alt="Business logo preview"
+                      className="max-h-full max-w-full object-contain"
+                    />
+                  ) : (
+                    <p className="text-xs text-on-surface-variant">No logo</p>
+                  )}
+                </div>
+              </div>
+
+              <div
+                data-testid="settings-logo-actions"
+                className="flex min-w-0 flex-col gap-2"
+              >
+                <p className="text-xs text-on-surface-variant">
+                  {`JPEG or PNG, up to ${logoSizeLimitLabel}. Appears on quote PDFs.`}
+                </p>
+                {isEditingBusinessProfile ? (
+                  <div className="flex flex-col items-start gap-2">
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      className="min-h-10 border border-outline-variant/30 px-3 text-xs text-on-surface"
+                      disabled={isLogoSubmitting}
+                      onClick={() => logoUploadInputRef.current?.click()}
+                    >
+                      Upload Logo
+                    </Button>
+                    <input
+                      ref={logoUploadInputRef}
+                      id="settings-logo-upload"
+                      aria-label="Upload logo"
+                      type="file"
+                      accept="image/jpeg,image/png"
+                      className="sr-only"
+                      disabled={isLogoSubmitting}
+                      onChange={onLogoUpload}
+                    />
+                    {hasLogo ? (
+                      <Button
+                        type="button"
+                        variant="destructive"
+                        size="sm"
+                        className="min-h-10 px-3 text-xs"
+                        disabled={isLogoSubmitting}
+                        onClick={onOpenRemoveLogo}
+                      >
+                        Remove
+                      </Button>
+                    ) : null}
+                  </div>
+                ) : (
+                  <p className="text-xs text-on-surface-variant">Tap Edit to update logo.</p>
+                )}
+                {logoError ? <p role="alert" className="text-xs text-error">{logoError}</p> : null}
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {isEditingBusinessProfile ? (
+          <>
+            <Input
+              id="settings-business-name"
+              label="Business name"
+              value={businessName}
+              onChange={(event) => onBusinessNameChange(event.target.value)}
+            />
+
+            <div
+              data-testid="settings-name-row"
+              className="grid grid-cols-1 gap-4 min-[360px]:grid-cols-2"
+            >
+              <Input
+                id="settings-first-name"
+                label="First name"
+                value={firstName}
+                onChange={(event) => onFirstNameChange(event.target.value)}
+              />
+              <Input
+                id="settings-last-name"
+                label="Last name"
+                value={lastName}
+                onChange={(event) => onLastNameChange(event.target.value)}
+              />
+            </div>
+
+            <div
+              data-testid="settings-profile-meta-row"
+              className="grid grid-cols-1 gap-4 min-[360px]:grid-cols-2"
+            >
+              <Select
+                id="settings-trade-type"
+                label="Trade type"
+                value={tradeType}
+                onChange={(event) => onTradeTypeChange(event.target.value as TradeType)}
+              >
+                {tradeTypeOptions.map((tradeTypeOption) => (
+                  <option key={tradeTypeOption} value={tradeTypeOption}>
+                    {tradeTypeOption}
+                  </option>
+                ))}
+              </Select>
+
+              <NumericField
+                id="settings-default-tax-rate"
+                label="Tax rate (%)"
+                step={0.01}
+                value={defaultTaxRate}
+                onChange={onTaxRateChange}
+                placeholder="8.25"
+                showStepControls={false}
+                formatOnBlur={false}
+              />
+            </div>
+
+            <Select
+              id="settings-timezone"
+              label="Timezone"
+              value={timezone}
+              onChange={(event) => onTimezoneChange(event.target.value)}
+            >
+              {timezoneOptions.map((timezoneOption) => (
+                <option key={timezoneOption} value={timezoneOption}>
+                  {timezoneOption}
+                </option>
+              ))}
+            </Select>
+
+            <Select
+              id="settings-theme"
+              label="Theme"
+              value={themePreference}
+              onChange={(event) => onThemeChange(event.target.value as ThemePreference)}
+            >
+              {themeOptions.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </Select>
+
+            <div className="flex flex-col gap-2 pt-2 min-[360px]:flex-row min-[360px]:justify-end">
+              <Button
+                type="button"
+                variant="ghost"
+                className="min-[360px]:w-auto"
+                onClick={onCancelEditor}
+              >
+                Cancel
+              </Button>
+              <Button
+                type="submit"
+                variant="primary"
+                className="min-[360px]:w-auto min-[360px]:px-8"
+                isLoading={isSubmitting}
+              >
+                Save Changes
+              </Button>
+            </div>
+          </>
+        ) : (
+          <div className="space-y-3" data-testid="settings-business-profile-display">
+            <div>
+              <Eyebrow>Business name</Eyebrow>
+              <p className="text-sm text-on-surface">{businessName || "Not set"}</p>
+            </div>
+            <div className="grid grid-cols-1 gap-3 min-[360px]:grid-cols-2">
+              <div>
+                <Eyebrow>First name</Eyebrow>
+                <p className="text-sm text-on-surface">{firstName || "Not set"}</p>
+              </div>
+              <div>
+                <Eyebrow>Last name</Eyebrow>
+                <p className="text-sm text-on-surface">{lastName || "Not set"}</p>
+              </div>
+            </div>
+            <div className="grid grid-cols-1 gap-3 min-[360px]:grid-cols-2">
+              <div>
+                <Eyebrow>Trade type</Eyebrow>
+                <p className="text-sm text-on-surface">{tradeType}</p>
+              </div>
+              <div>
+                <Eyebrow>Tax rate (%)</Eyebrow>
+                <p className="text-sm text-on-surface">{defaultTaxRate || "Not set"}</p>
+              </div>
+            </div>
+            <div className="grid grid-cols-1 gap-3 min-[360px]:grid-cols-2">
+              <div>
+                <Eyebrow>Timezone</Eyebrow>
+                <p className="text-sm text-on-surface">{timezone}</p>
+              </div>
+              <div>
+                <Eyebrow>Theme</Eyebrow>
+                <p className="text-sm text-on-surface">
+                  {themeOptions.find((option) => option.value === themePreference)?.label ?? "System default"}
+                </p>
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+    </Card>
+  );
+}

--- a/frontend/src/features/settings/components/SettingsScreen.tsx
+++ b/frontend/src/features/settings/components/SettingsScreen.tsx
@@ -1,9 +1,10 @@
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 
 import { useAuth } from "@/features/auth/hooks/useAuth";
 import { getTimezoneOptions } from "@/features/profile/lib/timezones";
 import { profileService } from "@/features/profile/services/profileService";
+import { SettingsBusinessProfileCard } from "@/features/settings/components/SettingsBusinessProfileCard";
 import { SettingsCatalogShortcutCard } from "@/features/settings/components/SettingsCatalogShortcutCard";
 import {
   TRADE_TYPES,
@@ -14,15 +15,12 @@ import { BottomNav } from "@/shared/components/BottomNav";
 import { Button } from "@/shared/components/Button";
 import { ConfirmModal } from "@/shared/components/ConfirmModal";
 import { FeedbackMessage } from "@/shared/components/FeedbackMessage";
-import { Input } from "@/shared/components/Input";
 import { ScreenHeader } from "@/shared/components/ScreenHeader";
 import { useTheme } from "@/shared/hooks/useTheme";
 import { formatByteLimit } from "@/shared/lib/formatters";
 import { MAX_LOGO_SIZE_BYTES } from "@/shared/lib/inputLimits";
 import { parseTaxPercentInput, toTaxPercentDisplay } from "@/shared/lib/pricing";
 import type { ThemePreference } from "@/shared/lib/theme";
-import { NumericField } from "@/ui/NumericField";
-import { Select } from "@/ui/Select";
 import { useToast } from "@/ui/Toast";
 import { Card } from "@/ui/Card";
 import { Eyebrow } from "@/ui/Eyebrow";
@@ -32,6 +30,15 @@ const THEME_OPTIONS: ReadonlyArray<{ label: string; value: ThemePreference }> = 
   { label: "Light", value: "light" },
   { label: "Dark", value: "dark" },
 ];
+
+interface BusinessProfileDraft {
+  businessName: string;
+  firstName: string;
+  lastName: string;
+  tradeType: TradeType;
+  timezone: string;
+  defaultTaxRate: string;
+}
 
 export function SettingsScreen(): React.ReactElement {
   const navigate = useNavigate();
@@ -53,22 +60,42 @@ export function SettingsScreen(): React.ReactElement {
   const [saveError, setSaveError] = useState<string | null>(null);
   const [saveSuccess, setSaveSuccess] = useState<string | null>(null);
   const [logoError, setLogoError] = useState<string | null>(null);
+  const [savedProfileDraft, setSavedProfileDraft] = useState<BusinessProfileDraft | null>(null);
+  const [isEditingBusinessProfile, setIsEditingBusinessProfile] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isLogoSubmitting, setIsLogoSubmitting] = useState(false);
   const [isRemoveLogoOpen, setIsRemoveLogoOpen] = useState(false);
   const [isSignOutConfirmOpen, setIsSignOutConfirmOpen] = useState(false);
   const [logoPreviewVersion, setLogoPreviewVersion] = useState(0);
   const logoUploadInputRef = useRef<HTMLInputElement>(null);
-  function applyProfile(profile: ProfileResponse): void {
-    setBusinessName(profile.business_name ?? "");
-    setFirstName(profile.first_name ?? "");
-    setLastName(profile.last_name ?? "");
-    setTradeType(profile.trade_type ?? TRADE_TYPES[0]);
-    setTimezone(profile.timezone ?? "UTC");
-    setDefaultTaxRate(toTaxPercentDisplay(profile.default_tax_rate));
+
+  const applyDraft = useCallback((draft: BusinessProfileDraft): void => {
+    setBusinessName(draft.businessName);
+    setFirstName(draft.firstName);
+    setLastName(draft.lastName);
+    setTradeType(draft.tradeType);
+    setTimezone(draft.timezone);
+    setDefaultTaxRate(draft.defaultTaxRate);
+  }, []);
+
+  const toDraft = useCallback((profile: ProfileResponse): BusinessProfileDraft => {
+    return {
+      businessName: profile.business_name ?? "",
+      firstName: profile.first_name ?? "",
+      lastName: profile.last_name ?? "",
+      tradeType: profile.trade_type ?? TRADE_TYPES[0],
+      timezone: profile.timezone ?? "UTC",
+      defaultTaxRate: toTaxPercentDisplay(profile.default_tax_rate),
+    };
+  }, []);
+
+  const applyProfile = useCallback((profile: ProfileResponse): void => {
+    const nextDraft = toDraft(profile);
+    applyDraft(nextDraft);
+    setSavedProfileDraft(nextDraft);
     setEmail(profile.email);
     setHasLogo(profile.has_logo);
-  }
+  }, [applyDraft, toDraft]);
 
   useEffect(() => {
     let isActive = true;
@@ -95,7 +122,7 @@ export function SettingsScreen(): React.ReactElement {
     return () => {
       isActive = false;
     };
-  }, []);
+  }, [applyProfile]);
 
   useEffect(() => {
     if (!saveSuccess) {
@@ -153,6 +180,23 @@ export function SettingsScreen(): React.ReactElement {
     await logout();
   };
 
+  const openBusinessProfileEditor = () => {
+    if (savedProfileDraft) {
+      applyDraft(savedProfileDraft);
+    }
+    setSaveError(null);
+    setIsEditingBusinessProfile(true);
+  };
+
+  const cancelBusinessProfileEditor = () => {
+    if (savedProfileDraft) {
+      applyDraft(savedProfileDraft);
+    }
+    setSaveError(null);
+    setLogoError(null);
+    setIsEditingBusinessProfile(false);
+  };
+
   const onSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     setSaveError(null);
@@ -172,6 +216,15 @@ export function SettingsScreen(): React.ReactElement {
       } catch {
         // Ignore refresh failures because profile save already succeeded.
       }
+      setSavedProfileDraft({
+        businessName,
+        firstName,
+        lastName,
+        tradeType,
+        timezone,
+        defaultTaxRate,
+      });
+      setIsEditingBusinessProfile(false);
       setSaveSuccess("Saved");
     } catch (error) {
       const message = error instanceof Error ? error.message : "Unable to save settings";
@@ -180,6 +233,7 @@ export function SettingsScreen(): React.ReactElement {
       setIsSubmitting(false);
     }
   };
+  const timezoneOptions = getTimezoneOptions(timezone);
 
   return (
     <main className="min-h-screen bg-background pb-24 pt-16">
@@ -199,166 +253,38 @@ export function SettingsScreen(): React.ReactElement {
               <FeedbackMessage variant="error">{saveError}</FeedbackMessage>
             ) : null}
 
-            <Card className="p-6">
-              <Eyebrow className="mb-4">Business Profile</Eyebrow>
-
-              <div className="mt-4 flex flex-col gap-4">
-                <div
-                  data-testid="settings-logo-block"
-                  className="rounded-[var(--radius-document)] bg-surface-container-low p-4"
-                >
-                  <div className="flex flex-col gap-3">
-                    <Eyebrow>Logo</Eyebrow>
-                    <div
-                      data-testid="settings-logo-content-row"
-                      className="flex flex-col gap-3 min-[360px]:grid min-[360px]:grid-cols-[128px_minmax(0,1fr)] min-[360px]:items-start min-[360px]:gap-4"
-                    >
-                      <div
-                        data-testid="settings-logo-preview-tile"
-                        className="flex h-[128px] w-[128px] rounded-[var(--radius-document)] bg-surface-container-lowest p-2"
-                      >
-                        <div className="flex h-full w-full items-center justify-center rounded-[var(--radius-document)] bg-surface-container p-2">
-                          {hasLogo ? (
-                            <img
-                              key={logoPreviewVersion}
-                              src={logoPreviewSrc}
-                              alt="Business logo preview"
-                              className="max-h-full max-w-full object-contain"
-                            />
-                          ) : (
-                            <p className="text-xs text-on-surface-variant">No logo</p>
-                          )}
-                        </div>
-                      </div>
-
-                      <div
-                        data-testid="settings-logo-actions"
-                        className="flex min-w-0 flex-col gap-2"
-                      >
-                        <p className="text-xs text-on-surface-variant">
-                          {`JPEG or PNG, up to ${logoSizeLimitLabel}. Appears on quote PDFs.`}
-                        </p>
-                        <div className="flex flex-col items-start gap-2">
-                          <Button
-                            type="button"
-                            variant="ghost"
-                            size="sm"
-                            className="min-h-10 border border-outline-variant/30 px-3 text-xs text-on-surface"
-                            disabled={isLogoSubmitting}
-                            onClick={() => logoUploadInputRef.current?.click()}
-                          >
-                            Upload Logo
-                          </Button>
-                          <input
-                            ref={logoUploadInputRef}
-                            id="settings-logo-upload"
-                            aria-label="Upload logo"
-                            type="file"
-                            accept="image/jpeg,image/png"
-                            className="sr-only"
-                            disabled={isLogoSubmitting}
-                            onChange={onLogoUpload}
-                          />
-                          {hasLogo ? (
-                            <Button
-                              type="button"
-                              variant="destructive"
-                              size="sm"
-                              className="min-h-10 px-3 text-xs"
-                              disabled={isLogoSubmitting}
-                              onClick={() => setIsRemoveLogoOpen(true)}
-                            >
-                              Remove
-                            </Button>
-                          ) : null}
-                        </div>
-                        {logoError ? <FeedbackMessage variant="error">{logoError}</FeedbackMessage> : null}
-                      </div>
-                    </div>
-                  </div>
-                </div>
-
-                <Input
-                  id="settings-business-name"
-                  label="Business name"
-                  value={businessName}
-                  onChange={(event) => setBusinessName(event.target.value)}
-                />
-
-                <div
-                  data-testid="settings-name-row"
-                  className="grid grid-cols-1 gap-4 min-[360px]:grid-cols-2"
-                >
-                  <Input
-                    id="settings-first-name"
-                    label="First name"
-                    value={firstName}
-                    onChange={(event) => setFirstName(event.target.value)}
-                  />
-                  <Input
-                    id="settings-last-name"
-                    label="Last name"
-                    value={lastName}
-                    onChange={(event) => setLastName(event.target.value)}
-                  />
-                </div>
-
-                <div
-                  data-testid="settings-profile-meta-row"
-                  className="grid grid-cols-1 gap-4 min-[360px]:grid-cols-2"
-                >
-                  <Select
-                    id="settings-trade-type"
-                    label="Trade type"
-                    value={tradeType}
-                    onChange={(event) => setTradeType(event.target.value as TradeType)}
-                  >
-                    {TRADE_TYPES.map((tradeTypeOption) => (
-                      <option key={tradeTypeOption} value={tradeTypeOption}>
-                        {tradeTypeOption}
-                      </option>
-                    ))}
-                  </Select>
-
-                  <NumericField
-                    id="settings-default-tax-rate"
-                    label="Tax rate (%)"
-                    step={0.01}
-                    value={defaultTaxRate}
-                    onChange={setDefaultTaxRate}
-                    placeholder="8.25"
-                    showStepControls={false}
-                    formatOnBlur={false}
-                  />
-                </div>
-
-                <Select
-                  id="settings-timezone"
-                  label="Timezone"
-                  value={timezone}
-                  onChange={(event) => setTimezone(event.target.value)}
-                >
-                  {getTimezoneOptions(timezone).map((timezoneOption) => (
-                    <option key={timezoneOption} value={timezoneOption}>
-                      {timezoneOption}
-                    </option>
-                  ))}
-                </Select>
-
-                <Select
-                  id="settings-theme"
-                  label="Theme"
-                  value={themePreference}
-                  onChange={(event) => setThemePreference(event.target.value as ThemePreference)}
-                >
-                  {THEME_OPTIONS.map((option) => (
-                    <option key={option.value} value={option.value}>
-                      {option.label}
-                    </option>
-                  ))}
-                </Select>
-              </div>
-            </Card>
+            <SettingsBusinessProfileCard
+              logoSizeLimitLabel={logoSizeLimitLabel}
+              hasLogo={hasLogo}
+              logoPreviewVersion={logoPreviewVersion}
+              logoPreviewSrc={logoPreviewSrc}
+              logoError={logoError}
+              isLogoSubmitting={isLogoSubmitting}
+              isEditingBusinessProfile={isEditingBusinessProfile}
+              businessName={businessName}
+              firstName={firstName}
+              lastName={lastName}
+              tradeType={tradeType}
+              timezone={timezone}
+              defaultTaxRate={defaultTaxRate}
+              themePreference={themePreference}
+              tradeTypeOptions={TRADE_TYPES}
+              timezoneOptions={timezoneOptions}
+              themeOptions={THEME_OPTIONS}
+              logoUploadInputRef={logoUploadInputRef}
+              isSubmitting={isSubmitting}
+              onOpenEditor={openBusinessProfileEditor}
+              onCancelEditor={cancelBusinessProfileEditor}
+              onOpenRemoveLogo={() => setIsRemoveLogoOpen(true)}
+              onLogoUpload={onLogoUpload}
+              onBusinessNameChange={setBusinessName}
+              onFirstNameChange={setFirstName}
+              onLastNameChange={setLastName}
+              onTradeTypeChange={setTradeType}
+              onTaxRateChange={setDefaultTaxRate}
+              onTimezoneChange={setTimezone}
+              onThemeChange={setThemePreference}
+            />
 
             <SettingsCatalogShortcutCard
               onOpenLineItemCatalog={() => navigate("/settings/line-item-catalog")}
@@ -384,16 +310,6 @@ export function SettingsScreen(): React.ReactElement {
               </div>
             </Card>
 
-            <div className="pt-2">
-              <Button
-                type="submit"
-                variant="primary"
-                className="w-full md:min-w-[13rem] md:w-auto md:px-8"
-                isLoading={isSubmitting}
-              >
-                Save Changes
-              </Button>
-            </div>
           </form>
         ) : null}
       </section>

--- a/frontend/src/features/settings/tests/SettingsScreen.test.tsx
+++ b/frontend/src/features/settings/tests/SettingsScreen.test.tsx
@@ -66,6 +66,11 @@ function renderScreen() {
   );
 }
 
+async function openBusinessProfileEditMode(): Promise<void> {
+  fireEvent.click(await screen.findByRole("button", { name: /edit business profile/i }));
+  await screen.findByLabelText(/business name/i);
+}
+
 beforeEach(() => {
   Object.defineProperty(window, "matchMedia", {
     writable: true,
@@ -113,7 +118,7 @@ afterEach(() => {
 describe("SettingsScreen", () => {
   const logoSizeLimitLabel = formatByteLimit(MAX_LOGO_SIZE_BYTES);
 
-  it("renders the top-level settings shell with grouped fields and inline save", async () => {
+  it("renders business profile in read-only mode by default and reveals form on edit", async () => {
     mockedProfileService.getProfile.mockResolvedValueOnce(
       makeProfileResponse({
         email: "owner@example.com",
@@ -126,11 +131,11 @@ describe("SettingsScreen", () => {
 
     renderScreen();
 
-    expect(await screen.findByDisplayValue("Bright Lawn Care")).toBeInTheDocument();
-    expect(screen.getByDisplayValue("Jordan")).toBeInTheDocument();
-    expect(screen.getByDisplayValue("Hill")).toBeInTheDocument();
-    expect(screen.getByLabelText(/trade type/i)).toHaveValue("Plumber");
-    expect(screen.getByLabelText(/timezone/i)).toHaveValue("America/New_York");
+    expect(await screen.findByText("Bright Lawn Care")).toBeInTheDocument();
+    expect(screen.getByText("Jordan")).toBeInTheDocument();
+    expect(screen.getByText("Hill")).toBeInTheDocument();
+    expect(screen.getByText("Plumber")).toBeInTheDocument();
+    expect(screen.getByText("America/New_York")).toBeInTheDocument();
     expect(screen.getByText("owner@example.com")).toBeInTheDocument();
     expect(screen.getByText("Email")).toHaveClass(
       "font-bold",
@@ -142,26 +147,23 @@ describe("SettingsScreen", () => {
     expect(
       screen.getByText(`JPEG or PNG, up to ${logoSizeLimitLabel}. Appears on quote PDFs.`),
     ).toBeInTheDocument();
-    expect(screen.getByTestId("settings-name-row")).toHaveClass(
-      "grid",
-      "grid-cols-1",
-      "gap-4",
-      "min-[360px]:grid-cols-2",
-    );
-    expect(screen.getByTestId("settings-profile-meta-row")).toHaveClass(
-      "grid",
-      "grid-cols-1",
-      "gap-4",
-      "min-[360px]:grid-cols-2",
-    );
-    expect(screen.getByLabelText(/upload logo/i)).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /save changes/i }).closest("footer")).toBeNull();
+    expect(screen.getByRole("button", { name: /edit business profile/i })).toBeInTheDocument();
+    expect(screen.queryByLabelText(/upload logo/i)).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /save changes/i })).not.toBeInTheDocument();
     expect(screen.getByText("Account").closest("div")).toHaveClass("bg-surface-container-low");
     expect(screen.queryByText("Session")).not.toBeInTheDocument();
     expect(screen.queryByLabelText(/^email$/i)).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /back/i })).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: /settings/i })).toHaveClass("text-primary");
     expect(screen.queryByText("Appearance")).not.toBeInTheDocument();
+
+    await openBusinessProfileEditMode();
+    expect(screen.getByDisplayValue("Bright Lawn Care")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("Jordan")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("Hill")).toBeInTheDocument();
+    expect(screen.getByLabelText(/trade type/i)).toHaveValue("Plumber");
+    expect(screen.getByLabelText(/timezone/i)).toHaveValue("America/New_York");
+    expect(screen.getByLabelText(/upload logo/i)).toBeInTheDocument();
   });
 
   it("normalizes null profile values before binding to controlled inputs", async () => {
@@ -178,7 +180,7 @@ describe("SettingsScreen", () => {
 
     renderScreen();
 
-    await screen.findByLabelText(/business name/i);
+    await openBusinessProfileEditMode();
 
     expect((screen.getByLabelText(/business name/i) as HTMLInputElement).value).toBe("");
     expect((screen.getByLabelText(/first name/i) as HTMLInputElement).value).toBe("");
@@ -218,7 +220,7 @@ describe("SettingsScreen", () => {
 
     renderScreen();
 
-    await screen.findByLabelText(/business name/i);
+    await openBusinessProfileEditMode();
 
     fireEvent.change(screen.getByLabelText(/business name/i), {
       target: { value: "North Star Lawn" },
@@ -254,12 +256,37 @@ describe("SettingsScreen", () => {
     expect(savedToast).not.toHaveClass("bg-success-container");
   });
 
+  it("restores last saved values when leaving edit mode without saving", async () => {
+    mockedProfileService.getProfile.mockResolvedValueOnce(makeProfileResponse({
+      business_name: "Summit Exterior Care",
+      first_name: "Alex",
+      last_name: "Stone",
+    }));
+
+    renderScreen();
+    await openBusinessProfileEditMode();
+
+    fireEvent.change(screen.getByLabelText(/business name/i), {
+      target: { value: "Unsaved Name" },
+    });
+    fireEvent.change(screen.getByLabelText(/first name/i), {
+      target: { value: "Unsaved First" },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /^cancel$/i }));
+
+    expect(screen.queryByLabelText(/business name/i)).not.toBeInTheDocument();
+    expect(screen.getByText("Summit Exterior Care")).toBeInTheDocument();
+    expect(screen.getByText("Alex")).toBeInTheDocument();
+    expect(mockedProfileService.updateProfile).not.toHaveBeenCalled();
+  });
+
   it("updates the theme preference immediately from the dropdown", async () => {
     mockedProfileService.getProfile.mockResolvedValueOnce(makeProfileResponse());
 
     renderScreen();
 
-    await screen.findByLabelText(/business name/i);
+    await openBusinessProfileEditMode();
 
     const themeSelect = screen.getByRole("combobox", { name: "Theme" });
 
@@ -299,6 +326,7 @@ describe("SettingsScreen", () => {
 
     renderScreen();
 
+    await openBusinessProfileEditMode();
     expect(await screen.findByDisplayValue("8.25")).toBeInTheDocument();
     fireEvent.change(screen.getByLabelText(/tax rate/i), {
       target: { value: "7.5" },
@@ -342,7 +370,7 @@ describe("SettingsScreen", () => {
 
     renderScreen();
 
-    await screen.findByLabelText(/business name/i);
+    await openBusinessProfileEditMode();
     fireEvent.click(screen.getByRole("button", { name: /save changes/i }));
 
     await waitFor(() => expect(mockedProfileService.updateProfile).toHaveBeenCalledTimes(1));
@@ -359,7 +387,7 @@ describe("SettingsScreen", () => {
 
     renderScreen();
 
-    await screen.findByLabelText(/business name/i);
+    await openBusinessProfileEditMode();
     fireEvent.click(screen.getByRole("button", { name: /save changes/i }));
 
     expect(await screen.findByRole("alert")).toHaveTextContent("Unable to save settings");
@@ -377,7 +405,7 @@ describe("SettingsScreen", () => {
 
     renderScreen();
 
-    await screen.findByLabelText(/business name/i);
+    await openBusinessProfileEditMode();
     fireEvent.click(screen.getByRole("button", { name: /save changes/i }));
 
     const submitButton = screen.getByRole("button", { name: /save changes/i });
@@ -385,7 +413,9 @@ describe("SettingsScreen", () => {
     expect(within(submitButton).getByTestId("button-spinner")).toHaveClass("animate-spin");
 
     resolveUpdate?.(makeProfileResponse());
-    await waitFor(() => expect(screen.getByRole("button", { name: /save changes/i })).toBeEnabled());
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /edit business profile/i })).toBeInTheDocument();
+    });
   });
 
   it("requires confirmation before signing out", async () => {
@@ -474,6 +504,9 @@ describe("SettingsScreen", () => {
       "max-w-full",
       "object-contain",
     );
+    expect(screen.queryByRole("button", { name: /remove/i })).not.toBeInTheDocument();
+    expect(screen.queryByLabelText(/upload logo/i)).not.toBeInTheDocument();
+    await openBusinessProfileEditMode();
     expect(screen.getByRole("button", { name: /remove/i })).toBeInTheDocument();
     expect(screen.getByLabelText(/upload logo/i)).toBeInTheDocument();
     expect(screen.queryByText(/upload new/i)).not.toBeInTheDocument();
@@ -516,6 +549,8 @@ describe("SettingsScreen", () => {
       screen.getByText(`JPEG or PNG, up to ${logoSizeLimitLabel}. Appears on quote PDFs.`),
     ).toBeInTheDocument();
     expect(within(previewTile).getByText("No logo")).toBeInTheDocument();
+    expect(screen.queryByLabelText(/upload logo/i)).not.toBeInTheDocument();
+    await openBusinessProfileEditMode();
     expect(screen.getByLabelText(/upload logo/i)).toBeInTheDocument();
     expect(screen.queryByText(/upload new/i)).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /remove/i })).not.toBeInTheDocument();
@@ -529,6 +564,7 @@ describe("SettingsScreen", () => {
 
     renderScreen();
 
+    await openBusinessProfileEditMode();
     const input = (await screen.findByLabelText(/upload logo/i)) as HTMLInputElement;
     const file = new File(["fake-logo"], "logo.png", { type: "image/png" });
     fireEvent.change(input, { target: { files: [file] } });
@@ -545,6 +581,7 @@ describe("SettingsScreen", () => {
 
     renderScreen();
 
+    await openBusinessProfileEditMode();
     const input = (await screen.findByLabelText(/upload logo/i)) as HTMLInputElement;
     const file = new File(["fake-logo"], "logo.png");
     fireEvent.change(input, { target: { files: [file] } });
@@ -561,6 +598,7 @@ describe("SettingsScreen", () => {
 
     renderScreen();
 
+    await openBusinessProfileEditMode();
     const input = (await screen.findByLabelText(/upload logo/i)) as HTMLInputElement;
     const file = new File(["fake-logo"], "logo.txt", { type: "text/plain" });
     fireEvent.change(input, { target: { files: [file] } });
@@ -574,6 +612,7 @@ describe("SettingsScreen", () => {
 
     renderScreen();
 
+    await openBusinessProfileEditMode();
     const input = (await screen.findByLabelText(/upload logo/i)) as HTMLInputElement;
     const file = new File(["fake-logo"], "logo.png", { type: "image/png" });
     Object.defineProperty(file, "size", { value: MAX_LOGO_SIZE_BYTES + 1 });
@@ -593,7 +632,8 @@ describe("SettingsScreen", () => {
 
     renderScreen();
 
-    fireEvent.click(await screen.findByRole("button", { name: /remove/i }));
+    await openBusinessProfileEditMode();
+    fireEvent.click(screen.getByRole("button", { name: /remove/i }));
 
     const dialog = await screen.findByRole("dialog");
     expect(within(dialog).getByText("Remove logo?")).toBeInTheDocument();
@@ -613,7 +653,8 @@ describe("SettingsScreen", () => {
 
     renderScreen();
 
-    fireEvent.click(await screen.findByRole("button", { name: /remove/i }));
+    await openBusinessProfileEditMode();
+    fireEvent.click(screen.getByRole("button", { name: /remove/i }));
     const dialog = await screen.findByRole("dialog");
     fireEvent.click(within(dialog).getByRole("button", { name: /^remove$/i }));
 
@@ -636,6 +677,7 @@ describe("SettingsScreen", () => {
 
     renderScreen();
 
+    await openBusinessProfileEditMode();
     const input = (await screen.findByLabelText(/upload logo/i)) as HTMLInputElement;
     const file = new File(["fake-logo"], "logo.png", { type: "image/png" });
     fireEvent.change(input, { target: { files: [file] } });
@@ -658,7 +700,8 @@ describe("SettingsScreen", () => {
     expect(screen.queryByLabelText(/business name/i)).not.toBeInTheDocument();
 
     resolveProfile?.(makeProfileResponse());
-    expect(await screen.findByLabelText(/business name/i)).toBeInTheDocument();
+    expect(await screen.findByRole("button", { name: /edit business profile/i })).toBeInTheDocument();
+    expect(screen.queryByLabelText(/business name/i)).not.toBeInTheDocument();
   });
 
   it("shows an error state when profile fetch fails and does not render the form", async () => {

--- a/frontend/src/features/settings/tests/SettingsScreen.test.tsx
+++ b/frontend/src/features/settings/tests/SettingsScreen.test.tsx
@@ -132,10 +132,9 @@ describe("SettingsScreen", () => {
     renderScreen();
 
     expect(await screen.findByText("Bright Lawn Care")).toBeInTheDocument();
-    expect(screen.getByText("Jordan")).toBeInTheDocument();
-    expect(screen.getByText("Hill")).toBeInTheDocument();
+    expect(screen.getByText("Jordan Hill")).toBeInTheDocument();
     expect(screen.getByText("Plumber")).toBeInTheDocument();
-    expect(screen.getByText("America/New_York")).toBeInTheDocument();
+    expect(screen.getByText(/America\/New_York/)).toBeInTheDocument();
     expect(screen.getByText("owner@example.com")).toBeInTheDocument();
     expect(screen.getByText("Email")).toHaveClass(
       "font-bold",
@@ -143,10 +142,6 @@ describe("SettingsScreen", () => {
       "tracking-[0.12em]",
       "text-outline",
     );
-    expect(screen.getByText("Stima")).toBeInTheDocument();
-    expect(
-      screen.getByText(`JPEG or PNG, up to ${logoSizeLimitLabel}. Appears on quote PDFs.`),
-    ).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /edit business profile/i })).toBeInTheDocument();
     expect(screen.queryByLabelText(/upload logo/i)).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /save changes/i })).not.toBeInTheDocument();
@@ -277,7 +272,7 @@ describe("SettingsScreen", () => {
 
     expect(screen.queryByLabelText(/business name/i)).not.toBeInTheDocument();
     expect(screen.getByText("Summit Exterior Care")).toBeInTheDocument();
-    expect(screen.getByText("Alex")).toBeInTheDocument();
+    expect(screen.getByText("Alex Stone")).toBeInTheDocument();
     expect(mockedProfileService.updateProfile).not.toHaveBeenCalled();
   });
 
@@ -461,7 +456,7 @@ describe("SettingsScreen", () => {
     await waitFor(() => expect(logout).toHaveBeenCalledTimes(1));
   });
 
-  it("renders logo preview and remove action when profile has a logo", async () => {
+  it("renders compact logo preview in display mode and full controls in edit mode", async () => {
     mockedProfileService.getProfile.mockResolvedValueOnce(
       makeProfileResponse({ has_logo: true }),
     );
@@ -469,88 +464,40 @@ describe("SettingsScreen", () => {
     renderScreen();
 
     expect(await screen.findByText("Business Profile")).toBeInTheDocument();
-    expect(screen.getByTestId("settings-logo-block")).toHaveClass(
-      "rounded-[var(--radius-document)]",
-      "bg-surface-container-low",
-      "p-4",
-    );
-    expect(screen.getByTestId("settings-logo-content-row")).toHaveClass(
-      "flex",
-      "flex-col",
-      "gap-3",
-      "min-[360px]:grid",
-      "min-[360px]:grid-cols-[128px_minmax(0,1fr)]",
-      "min-[360px]:items-start",
-      "min-[360px]:gap-4",
-    );
-    expect(screen.getByTestId("settings-logo-actions")).toHaveClass(
-      "flex",
-      "min-w-0",
-      "flex-col",
-      "gap-2",
-    );
-    const previewTile = await screen.findByTestId("settings-logo-preview-tile");
-    expect(previewTile).toHaveClass(
-      "h-[128px]",
-      "w-[128px]",
-      "rounded-[var(--radius-document)]",
-      "bg-surface-container-lowest",
-    );
-    expect(
-      screen.getByText(`JPEG or PNG, up to ${logoSizeLimitLabel}. Appears on quote PDFs.`),
-    ).toBeInTheDocument();
-    expect(await screen.findByAltText(/business logo preview/i)).toHaveClass(
-      "max-h-full",
-      "max-w-full",
+    expect(screen.queryByTestId("settings-logo-block")).not.toBeInTheDocument();
+    expect(await screen.findByAltText(/business logo/i)).toHaveClass(
+      "h-full",
+      "w-full",
       "object-contain",
     );
     expect(screen.queryByRole("button", { name: /remove/i })).not.toBeInTheDocument();
     expect(screen.queryByLabelText(/upload logo/i)).not.toBeInTheDocument();
     await openBusinessProfileEditMode();
-    expect(screen.getByRole("button", { name: /remove/i })).toBeInTheDocument();
-    expect(screen.getByLabelText(/upload logo/i)).toBeInTheDocument();
-    expect(screen.queryByText(/upload new/i)).not.toBeInTheDocument();
-  });
-
-  it("renders a fixed no-logo preview frame with the updated upload label", async () => {
-    mockedProfileService.getProfile.mockResolvedValueOnce(makeProfileResponse());
-
-    renderScreen();
-
-    expect(await screen.findByText("Business Profile")).toBeInTheDocument();
     expect(screen.getByTestId("settings-logo-block")).toHaveClass(
       "rounded-[var(--radius-document)]",
       "bg-surface-container-low",
       "p-4",
     );
-    expect(screen.getByTestId("settings-logo-content-row")).toHaveClass(
-      "flex",
-      "flex-col",
-      "gap-3",
-      "min-[360px]:grid",
-      "min-[360px]:grid-cols-[128px_minmax(0,1fr)]",
-      "min-[360px]:items-start",
-      "min-[360px]:gap-4",
-    );
-    expect(screen.getByTestId("settings-logo-actions")).toHaveClass(
-      "flex",
-      "min-w-0",
-      "flex-col",
-      "gap-2",
-    );
-    const previewTile = await screen.findByTestId("settings-logo-preview-tile");
-    expect(previewTile).toHaveClass(
-      "h-[128px]",
-      "w-[128px]",
-      "rounded-[var(--radius-document)]",
-      "bg-surface-container-lowest",
-    );
-    expect(
-      screen.getByText(`JPEG or PNG, up to ${logoSizeLimitLabel}. Appears on quote PDFs.`),
-    ).toBeInTheDocument();
-    expect(within(previewTile).getByText("No logo")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /remove/i })).toBeInTheDocument();
+    expect(screen.getByLabelText(/upload logo/i)).toBeInTheDocument();
+    expect(screen.queryByText(/upload new/i)).not.toBeInTheDocument();
+  });
+
+  it("shows a business icon placeholder in display mode and full upload controls in edit mode", async () => {
+    mockedProfileService.getProfile.mockResolvedValueOnce(makeProfileResponse());
+
+    renderScreen();
+
+    expect(await screen.findByText("Business Profile")).toBeInTheDocument();
+    expect(screen.queryByTestId("settings-logo-block")).not.toBeInTheDocument();
+    expect(screen.getByText("business")).toBeInTheDocument();
     expect(screen.queryByLabelText(/upload logo/i)).not.toBeInTheDocument();
     await openBusinessProfileEditMode();
+    expect(screen.getByTestId("settings-logo-block")).toHaveClass(
+      "rounded-[var(--radius-document)]",
+      "bg-surface-container-low",
+      "p-4",
+    );
     expect(screen.getByLabelText(/upload logo/i)).toBeInTheDocument();
     expect(screen.queryByText(/upload new/i)).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /remove/i })).not.toBeInTheDocument();

--- a/frontend/src/ui/Select.test.tsx
+++ b/frontend/src/ui/Select.test.tsx
@@ -14,6 +14,7 @@ describe("Select", () => {
 
     const select = screen.getByLabelText("Theme");
     expect(select).toHaveValue("light");
+    expect(select).toHaveClass("min-h-[var(--tap-target-min)]", "py-0");
     expect(select).toHaveAttribute("aria-describedby", "theme-hint");
     expect(screen.getByText("Choose your app theme")).toHaveAttribute("id", "theme-hint");
   });

--- a/frontend/src/ui/Select.tsx
+++ b/frontend/src/ui/Select.tsx
@@ -35,6 +35,7 @@ export function Select({
   const errorId = error ? `${accessibilityBaseId}-error` : undefined;
   const describedBy = [hintId, errorId].filter(Boolean).join(" ") || undefined;
   const hasError = invalid || Boolean(error);
+  const selectSizeClass = size === "md" ? "min-h-[var(--tap-target-min)]" : "min-h-9";
 
   const fieldClassName = [
     "relative rounded-[var(--radius-document)] bg-surface-container-high px-4 font-body text-sm text-on-surface transition-all",
@@ -69,7 +70,8 @@ export function Select({
           aria-invalid={hasError}
           aria-describedby={describedBy}
           className={[
-            "h-full w-full appearance-none bg-transparent py-2 pr-6 text-sm text-on-surface outline-none",
+            "w-full appearance-none bg-transparent py-0 pr-6 text-sm leading-normal text-on-surface outline-none",
+            selectSizeClass,
             className,
           ]
             .filter(Boolean)


### PR DESCRIPTION
## Summary
- make Business Profile display-first by default with a top-right Edit action
- add explicit edit-mode controls with Cancel/Save; cancel restores last saved values
- keep existing profile save and success-toast behavior
- keep logo preview visible in display mode; gate upload/remove actions to edit mode
- move business profile UI into a task-local component to keep file-size limits unblocked
- normalize shared Select value vertical alignment by setting explicit control min-height and zero vertical padding
- update Settings and Select tests for default display mode, edit toggle/revert behavior, and select field class contract

## Verification
- cd frontend && ./node_modules/.bin/vitest run src/ui/Select.test.tsx src/features/settings/tests/SettingsScreen.test.tsx
- make frontend-verify

Closes #590