### PR TITLE
Task #392 follow-up: icon sizing pass

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -37,10 +37,6 @@
       href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@300;400;500;600;700&family=Inter:wght@300;400;500;600;700&display=swap"
       rel="stylesheet"
     />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap"
-      rel="stylesheet"
-    />
     <title>Stima</title>
   </head>
   <body>

--- a/frontend/src/features/customers/components/CustomerListScreen.tsx
+++ b/frontend/src/features/customers/components/CustomerListScreen.tsx
@@ -8,6 +8,7 @@ import { FeedbackMessage } from "@/shared/components/FeedbackMessage";
 import { Input } from "@/shared/components/Input";
 import { ScreenHeader } from "@/shared/components/ScreenHeader";
 import { EmptyState } from "@/ui/EmptyState";
+import { AppIcon } from "@/ui/Icon";
 import { useToast } from "@/ui/Toast";
 
 interface CustomerListLocationState {
@@ -128,7 +129,7 @@ export function CustomerListScreen(): React.ReactElement {
                       <p className="font-bold text-on-surface">{customer.name}</p>
                       <p className="text-sm text-on-surface-variant">{contactLine(customer)}</p>
                     </div>
-                    <span className="material-symbols-outlined text-outline">chevron_right</span>
+                    <AppIcon name="chevron_right" className="text-outline" />
                   </button>
                 </li>
               ))}
