### PR TITLE
Task #623: split dependency audit into dedicated workflow

### DIFF
--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -39,11 +39,6 @@ jobs:
           python -m venv backend/.venv
           backend/.venv/bin/pip install --upgrade pip
           backend/.venv/bin/pip install -r backend/requirements.txt
-          backend/.venv/bin/pip install pip-audit==2.10.0
-      - name: Validate dependency audit exceptions
-        run: python3 scripts/validate_dependency_audit_exceptions.py
-      - name: Backend dependency audit
-        run: backend/.venv/bin/pip-audit -r backend/requirements.txt
       - name: Template guard
         run: make template-verify
       - name: Backend static verify

--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -1,0 +1,48 @@
+name: Dependency Audit
+
+on:
+  workflow_call:
+  schedule:
+    - cron: "0 10 * * 1"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  dependency-audit:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.13'
+          cache: 'pip'
+          cache-dependency-path: backend/requirements.txt
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '24.0.0'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install backend dependencies
+        run: |
+          python -m venv backend/.venv
+          backend/.venv/bin/pip install --upgrade pip
+          backend/.venv/bin/pip install -r backend/requirements.txt
+          backend/.venv/bin/pip install pip-audit==2.10.0
+
+      - name: Install frontend dependencies
+        run: npm ci --prefix frontend
+
+      - name: Validate dependency audit exceptions
+        run: python3 scripts/validate_dependency_audit_exceptions.py
+
+      - name: Backend dependency audit
+        run: backend/.venv/bin/pip-audit -r backend/requirements.txt
+
+      - name: Frontend dependency audit
+        run: npm audit --prefix frontend --audit-level=high

--- a/.github/workflows/frontend-test.yml
+++ b/.github/workflows/frontend-test.yml
@@ -15,9 +15,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
-        with:
-          python-version: '3.13'
       - uses: actions/setup-node@v6
         with:
           node-version: '24.0.0'
@@ -25,9 +22,5 @@ jobs:
           cache-dependency-path: frontend/package-lock.json
       - name: Install dependencies
         run: npm ci --prefix frontend
-      - name: Validate dependency audit exceptions
-        run: python3 scripts/validate_dependency_audit_exceptions.py
-      - name: Frontend dependency audit
-        run: npm audit --prefix frontend --audit-level=high
       - name: Frontend verify
         run: make frontend-verify


### PR DESCRIPTION
## Summary
- add dedicated `.github/workflows/dependency-audit.yml` with `workflow_call`, weekly schedule, and `workflow_dispatch`
- move `pip-audit`, `npm audit`, and `scripts/validate_dependency_audit_exceptions.py` out of always-on backend/frontend test workflows
- remove Python setup from `frontend-test.yml` now that exception validation moved

## Verification
- `make template-verify`

Closes #623