### PR TITLE
Task #621: low-risk GitHub Actions cleanup

### DIFF
--- a/.github/workflows/backend-deploy.yml
+++ b/.github/workflows/backend-deploy.yml
@@ -4,6 +4,11 @@ on:
   push:
     branches:
       - main
+    paths:
+      - backend/**
+      - ops/**
+      - .github/workflows/backend-deploy.yml
+      - .github/workflows/backend-test.yml
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -2,10 +2,11 @@ name: Backend Test
 
 on:
   pull_request:
-  push:
-    branches:
-      - main
   workflow_call:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   backend-static:

--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -5,7 +5,7 @@ on:
   workflow_call:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/frontend-test.yml
+++ b/.github/workflows/frontend-test.yml
@@ -7,7 +7,7 @@ on:
       - main
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/frontend-test.yml
+++ b/.github/workflows/frontend-test.yml
@@ -6,6 +6,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   frontend-test:
     runs-on: ubuntu-latest
@@ -17,6 +21,8 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: '24.0.0'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
       - name: Install dependencies
         run: npm ci --prefix frontend
       - name: Validate dependency audit exceptions


### PR DESCRIPTION
## Summary
- add per-workflow concurrency cancellation to backend/frontend test workflows
- remove redundant `push: main` trigger from backend test workflow (deploy calls it via `workflow_call`)
- add npm cache settings to frontend test workflow
- gate backend deploy `push` trigger with backend/ops/workflow path filters to skip docs-only merges

## Verification
- make verify

Closes #621