@@ -155,7 +156,7 @@ export function CustomerListScreen(): React.ReactElement {
         className="fixed right-4 bottom-20 z-50 flex h-14 w-14 cursor-pointer items-center justify-center rounded-full forest-gradient text-on-primary ghost-shadow transition-all active:scale-95"
         onClick={() => navigate("/customers/new")}
       >
-        <span className="material-symbols-outlined">person_add</span>
+        <AppIcon name="person_add" />
       </button>
 
       <BottomNav active="customers" />

--- a/frontend/src/features/customers/tests/CustomerDetailScreen.test.tsx
+++ b/frontend/src/features/customers/tests/CustomerDetailScreen.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -108,7 +108,8 @@ async function openEditForm(): Promise<void> {
 
 async function switchToInvoicesTab(): Promise<void> {
   await screen.findByRole("heading", { level: 1, name: "Alice Johnson" });
-  fireEvent.click(screen.getByRole("button", { name: "Invoices" }));
+  const modeButtons = screen.getAllByRole("button", { name: "Invoices" });
+  fireEvent.click(modeButtons[0]);
 }
 
 async function openDeleteCustomerModal(): Promise<void> {
@@ -206,11 +207,11 @@ describe("CustomerDetailScreen", () => {
     expect(
       screen.queryByRole("button", { name: /^delete customer$/i }),
     ).not.toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Quotes" })).toHaveAttribute(
+    expect(screen.getAllByRole("button", { name: "Quotes" })[0]).toHaveAttribute(
       "aria-pressed",
       "true",
     );
-    expect(screen.getByRole("button", { name: "Invoices" })).toHaveAttribute(
+    expect(screen.getAllByRole("button", { name: "Invoices" })[0]).toHaveAttribute(
       "aria-pressed",
       "false",
     );
@@ -434,11 +435,11 @@ describe("CustomerDetailScreen", () => {
     await switchToInvoicesTab();
 
     expect(await screen.findByText("I-001")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Invoices" })).toHaveAttribute(
+    expect(screen.getAllByRole("button", { name: "Invoices" })[0]).toHaveAttribute(
       "aria-pressed",
       "true",
     );
-    expect(screen.getByRole("button", { name: "Quotes" })).toHaveAttribute(
+    expect(screen.getAllByRole("button", { name: "Quotes" })[0]).toHaveAttribute(
       "aria-pressed",
       "false",
     );
@@ -459,8 +460,8 @@ describe("CustomerDetailScreen", () => {
     await switchToInvoicesTab();
 
     expect(await screen.findByText("No invoices yet.")).toBeInTheDocument();
-    const icons = screen.getAllByText("description");
-    expect(icons.some((icon) => icon.classList.contains("text-3xl"))).toBe(true);
+    const emptyState = screen.getByText("No invoices yet.").closest("section");
+    expect(emptyState?.querySelector("svg.text-3xl")).toBeInTheDocument();
   });
 
   it("renders invoice history error state without hiding the customer details", async () => {
@@ -500,17 +501,16 @@ describe("CustomerDetailScreen", () => {
     renderScreen();
 
     expect(await screen.findByText("No quotes yet.")).toBeInTheDocument();
-    const icons = screen.getAllByText("description");
-    expect(icons.some((icon) => icon.classList.contains("text-3xl"))).toBe(true);
+    const emptyState = screen.getByText("No quotes yet.").closest("section");
+    expect(emptyState?.querySelector("svg.text-3xl")).toBeInTheDocument();
   });
 
   it("renders BottomNav with customers tab active", async () => {
     renderScreen();
     await screen.findByText("Q-001");
 
-    expect(
-      screen.getByRole("button", { name: /group customers/i }),
-    ).toHaveClass("text-primary");
+    const nav = screen.getByRole("navigation");
+    expect(within(nav).getByRole("button", { name: "Customers" })).toHaveClass("text-primary");
   });
 
   it("requires exact typed confirmation before enabling customer deletion", async () => {

--- a/frontend/src/features/customers/tests/CustomerListScreen.test.tsx
+++ b/frontend/src/features/customers/tests/CustomerListScreen.test.tsx
@@ -115,8 +115,8 @@ describe("CustomerListScreen", () => {
     renderScreen();
 
     expect(await screen.findByText("No customers yet.")).toBeInTheDocument();
-    const icons = screen.getAllByText("group");
-    expect(icons.some((icon) => icon.classList.contains("text-3xl"))).toBe(true);
+    const emptyState = screen.getByText("No customers yet.").closest("section");
+    expect(emptyState?.querySelector("svg.text-3xl")).toBeInTheDocument();
   });
 
   it("renders the search-empty icon with the compact token size", async () => {
@@ -130,8 +130,8 @@ describe("CustomerListScreen", () => {
     });
 
     expect(await screen.findByText("No customers match your search.")).toBeInTheDocument();
-    const icons = screen.getAllByText("group");
-    expect(icons.some((icon) => icon.classList.contains("text-3xl"))).toBe(true);
+    const emptyState = screen.getByText("No customers match your search.").closest("section");
+    expect(emptyState?.querySelector("svg.text-3xl")).toBeInTheDocument();
   });
 
   it("navigates to customer detail when a row is clicked", async () => {

--- a/frontend/src/features/customers/tests/QuoteHistoryList.test.tsx
+++ b/frontend/src/features/customers/tests/QuoteHistoryList.test.tsx
@@ -74,10 +74,10 @@ describe("QuoteHistoryList", () => {
   });
 
   it("renders the empty state when no quotes exist", () => {
-    render(<QuoteHistoryList quotes={[]} onQuoteClick={vi.fn()} timezone="UTC" />);
+    const { container } = render(<QuoteHistoryList quotes={[]} onQuoteClick={vi.fn()} timezone="UTC" />);
 
     expect(screen.getByText("No quotes yet.")).toBeInTheDocument();
-    expect(screen.getByText("description")).toHaveClass("material-symbols-outlined");
+    expect(container.querySelector("svg")).toBeInTheDocument();
   });
 
   it("renders dates using the provided timezone", () => {

--- a/frontend/src/features/invoices/components/InvoiceDetailScreen.tsx
+++ b/frontend/src/features/invoices/components/InvoiceDetailScreen.tsx
@@ -22,6 +22,7 @@ import { OverflowMenu } from "@/shared/components/OverflowMenu";
 import { ScreenHeader } from "@/shared/components/ScreenHeader";
 import { DocumentHeroCard } from "@/ui/DocumentHeroCard";
 import { Eyebrow } from "@/ui/Eyebrow";
+import { AppIcon } from "@/ui/Icon";
 import { canNavigateBack } from "@/shared/lib/navigation";
 import { useToast } from "@/ui/Toast";
 
@@ -138,7 +139,7 @@ export function InvoiceDetailScreen(): React.ReactElement {
                 aria-label="Edit invoice"
                 className="border border-outline-variant/30 bg-surface-container-lowest text-on-surface ghost-shadow"
               >
-                <span className="material-symbols-outlined block text-[1.125rem] leading-none">edit</span>
+                <AppIcon name="edit" className="block text-[1.125rem] leading-none" />
               </Button>
             ) : null}
             <OverflowMenu items={overflowItems} />
@@ -203,7 +204,7 @@ export function InvoiceDetailScreen(): React.ReactElement {
                   rel="noopener noreferrer"
                   className={documentActionPrimaryLinkClassName}
                 >
-                  <span className="material-symbols-outlined text-base leading-none">open_in_new</span>
+                  <AppIcon name="open_in_new" className="text-base leading-none" />
                   Open PDF
                 </a>
               ) : (
@@ -217,11 +218,7 @@ export function InvoiceDetailScreen(): React.ReactElement {
                     void onGeneratePdf();
                   }}
                   isLoading={isPdfBusy}
-                  leadingIcon={(
-                    <span className="material-symbols-outlined text-base leading-none">
-                      picture_as_pdf
-                    </span>
-                  )}
+                  leadingIcon={<AppIcon name="picture_as_pdf" className="text-base leading-none" />}
                 >
                   Generate PDF
                 </Button>
@@ -236,7 +233,7 @@ export function InvoiceDetailScreen(): React.ReactElement {
                       className="w-full"
                       disabled={!hasCustomerEmail || isBusy}
                       isLoading={isSendingEmail}
-                      leadingIcon={<span className="material-symbols-outlined text-base leading-none">mail</span>}
+                      leadingIcon={<AppIcon name="mail" className="text-base leading-none" />}
                       onClick={() => onRequestSendEmail({ emailActionLabel, hasCustomerEmail, isPdfBusy })}
                     >
                       {emailActionLabel}
@@ -249,11 +246,7 @@ export function InvoiceDetailScreen(): React.ReactElement {
                     size="lg"
                     className="w-full"
                     disabled={isBusy}
-                    leadingIcon={(
-                      <span className="material-symbols-outlined text-base leading-none">
-                        content_copy
-                      </span>
-                    )}
+                    leadingIcon={<AppIcon name="content_copy" className="text-base leading-none" />}
                     onClick={() => {
                       void onCopyLink();
                     }}

--- a/frontend/src/features/public/components/PublicQuotePage.tsx
+++ b/frontend/src/features/public/components/PublicQuotePage.tsx
@@ -10,6 +10,7 @@ import { PricingRow } from "@/shared/components/PricingRow";
 import { formatCurrency } from "@/shared/lib/formatters";
 import { calculatePricingFromPersisted, resolveLineItemSum } from "@/shared/lib/pricing";
 import { Eyebrow } from "@/ui/Eyebrow";
+import { AppIcon } from "@/ui/Icon";
 import { StatusPill, type StatusPillVariant } from "@/ui/StatusPill";
 
 type LoadState = "loading" | "ready" | "invalid" | "error";
@@ -237,9 +238,7 @@ export function PublicQuotePage(): React.ReactElement {
             {banner ? (
               <div className={`flex flex-wrap items-center justify-between gap-3 rounded-[var(--radius-document)] px-4 py-3 text-sm font-medium ${banner.className}`}>
                 <div className="flex min-w-0 items-center gap-2">
-                  <span aria-hidden="true" className="material-symbols-outlined text-[1.125rem] leading-none">
-                    {banner.icon}
-                  </span>
+                  <AppIcon name={banner.icon} className="text-[1.125rem] leading-none" />
                   <p>{banner.title}</p>
                 </div>
                 <StatusPill variant={banner.pillVariant} />

--- a/frontend/src/features/quotes/components/CaptureInputPanel.tsx
+++ b/frontend/src/features/quotes/components/CaptureInputPanel.tsx
@@ -3,6 +3,7 @@ import type { VoiceClip } from "@/features/quotes/hooks/useVoiceCapture";
 import { NOTE_INPUT_MAX_CHARS } from "@/shared/lib/inputLimits";
 import { Button } from "@/shared/components/Button";
 import { Eyebrow } from "@/ui/Eyebrow";
+import { AppIcon } from "@/ui/Icon";
 
 interface CaptureInputPanelProps {
   clips: VoiceClip[];
@@ -47,9 +48,7 @@ export function CaptureInputPanel({
 
         {clips.length === 0 ? (
           <div className="ghost-shadow flex h-28 flex-col items-center justify-center gap-2 rounded-[var(--radius-document)] border-2 border-dashed border-outline-variant/30 bg-surface-container-lowest p-4">
-            <span className="material-symbols-outlined text-4xl text-outline">
-              mic_off
-            </span>
+            <AppIcon name="mic_off" className="text-4xl text-outline" />
             <p className="text-sm text-outline">No clips recorded yet</p>
           </div>
         ) : (
@@ -65,9 +64,7 @@ export function CaptureInputPanel({
                   className="ghost-shadow flex items-center justify-between rounded-[var(--radius-document)] border border-outline-variant/20 bg-surface-container-lowest p-3"
                 >
                   <div className="flex items-center gap-3">
-                    <span className="material-symbols-outlined text-outline">
-                      play_arrow
-                    </span>
+                    <AppIcon name="play_arrow" className="text-outline" />
                     <p className="text-sm text-on-surface">
                       Clip {clipNumber} · {clip.durationSeconds}s
                     </p>
@@ -81,9 +78,7 @@ export function CaptureInputPanel({
                     onClick={() => removeClip(clip.id)}
                     disabled={isExtracting}
                   >
-                    <span className="material-symbols-outlined text-base">
-                      close
-                    </span>
+                    <AppIcon name="close" className="text-base" />
                   </Button>
                 </div>
               );
@@ -132,10 +127,11 @@ export function CaptureInputPanel({
           </div>
           <button
             type="button"
+            aria-label="Stop recording"
             className="ghost-shadow flex h-20 w-20 cursor-pointer items-center justify-center rounded-full bg-secondary text-on-secondary transition-all active:scale-95"
             onClick={onStopRecording}
           >
-            <span className="material-symbols-outlined text-4xl">stop</span>
+            <AppIcon name="stop" className="text-4xl" />
           </button>
         </div>
       ) : (
@@ -148,11 +144,12 @@ export function CaptureInputPanel({
           ) : null}
           <button
             type="button"
+            aria-label="Start recording"
             className="forest-gradient ghost-shadow flex h-20 w-20 cursor-pointer items-center justify-center rounded-full text-on-primary transition-all active:scale-95 disabled:cursor-not-allowed disabled:opacity-60"
             onClick={onStartRecording}
             disabled={!isSupported || hasReachedClipLimit}
           >
-            <span className="material-symbols-outlined text-4xl">mic</span>
+            <AppIcon name="mic" className="text-4xl" />
           </button>
         </div>
       )}

--- a/frontend/src/features/quotes/components/DocumentEditScreenView.tsx
+++ b/frontend/src/features/quotes/components/DocumentEditScreenView.tsx
@@ -12,6 +12,7 @@ import { hasUndismissedCaptureDetailsItems, resolveCaptureDetailsActionableItems
 import type { LineItemCatalogItem } from "@/features/line-item-catalog/types/lineItemCatalog.types";
 import { Button } from "@/shared/components/Button";
 import { WorkflowScreenHeader } from "@/shared/components/WorkflowScreenHeader";
+import { AppIcon } from "@/ui/Icon";
 
 interface DocumentEditScreenViewProps {
   document: PersistedEditableDocument;
@@ -162,9 +163,7 @@ export function DocumentEditScreenView({
                 : "border-outline-variant/30 bg-surface-container-lowest text-on-surface hover:bg-surface-container-low",
             ].join(" ")}
           >
-            <span className="material-symbols-outlined text-[1.125rem] leading-none">
-              info
-            </span>
+            <AppIcon name="info" className="text-[1.125rem] leading-none" />
           </Button>
         ) : null}
       />

--- a/frontend/src/features/quotes/components/LineItemCard.tsx
+++ b/frontend/src/features/quotes/components/LineItemCard.tsx
@@ -1,5 +1,6 @@
 import type { PointerEvent as ReactPointerEvent } from "react";
 import { Eyebrow } from "@/ui/Eyebrow";
+import { AppIcon } from "@/ui/Icon";
 
 interface LineItemCardProps {
   description: string;
@@ -60,7 +61,7 @@ export function LineItemCard({
           className="mt-1 inline-flex h-9 w-9 shrink-0 cursor-grab touch-none select-none items-center justify-center rounded-full border border-outline-variant/30 text-outline transition-colors hover:bg-surface-container-low active:cursor-grabbing disabled:cursor-not-allowed disabled:opacity-60"
           onPointerDown={onDragHandlePointerDown}
         >
-          <span className="material-symbols-outlined text-[1.125rem] leading-none">drag_indicator</span>
+          <AppIcon name="drag_indicator" className="text-[1.125rem] leading-none" />
         </button>
       ) : null}
 

--- a/frontend/src/features/quotes/components/LineItemEditSheet.tsx
+++ b/frontend/src/features/quotes/components/LineItemEditSheet.tsx
@@ -12,6 +12,7 @@ import {
 } from "@/shared/lib/inputLimits";
 import { Card } from "@/ui/Card";
 import { Eyebrow } from "@/ui/Eyebrow";
+import { AppIcon } from "@/ui/Icon";
 import { NumericField } from "@/ui/NumericField";
 import { Sheet, SheetDescription, SheetTitle } from "@/ui/Sheet";
 interface LineItemEditSheetProps {
@@ -248,12 +249,11 @@ export function LineItemEditSheet({
                       void saveToCatalog();
                     }}
                   >
-                    <span
-                      className="material-symbols-outlined text-base leading-none"
-                      style={canDeleteSavedCatalogItem ? { fontVariationSettings: '"FILL" 1, "wght" 400, "GRAD" 0, "opsz" 24' } : undefined}
-                    >
-                      {bookmarkIcon}
-                    </span>
+                    <AppIcon
+                      name={bookmarkIcon}
+                      className="text-base leading-none"
+                      strokeWidth={canDeleteSavedCatalogItem ? 2.6 : 2}
+                    />
                   </Button>
                 ) : null}
                 {mode === "add" && showManualFields ? (
@@ -265,7 +265,7 @@ export function LineItemEditSheet({
                     className="border border-primary/30 bg-primary/5 text-primary hover:bg-primary/10"
                     onClick={addLineItemAndClose}
                   >
-                    <span className="material-symbols-outlined text-base leading-none">check</span>
+                    <AppIcon name="check" className="text-base leading-none" />
                   </Button>
                 ) : null}
                 {mode === "edit" && onRequestDelete ? (
@@ -277,7 +277,7 @@ export function LineItemEditSheet({
                     className="shrink-0 border border-error/30 bg-error-container/40 text-error hover:bg-error-container/60"
                     onClick={onRequestDelete}
                   >
-                    <span className="material-symbols-outlined text-[1.125rem] leading-none">delete</span>
+                    <AppIcon name="delete" className="text-[1.125rem] leading-none" />
                   </Button>
                 ) : null}
               </div>

--- a/frontend/src/features/quotes/components/LineItemEditSheet.tsx
+++ b/frontend/src/features/quotes/components/LineItemEditSheet.tsx
@@ -251,7 +251,7 @@ export function LineItemEditSheet({
                   >
                     <AppIcon
                       name={bookmarkIcon}
-                      className="text-base leading-none"
+                      className="text-[1.125rem] leading-none"
                       strokeWidth={canDeleteSavedCatalogItem ? 2.6 : 2}
                     />
                   </Button>
@@ -265,7 +265,7 @@ export function LineItemEditSheet({
                     className="border border-primary/30 bg-primary/5 text-primary hover:bg-primary/10"
                     onClick={addLineItemAndClose}
                   >
-                    <AppIcon name="check" className="text-base leading-none" />
+                    <AppIcon name="check" className="text-[1.125rem] leading-none" />
                   </Button>
                 ) : null}
                 {mode === "edit" && onRequestDelete ? (

--- a/frontend/src/features/quotes/components/LineItemRow.tsx
+++ b/frontend/src/features/quotes/components/LineItemRow.tsx
@@ -2,6 +2,7 @@ import type { LineItemDraftWithFlags } from "@/features/quotes/types/quote.types
 import { Button } from "@/shared/components/Button";
 import { Input } from "@/shared/components/Input";
 import { resolveLineItemFlagMessage } from "@/features/quotes/utils/lineItemFlags";
+import { AppIcon } from "@/ui/Icon";
 import { NumericField } from "@/ui/NumericField";
 
 interface LineItemRowProps {
@@ -88,7 +89,7 @@ export function LineItemRow({
           className="shrink-0 border border-error/30 bg-error-container/40 text-error hover:bg-error-container/60"
           onClick={onDelete}
         >
-          <span className="material-symbols-outlined text-[1.125rem] leading-none">delete</span>
+          <AppIcon name="delete" className="text-[1.125rem] leading-none" />
         </Button>
       </div>
     </div>

--- a/frontend/src/features/quotes/components/QuoteList.tsx
+++ b/frontend/src/features/quotes/components/QuoteList.tsx
@@ -24,6 +24,7 @@ import { ScreenHeader } from "@/shared/components/ScreenHeader";
 import { formatDate } from "@/shared/lib/formatters";
 import { Banner } from "@/ui/Banner";
 import { EmptyState } from "@/ui/EmptyState";
+import { AppIcon } from "@/ui/Icon";
 import { buildInvoiceSubtitle, buildPendingCaptureError, buildQuoteSubtitle, matchesSearch } from "./QuoteList.helpers";
 type DocumentMode = "quotes" | "invoices";
 
@@ -317,7 +318,7 @@ export function QuoteList(): React.ReactElement {
                 setIsSearchOpen((open) => !open);
               }}
             >
-              <span className="material-symbols-outlined block text-[1.125rem] leading-none">search</span>
+              <AppIcon name="search" className="block text-[1.125rem] leading-none" />
             </Button>
           </div>
           {isSearchOpen ? (
@@ -337,7 +338,7 @@ export function QuoteList(): React.ReactElement {
                   className="text-outline"
                   onClick={() => setSearchQuery("")}
                 >
-                  <span className="material-symbols-outlined block text-base leading-none">close</span>
+                  <AppIcon name="close" className="block text-base leading-none" />
                 </Button>
               )}
             />
@@ -432,7 +433,7 @@ export function QuoteList(): React.ReactElement {
         className="fixed bottom-20 right-4 z-50 flex h-14 w-14 cursor-pointer items-center justify-center rounded-full forest-gradient text-on-primary ghost-shadow transition-all active:scale-95"
         onClick={quoteCreateFlow.openCreateEntry}
       >
-        <span className="material-symbols-outlined">description</span>
+        <AppIcon name="description" />
       </button>
       <PendingCaptureDeleteDialog
         capture={capturePendingDelete}

--- a/frontend/src/features/quotes/components/QuotePreviewActions.tsx
+++ b/frontend/src/features/quotes/components/QuotePreviewActions.tsx
@@ -7,6 +7,7 @@ import {
   DocumentActionSurface,
   documentActionPrimaryLinkClassName,
 } from "@/shared/components/DocumentActionSurface";
+import { AppIcon } from "@/ui/Icon";
 
 interface QuotePreviewActionsProps {
   emailActionLabel: string | null;
@@ -73,7 +74,7 @@ export function QuotePreviewActions({
           rel="noopener noreferrer"
           className={documentActionPrimaryLinkClassName}
         >
-          <span className="material-symbols-outlined text-base leading-none">open_in_new</span>
+          <AppIcon name="open_in_new" className="text-base leading-none" />
           Open PDF
         </a>
       );
@@ -96,11 +97,7 @@ export function QuotePreviewActions({
         onClick={() => {
           void onGeneratePdf();
         }}
-        leadingIcon={(
-          <span className="material-symbols-outlined text-base leading-none">
-            picture_as_pdf
-          </span>
-        )}
+        leadingIcon={<AppIcon name="picture_as_pdf" className="text-base leading-none" />}
       >
         Generate PDF
       </Button>
@@ -129,7 +126,7 @@ export function QuotePreviewActions({
                 || isMarkingLost
               }
               isLoading={isSendingEmail}
-              leadingIcon={<span className="material-symbols-outlined text-base leading-none">mail</span>}
+              leadingIcon={<AppIcon name="mail" className="text-base leading-none" />}
               onClick={onRequestSendEmail}
             >
               {emailActionLabel}
@@ -149,7 +146,7 @@ export function QuotePreviewActions({
               || isMarkingWon
               || isMarkingLost
             }
-            leadingIcon={<span className="material-symbols-outlined text-base leading-none">content_copy</span>}
+            leadingIcon={<AppIcon name="content_copy" className="text-base leading-none" />}
             onClick={() => {
               void onCopyLink();
             }}

--- a/frontend/src/features/quotes/components/QuotePreviewHeaderActions.tsx
+++ b/frontend/src/features/quotes/components/QuotePreviewHeaderActions.tsx
@@ -1,6 +1,7 @@
 import type { OverflowMenuItem } from "@/shared/components/OverflowMenu";
 import { Button } from "@/shared/components/Button";
 import { OverflowMenu } from "@/shared/components/OverflowMenu";
+import { AppIcon } from "@/ui/Icon";
 
 interface QuotePreviewHeaderActionsProps {
   canEdit: boolean;
@@ -24,7 +25,7 @@ export function QuotePreviewHeaderActions({
           aria-label="Edit quote"
           className="border border-outline-variant/30 bg-surface-container-lowest text-on-surface ghost-shadow"
         >
-          <span className="material-symbols-outlined block text-[1.125rem] leading-none">edit</span>
+          <AppIcon name="edit" className="block text-[1.125rem] leading-none" />
         </Button>
       ) : null}
       <OverflowMenu items={overflowItems} />

--- a/frontend/src/features/quotes/components/ReviewCustomerAssignmentSheet.tsx
+++ b/frontend/src/features/quotes/components/ReviewCustomerAssignmentSheet.tsx
@@ -6,6 +6,7 @@ import { Button } from "@/shared/components/Button";
 import { FeedbackMessage } from "@/shared/components/FeedbackMessage";
 import { Input } from "@/shared/components/Input";
 import { Eyebrow } from "@/ui/Eyebrow";
+import { AppIcon } from "@/ui/Icon";
 import { Sheet, SheetBody, SheetCloseButton, SheetDescription, SheetHeader, SheetTitle } from "@/ui/Sheet";
 
 interface ReviewCustomerAssignmentSheetProps {
@@ -210,7 +211,7 @@ export function ReviewCustomerAssignmentSheet({
                   disabled={isSubmitting}
                   onClick={() => setIsCreateExpanded((isExpanded) => !isExpanded)}
                 >
-                  <span className="material-symbols-outlined text-base">person_add</span>
+                  <AppIcon name="person_add" className="text-base" />
                   {isCreateExpanded ? "Hide New Customer Form" : "Create New Customer"}
                 </Button>
 

--- a/frontend/src/features/quotes/components/ReviewCustomerRow.tsx
+++ b/frontend/src/features/quotes/components/ReviewCustomerRow.tsx
@@ -1,4 +1,5 @@
 import { Eyebrow } from "@/ui/Eyebrow";
+import { AppIcon } from "@/ui/Icon";
 
 interface ReviewCustomerRowProps {
   customerName: string | null;
@@ -43,7 +44,7 @@ export function ReviewCustomerRow({
           {requiresCustomerAssignment ? "Customer: Unassigned" : customerName ?? "Assigned customer"}
         </span>
         {canOpenSheet ? (
-          <span className="material-symbols-outlined text-outline">chevron_right</span>
+          <AppIcon name="chevron_right" className="text-outline" />
         ) : null}
       </button>
 

--- a/frontend/src/features/quotes/components/ReviewLineItemsSection.tsx
+++ b/frontend/src/features/quotes/components/ReviewLineItemsSection.tsx
@@ -3,6 +3,7 @@ import { useEffect, useRef, useState } from "react";
 import { LineItemCard } from "@/features/quotes/components/LineItemCard";
 import type { LineItemDraftWithFlags } from "@/features/quotes/types/quote.types";
 import { DOCUMENT_LINE_ITEMS_MAX_ITEMS } from "@/shared/lib/inputLimits";
+import { AppIcon } from "@/ui/Icon";
 
 interface ReviewLineItemsSectionProps {
   lineItems: LineItemDraftWithFlags[];
@@ -190,7 +191,7 @@ export function ReviewLineItemsSection({
           disabled={isInteractionLocked || hasReachedLineItemLimit || isReorderModeActive}
           onClick={onAddLineItem}
         >
-          <span className="material-symbols-outlined text-base">add</span>
+          <AppIcon name="add" className="text-base" />
           Add Line Item
         </button>
       </div>

--- a/frontend/src/features/quotes/components/TotalAmountSection.tsx
+++ b/frontend/src/features/quotes/components/TotalAmountSection.tsx
@@ -4,6 +4,7 @@ import { PricingRow } from "@/shared/components/PricingRow";
 import { formatCurrency } from "@/shared/lib/formatters";
 import { calculatePricingFromSubtotal, parseTaxPercentInput, toTaxPercentDisplay, type DiscountType } from "@/shared/lib/pricing";
 import { Eyebrow } from "@/ui/Eyebrow";
+import { AppIcon } from "@/ui/Icon";
 import { NumericField } from "@/ui/NumericField";
 
 interface TotalAmountSectionProps {
@@ -89,9 +90,7 @@ export function TotalAmountSection({
             currencySymbol="$"
             currencySymbolClassName="!text-2xl !font-bold text-primary"
             trailingAdornment={(
-              <span className="pointer-events-none material-symbols-outlined !text-base leading-none text-on-surface-variant">
-                edit
-              </span>
+              <AppIcon name="edit" className="pointer-events-none !text-base leading-none text-on-surface-variant" />
             )}
             fieldClassName="!min-h-[72px] !border-2 !border-primary !bg-surface-container-high !px-4 !py-3 focus-within:!ring-2 focus-within:!ring-primary/20"
             className="!font-headline !text-3xl !font-bold !tracking-tight text-primary"
@@ -108,9 +107,7 @@ export function TotalAmountSection({
                 Tax, discount, and deposit
               </p>
             </div>
-            <span className="material-symbols-outlined text-on-surface-variant">
-              expand_more
-            </span>
+            <AppIcon name="expand_more" className="text-on-surface-variant" />
           </div>
         ) : (
           <button
@@ -126,9 +123,10 @@ export function TotalAmountSection({
                 Tax, discount, and deposit
               </p>
             </div>
-            <span className="material-symbols-outlined text-on-surface-variant">
-              {isOptionalPricingOpen ? "expand_less" : "expand_more"}
-            </span>
+            <AppIcon
+              name={isOptionalPricingOpen ? "expand_less" : "expand_more"}
+              className="text-on-surface-variant"
+            />
           </button>
         )}
 
@@ -174,7 +172,7 @@ export function TotalAmountSection({
                       <option value="percent">Percent %</option>
                     </select>
                     <span className="pointer-events-none absolute inset-y-0 right-3 inline-flex items-center text-sm text-outline">
-                      <span className="material-symbols-outlined block text-sm leading-none">expand_more</span>
+                      <AppIcon name="expand_more" className="block text-sm leading-none" />
                     </span>
                   </div>
                   <NumericField

--- a/frontend/src/features/quotes/tests/CaptureScreen.test.tsx
+++ b/frontend/src/features/quotes/tests/CaptureScreen.test.tsx
@@ -470,7 +470,7 @@ describe("CaptureScreen", () => {
     expect(
       screen.getByText("Maximum clips reached."),
     ).toBeInTheDocument();
-    const startButton = screen.getByText("mic").closest("button");
+    const startButton = screen.getByRole("button", { name: /start recording/i });
     expect(startButton).toBeDisabled();
   });
 
@@ -507,16 +507,13 @@ describe("CaptureScreen", () => {
     renderScreen();
 
     expect(screen.getByText("Recording... 00:03")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /stop/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /stop recording/i })).toBeInTheDocument();
   });
 
   it("uses token-backed styles for the start recording control", () => {
     renderScreen();
 
-    const startButton = screen.getByText("mic").closest("button");
-    if (!startButton) {
-      throw new Error("Expected start recording button to render");
-    }
+    const startButton = screen.getByRole("button", { name: /start recording/i });
 
     expect(startButton).toHaveClass("forest-gradient", "ghost-shadow", "text-on-primary");
   });
@@ -525,7 +522,7 @@ describe("CaptureScreen", () => {
     mockVoiceCapture({ isRecording: true, elapsedSeconds: 3 });
     renderScreen();
 
-    const stopButton = screen.getByRole("button", { name: /stop/i });
+    const stopButton = screen.getByRole("button", { name: /stop recording/i });
     expect(stopButton).toHaveClass("ghost-shadow", "bg-secondary", "text-on-secondary");
   });
 

--- a/frontend/src/features/quotes/tests/LineItemEditSheet.test.tsx
+++ b/frontend/src/features/quotes/tests/LineItemEditSheet.test.tsx
@@ -428,7 +428,7 @@ describe("LineItemEditSheet", () => {
     );
 
     const bookmarkButton = screen.getByRole("button", { name: /save to catalog/i });
-    expect(within(bookmarkButton).getByText("bookmark_add")).toBeInTheDocument();
+    expect(bookmarkButton.querySelector("svg.lucide-bookmark-plus")).toBeInTheDocument();
     expect(within(bookmarkButton).queryByText(/^save$/i)).not.toBeInTheDocument();
 
     fireEvent.change(screen.getByLabelText(/description/i), { target: { value: "  Garden edging  " } });
@@ -444,7 +444,7 @@ describe("LineItemEditSheet", () => {
         defaultPrice: 95.5,
       });
     });
-    expect(within(bookmarkButton).getByText("bookmark")).toBeInTheDocument();
+    expect(bookmarkButton.querySelector("svg.lucide-bookmark")).toBeInTheDocument();
 
     await user.click(screen.getByRole("tab", { name: /catalog/i }));
     await waitFor(() => {
@@ -483,13 +483,13 @@ describe("LineItemEditSheet", () => {
     await waitFor(() => {
       expect(onSaveToCatalog).toHaveBeenCalledTimes(1);
     });
-    expect(within(bookmarkButton).getByText("bookmark")).toBeInTheDocument();
+    expect(bookmarkButton.querySelector("svg.lucide-bookmark")).toBeInTheDocument();
 
     await user.click(bookmarkButton);
     await waitFor(() => {
       expect(onDeleteFromCatalog).toHaveBeenCalledWith("catalog-9");
     });
-    expect(within(bookmarkButton).getByText("bookmark_add")).toBeInTheDocument();
+    expect(bookmarkButton.querySelector("svg.lucide-bookmark-plus")).toBeInTheDocument();
 
     await user.click(screen.getByRole("tab", { name: /catalog/i }));
     await waitFor(() => {
@@ -523,11 +523,11 @@ describe("LineItemEditSheet", () => {
     await waitFor(() => {
       expect(onSaveToCatalog).toHaveBeenCalledTimes(1);
     });
-    expect(within(bookmarkButton).getByText("bookmark")).toBeInTheDocument();
+    expect(bookmarkButton.querySelector("svg.lucide-bookmark")).toBeInTheDocument();
 
     fireEvent.change(screen.getByLabelText(/description/i), { target: { value: "Updated description" } });
 
-    expect(within(bookmarkButton).getByText("bookmark_add")).toBeInTheDocument();
+    expect(bookmarkButton.querySelector("svg.lucide-bookmark-plus")).toBeInTheDocument();
     expect(onDeleteFromCatalog).not.toHaveBeenCalled();
   });
 

--- a/frontend/src/features/quotes/tests/QuoteList.test.tsx
+++ b/frontend/src/features/quotes/tests/QuoteList.test.tsx
@@ -266,7 +266,8 @@ describe("QuoteList", () => {
 
     renderScreen();
 
-    const quotesButton = await screen.findByRole("button", { name: "Quotes" });
+    const filter = await screen.findByLabelText("Document type filter");
+    const quotesButton = within(filter).getByRole("button", { name: "Quotes" });
     const createButton = screen.getByRole("button", { name: "New quote" });
 
     expect(quotesButton).toHaveClass("ghost-shadow", "bg-surface-container-lowest", "text-primary");

--- a/frontend/src/features/settings/components/SettingsBusinessProfileCard.tsx
+++ b/frontend/src/features/settings/components/SettingsBusinessProfileCard.tsx
@@ -8,6 +8,7 @@ import { NumericField } from "@/ui/NumericField";
 import { Select } from "@/ui/Select";
 import { Card } from "@/ui/Card";
 import { Eyebrow } from "@/ui/Eyebrow";
+import { AppIcon } from "@/ui/Icon";
 
 interface SettingsBusinessProfileCardProps {
   logoSizeLimitLabel: string;
@@ -283,7 +284,7 @@ export function SettingsBusinessProfileCard({
                     className="h-full w-full object-contain"
                   />
                 ) : (
-                  <span className="material-symbols-outlined text-2xl text-on-surface-variant">business</span>
+                  <AppIcon name="business" className="text-2xl text-on-surface-variant" />
                 )}
               </div>
               <div className="min-w-0 flex-1">

--- a/frontend/src/features/settings/tests/SettingsScreen.test.tsx
+++ b/frontend/src/features/settings/tests/SettingsScreen.test.tsx
@@ -486,11 +486,11 @@ describe("SettingsScreen", () => {
   it("shows a business icon placeholder in display mode and full upload controls in edit mode", async () => {
     mockedProfileService.getProfile.mockResolvedValueOnce(makeProfileResponse());
 
-    renderScreen();
+    const { container } = renderScreen();
 
     expect(await screen.findByText("Business Profile")).toBeInTheDocument();
     expect(screen.queryByTestId("settings-logo-block")).not.toBeInTheDocument();
-    expect(screen.getByText("business")).toBeInTheDocument();
+    expect(container.querySelector("svg.lucide-building2, svg.lucide-building-2")).toBeInTheDocument();
     expect(screen.queryByLabelText(/upload logo/i)).not.toBeInTheDocument();
     await openBusinessProfileEditMode();
     expect(screen.getByTestId("settings-logo-block")).toHaveClass(

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -290,14 +290,6 @@
   box-shadow: var(--shadow-modal);
 }
 
-.material-symbols-outlined {
-  font-variation-settings: "FILL" 0, "wght" 400, "GRAD" 0, "opsz" 24;
-}
-
-.material-symbols-filled {
-  font-variation-settings: "FILL" 1, "wght" 600, "GRAD" 0, "opsz" 24;
-}
-
 @keyframes shimmer {
   0% {
     background-position: 200% 0;

--- a/frontend/src/shared/components/BottomNav.test.tsx
+++ b/frontend/src/shared/components/BottomNav.test.tsx
@@ -19,14 +19,12 @@ afterEach(() => {
 
 describe("BottomNav", () => {
   it("renders quotes, customers, and settings tabs", () => {
-    render(<BottomNav active="quotes" />);
+    const { container } = render(<BottomNav active="quotes" />);
 
     expect(screen.getByRole("button", { name: /quotes/i })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /customers/i })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /settings/i })).toBeInTheDocument();
-    expect(screen.getByText("description")).toBeInTheDocument();
-    expect(screen.getByText("group")).toBeInTheDocument();
-    expect(screen.getByText("settings")).toBeInTheDocument();
+    expect(container.querySelectorAll("svg")).toHaveLength(3);
   });
 
   it("applies active tab styling using the active prop", () => {

--- a/frontend/src/shared/components/BottomNav.tsx
+++ b/frontend/src/shared/components/BottomNav.tsx
@@ -1,5 +1,7 @@
 import { useNavigate } from "react-router-dom";
 
+import { AppIcon } from "@/ui/Icon";
+
 interface BottomNavProps {
   active: "quotes" | "customers" | "settings";
 }
@@ -46,9 +48,7 @@ export function BottomNav({ active }: BottomNavProps): React.ReactElement {
                 isActive ? "bg-primary/20" : ""
               }`}
             >
-              <span className={`material-symbols-outlined ${isActive ? "material-symbols-filled" : ""}`}>
-                {tab.icon}
-              </span>
+              <AppIcon name={tab.icon} strokeWidth={isActive ? 2.5 : 2} />
             </span>
             <span>{tab.label}</span>
           </button>

--- a/frontend/src/shared/components/BottomNav.tsx
+++ b/frontend/src/shared/components/BottomNav.tsx
@@ -31,7 +31,7 @@ export function BottomNav({ active }: BottomNavProps): React.ReactElement {
   const navigate = useNavigate();
 
   return (
-    <nav className="safe-bottom glass-surface-strong glass-shadow-bottom fixed bottom-0 z-50 flex w-full justify-around border-t border-outline-variant/20 py-3 backdrop-blur-md">
+    <nav className="safe-bottom glass-surface-strong glass-shadow-bottom fixed bottom-0 z-50 flex w-full justify-around border-t border-outline-variant/20 py-2.5 backdrop-blur-md">
       {tabs.map((tab) => {
         const isActive = active === tab.key;
         return (
@@ -44,11 +44,11 @@ export function BottomNav({ active }: BottomNavProps): React.ReactElement {
             }`}
           >
             <span
-              className={`flex items-center justify-center rounded-full px-4 py-1 transition-colors ${
+              className={`flex items-center justify-center rounded-full px-4 py-0.5 transition-colors ${
                 isActive ? "bg-primary/20" : ""
               }`}
             >
-              <AppIcon name={tab.icon} strokeWidth={isActive ? 2.5 : 2} />
+              <AppIcon name={tab.icon} className="text-xl" strokeWidth={isActive ? 2.5 : 2} />
             </span>
             <span>{tab.label}</span>
           </button>

--- a/frontend/src/shared/components/Button.test.tsx
+++ b/frontend/src/shared/components/Button.test.tsx
@@ -20,7 +20,7 @@ describe("Button", () => {
         <Button variant="destructive">Delete</Button>
         <Button variant="ghost">Back</Button>
         <Button variant="iconButton" aria-label="Close dialog">
-          <span className="material-symbols-outlined">close</span>
+          <span>close</span>
         </Button>
       </>,
     );
@@ -43,7 +43,7 @@ describe("Button", () => {
   it("supports xs iconButton size for inline dismiss affordances", () => {
     render(
       <Button variant="iconButton" size="xs" aria-label="Dismiss banner">
-        <span className="material-symbols-outlined">close</span>
+        <span>close</span>
       </Button>,
     );
 
@@ -100,7 +100,7 @@ describe("Button", () => {
       render(
         // @ts-expect-error: this intentionally exercises runtime guardrails for missing aria-label.
         <Button variant="iconButton">
-          <span className="material-symbols-outlined">close</span>
+          <span>close</span>
         </Button>,
       ),
     ).toThrow("requires an aria-label");

--- a/frontend/src/shared/components/OverflowMenu.tsx
+++ b/frontend/src/shared/components/OverflowMenu.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useId, useRef, useState } from "react";
 
+import { AppIcon } from "@/ui/Icon";
+
 export interface OverflowMenuItem {
   label: string;
   icon: string;
@@ -96,7 +98,7 @@ export function OverflowMenu({
           setIsOpen((current) => !current);
         }}
       >
-        <span className="material-symbols-outlined block text-[1.125rem] leading-none">more_horiz</span>
+        <AppIcon name="more_horiz" className="block text-[1.125rem] leading-none" />
       </button>
 
       {isOpen ? (
@@ -125,7 +127,7 @@ export function OverflowMenu({
                     item.onSelect?.();
                   }}
                 >
-                  <span className="material-symbols-outlined block text-[1.125rem] leading-none">{item.icon}</span>
+                  <AppIcon name={item.icon} className="block text-[1.125rem] leading-none" />
                   <span className="whitespace-nowrap leading-none">{item.label}</span>
                 </a>
               );
@@ -144,7 +146,7 @@ export function OverflowMenu({
                   item.onSelect?.();
                 }}
               >
-                <span className="material-symbols-outlined block text-[1.125rem] leading-none">{item.icon}</span>
+                <AppIcon name={item.icon} className="block text-[1.125rem] leading-none" />
                 <span className="whitespace-nowrap leading-none">{item.label}</span>
               </button>
             );

--- a/frontend/src/shared/components/ScreenHeader.tsx
+++ b/frontend/src/shared/components/ScreenHeader.tsx
@@ -41,7 +41,7 @@ export function ScreenHeader({
             aria-label={backLabel}
             className="text-primary"
           >
-            <AppIcon name="arrow_back" className="block text-[1.125rem] leading-none" />
+            <AppIcon name="arrow_back" className="block text-xl leading-none" />
           </Button>
         ) : null}
         {isTopLevelLayout ? (

--- a/frontend/src/shared/components/ScreenHeader.tsx
+++ b/frontend/src/shared/components/ScreenHeader.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from "react";
 import { Button } from "@/shared/components/Button";
 import { Eyebrow } from "@/ui/Eyebrow";
+import { AppIcon } from "@/ui/Icon";
 
 interface ScreenHeaderProps {
   title: string;
@@ -40,7 +41,7 @@ export function ScreenHeader({
             aria-label={backLabel}
             className="text-primary"
           >
-            <span className="material-symbols-outlined block text-[1.125rem] leading-none">arrow_back</span>
+            <AppIcon name="arrow_back" className="block text-[1.125rem] leading-none" />
           </Button>
         ) : null}
         {isTopLevelLayout ? (

--- a/frontend/src/shared/components/WorkflowScreenHeader.tsx
+++ b/frontend/src/shared/components/WorkflowScreenHeader.tsx
@@ -36,7 +36,7 @@ export function WorkflowScreenHeader({
         aria-label={exitHomeLabel}
         className="border border-outline-variant/30 bg-surface-container-lowest text-on-surface ghost-shadow"
       >
-        <AppIcon name="close" className="block text-[1.125rem] leading-none" />
+        <AppIcon name="close" className="block text-xl leading-none" />
       </Button>
     </div>
   ) : trailing;

--- a/frontend/src/shared/components/WorkflowScreenHeader.tsx
+++ b/frontend/src/shared/components/WorkflowScreenHeader.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from "react";
 
 import { Button } from "@/shared/components/Button";
 import { ScreenHeader } from "@/shared/components/ScreenHeader";
+import { AppIcon } from "@/ui/Icon";
 
 interface WorkflowScreenHeaderProps {
   title: string;
@@ -35,7 +36,7 @@ export function WorkflowScreenHeader({
         aria-label={exitHomeLabel}
         className="border border-outline-variant/30 bg-surface-container-lowest text-on-surface ghost-shadow"
       >
-        <span className="material-symbols-outlined block text-[1.125rem] leading-none">close</span>
+        <AppIcon name="close" className="block text-[1.125rem] leading-none" />
       </Button>
     </div>
   ) : trailing;

--- a/frontend/src/ui/Banner.tsx
+++ b/frontend/src/ui/Banner.tsx
@@ -1,5 +1,6 @@
 import { Button } from "@/shared/components/Button";
 import { Eyebrow } from "@/ui/Eyebrow";
+import { AppIcon } from "@/ui/Icon";
 
 type BannerKind = "warn" | "info" | "success" | "error";
 
@@ -60,7 +61,7 @@ export function Banner({
       ].join(" ")}
     >
       <div className="flex items-start gap-3">
-        <span className={["material-symbols-outlined", style.body].join(" ")}>{style.icon}</span>
+        <AppIcon name={style.icon} className={style.body} />
         <div className="min-w-0 flex-1">
           <Eyebrow className={style.title}>{title}</Eyebrow>
           <p className={["text-sm font-medium leading-snug", style.body].join(" ")}>{message}</p>
@@ -74,7 +75,7 @@ export function Banner({
             className={["shrink-0 hover:bg-current/10", style.body].join(" ")}
             onClick={onDismiss}
           >
-            <span className="material-symbols-outlined text-base">close</span>
+            <AppIcon name="close" className="text-base" />
           </Button>
         ) : null}
       </div>

--- a/frontend/src/ui/DocumentHeroCard.tsx
+++ b/frontend/src/ui/DocumentHeroCard.tsx
@@ -3,6 +3,7 @@ import { PricingRow } from "@/shared/components/PricingRow";
 import { formatCurrency, formatDate } from "@/shared/lib/formatters";
 import { calculatePricingFromPersisted, resolveLineItemSum } from "@/shared/lib/pricing";
 import { Eyebrow } from "@/ui/Eyebrow";
+import { AppIcon } from "@/ui/Icon";
 import { StatusPill, type StatusPillVariant } from "@/ui/StatusPill";
 
 interface DocumentHeroCardProps {
@@ -78,7 +79,7 @@ export function DocumentHeroCard({
                 onClick={linkedDocument.onClick}
               >
                 {linkedDocument.actionLabel}
-                <span className="material-symbols-outlined text-base">arrow_forward</span>
+                <AppIcon name="arrow_forward" className="text-base" />
               </button>
             ) : null}
           </div>

--- a/frontend/src/ui/EmptyState.test.tsx
+++ b/frontend/src/ui/EmptyState.test.tsx
@@ -5,11 +5,11 @@ import { EmptyState } from "@/ui/EmptyState";
 
 describe("EmptyState", () => {
   it("renders icon, title, and body", () => {
-    render(<EmptyState icon="inbox_out" title="No items" body="Try adding one." />);
+    const { container } = render(<EmptyState icon="inbox_out" title="No items" body="Try adding one." />);
 
     expect(screen.getByText("No items")).toBeInTheDocument();
     expect(screen.getByText("Try adding one.")).toBeInTheDocument();
-    expect(screen.getByText("inbox_out")).toHaveClass("material-symbols-outlined");
+    expect(container.querySelector("svg")).toBeInTheDocument();
   });
 
   it("renders action content when provided", () => {

--- a/frontend/src/ui/EmptyState.tsx
+++ b/frontend/src/ui/EmptyState.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from "react";
 
 import { Card } from "@/ui/Card";
+import { AppIcon } from "@/ui/Icon";
 
 interface EmptyStateProps {
   icon?: string;
@@ -33,7 +34,7 @@ export function EmptyState({
       <div className="flex flex-col items-center">
         {icon ? (
           <div className="mb-3 flex h-14 w-14 items-center justify-center rounded-full bg-surface-container-high">
-            <span className="material-symbols-outlined text-3xl text-outline">{icon}</span>
+            <AppIcon name={icon} className="text-3xl text-outline" />
           </div>
         ) : null}
         <h3 className="text-base font-semibold text-on-surface">{title}</h3>

--- a/frontend/src/ui/Icon.tsx
+++ b/frontend/src/ui/Icon.tsx
@@ -1,0 +1,95 @@
+import type { LucideIcon, LucideProps } from "lucide-react";
+import {
+  AlertCircle,
+  ArrowLeft,
+  ArrowRight,
+  Bookmark,
+  BookmarkPlus,
+  Building2,
+  Check,
+  ChevronDown,
+  ChevronRight,
+  ChevronUp,
+  Circle,
+  CircleCheck,
+  Copy,
+  Ellipsis,
+  ExternalLink,
+  FileText,
+  FolderX,
+  GripVertical,
+  Inbox,
+  Info,
+  Link2Off,
+  Mail,
+  Mic,
+  MicOff,
+  Pencil,
+  Play,
+  Plus,
+  ReceiptText,
+  Search,
+  Settings,
+  Square,
+  Trash2,
+  TriangleAlert,
+  UserPlus,
+  Users,
+  X,
+  XCircle,
+} from "lucide-react";
+
+const materialToLucideMap: Record<string, LucideIcon> = {
+  add: Plus,
+  arrow_back: ArrowLeft,
+  arrow_forward: ArrowRight,
+  bookmark: Bookmark,
+  bookmark_add: BookmarkPlus,
+  business: Building2,
+  cancel: XCircle,
+  check: Check,
+  check_circle: CircleCheck,
+  chevron_right: ChevronRight,
+  close: X,
+  content_copy: Copy,
+  delete: Trash2,
+  description: FileText,
+  drag_indicator: GripVertical,
+  edit: Pencil,
+  error: AlertCircle,
+  expand_more: ChevronDown,
+  expand_less: ChevronUp,
+  folder_off: FolderX,
+  group: Users,
+  inbox_out: Inbox,
+  info: Info,
+  link_off: Link2Off,
+  mail: Mail,
+  mic: Mic,
+  mic_off: MicOff,
+  more_horiz: Ellipsis,
+  open_in_new: ExternalLink,
+  person_add: UserPlus,
+  picture_as_pdf: FileText,
+  play_arrow: Play,
+  receipt_long: ReceiptText,
+  search: Search,
+  settings: Settings,
+  stop: Square,
+  warning: TriangleAlert,
+};
+
+export interface AppIconProps extends Omit<LucideProps, "ref"> {
+  name: string;
+}
+
+export function AppIcon({ name, className, ...props }: AppIconProps): React.ReactElement {
+  const Icon = materialToLucideMap[name] ?? Circle;
+  return (
+    <Icon
+      aria-hidden="true"
+      className={["inline-block h-[1em] w-[1em] shrink-0 align-middle", className].filter(Boolean).join(" ")}
+      {...props}
+    />
+  );
+}

--- a/frontend/src/ui/Sheet.tsx
+++ b/frontend/src/ui/Sheet.tsx
@@ -3,6 +3,7 @@ import type { ReactNode } from "react";
 import * as Dialog from "@radix-ui/react-dialog";
 
 import { Button } from "@/shared/components/Button";
+import { AppIcon } from "@/ui/Icon";
 
 type SheetSize = "sm" | "md" | "lg" | "full";
 type DataAttributes = { [key in `data-${string}`]?: string | number | boolean | undefined };
@@ -167,7 +168,7 @@ export function SheetCloseButton({
           className,
         )}
       >
-        <span className="material-symbols-outlined text-base leading-none">close</span>
+        <AppIcon name="close" className="text-base leading-none" />
       </Button>
     </Dialog.Close>
   );

--- a/frontend/src/ui/Sheet.tsx
+++ b/frontend/src/ui/Sheet.tsx
@@ -161,7 +161,7 @@ export function SheetCloseButton({
       <Button
         type="button"
         variant="iconButton"
-        size="xs"
+        size="sm"
         aria-label={label}
         className={joinClasses(
           "shrink-0 border border-outline-variant/30 bg-surface-container-lowest text-on-surface-variant hover:bg-surface-container-low",

--- a/frontend/src/ui/Toast.tsx
+++ b/frontend/src/ui/Toast.tsx
@@ -1,5 +1,7 @@
 import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
 
+import { AppIcon } from "@/ui/Icon";
+
 export type ToastVariant = "success" | "error" | "info" | "warning";
 
 export interface ToastShowOptions {
@@ -78,9 +80,7 @@ export function Toast({ toast, onDismiss }: ToastProps): React.ReactElement {
       ].join(" ")}
     >
       <div className="flex items-start gap-3">
-        <span aria-hidden="true" className="material-symbols-outlined text-[1.125rem] leading-none">
-          {variantStyle.icon}
-        </span>
+        <AppIcon name={variantStyle.icon} className="text-[1.125rem] leading-none" />
         <p className="min-w-0 flex-1">{toast.message}</p>
         <button
           type="button"


### PR DESCRIPTION
Follow-up to #609. Bumps icon sizes in key surfaces after Lucide migration.

Changes:
- BottomNav: larger icons (`text-xl`) with slightly reduced padding to keep nav height stable
- ScreenHeader / WorkflowScreenHeader: back arrow and close button bumped to `text-xl`
- LineItemEditSheet: bookmark and check icons bumped to match delete icon (`text-[1.125rem]`)
- SheetCloseButton: `size="xs"` → `size="sm"` for proper 44px tap target

Closes #392