### PR TITLE
Task #605: Force auth redirect on explicit missing/invalid token failures

### DIFF
--- a/frontend/src/features/auth/components/LoginForm.tsx
+++ b/frontend/src/features/auth/components/LoginForm.tsx
@@ -42,7 +42,16 @@ export function LoginForm(): React.ReactElement {
     try {
       await login({ email, password });
       const from = (location.state as LoginLocationState | undefined)?.from;
-      navigate(from?.pathname ?? "/", { replace: true });
+      navigate(
+        from
+          ? {
+            pathname: from.pathname,
+            search: from.search,
+            hash: from.hash,
+          }
+          : "/",
+        { replace: true },
+      );
     } catch (submitError) {
       const message = submitError instanceof Error ? submitError.message : "Login failed";
       setError(message);

--- a/frontend/src/features/auth/hooks/useAuth.ts
+++ b/frontend/src/features/auth/hooks/useAuth.ts
@@ -22,7 +22,7 @@ import type { AuthMode, LoginRequest, RegisterRequest, User } from "@/features/a
 import { clearDraftsForUser, deleteStaleLocalDrafts } from "@/features/quotes/offline/draftRepository";
 import { runOutboxPass } from "@/features/quotes/offline/outboxEngine";
 import { LoadingScreen } from "@/shared/components/LoadingScreen";
-import { hydrateCsrfTokenFromCookie } from "@/shared/lib/http";
+import { AUTH_FAILURE_EVENT, clearCsrfToken, hydrateCsrfTokenFromCookie } from "@/shared/lib/http";
 
 interface AuthContextValue {
   user: User | null;
@@ -53,6 +53,13 @@ export function AuthProvider({ children }: { children: React.ReactNode }): React
     });
   }, []);
 
+  const forceSignedOut = useCallback(() => {
+    clearCsrfToken();
+    clearOfflineUserSnapshot();
+    setUser(null);
+    setAuthMode("signed_out");
+  }, []);
+
   const refreshUser = useCallback(async () => {
     const currentUser = await authService.me();
     setVerifiedUser(currentUser);
@@ -80,9 +87,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }): React
         }
 
         if (isExplicitAuthFailure(bootstrapError)) {
-          clearOfflineUserSnapshot();
-          setUser(null);
-          setAuthMode("signed_out");
+          forceSignedOut();
           return;
         }
 
@@ -115,7 +120,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }): React
     return () => {
       active = false;
     };
-  }, [setVerifiedUser]);
+  }, [forceSignedOut, setVerifiedUser]);
 
   const reverifyOfflineRecoveredUser = useCallback(async () => {
     if (authMode !== "offline_recovered" || !user?.id) {
@@ -127,9 +132,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }): React
       await runOutboxPass(user.id, { forceAfterAuth: true });
     } catch (error) {
       if (isExplicitAuthFailure(error)) {
-        clearOfflineUserSnapshot();
-        setUser(null);
-        setAuthMode("signed_out");
+        forceSignedOut();
         return;
       }
 
@@ -139,7 +142,23 @@ export function AuthProvider({ children }: { children: React.ReactNode }): React
 
       console.warn("Unable to reverify offline-recovered auth state.", error);
     }
