### PR TITLE
Task #635: always show degraded warning on review/edit

### DIFF
--- a/frontend/src/features/quotes/components/ReviewFormContent.tsx
+++ b/frontend/src/features/quotes/components/ReviewFormContent.tsx
@@ -1,6 +1,7 @@
 import { ReviewCustomerRow } from "@/features/quotes/components/ReviewCustomerRow";
 import { ReviewDocumentTypeSelector, type ReviewDocumentType } from "@/features/quotes/components/ReviewDocumentTypeSelector";
 import { ReviewLineItemsSection } from "@/features/quotes/components/ReviewLineItemsSection";
+import { resolveExtractionDegradedCopyFromReasonCode } from "@/features/quotes/components/quotePreview.helpers";
 import { TotalAmountSection } from "@/features/quotes/components/TotalAmountSection";
 import type { ExtractionTier } from "@/features/quotes/types/quote.types";
 import { FeedbackMessage } from "@/shared/components/FeedbackMessage";
@@ -90,8 +91,10 @@ export function ReviewFormContent({
   onNotesChange,
 }: ReviewFormContentProps): React.ReactElement {
   const showDueDateField = documentType === "invoice";
-  const showSevereDegradedMarker = extractionTier === "degraded"
-    && draft.lineItems.length === 0;
+  const extractionDegradedCopy = resolveExtractionDegradedCopyFromReasonCode(
+    extractionTier,
+    extractionDegradedReasonCode,
+  );
 
   return (
     <form
@@ -113,12 +116,10 @@ export function ReviewFormContent({
         <FeedbackMessage variant="error">{saveError}</FeedbackMessage>
       ) : null}
 
-      {showSevereDegradedMarker ? (
+      {extractionDegradedCopy ? (
         <Banner
           title="Review Required"
-          message={extractionDegradedReasonCode
-            ? "Extraction degraded and no line items were found. Review capture details before continuing."
-            : "No line items were found from this capture. Review capture details before continuing."}
+          message={extractionDegradedCopy}
         />
       ) : null}
 

--- a/frontend/src/features/quotes/components/quotePreview.helpers.ts
+++ b/frontend/src/features/quotes/components/quotePreview.helpers.ts
@@ -1,4 +1,4 @@
-import type { QuoteDetail, QuoteStatus } from "@/features/quotes/types/quote.types";
+import type { ExtractionTier, QuoteDetail, QuoteStatus } from "@/features/quotes/types/quote.types";
 import type { OverflowMenuItem } from "@/shared/components/OverflowMenu";
 import { isHttpRequestError } from "@/shared/lib/http";
 
@@ -29,14 +29,24 @@ export function readOptionalQuoteText(
 }
 
 export function resolveExtractionDegradedCopy(quote: QuoteDetail | null): string | null {
-  if (!quote || quote.extraction_tier !== "degraded") {
+  return resolveExtractionDegradedCopyFromReasonCode(
+    quote?.extraction_tier ?? null,
+    quote?.extraction_degraded_reason_code ?? null,
+  );
+}
+
+export function resolveExtractionDegradedCopyFromReasonCode(
+  extractionTier: ExtractionTier | null,
+  degradedReasonCode: string | null,
+): string | null {
+  if (extractionTier !== "degraded") {
     return null;
   }
-  if (!quote.extraction_degraded_reason_code) {
+  if (!degradedReasonCode) {
     return "We saved your transcript, but extraction quality was degraded. Please review this draft before sharing.";
   }
   return (
-    DEGRADED_REASON_COPY[quote.extraction_degraded_reason_code]
+    DEGRADED_REASON_COPY[degradedReasonCode]
     ?? "We saved your transcript, but extraction quality was degraded. Please review this draft before sharing."
   );
 }

--- a/frontend/src/features/quotes/tests/ReviewScreen.test.tsx
+++ b/frontend/src/features/quotes/tests/ReviewScreen.test.tsx
@@ -470,20 +470,53 @@ describe("DocumentEditScreen", () => {
     });
 
     expect(await screen.findByText("Review Required")).toBeInTheDocument();
-    expect(screen.getByText("No line items were found from this capture. Review capture details before continuing.")).toBeInTheDocument();
+    expect(screen.getByText("We saved your transcript, but extraction quality was degraded. Please review this draft before sharing.")).toBeInTheDocument();
   });
 
   it("shows the degraded-specific high-severity marker copy when a degraded reason code is present", async () => {
     renderScreen({
       document: makeQuote({
         extraction_tier: "degraded",
-        extraction_degraded_reason_code: "no_line_items_from_substantial_capture",
+        extraction_degraded_reason_code: "provider_retryable_error",
         line_items: [],
       }),
     });
 
     expect(await screen.findByText("Review Required")).toBeInTheDocument();
-    expect(screen.getByText("Extraction degraded and no line items were found. Review capture details before continuing.")).toBeInTheDocument();
+    expect(screen.getByText("We saved your transcript, but line item extraction was temporarily unavailable. Please review and complete this draft before sharing.")).toBeInTheDocument();
+  });
+
+  it("shows the review marker when extraction is degraded and line items were recovered", async () => {
+    renderScreen({
+      document: makeQuote({
+        extraction_tier: "degraded",
+        extraction_degraded_reason_code: null,
+        line_items: [
+          {
+            id: "line-1",
+            description: "Brown mulch",
+            details: "5 yards",
+            price: 120,
+            sort_order: 0,
+          },
+        ],
+      }),
+    });
+
+    expect(await screen.findByText("Review Required")).toBeInTheDocument();
+    expect(screen.getByText("We saved your transcript, but extraction quality was degraded. Please review this draft before sharing.")).toBeInTheDocument();
+  });
+
+  it("does not show the review marker for non-degraded extraction", async () => {
+    renderScreen({
+      document: makeQuote({
+        extraction_tier: "primary",
+        extraction_degraded_reason_code: null,
+      }),
+    });
+
+    await screen.findByRole("button", { name: /continue to preview/i });
+    expect(screen.queryByText("Review Required")).not.toBeInTheDocument();
   });
 
   it("continues without a review modal when visible review markers remain", async () => {


### PR DESCRIPTION
## Summary
- remove the line-item-count gate so degraded extraction warning always renders on review/edit
- export `resolveExtractionDegradedCopyFromReasonCode(extractionTier, reasonCode)` from preview helpers and reuse it in review banner
- align review degraded copy with preview degraded copy and expand tests for degraded with/without line items plus non-degraded path

## Verification
- cd frontend && npx tsc --noEmit
- cd frontend && npx eslint src/features/quotes/components/ReviewFormContent.tsx
- cd frontend && npx vitest run src/features/quotes/tests/ReviewScreen.test.tsx
- make frontend-verify

Closes #635
