### PR TITLE
Task #634: remove customer_id fallback in QuotePreview

### DIFF
--- a/frontend/src/features/quotes/components/QuotePreview.tsx
+++ b/frontend/src/features/quotes/components/QuotePreview.tsx
@@ -53,7 +53,7 @@ export function QuotePreview(): React.ReactElement {
   const headerSubtitle = quote
     ? (quoteTitle ? `${quote.doc_number} · ${quoteTitle}` : quote.doc_number)
     : undefined;
-  const clientName = readOptionalQuoteText(quote, "customer_name") ?? quote?.customer_id ?? "Unknown customer";
+  const clientName = readOptionalQuoteText(quote, "customer_name") ?? "Unknown customer";
   const clientContact = readOptionalQuoteText(quote, "customer_phone") ?? readOptionalQuoteText(quote, "customer_email") ?? "No contact details";
   const extractionDegradedCopy = resolveExtractionDegradedCopy(quote);
   const canEdit = Boolean(quote && id && isQuoteEditableStatus(actionState));

--- a/frontend/src/features/quotes/tests/QuotePreview.test.tsx
+++ b/frontend/src/features/quotes/tests/QuotePreview.test.tsx
@@ -728,7 +728,7 @@ describe("QuotePreview", () => {
     expect(screen.queryByRole("button", { name: /generate pdf/i })).not.toBeInTheDocument();
   });
 
-  it("renders amount and falls back to customer_id when customer details are unavailable", async () => {
+  it("renders amount and falls back to Unknown customer when customer details are unavailable", async () => {
     mockedQuoteService.getQuote.mockResolvedValueOnce(
       makeQuoteDetail({
         total_amount: 245.5,
@@ -740,7 +740,8 @@ describe("QuotePreview", () => {
 
     expect(await screen.findByText("$245.50")).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Quote Preview" })).toBeInTheDocument();
-    expect(screen.getAllByText("cust-1")).toHaveLength(1);
+    expect(screen.getByText("Unknown customer")).toBeInTheDocument();
+    expect(screen.queryByText("cust-1")).not.toBeInTheDocument();
     expect(screen.getByText("No contact details")).toBeInTheDocument();
   });
 


### PR DESCRIPTION
## Summary
- remove `customer_id` fallback from `clientName` resolution in QuotePreview
- keep fallback copy user-safe as `Unknown customer` when `customer_name` is missing
- update QuotePreview test to assert UUID is not rendered

## Verification
- cd frontend && npx tsc --noEmit
- cd frontend && npx eslint src/features/quotes/components/QuotePreview.tsx
- cd frontend && npx vitest run src/features/quotes/tests/QuotePreview.test.tsx
- make frontend-verify

Closes #634
