### PR TITLE
Task #607: Show session-expired flash message on forced auth redirect

### DIFF
--- a/frontend/src/features/auth/components/LoginForm.tsx
+++ b/frontend/src/features/auth/components/LoginForm.tsx
@@ -3,6 +3,10 @@ import { Link, useLocation, useNavigate } from "react-router-dom";
 import type { Location } from "react-router-dom";
 
 import { useAuth } from "@/features/auth/hooks/useAuth";
+import {
+  AUTH_SESSION_EXPIRED_FLASH_KEY,
+  AUTH_SESSION_EXPIRED_FLASH_MESSAGE,
+} from "@/features/auth/sessionFlash";
 import { Button } from "@/shared/components/Button";
 import { Input } from "@/shared/components/Input";
 import { PasswordField } from "@/ui/PasswordField";
@@ -22,9 +26,22 @@ export function LoginForm(): React.ReactElement {
   const [password, setPassword] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [sessionExpiredMessage, setSessionExpiredMessage] = useState<string | null>(null);
   const [flashMessage, setFlashMessage] = useState(
     (location.state as LoginLocationState | undefined)?.flashMessage ?? null,
   );
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    const sessionExpiredSignal = window.sessionStorage.getItem(AUTH_SESSION_EXPIRED_FLASH_KEY);
+    if (sessionExpiredSignal) {
+      setSessionExpiredMessage(AUTH_SESSION_EXPIRED_FLASH_MESSAGE);
+      window.sessionStorage.removeItem(AUTH_SESSION_EXPIRED_FLASH_KEY);
+    }
+  }, []);
 
   useEffect(() => {
     if (!flashMessage) {
@@ -66,6 +83,11 @@ export function LoginForm(): React.ReactElement {
       <section className="w-full max-w-sm rounded-[var(--radius-document)] bg-surface-container-lowest p-6 ghost-shadow">
         <h2 className="mb-6 font-headline text-2xl font-bold text-on-surface">Welcome Back</h2>
         <form className="flex flex-col gap-4" onSubmit={onSubmit}>
+          {sessionExpiredMessage ? (
+            <div className="rounded-[var(--radius-document)] border-l-4 border-secondary bg-secondary-container p-4">
+              <p className="text-sm font-medium text-on-secondary-container">{sessionExpiredMessage}</p>
+            </div>
+          ) : null}
           <Input
             id="email"
             label="Email"

--- a/frontend/src/features/auth/hooks/useAuth.ts
+++ b/frontend/src/features/auth/hooks/useAuth.ts
@@ -18,6 +18,7 @@ import {
   writeOfflineUserSnapshot,
 } from "@/features/auth/offline/offlineUserSnapshot";
 import { authService } from "@/features/auth/services/authService";
+import { AUTH_SESSION_EXPIRED_FLASH_KEY } from "@/features/auth/sessionFlash";
 import type { AuthMode, LoginRequest, RegisterRequest, User } from "@/features/auth/types/auth.types";
 import { clearDraftsForUser, deleteStaleLocalDrafts } from "@/features/quotes/offline/draftRepository";
 import { runOutboxPass } from "@/features/quotes/offline/outboxEngine";
@@ -150,6 +151,9 @@ export function AuthProvider({ children }: { children: React.ReactNode }): React
     }
 
     const handleAuthFailure = () => {
+      if (typeof window !== "undefined") {
+        window.sessionStorage.setItem(AUTH_SESSION_EXPIRED_FLASH_KEY, "1");
+      }
       setIsLoading(false);
       forceSignedOut();
     };

--- a/frontend/src/features/auth/sessionFlash.ts
+++ b/frontend/src/features/auth/sessionFlash.ts
@@ -1,0 +1,2 @@
+export const AUTH_SESSION_EXPIRED_FLASH_KEY = "stima:auth-session-expired-flash";
+export const AUTH_SESSION_EXPIRED_FLASH_MESSAGE = "Your session expired. Please sign in again.";

--- a/frontend/src/features/auth/tests/LoginForm.test.tsx
+++ b/frontend/src/features/auth/tests/LoginForm.test.tsx
@@ -5,6 +5,10 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { LoginForm } from "@/features/auth/components/LoginForm";
 import { AuthProvider } from "@/features/auth/hooks/useAuth";
 import { authService } from "@/features/auth/services/authService";
+import {
+  AUTH_SESSION_EXPIRED_FLASH_KEY,
+  AUTH_SESSION_EXPIRED_FLASH_MESSAGE,
+} from "@/features/auth/sessionFlash";
 import { clearCsrfToken } from "@/shared/lib/http";
 import { ToastProvider } from "@/ui/Toast";
 
@@ -43,6 +47,7 @@ function renderLogin(initialEntry: string | { pathname: string; state?: unknown 
 afterEach(() => {
   vi.clearAllMocks();
   clearCsrfToken();
+  window.sessionStorage.clear();
 });
 
 describe("LoginForm", () => {
@@ -168,6 +173,49 @@ describe("LoginForm", () => {
       state: { flashMessage: "Password reset successful. Please sign in." },
     });
 
+    expect(
+      await screen.findByText("Password reset successful. Please sign in."),
+    ).toBeInTheDocument();
+  });
+
+  it("shows inline session-expired banner when auth-failure flash key is present", async () => {
+    mockedAuthService.me.mockRejectedValueOnce(new Error("Not authenticated"));
+    window.sessionStorage.setItem(AUTH_SESSION_EXPIRED_FLASH_KEY, "1");
+
+    renderLogin();
+
+    expect(await screen.findByText(AUTH_SESSION_EXPIRED_FLASH_MESSAGE)).toBeInTheDocument();
+  });
+
+  it("clears session-expired flash key after showing the inline banner", async () => {
+    mockedAuthService.me.mockRejectedValueOnce(new Error("Not authenticated"));
+    window.sessionStorage.setItem(AUTH_SESSION_EXPIRED_FLASH_KEY, "1");
+
+    renderLogin();
+
+    await screen.findByText(AUTH_SESSION_EXPIRED_FLASH_MESSAGE);
+    expect(window.sessionStorage.getItem(AUTH_SESSION_EXPIRED_FLASH_KEY)).toBeNull();
+  });
+
+  it("does not show session-expired banner for manual navigation to login", async () => {
+    mockedAuthService.me.mockRejectedValueOnce(new Error("Not authenticated"));
+
+    renderLogin();
+
+    await screen.findByRole("main");
+    expect(screen.queryByText(AUTH_SESSION_EXPIRED_FLASH_MESSAGE)).not.toBeInTheDocument();
+  });
+
+  it("keeps flashMessage toast behavior when session-expired banner also exists", async () => {
+    mockedAuthService.me.mockRejectedValueOnce(new Error("Not authenticated"));
+    window.sessionStorage.setItem(AUTH_SESSION_EXPIRED_FLASH_KEY, "1");
+
+    renderLogin({
+      pathname: "/login",
+      state: { flashMessage: "Password reset successful. Please sign in." },
+    });
+
+    expect(await screen.findByText(AUTH_SESSION_EXPIRED_FLASH_MESSAGE)).toBeInTheDocument();
     expect(
       await screen.findByText("Password reset successful. Please sign in."),
     ).toBeInTheDocument();

--- a/frontend/src/features/auth/tests/useAuth.test.tsx
+++ b/frontend/src/features/auth/tests/useAuth.test.tsx
@@ -8,6 +8,7 @@ import {
   writeOfflineUserSnapshot,
 } from "@/features/auth/offline/offlineUserSnapshot";
 import { authService } from "@/features/auth/services/authService";
+import { AUTH_SESSION_EXPIRED_FLASH_KEY } from "@/features/auth/sessionFlash";
 import { clearDraftsForUser, deleteStaleLocalDrafts } from "@/features/quotes/offline/draftRepository";
 import { runOutboxPass } from "@/features/quotes/offline/outboxEngine";
 import { AUTH_FAILURE_EVENT, HttpRequestError, hydrateCsrfTokenFromCookie } from "@/shared/lib/http";
@@ -97,6 +98,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  window.sessionStorage.clear();
   if (ORIGINAL_NAVIGATOR_ONLINE_DESCRIPTOR) {
     Object.defineProperty(window.navigator, "onLine", ORIGINAL_NAVIGATOR_ONLINE_DESCRIPTOR);
     return;
@@ -354,7 +356,33 @@ describe("useAuth", () => {
       expect(screen.getByTestId("auth-state")).toHaveTextContent("none");
       expect(screen.getByTestId("auth-mode")).toHaveTextContent("signed_out");
     });
+    expect(window.sessionStorage.getItem(AUTH_SESSION_EXPIRED_FLASH_KEY)).toBe("1");
     expect(mockedClearOfflineUserSnapshot).toHaveBeenCalled();
+  });
+
+  it("does not set session-expired flash key on manual logout", async () => {
+    mockedAuthService.me.mockResolvedValueOnce({
+      id: "user-2",
+      email: "user@example.com",
+      is_active: true,
+      is_onboarded: true,
+      timezone: "America/New_York",
+    });
+    mockedAuthService.logout.mockResolvedValueOnce();
+
+    render(
+      <AuthProvider>
+        <AuthHarness />
+      </AuthProvider>,
+    );
+
+    expect(await screen.findByText("user@example.com")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Logout" }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("auth-mode")).toHaveTextContent("signed_out");
+    });
+    expect(window.sessionStorage.getItem(AUTH_SESSION_EXPIRED_FLASH_KEY)).toBeNull();
   });
 
   it("throws when used outside AuthProvider", () => {


### PR DESCRIPTION
## Summary
- set a one-time `sessionStorage` flash signal in `AuthProvider` only when `AUTH_FAILURE_EVENT` forces sign-out
- add a login-page inline info banner for expired session (`Your session expired. Please sign in again.`), read-once and cleared immediately
- keep existing `flashMessage` toast flows intact, including coexistence with the new inline banner
- keep manual logout and offline/network paths unchanged (no session-expired flash signal)

## Verification
- `cd frontend && rtk vitest run src/features/auth/tests/LoginForm.test.tsx src/features/auth/tests/useAuth.test.tsx`
- `rtk make frontend-verify`

Closes #607
