### PR TITLE
Task #638: preserve spoken-money shorthand in transcription

### DIFF
--- a/backend/app/features/quotes/extraction_service.py
+++ b/backend/app/features/quotes/extraction_service.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import re
 from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Literal, Protocol
@@ -21,6 +22,7 @@ from app.integrations.audio import AudioClip, AudioError
 from app.integrations.extraction import ExtractionError
 from app.integrations.transcription import TranscriptionError
 from app.shared.event_logger import log_event
+from app.shared.extraction_logger import log_extraction_trace
 from app.shared.input_limits import (
     AUDIO_TRANSCRIPT_MAX_CHARS,
     EXTRACTION_TRANSCRIPT_MAX_CHARS,
@@ -68,10 +70,14 @@ class ExtractionService:
         extraction_integration: ExtractionIntegrationProtocol,
         audio_integration: AudioIntegrationProtocol,
         transcription_integration: TranscriptionIntegrationProtocol,
+        transcription_model: str | None = None,
+        transcription_prompt_enabled: bool = True,
     ) -> None:
         self._extraction = extraction_integration
         self._audio = audio_integration
         self._transcription = transcription_integration
+        self._transcription_model = transcription_model
+        self._transcription_prompt_enabled = transcription_prompt_enabled
 
     async def convert_notes(self, notes: str) -> ExtractionResult:
         """Extract structured line items from freeform notes."""
@@ -123,6 +129,16 @@ class ExtractionService:
             source_type = "voice"
         else:
             source_type = "text"
+
+        log_extraction_trace(
+            "extraction.trace",
+            stage="capture_input",
+            outcome="prepared",
+            source_type=source_type,
+            transcription_model=self._transcription_model,
+            transcription_prompt_enabled=self._transcription_prompt_enabled if has_clips else None,
+            raw_transcript_currency_decimal_count=_count_currency_decimals(raw_transcript),
+        )
         return PreparedCaptureInput(
             transcript=combined_text,
             source_type=source_type,
@@ -238,3 +254,12 @@ def _validate_transcript_length(transcript: str, *, max_chars: int) -> None:
         detail=f"Transcript exceeds maximum length of {max_chars} characters",
         status_code=422,
     )
+
+
+_CURRENCY_DECIMAL_PATTERN = re.compile(r"\$\s*\d+(?:,\d{3})*\.\d{2}\b")
+
+
+def _count_currency_decimals(raw_transcript: str | None) -> int:
+    if not raw_transcript:
+        return 0
+    return len(_CURRENCY_DECIMAL_PATTERN.findall(raw_transcript))

--- a/backend/app/features/quotes/tests/test_extraction.py
+++ b/backend/app/features/quotes/tests/test_extraction.py
@@ -1171,6 +1171,64 @@ async def test_guard_noops_when_provider_price_already_matches_spoken_hint() -> 
     assert result.line_items[0].flag_reason is None
 
 
