### PR TITLE
Task #630: Reconcile pilot funnel event persistence

### DIFF
--- a/backend/app/features/invoices/email_delivery_service.py
+++ b/backend/app/features/invoices/email_delivery_service.py
@@ -214,8 +214,8 @@ class InvoiceEmailDeliveryService:
         log_event(
             "email_sent",
             user_id=context.user_id,
+            invoice_id=context.invoice_id,
             customer_id=context.customer_id,
-            persist_async=False,
         )
 
     async def _enforce_duplicate_send_guard(self, context: InvoiceEmailContext) -> None:

--- a/backend/app/features/invoices/share/service.py
+++ b/backend/app/features/invoices/share/service.py
@@ -116,6 +116,12 @@ class InvoiceShareService:
             invoice.share_token_created_at = now
             invoice.share_token_expires_at = _build_share_token_expiry(now)
             invoice.share_token_revoked_at = None
+            log_event(
+                "invoice_shared",
+                user_id=user_id,
+                invoice_id=invoice.id,
+                customer_id=invoice.customer_id,
+            )
 
         if invoice.status not in _OUTCOME_SHARE_NON_REGRESSION_STATUSES:
             invoice.shared_at = now

--- a/backend/app/features/invoices/tests/test_invoice_outcomes.py
+++ b/backend/app/features/invoices/tests/test_invoice_outcomes.py
@@ -233,3 +233,40 @@ async def test_invoice_outcome_labels_remain_editable_shareable_and_public(
     public_response = await client.get(f"/api/public/doc/{original_share_token}")
     assert public_response.status_code == 200
     assert public_response.json()["doc_type"] == "invoice"
+
+
+async def test_invoice_share_emits_invoice_shared_event_with_id_only_payload(
+    client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    emitted_events: list[dict[str, str]] = []
+
+    def _capture(message: str) -> None:
+        emitted_events.append(json.loads(message))
+
+    monkeypatch.setattr(event_logger._EVENT_LOGGER, "info", _capture)  # noqa: SLF001
+    csrf_token = await _register_and_login(client, _credentials())
+    customer_id = await _create_customer(client, csrf_token)
+    invoice = await _create_direct_invoice(
+        client,
+        csrf_token,
+        customer_id,
+        title="Invoice",
+        transcript="invoice transcript",
+        total_amount=120,
+    )
+
+    response = await client.post(
+        f"/api/invoices/{invoice['id']}/share",
+        headers={"X-CSRF-Token": csrf_token},
+    )
+
+    assert response.status_code == 200
+    matching_events = [
+        payload
+        for payload in emitted_events
+        if payload.get("event") == "invoice_shared" and payload.get("invoice_id") == invoice["id"]
+    ]
+    assert len(matching_events) == 1
+    assert matching_events[0]["customer_id"] == customer_id
+    assert "share_token" not in matching_events[0]

--- a/backend/app/features/quotes/email_delivery_service.py
+++ b/backend/app/features/quotes/email_delivery_service.py
@@ -223,7 +223,6 @@ class QuoteEmailDeliveryService:
             user_id=context.user_id,
             quote_id=context.quote_id,
             customer_id=context.customer_id,
-            persist_async=False,
         )
 
     async def _enforce_duplicate_send_guard(self, context: QuoteEmailContext) -> None:

--- a/backend/app/shared/event_logger.py
+++ b/backend/app/shared/event_logger.py
@@ -33,7 +33,9 @@ _PILOT_EVENT_NAMES = frozenset(
         "quote_viewed",
         "email_sent",
         "invoice_created",
+        "invoice_shared",
         "invoice_viewed",
+        "invoice_paid",
     }
 )
 _PENDING_EVENT_TASKS: set[asyncio.Task[None]] = set()

--- a/backend/app/shared/tests/test_event_logger.py
+++ b/backend/app/shared/tests/test_event_logger.py
@@ -361,5 +361,7 @@ def test_pilot_event_whitelist_matches_v1_analytics_contract() -> None:
         "quote_viewed",
         "email_sent",
         "invoice_created",
+        "invoice_shared",
         "invoice_viewed",
+        "invoice_paid",
     }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -201,6 +201,7 @@ Pilot event set:
 - `quote_viewed`
 - `email_sent`
 - `invoice_created`
+- `invoice_shared`
 - `invoice_viewed`
 - `invoice_paid`
 - `invoice_voided`
@@ -208,6 +209,8 @@ Pilot event set:
 `draft_generated` event metadata includes `extraction_outcome` with canonical values `primary` or `degraded`.
 
 These underscore names are the canonical quote-flow vocabulary for pilot instrumentation; dot-notation events such as `quote.created`, `quote.updated`, `quote.deleted`, and `customer.created` remain separate operational logs outside the pilot analytics scope.
+
+`manual_draft_created` remains in use until `quote.created` is persist-allowlisted (or another equivalent persisted intake event exists) so manual draft creation stays visible in pilot reporting.
 
 Internal analytics access:
 - `GET /api/admin/events?start_date=YYYY-MM-DD&end_date=YYYY-MM-DD&event_name?=...`


### PR DESCRIPTION
## Summary
- persist email_sent telemetry for quote and invoice email delivery by removing explicit persistence bypass
- include invoice_id in invoice email_sent event payload
- add invoice_paid and invoice_shared to pilot event allowlist, and emit invoice_shared when a share token is created
- document manual draft consolidation deferral (keep manual_draft_created until a persisted equivalent intake event exists)

## Verification
- cd backend && .venv/bin/pytest app/shared/tests/test_event_logger.py app/features/invoices/tests/test_invoice_outcomes.py -x --tb=short
- make backend-static-verify
- make backend-verify

Closes #630
