### PR TITLE
Task #614: Auto-refetch quote surfaces on network reconnect

### DIFF
--- a/frontend/src/features/auth/hooks/useAuth.ts
+++ b/frontend/src/features/auth/hooks/useAuth.ts
@@ -5,6 +5,7 @@ import {
   useContext,
   useEffect,
   useMemo,
+  useRef,
   useState,
 } from "react";
 
@@ -37,11 +38,14 @@ interface AuthContextValue {
 }
 
 const AuthContext = createContext<AuthContextValue | undefined>(undefined);
+const RECONNECT_REVERIFY_DEBOUNCE_MS = 1_500;
 
 export function AuthProvider({ children }: { children: React.ReactNode }): React.ReactElement {
   const [user, setUser] = useState<User | null>(null);
   const [authMode, setAuthMode] = useState<AuthMode>("signed_out");
   const [isLoading, setIsLoading] = useState(true);
+  const isReverifyInFlightRef = useRef(false);
+  const lastReverifyAtRef = useRef(0);
 
   const setVerifiedUser = useCallback((currentUser: User) => {
     setUser(currentUser);
@@ -173,7 +177,16 @@ export function AuthProvider({ children }: { children: React.ReactNode }): React
       if (!window.navigator.onLine) {
         return;
       }
-      void reverifyOfflineRecoveredUser();
+      const now = Date.now();
+      if (isReverifyInFlightRef.current || now - lastReverifyAtRef.current < RECONNECT_REVERIFY_DEBOUNCE_MS) {
+        return;
+      }
+
+      isReverifyInFlightRef.current = true;
+      lastReverifyAtRef.current = now;
+      void reverifyOfflineRecoveredUser().finally(() => {
+        isReverifyInFlightRef.current = false;
+      });
     };
 
     window.addEventListener("online", onOnline);

--- a/frontend/src/features/auth/tests/useAuth.test.tsx
+++ b/frontend/src/features/auth/tests/useAuth.test.tsx
@@ -330,6 +330,65 @@ describe("useAuth", () => {
     });
   });
 