+async def test_guard_does_not_correct_explicit_dollars_and_cents_phrase() -> None:
+    transcript = "Add three dollars and twenty five cents for a small hardware fee."
+    client = _FakeClient(
+        lambda _: _FakeResponse(
+            content=[
+                {
+                    "type": "tool_use",
+                    "input": {
+                        "transcript": transcript,
+                        "line_items": [
+                            {
+                                "description": "Small hardware fee",
+                                "details": transcript,
+                                "price": 3.25,
+                            }
+                        ],
+                        "total": None,
+                    },
+                }
+            ]
+        )
+    )
+    integration = ExtractionIntegration(api_key="test", model="test-model", client=client)
+
+    result = await integration.extract(transcript)
+
+    assert result.line_items[0].price == 3.25
+    assert result.line_items[0].flag_reason is None
+
+
+async def test_guard_leaves_provider_normalized_decimal_failure_shape_unchanged() -> None:
+    transcript = "River Rock price is $4.50, Mulch price is $1.25, Mow Grass price is $3.75."
+    client = _FakeClient(
+        lambda _: _FakeResponse(
+            content=[
+                {
+                    "type": "tool_use",
+                    "input": {
+                        "transcript": transcript,
+                        "line_items": [
+                            {"description": "River Rock", "details": None, "price": 4.5},
+                            {"description": "Mulch", "details": None, "price": 1.25},
+                            {"description": "Mow Grass", "details": None, "price": 3.75},
+                        ],
+                        "total": None,
+                    },
+                }
+            ]
+        )
+    )
+    integration = ExtractionIntegration(api_key="test", model="test-model", client=client)
+
+    result = await integration.extract(transcript)
+
+    assert [item.price for item in result.line_items] == [4.5, 1.25, 3.75]
+    assert all(item.flag_reason is None for item in result.line_items)
+
+
 async def test_guard_applies_at_most_one_correction_per_spoken_hint() -> None:
     transcript = "Price is four fifty for front mulch."
     client = _FakeClient(

--- a/backend/app/features/quotes/tests/test_extraction.py
+++ b/backend/app/features/quotes/tests/test_extraction.py
@@ -1264,3 +1264,56 @@ async def test_guard_applies_at_most_one_correction_per_spoken_hint() -> None:
     assert result.line_items[0].flag_reason == SPOKEN_MONEY_CORRECTION_FLAG_REASON
     assert result.line_items[1].price == 4.5
     assert result.line_items[1].flagged is False
+
+
+async def test_result_trace_includes_spoken_money_counts_when_guard_corrects(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    transcript = "Price is four fifty for front mulch."
+    trace_calls: list[dict[str, object]] = []
+
+    def _capture_trace(
+        event: str,
+        *,
+        stage: str,
+        outcome: str,
+        **fields: object,
+    ) -> None:
+        trace_calls.append(
+            {
+                "event": event,
+                "stage": stage,
+                "outcome": outcome,
+                **fields,
+            }
+        )
+
+    monkeypatch.setattr(extraction_module, "log_extraction_trace", _capture_trace)
+    client = _FakeClient(
+        lambda _: _FakeResponse(
+            content=[
+                {
+                    "type": "tool_use",
+                    "input": {
+                        "transcript": transcript,
+                        "line_items": [
+                            {
+                                "description": "Front mulch",
+                                "details": "price is four fifty for front mulch",
+                                "price": 4.5,
+                            }
+                        ],
+                        "total": None,
+                    },
+                }
+            ]
+        )
+    )
+    integration = ExtractionIntegration(api_key="test", model="test-model", client=client)
+
+    await integration.extract(transcript)
+
+    result_calls = [call for call in trace_calls if call["stage"] == "result"]
+    assert len(result_calls) == 1
+    assert result_calls[0]["spoken_money_hint_count"] == 1
+    assert result_calls[0]["spoken_money_correction_count"] == 1

--- a/backend/app/features/quotes/tests/test_extraction_service.py
+++ b/backend/app/features/quotes/tests/test_extraction_service.py
@@ -7,6 +7,7 @@ from collections.abc import Sequence
 import pytest
 import sentry_sdk
 
+import app.features.quotes.extraction_service as extraction_service_module
 from app.features.quotes.extraction_service import CaptureAudioClip, ExtractionService
 from app.features.quotes.schemas import ExtractionMode, ExtractionResult, PreparedCaptureInput
 from app.features.quotes.service import QuoteServiceError
@@ -149,6 +150,65 @@ async def test_extract_combined_allows_audio_and_notes_up_to_extraction_limit() 
     assert extraction_mode == "initial"
     assert result.transcript == expected_transcript
     assert len(result.transcript) == EXTRACTION_TRANSCRIPT_MAX_CHARS
+
+
+async def test_convert_notes_does_not_call_transcription_integration() -> None:
+    extraction = _SuccessfulExtractionIntegration()
+    transcription = _SuccessfulTranscriptionIntegration()
+    calls: list[bytes] = []
+
+    async def _capture(audio_wav: bytes) -> str:
+        calls.append(audio_wav)
+        return "should-not-be-used"
+
+    transcription.transcribe = _capture  # type: ignore[method-assign]
+    service = ExtractionService(
+        extraction_integration=extraction,
+        audio_integration=_SuccessfulAudioIntegration(),
+        transcription_integration=transcription,
+    )
+
+    result = await service.convert_notes("hardware fee 3.25")
+
+    assert calls == []
+    assert result.transcript == "hardware fee 3.25"
+
+
+async def test_prepare_capture_input_logs_metadata_without_raw_transcript_content(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    traces: list[dict[str, object]] = []
+
+    def _capture_trace(
+        event: str,
+        *,
+        stage: str,
+        outcome: str,
+        **fields: object,
+    ) -> None:
+        traces.append({"event": event, "stage": stage, "outcome": outcome, **fields})
+
+    monkeypatch.setattr(extraction_service_module, "log_extraction_trace", _capture_trace)
+    service = ExtractionService(
+        extraction_integration=_SuccessfulExtractionIntegration(),
+        audio_integration=_SuccessfulAudioIntegration(),
+        transcription_integration=_SuccessfulTranscriptionIntegration("River Rock price is $4.50."),
+        transcription_model="whisper-1",
+        transcription_prompt_enabled=True,
+    )
+
+    prepared_capture_input = await service.prepare_capture_input([_clip()], "typed")
+
+    assert prepared_capture_input.source_type == "voice+text"
+    assert traces
+    metadata_trace = traces[-1]
+    assert metadata_trace["stage"] == "capture_input"
+    assert metadata_trace["outcome"] == "prepared"
+    assert metadata_trace["source_type"] == "voice+text"
+    assert metadata_trace["transcription_model"] == "whisper-1"
+    assert metadata_trace["transcription_prompt_enabled"] is True
+    assert metadata_trace["raw_transcript_currency_decimal_count"] == 1
+    assert "raw_transcript" not in metadata_trace
 
 
 def _clip() -> CaptureAudioClip:

--- a/backend/app/integrations/extraction.py
+++ b/backend/app/integrations/extraction.py
@@ -1456,6 +1456,13 @@ def _log_result_trace(
     model_id: str,
     prompt_variant: str,
 ) -> None:
+    capture_segments = getattr(result, "capture_segments", ())
+    spoken_money_hint_count = sum(
+        len(segment.hints.spoken_money_hints) for segment in capture_segments
+    )
+    spoken_money_correction_count = sum(
+        1 for item in result.line_items if item.flag_reason == SPOKEN_MONEY_CORRECTION_FLAG_REASON
+    )
     log_extraction_trace(
         _TRACE_EVENT_NAME,
         stage="result",
@@ -1467,6 +1474,8 @@ def _log_result_trace(
         extraction_degraded_reason_code=result.extraction_degraded_reason_code,
         line_item_count=len(result.line_items),
         flagged_line_item_count=sum(1 for item in result.line_items if item.flagged),
+        spoken_money_hint_count=spoken_money_hint_count,
+        spoken_money_correction_count=spoken_money_correction_count,
         unresolved_segment_count=len(result.unresolved_segments),
         total_present=result.pricing_hints.explicit_total is not None,
         raw_transcript=result.transcript,

--- a/backend/app/integrations/extraction.py
+++ b/backend/app/integrations/extraction.py
@@ -1456,7 +1456,7 @@ def _log_result_trace(
     model_id: str,
     prompt_variant: str,
 ) -> None:
-    capture_segments = getattr(result, "capture_segments", ())
+    capture_segments = _segment_capture_input(result.transcript)
     spoken_money_hint_count = sum(
         len(segment.hints.spoken_money_hints) for segment in capture_segments
     )

--- a/backend/app/integrations/tests/test_transcription.py
+++ b/backend/app/integrations/tests/test_transcription.py
@@ -14,8 +14,10 @@ class _FakeTranscriptions:
     def __init__(self) -> None:
         self.response: object = type("Response", (), {"text": " transcript "})()
         self.should_raise = False
+        self.calls: list[dict[str, object]] = []
 
-    async def create(self, **_: object) -> object:
+    async def create(self, **kwargs: object) -> object:
+        self.calls.append(kwargs)
         if self.should_raise:
             raise RuntimeError("provider unavailable")
         return self.response
@@ -40,11 +42,14 @@ async def test_transcribe_rejects_empty_audio_payload() -> None:
 
 
 async def test_transcribe_returns_trimmed_text() -> None:
-    integration = TranscriptionIntegration(api_key="test", model="whisper-1", client=_FakeClient())
+    client = _FakeClient()
+    integration = TranscriptionIntegration(api_key="test", model="whisper-1", client=client)
 
     transcript = await integration.transcribe(b"wav-bytes")
 
     assert transcript == "transcript"  # nosec B101
+    assert client.transcriptions.calls  # nosec B101
+    assert "prompt" in client.transcriptions.calls[0]  # nosec B101
 
 
 async def test_transcribe_rejects_missing_text_response() -> None:

--- a/backend/app/integrations/tests/test_transcription.py
+++ b/backend/app/integrations/tests/test_transcription.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 import httpx
 import openai
 import pytest
-from app.integrations.transcription import TranscriptionError, TranscriptionIntegration
+from app.integrations.transcription import (
+    TRANSCRIPTION_PROMPT_CONTRACTOR_PRICE_SHORTHAND,
+    TranscriptionError,
+    TranscriptionIntegration,
+)
 
 pytestmark = pytest.mark.asyncio
 
@@ -50,6 +54,23 @@ async def test_transcribe_returns_trimmed_text() -> None:
     assert transcript == "transcript"  # nosec B101
     assert client.transcriptions.calls  # nosec B101
     assert "prompt" in client.transcriptions.calls[0]  # nosec B101
+    assert (
+        client.transcriptions.calls[0]["prompt"] == TRANSCRIPTION_PROMPT_CONTRACTOR_PRICE_SHORTHAND
+    )  # nosec B101
+
+
+async def test_transcribe_uses_custom_prompt_when_provided() -> None:
+    client = _FakeClient()
+    integration = TranscriptionIntegration(
+        api_key="test",
+        model="whisper-1",
+        client=client,
+        prompt="Custom prompt",
+    )
+
+    await integration.transcribe(b"wav-bytes")
+
+    assert client.transcriptions.calls[0]["prompt"] == "Custom prompt"  # nosec B101
 
 
 async def test_transcribe_rejects_missing_text_response() -> None:

--- a/backend/app/integrations/transcription.py
+++ b/backend/app/integrations/transcription.py
@@ -13,6 +13,12 @@ from app.shared.observability import log_provider_quota_exhausted, log_provider_
 
 _RETRY_BASE_DELAY_SECONDS = 0.25
 _RETRY_MAX_DELAY_SECONDS = 2.0
+TRANSCRIPTION_PROMPT_CONTRACTOR_PRICE_SHORTHAND = (
+    "Transcribe contractor quote notes verbatim. Preserve spoken price shorthand as words. "
+    'Write contractor shorthand like "four fifty" and "one twenty five" as words, '
+    'not as "$4.50" or "$1.25". Only write "$4.50" when the speaker explicitly '
+    'says "four dollars and fifty cents".'
+)
 
 
 class TranscriptionError(Exception):
@@ -30,12 +36,14 @@ class TranscriptionIntegration:
         timeout_seconds: float = 30.0,
         max_attempts: int = 3,
         client: object | None = None,
+        prompt: str = TRANSCRIPTION_PROMPT_CONTRACTOR_PRICE_SHORTHAND,
     ) -> None:
         self._api_key = api_key
         self._model = model
         self._timeout_seconds = timeout_seconds
         self._max_attempts = max_attempts
         self._client = client
+        self._prompt = prompt
 
     async def transcribe(self, audio_wav: bytes) -> str:
         """Return normalized transcript text from WAV bytes."""
@@ -72,6 +80,7 @@ class TranscriptionIntegration:
                 return await typed_client.audio.transcriptions.create(
                     model=self._model,
                     file=("audio.wav", audio_wav, "audio/wav"),
+                    prompt=self._prompt,
                 )
             except Exception as exc:
                 last_error = exc

--- a/backend/app/shared/dependencies.py
+++ b/backend/app/shared/dependencies.py
@@ -252,10 +252,13 @@ def get_invoice_email_delivery_service(
 
 def get_extraction_service() -> ExtractionService:
     """Build a request-scoped extraction service wired to external integrations."""
+    settings = get_settings()
     return ExtractionService(
         extraction_integration=get_extraction_integration(),
         audio_integration=AudioIntegration(),
         transcription_integration=get_transcription_integration(),
+        transcription_model=settings.transcription_model,
+        transcription_prompt_enabled=True,
     )
 
 


### PR DESCRIPTION
## Summary
- add OpenAI transcription prompt to preserve contractor spoken-money shorthand as words
- add metadata-only extraction trace fields for transcription prompt/model + raw transcript decimal count
- add spoken-money hint/correction result metrics and regressions for explicit cents, normalized-decimal failure shape, and typed-only no-transcription path

## Verification
- cd backend && .venv/bin/pytest app/integrations/tests/test_transcription.py app/features/quotes/tests/test_extraction_service.py app/features/quotes/tests/test_extraction.py -x --tb=short
- make backend-static-verify
- make backend-verify

Closes #638