-  }, [authMode, refreshUser, user?.id]);
+  }, [authMode, forceSignedOut, refreshUser, user?.id]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    const handleAuthFailure = () => {
+      setIsLoading(false);
+      forceSignedOut();
+    };
+
+    window.addEventListener(AUTH_FAILURE_EVENT, handleAuthFailure);
+    return () => {
+      window.removeEventListener(AUTH_FAILURE_EVENT, handleAuthFailure);
+    };
+  }, [forceSignedOut]);
 
   useEffect(() => {
     if (typeof window === "undefined" || authMode !== "offline_recovered") {

--- a/frontend/src/features/auth/offline/authBootstrapErrors.ts
+++ b/frontend/src/features/auth/offline/authBootstrapErrors.ts
@@ -1,7 +1,45 @@
 import { isHttpRequestError } from "@/shared/lib/http";
 
+function isAuthErrorMessage(value: unknown): boolean {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    return false;
+  }
+
+  const normalized = value.toLowerCase();
+  return (
+    normalized.includes("csrf token missing")
+    || normalized.includes("missing csrf")
+    || normalized.includes("missing access token")
+    || normalized.includes("access token missing")
+    || normalized.includes("refresh token expired")
+    || normalized.includes("invalid refresh token")
+    || normalized.includes("invalid access token")
+    || normalized.includes("authentication required")
+    || normalized.includes("not authenticated")
+    || normalized.includes("unauthorized")
+    || normalized.includes("forbidden")
+  );
+}
+
 export function isExplicitAuthFailure(error: unknown): boolean {
-  return isHttpRequestError(error) && (error.status === 401 || error.status === 403);
+  if (!isHttpRequestError(error)) {
+    return false;
+  }
+
+  if (error.status === 401 || error.status === 403) {
+    return true;
+  }
+
+  if (isAuthErrorMessage(error.message)) {
+    return true;
+  }
+
+  if (error.payload && typeof error.payload === "object") {
+    const payload = error.payload as { detail?: unknown; message?: unknown };
+    return isAuthErrorMessage(payload.detail) || isAuthErrorMessage(payload.message);
+  }
+
+  return false;
 }
 
 export function isOfflineOrNetworkFailure(error: unknown): boolean {

--- a/frontend/src/features/auth/tests/App.routes.test.tsx
+++ b/frontend/src/features/auth/tests/App.routes.test.tsx
@@ -22,12 +22,14 @@ const mockedAuthService = vi.mocked(authService);
 interface RouteLocationState {
   from?: {
     pathname?: string;
+    search?: string;
   };
 }
 
 function LocationProbe(): React.ReactElement {
   const location = useLocation();
-  const fromPathname = (location.state as RouteLocationState | undefined)?.from?.pathname ?? "";
+  const from = (location.state as RouteLocationState | undefined)?.from;
+  const fromPathname = from ? `${from.pathname ?? ""}${from.search ?? ""}` : "";
 
   return (
     <>
@@ -177,11 +179,11 @@ describe("App routes", () => {
   it("preserves the protected route in login state so users return after sign-in", async () => {
     mockedAuthService.me.mockRejectedValueOnce(new Error("Not authenticated"));
 
-    renderApp("/settings");
+    renderApp("/settings?tab=drafts");
 
     expect(await screen.findByRole("heading", { name: /welcome back/i })).toBeInTheDocument();
     expect(screen.getByTestId("location-pathname")).toHaveTextContent("/login");
-    expect(screen.getByTestId("location-from-pathname")).toHaveTextContent("/settings");
+    expect(screen.getByTestId("location-from-pathname")).toHaveTextContent("/settings?tab=drafts");
   });
 
   it("routes retired quote line-item edit deep links to the default fallback", async () => {

--- a/frontend/src/features/auth/tests/LoginForm.test.tsx
+++ b/frontend/src/features/auth/tests/LoginForm.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { LoginForm } from "@/features/auth/components/LoginForm";
@@ -19,6 +19,11 @@ vi.mock("@/features/auth/services/authService", () => ({
 
 const mockedAuthService = vi.mocked(authService);
 
+function DashboardProbe(): React.ReactElement {
+  const location = useLocation();
+  return <div>{`Dashboard${location.search}`}</div>;
+}
+
 function renderLogin(initialEntry: string | { pathname: string; state?: unknown } = "/login") {
   return render(
     <MemoryRouter initialEntries={[initialEntry]}>
@@ -27,7 +32,7 @@ function renderLogin(initialEntry: string | { pathname: string; state?: unknown 
           <Routes>
             <Route path="/login" element={<LoginForm />} />
             <Route path="/" element={<div>Home</div>} />
-            <Route path="/dashboard" element={<div>Dashboard</div>} />
+            <Route path="/dashboard" element={<DashboardProbe />} />
           </Routes>
         </AuthProvider>
       </ToastProvider>
@@ -99,6 +104,33 @@ describe("LoginForm", () => {
     fireEvent.click(screen.getByRole("button", { name: /sign in/i }));
 
     expect(await screen.findByText("Dashboard")).toBeInTheDocument();
+  });
+
+  it("preserves query params when redirecting to state.from", async () => {
+    mockedAuthService.me.mockRejectedValueOnce(new Error("Not authenticated"));
+    mockedAuthService.login.mockResolvedValueOnce();
+    mockedAuthService.me.mockResolvedValueOnce({
+      id: "user-2",
+      email: "user@example.com",
+      is_active: true,
+      is_onboarded: true,
+      timezone: "America/New_York",
+    });
+
+    renderLogin({
+      pathname: "/login",
+      state: { from: { pathname: "/dashboard", search: "?tab=drafts" } },
+    });
+
+    fireEvent.change(await screen.findByLabelText(/email/i), {
+      target: { value: "user@example.com" },
+    });
+    fireEvent.change(await screen.findByLabelText(/^password$/i), {
+      target: { value: "super-secret" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /sign in/i }));
+
+    expect(await screen.findByText("Dashboard?tab=drafts")).toBeInTheDocument();
   });
 
   it("renders an alert when login fails", async () => {

--- a/frontend/src/features/auth/tests/useAuth.test.tsx
+++ b/frontend/src/features/auth/tests/useAuth.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { AuthProvider, useAuth } from "@/features/auth/hooks/useAuth";
@@ -10,7 +10,7 @@ import {
 import { authService } from "@/features/auth/services/authService";
 import { clearDraftsForUser, deleteStaleLocalDrafts } from "@/features/quotes/offline/draftRepository";
 import { runOutboxPass } from "@/features/quotes/offline/outboxEngine";
-import { HttpRequestError, hydrateCsrfTokenFromCookie } from "@/shared/lib/http";
+import { AUTH_FAILURE_EVENT, HttpRequestError, hydrateCsrfTokenFromCookie } from "@/shared/lib/http";
 
 vi.mock("@/features/auth/services/authService", () => ({
   authService: {
@@ -56,7 +56,7 @@ const mockedRunOutboxPass = vi.mocked(runOutboxPass);
 const ORIGINAL_NAVIGATOR_ONLINE_DESCRIPTOR = Object.getOwnPropertyDescriptor(window.navigator, "onLine");
 
 function AuthHarness(): React.ReactElement {
-  const { authMode, user, register, logout } = useAuth();
+  const { authMode, user, refreshUser, register, logout } = useAuth();
 
   return (
     <div>
@@ -73,6 +73,9 @@ function AuthHarness(): React.ReactElement {
         }
       >
         Register
+      </button>
+      <button type="button" onClick={() => void refreshUser()}>
+        Refresh
       </button>
       <button type="button" onClick={() => void logout()}>
         Logout
@@ -197,6 +200,31 @@ describe("useAuth", () => {
     expect(mockedReadOfflineUserSnapshot).not.toHaveBeenCalled();
   });
 
+  it("treats missing access-token errors as explicit auth failures", async () => {
+    mockedAuthService.me.mockRejectedValueOnce(
+      new HttpRequestError("Missing access token", 400, { detail: "Missing access token" }),
+    );
+    mockedReadOfflineUserSnapshot.mockReturnValue({
+      userId: "user-stale",
+      isOnboarded: true,
+      timezone: "UTC",
+      lastVerifiedAt: new Date().toISOString(),
+    });
+
+    render(
+      <AuthProvider>
+        <AuthHarness />
+      </AuthProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("auth-state")).toHaveTextContent("none");
+    });
+    expect(screen.getByTestId("auth-mode")).toHaveTextContent("signed_out");
+    expect(mockedClearOfflineUserSnapshot).toHaveBeenCalledTimes(1);
+    expect(mockedReadOfflineUserSnapshot).not.toHaveBeenCalled();
+  });
+
   it("restores offline snapshot for failed-fetch bootstrap failures", async () => {
     mockedAuthService.me.mockRejectedValueOnce(new TypeError("Failed to fetch"));
     mockedReadOfflineUserSnapshot.mockReturnValue({
@@ -298,6 +326,35 @@ describe("useAuth", () => {
       expect(screen.getByTestId("auth-state")).toHaveTextContent("user9@example.com");
       expect(mockedRunOutboxPass).toHaveBeenCalledWith("user-9", { forceAfterAuth: true });
     });
+  });
+
+  it("forces signed_out when explicit auth-failure event is broadcast", async () => {
+    mockedAuthService.me.mockResolvedValueOnce({
+      id: "user-1",
+      email: "user@example.com",
+      is_active: true,
+      is_onboarded: true,
+      timezone: "America/New_York",
+    });
+
+    render(
+      <AuthProvider>
+        <AuthHarness />
+      </AuthProvider>,
+    );
+
+    expect(await screen.findByText("user@example.com")).toBeInTheDocument();
+    expect(screen.getByTestId("auth-mode")).toHaveTextContent("verified");
+
+    act(() => {
+      window.dispatchEvent(new CustomEvent(AUTH_FAILURE_EVENT));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("auth-state")).toHaveTextContent("none");
+      expect(screen.getByTestId("auth-mode")).toHaveTextContent("signed_out");
+    });
+    expect(mockedClearOfflineUserSnapshot).toHaveBeenCalled();
   });
 
   it("throws when used outside AuthProvider", () => {

--- a/frontend/src/shared/lib/http.test.ts
+++ b/frontend/src/shared/lib/http.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { User } from "@/features/auth/types/auth.types";
 import { captureException } from "@/sentry";
 import {
+  AUTH_FAILURE_EVENT,
   clearCsrfToken,
   request,
   requestBlob,
@@ -135,6 +136,25 @@ describe("http request helper", () => {
       (call) => call[0] === "/api/auth/refresh",
     );
     expect(refreshCalls).toHaveLength(1);
+  });
+
+  it("emits one explicit-auth-failure signal for parallel auth failures", async () => {
+    const fetchMock = vi.mocked(fetch);
+    const onAuthFailure = vi.fn();
+    window.addEventListener(AUTH_FAILURE_EVENT, onAuthFailure);
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse({ detail: "CSRF token missing" }, 403))
+      .mockResolvedValueOnce(jsonResponse({ detail: "Missing access token" }, 401));
+
+    await Promise.allSettled([
+      request("/api/quotes", { method: "POST", body: { name: "one" }, skipRefresh: true }),
+      request("/api/quotes", { method: "POST", body: { name: "two" }, skipRefresh: true }),
+    ]);
+
+    await Promise.resolve();
+
+    expect(onAuthFailure).toHaveBeenCalledTimes(1);
+    window.removeEventListener(AUTH_FAILURE_EVENT, onAuthFailure);
   });
 
   it("uses the rotated CSRF token from refresh on the replayed request", async () => {

--- a/frontend/src/shared/lib/http.ts
+++ b/frontend/src/shared/lib/http.ts
@@ -4,9 +4,25 @@ import { captureException } from "@/sentry";
 const MUTATING_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
 const API_BASE = import.meta.env.VITE_API_URL ?? "";
 const CSRF_COOKIE_NAME = "stima_csrf_token";
+const AUTH_ERROR_MESSAGE_SNIPPETS = [
+  "csrf token missing",
+  "missing csrf",
+  "missing access token",
+  "access token missing",
+  "refresh token expired",
+  "invalid refresh token",
+  "invalid access token",
+  "authentication required",
+  "not authenticated",
+  "unauthorized",
+  "forbidden",
+] as const;
 
 let csrfToken: string | null = null;
 let refreshInFlight: Promise<void> | null = null;
+let authFailureDispatchQueued = false;
+
+export const AUTH_FAILURE_EVENT = "stima:auth-failure";
 
 export function setCsrfToken(token: string): void {
   csrfToken = token;
@@ -150,6 +166,35 @@ function getErrorMessage(payload: unknown, fallback: string): string {
   return fallback;
 }
 
+function shouldSignalAuthFailure(status: number, message: string): boolean {
+  if (status === 401 || status === 403) {
+    return true;
+  }
+
+  const normalizedMessage = message.toLowerCase();
+  return AUTH_ERROR_MESSAGE_SNIPPETS.some((snippet) => normalizedMessage.includes(snippet));
+}
+
+function signalExplicitAuthFailure(status: number, message: string): void {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  if (!shouldSignalAuthFailure(status, message)) {
+    return;
+  }
+
+  if (authFailureDispatchQueued) {
+    return;
+  }
+
+  authFailureDispatchQueued = true;
+  queueMicrotask(() => {
+    authFailureDispatchQueued = false;
+    window.dispatchEvent(new CustomEvent(AUTH_FAILURE_EVENT));
+  });
+}
+
 async function requestRefresh(): Promise<void> {
   if (!refreshInFlight) {
     refreshInFlight = (async () => {
@@ -219,7 +264,14 @@ async function requestWithParser<T>(
   }
 
   if (response.status === 401 && !options.skipRefresh && url !== "/api/auth/refresh") {
-    await requestRefresh();
+    try {
+      await requestRefresh();
+    } catch (refreshError) {
+      if (isHttpRequestError(refreshError)) {
+        signalExplicitAuthFailure(refreshError.status, refreshError.message);
+      }
+      throw refreshError;
+    }
 
     return requestWithParser(url, {
       ...options,
@@ -236,6 +288,7 @@ async function requestWithParser<T>(
       response.status,
       payload,
     );
+    signalExplicitAuthFailure(error.status, error.message);
     if (response.status >= 500) {
       captureException(error);
     }


### PR DESCRIPTION
## Summary
- emit a global explicit-auth-failure signal from shared HTTP request handling on missing/invalid token paths (401/403 and explicit token-auth error messages)
- have `AuthProvider` consume that signal and force immediate `signed_out` state, clearing stale session/user state so protected routes redirect to `/login`
- preserve full `from` location (pathname + query + hash) after login redirect so return navigation keeps query params
- broaden explicit auth-failure classifier for bootstrap/reverify flows to include missing csrf/access-token and expired/invalid token message variants
- add regression tests for event-driven sign-out, missing-access-token classification, query-preserving return routing, and single auth-failure signal on parallel failures

## Verification
- `cd frontend && rtk vitest run src/features/auth/tests/useAuth.test.tsx src/features/auth/tests/App.routes.test.tsx src/features/quotes/tests/QuoteList.test.tsx src/features/auth/tests/LoginForm.test.tsx src/shared/lib/http.test.ts`
- `rtk make frontend-verify`

Closes #605