### PR TITLE
Task #392 follow-up: icon sizing pass

### DIFF
--- a/frontend/src/features/quotes/components/LineItemEditSheet.tsx
+++ b/frontend/src/features/quotes/components/LineItemEditSheet.tsx
@@ -251,7 +251,7 @@ export function LineItemEditSheet({
                   >
                     <AppIcon
                       name={bookmarkIcon}
-                      className="text-base leading-none"
+                      className="text-[1.125rem] leading-none"
                       strokeWidth={canDeleteSavedCatalogItem ? 2.6 : 2}
                     />
                   </Button>
@@ -265,7 +265,7 @@ export function LineItemEditSheet({
                     className="border border-primary/30 bg-primary/5 text-primary hover:bg-primary/10"
                     onClick={addLineItemAndClose}
                   >
-                    <AppIcon name="check" className="text-base leading-none" />
+                    <AppIcon name="check" className="text-[1.125rem] leading-none" />
                   </Button>
                 ) : null}
                 {mode === "edit" && onRequestDelete ? (

--- a/frontend/src/shared/components/BottomNav.tsx
+++ b/frontend/src/shared/components/BottomNav.tsx
@@ -31,7 +31,7 @@ export function BottomNav({ active }: BottomNavProps): React.ReactElement {
   const navigate = useNavigate();
 
   return (
-    <nav className="safe-bottom glass-surface-strong glass-shadow-bottom fixed bottom-0 z-50 flex w-full justify-around border-t border-outline-variant/20 py-3 backdrop-blur-md">
+    <nav className="safe-bottom glass-surface-strong glass-shadow-bottom fixed bottom-0 z-50 flex w-full justify-around border-t border-outline-variant/20 py-2.5 backdrop-blur-md">
       {tabs.map((tab) => {
         const isActive = active === tab.key;
         return (
@@ -44,11 +44,11 @@ export function BottomNav({ active }: BottomNavProps): React.ReactElement {
             }`}
           >
             <span
-              className={`flex items-center justify-center rounded-full px-4 py-1 transition-colors ${
+              className={`flex items-center justify-center rounded-full px-4 py-0.5 transition-colors ${
                 isActive ? "bg-primary/20" : ""
               }`}
             >
-              <AppIcon name={tab.icon} strokeWidth={isActive ? 2.5 : 2} />
+              <AppIcon name={tab.icon} className="text-xl" strokeWidth={isActive ? 2.5 : 2} />
             </span>
             <span>{tab.label}</span>
           </button>

--- a/frontend/src/shared/components/ScreenHeader.tsx
+++ b/frontend/src/shared/components/ScreenHeader.tsx
@@ -41,7 +41,7 @@ export function ScreenHeader({
             aria-label={backLabel}
             className="text-primary"
           >
-            <AppIcon name="arrow_back" className="block text-[1.125rem] leading-none" />
+            <AppIcon name="arrow_back" className="block text-xl leading-none" />
           </Button>
         ) : null}
         {isTopLevelLayout ? (

--- a/frontend/src/shared/components/WorkflowScreenHeader.tsx
+++ b/frontend/src/shared/components/WorkflowScreenHeader.tsx
@@ -36,7 +36,7 @@ export function WorkflowScreenHeader({
         aria-label={exitHomeLabel}
         className="border border-outline-variant/30 bg-surface-container-lowest text-on-surface ghost-shadow"
       >
-        <AppIcon name="close" className="block text-[1.125rem] leading-none" />
+        <AppIcon name="close" className="block text-xl leading-none" />
       </Button>
     </div>
   ) : trailing;

--- a/frontend/src/ui/Sheet.tsx
+++ b/frontend/src/ui/Sheet.tsx
@@ -161,7 +161,7 @@ export function SheetCloseButton({
       <Button
         type="button"
         variant="iconButton"
-        size="xs"
+        size="sm"
         aria-label={label}
         className={joinClasses(
           "shrink-0 border border-outline-variant/30 bg-surface-container-lowest text-on-surface-variant hover:bg-surface-container-low",


### PR DESCRIPTION
Follow-up to #609. Bumps icon sizes in key surfaces after Lucide migration.

Changes:
- BottomNav: larger icons (`text-xl`) with slightly reduced padding to keep nav height stable
- ScreenHeader / WorkflowScreenHeader: back arrow and close button bumped to `text-xl`
- LineItemEditSheet: bookmark and check icons bumped to match delete icon (`text-[1.125rem]`)
- SheetCloseButton: `size="xs"` → `size="sm"` for proper 44px tap target

Closes #392