### PR TITLE
docs: align CI policy docs with deferred controller decision

### DIFF
--- a/docs/ISSUES_WORKFLOW.md
+++ b/docs/ISSUES_WORKFLOW.md
@@ -63,6 +63,17 @@ Label selection rules:
 
 Guiding principle: be strict about scope, contracts, acceptance criteria, verification, and layer boundaries. Be flexible about internal decomposition and helper structure as long as the implementation stays readable, testable, and consistent with repo patterns.
 
+## CI Policy Snapshot (Deferred Controller)
+
+Current simplified CI policy on `main`:
+
+- `backend-test.yml` and `frontend-test.yml` are the normal direct PR checks.
+- `backend-test.yml` is reusable (`workflow_call`) for deploy and does not run independently on `push: main`.
+- `backend-deploy.yml` is path-gated so docs-only pushes to `main` do not trigger backend deployment.
+- `dependency-audit.yml` is separate and runs on schedule/manual, or explicit invocation.
+- Docs-only PRs may still run backend/frontend CI for now.
+- `ci.yml` controller migration is intentionally deferred and must be handled only by a new explicit task.
+
 ## Execution Modes (Choose Before Opening Issues)
 
 Use `single` by default. Use `gated` or `fast` only when explicitly requested.

--- a/docs/REVIEW_CHECKLIST.md
+++ b/docs/REVIEW_CHECKLIST.md
@@ -42,3 +42,8 @@
 
 ## CI
 - [ ] CI status checked (`GitHub Actions: .github/workflows/backend-test.yml and .github/workflows/frontend-test.yml`)
+- [ ] CI policy alignment confirmed for CI/docs tasks:
+  - `backend-test.yml` and `frontend-test.yml` remain direct PR checks
+  - `backend-deploy.yml` is path-gated (docs-only pushes to `main` should not deploy backend)
+  - `dependency-audit.yml` is separate scheduled/manual (or explicit `workflow_call`), not default PR-blocking while controller migration is deferred
+  - `ci.yml` controller migration remains deferred unless a new explicit task says otherwise

--- a/docs/template/KICKOFF.md
+++ b/docs/template/KICKOFF.md
@@ -17,6 +17,7 @@ Use these prompts to start work on already-scoped tasks without reloading unnece
 - After `ACTIONABLE`, patch listed findings only unless scope expands.
 - Verification follows tiers from `docs/workflow/VERIFY.md`.
 - For backend code changes, run the targeted behavior check plus `make backend-static-verify` before push/PR update.
+- CI policy guardrail: unless a task explicitly says otherwise, treat `.github/workflows/backend-test.yml` and `.github/workflows/frontend-test.yml` as direct PR checks, treat `ci.yml` controller migration as deferred, and do not remove backend/frontend `pull_request` triggers.
 
 ## When To Load Which Asset
 


### PR DESCRIPTION
## Summary
- align control-plane docs with current simplified CI policy on `main`
- keep required PR checks documented as `.github/workflows/backend-test.yml` + `.github/workflows/frontend-test.yml`
- document deferred `ci.yml` migration and separate dependency-audit behavior

## Scope
- docs-only changes to review checklist and kickoff/workflow control-plane guidance
- no workflow yaml, branch protection, or application code changes

## Verification
- targeted grep for stale controller/required-check guidance in docs
- targeted diff review for docs files changed

Closes #624