+  it("deduplicates rapid online events while offline_recovered reverify is in flight", async () => {
+    let resolveReverify: ((value: {
+      id: string;
+      email: string;
+      is_active: boolean;
+      is_onboarded: boolean;
+      timezone: string;
+    }) => void) | undefined;
+    const pendingReverify = new Promise<{
+      id: string;
+      email: string;
+      is_active: boolean;
+      is_onboarded: boolean;
+      timezone: string;
+    }>((resolve) => {
+      resolveReverify = resolve;
+    });
+
+    mockedAuthService.me
+      .mockRejectedValueOnce(new TypeError("Failed to fetch"))
+      .mockReturnValueOnce(pendingReverify);
+    mockedReadOfflineUserSnapshot.mockReturnValue({
+      userId: "user-9",
+      isOnboarded: true,
+      timezone: "America/New_York",
+      lastVerifiedAt: new Date().toISOString(),
+    });
+
+    render(
+      <AuthProvider>
+        <AuthHarness />
+      </AuthProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("auth-mode")).toHaveTextContent("offline_recovered");
+    });
+
+    window.dispatchEvent(new Event("online"));
+    window.dispatchEvent(new Event("online"));
+
+    await waitFor(() => {
+      expect(mockedAuthService.me).toHaveBeenCalledTimes(2);
+    });
+
+    resolveReverify?.({
+      id: "user-9",
+      email: "user9@example.com",
+      is_active: true,
+      is_onboarded: true,
+      timezone: "America/New_York",
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("auth-mode")).toHaveTextContent("verified");
+      expect(mockedRunOutboxPass).toHaveBeenCalledWith("user-9", { forceAfterAuth: true });
+    });
+  });
+
   it("forces signed_out when explicit auth-failure event is broadcast", async () => {
     mockedAuthService.me.mockResolvedValueOnce({
       id: "user-1",

--- a/frontend/src/features/quotes/components/QuoteList.tsx
+++ b/frontend/src/features/quotes/components/QuoteList.tsx
@@ -6,6 +6,7 @@ import { invoiceService } from "@/features/invoices/services/invoiceService";
 import type { InvoiceListItem } from "@/features/invoices/types/invoice.types";
 import { PendingCaptureDeleteDialog } from "@/features/quotes/components/PendingCaptureDeleteDialog";
 import { PendingCapturesSection } from "@/features/quotes/components/PendingCapturesSection";
+import { useReconnectRefresh } from "@/features/quotes/components/useReconnectRefresh";
 import { useOutboxSuccessQuoteRefresh } from "@/features/quotes/components/useOutboxSuccessQuoteRefresh";
 import { useQuoteCreateFlow } from "@/features/quotes/hooks/useQuoteCreateFlow";
 import { getStorageErrorMessage } from "@/features/quotes/offline/captureDb";
@@ -42,7 +43,6 @@ export function QuoteList(): React.ReactElement {
   const [invoiceLoadError, setInvoiceLoadError] = useState<string | null>(null);
   const [pendingCaptureActionError, setPendingCaptureActionError] = useState<string | null>(null);
   const [capturePendingDelete, setCapturePendingDelete] = useState<LocalCaptureSummary | null>(null);
-  const [isOnline, setIsOnline] = useState(typeof navigator === "undefined" ? true : navigator.onLine);
   const {
     captures: recoverableCaptures,
     isLoading: isLoadingRecoverableCaptures,
@@ -50,6 +50,7 @@ export function QuoteList(): React.ReactElement {
     refresh: refreshRecoverableCaptures,
     deleteCapture,
   } = useRecoverableCaptures(user?.id);
+  const { isOnline, reconnectTick } = useReconnectRefresh(refreshRecoverableCaptures);
   useOutboxSuccessQuoteRefresh({
     userId: user?.id,
     onQuotesLoaded: setQuotes,
@@ -112,7 +113,7 @@ export function QuoteList(): React.ReactElement {
     return () => {
       isActive = false;
     };
-  }, [authMode, documentMode, isOnline]);
+  }, [authMode, documentMode, reconnectTick]);
 
   useEffect(() => {
     if (!isSearchOpen) {
@@ -123,21 +124,6 @@ export function QuoteList(): React.ReactElement {
       inputElement.focus();
     }
   }, [isSearchOpen]);
-  useEffect(() => {
-    if (typeof window === "undefined") {
-      return;
-    }
-    function onOnlineChange(): void {
-      setIsOnline(window.navigator.onLine);
-    }
-    window.addEventListener("online", onOnlineChange);
-    window.addEventListener("offline", onOnlineChange);
-    return () => {
-      window.removeEventListener("online", onOnlineChange);
-      window.removeEventListener("offline", onOnlineChange);
-    };
-  }, []);
-
   const normalizedSearchQuery = searchQuery.trim().toLowerCase();
   const filteredQuotes = useMemo(
     () => quotes.filter((quote) => matchesSearch(quote, normalizedSearchQuery)),

--- a/frontend/src/features/quotes/components/useReconnectRefresh.ts
+++ b/frontend/src/features/quotes/components/useReconnectRefresh.ts
@@ -1,0 +1,50 @@
+import { useEffect, useRef, useState } from "react";
+
+const RECONNECT_REFRESH_DEBOUNCE_MS = 1_500;
+
+interface UseReconnectRefreshResult {
+  isOnline: boolean;
+  reconnectTick: number;
+}
+
+export function useReconnectRefresh(onReconnect: () => Promise<void>): UseReconnectRefreshResult {
+  const [isOnline, setIsOnline] = useState(typeof navigator === "undefined" ? true : navigator.onLine);
+  const [reconnectTick, setReconnectTick] = useState(0);
+  const lastOnlineRef = useRef(typeof navigator === "undefined" ? true : navigator.onLine);
+  const lastReconnectRefreshAtRef = useRef(0);
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    function onOnlineChange(): void {
+      const currentlyOnline = window.navigator.onLine;
+      const now = Date.now();
+      const wasOnline = lastOnlineRef.current;
+
+      setIsOnline(currentlyOnline);
+      lastOnlineRef.current = currentlyOnline;
+
+      if (
+        currentlyOnline
+        && !wasOnline
+        && now - lastReconnectRefreshAtRef.current >= RECONNECT_REFRESH_DEBOUNCE_MS
+      ) {
+        lastReconnectRefreshAtRef.current = now;
+        setReconnectTick((current) => current + 1);
+        void onReconnect();
+      }
+    }
+
+    window.addEventListener("online", onOnlineChange);
+    window.addEventListener("offline", onOnlineChange);
+
+    return () => {
+      window.removeEventListener("online", onOnlineChange);
+      window.removeEventListener("offline", onOnlineChange);
+    };
+  }, [onReconnect]);
+
+  return { isOnline, reconnectTick };
+}

--- a/frontend/src/features/quotes/tests/QuoteList.test.tsx
+++ b/frontend/src/features/quotes/tests/QuoteList.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -334,6 +334,48 @@ describe("QuoteList", () => {
     await waitFor(() => {
       expect(mockedQuoteService.listQuotes).toHaveBeenCalledTimes(2);
     });
+    expect(await screen.findByText(/Q-002/)).toBeInTheDocument();
+  });
+
+  it("refreshes quotes and pending captures once on rapid reconnect flaps", async () => {
+    setNavigatorOnline(true);
+    const refreshRecoverableCaptures = vi.fn(async () => undefined);
+    mockedUseRecoverableCaptures.mockReturnValue({
+      captures: [],
+      isLoading: false,
+      error: null,
+      refresh: refreshRecoverableCaptures,
+      deleteCapture: vi.fn(async () => undefined),
+    });
+    mockedQuoteService.listQuotes
+      .mockResolvedValueOnce([makeQuoteListItem()])
+      .mockResolvedValueOnce([
+        makeQuoteListItem({
+          id: "quote-2",
+          doc_number: "Q-002",
+        }),
+      ]);
+
+    renderScreen();
+    await screen.findByText(/Q-001/);
+    expect(mockedQuoteService.listQuotes).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      setNavigatorOnline(false);
+      window.dispatchEvent(new Event("offline"));
+      setNavigatorOnline(true);
+      window.dispatchEvent(new Event("online"));
+
+      setNavigatorOnline(false);
+      window.dispatchEvent(new Event("offline"));
+      setNavigatorOnline(true);
+      window.dispatchEvent(new Event("online"));
+    });
+
+    await waitFor(() => {
+      expect(mockedQuoteService.listQuotes).toHaveBeenCalledTimes(2);
+    });
+    expect(refreshRecoverableCaptures).toHaveBeenCalledTimes(1);
     expect(await screen.findByText(/Q-002/)).toBeInTheDocument();
   });
 


### PR DESCRIPTION
## Summary
- dedupe offline-recovered auth reverify on reconnect bursts using in-flight and debounce guards
- refetch quote/invoice list on reconnect transition only and refresh pending captures from a dedicated reconnect hook
- add reconnect flap tests to ensure one refresh pass per burst for auth and quote surfaces

## Verification
- cd frontend && rtk proxy "npx vitest run src/features/quotes/tests/QuoteList.test.tsx src/features/auth/tests/useAuth.test.tsx"
- rtk make frontend-verify

Closes #614