### PR TITLE
Preserve mixed voice+text capture provenance

### DIFF
--- a/backend/app/features/invoices/schemas.py
+++ b/backend/app/features/invoices/schemas.py
@@ -45,7 +45,7 @@ class InvoiceCreateRequest(BaseModel):
     discount_value: float | None = None
     deposit_amount: float | None = None
     notes: str | None = Field(default=None, max_length=DOCUMENT_NOTES_MAX_CHARS)
-    source_type: Literal["text", "voice"]
+    source_type: Literal["text", "voice", "voice+text"]
 
     _normalize_title = field_validator("title", mode="before")(_normalize_optional_title)
 

--- a/backend/app/features/invoices/tests/test_invoice_api.py
+++ b/backend/app/features/invoices/tests/test_invoice_api.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from uuid import UUID
+
 import pytest
 from app.features.quotes.models import Document, QuoteStatus
 from app.features.quotes.tests import test_quotes as quotes_test_module
@@ -136,6 +138,33 @@ async def test_create_direct_invoice_sets_default_due_date_and_keeps_quote_list_
     )
     assert quote_count == 0
     assert invoice_count == 1
+
+
+async def test_create_direct_invoice_accepts_mixed_source_type(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    csrf_token = await _register_and_login(client, _credentials())
+    customer_id = await _create_customer(client, csrf_token)
+
+    create_response = await client.post(
+        "/api/invoices",
+        json={
+            "customer_id": customer_id,
+            "transcript": "mixed capture transcript",
+            "line_items": [{"description": "line item", "details": None, "price": 55}],
+            "total_amount": 55,
+            "notes": "typed notes",
+            "source_type": "voice+text",
+        },
+        headers={"X-CSRF-Token": csrf_token},
+    )
+
+    assert create_response.status_code == 201
+    invoice_id = create_response.json()["id"]
+    persisted_invoice = await db_session.get(Document, UUID(invoice_id))
+    assert persisted_invoice is not None
+    assert persisted_invoice.source_type == "voice+text"
 
 
 async def test_list_invoices_returns_direct_and_quote_derived_summaries_newest_first(

--- a/backend/app/features/quotes/api.py
+++ b/backend/app/features/quotes/api.py
@@ -279,7 +279,7 @@ async def extract_combined(
     clip_inputs = await _parse_upload_clips(clips or [])
     clip_hashes = [sha256(clip.content).hexdigest() for clip in clip_inputs]
     capture_detail = _resolve_capture_detail(clip_inputs, notes)
-    source_type = _resolve_source_type(clip_inputs)
+    source_type = _resolve_source_type(clip_inputs, notes)
 
     try:
         await quote_service.ensure_customer_exists_for_user(
@@ -515,7 +515,13 @@ def _build_extraction_fingerprint(
     return sha256("|".join(normalized_parts).encode()).hexdigest()
 
 
-def _resolve_source_type(clips: list[CaptureAudioClip]) -> Literal["text", "voice"]:
+def _resolve_source_type(
+    clips: list[CaptureAudioClip],
+    notes: str | None,
+) -> Literal["text", "voice", "voice+text"]:
+    has_notes = bool((notes or "").strip())
+    if clips and has_notes:
+        return "voice+text"
     return "voice" if clips else "text"
 
 
@@ -586,7 +592,7 @@ async def get_quote(
         doc_number=quote.doc_number,
         title=quote.title,
         status=cast(str, quote.status),
-        source_type=cast(Literal["text", "voice"], quote.source_type),
+        source_type=cast(Literal["text", "voice", "voice+text"], quote.source_type),
         transcript=quote.transcript,
         extraction_tier=cast(Literal["primary", "degraded"] | None, quote.extraction_tier),
         extraction_degraded_reason_code=quote.extraction_degraded_reason_code,

--- a/backend/app/features/quotes/creation/service.py
+++ b/backend/app/features/quotes/creation/service.py
@@ -130,7 +130,7 @@ class QuoteCreationService:
         user_id: UUID,
         customer_id: UUID | None,
         extraction_result: ExtractionResult,
-        source_type: Literal["text", "voice"],
+        source_type: Literal["text", "voice", "voice+text"],
         commit: bool = True,
     ) -> Document:
         """Persist one extraction result as a draft quote."""
@@ -343,7 +343,7 @@ class QuoteCreationService:
         discount_value: float | None,
         deposit_amount: float | None,
         notes: str | None,
-        source_type: Literal["text", "voice"],
+        source_type: Literal["text", "voice", "voice+text"],
         extraction_tier: str | None = None,
         extraction_degraded_reason_code: str | None = None,
         extraction_review_metadata: dict[str, object] | None = None,

--- a/backend/app/features/quotes/schemas.py
+++ b/backend/app/features/quotes/schemas.py
@@ -562,7 +562,7 @@ class QuoteCreateRequest(BaseModel):
     discount_value: float | None = None
     deposit_amount: float | None = None
     notes: str | None = Field(default=None, max_length=DOCUMENT_NOTES_MAX_CHARS)
-    source_type: Literal["text", "voice"]
+    source_type: Literal["text", "voice", "voice+text"]
 
     _normalize_title = field_validator("title", mode="before")(_normalize_optional_title)
 
@@ -719,7 +719,7 @@ class QuoteResponse(BaseModel):
     doc_number: str
     title: str | None
     status: str
-    source_type: Literal["text", "voice"]
+    source_type: Literal["text", "voice", "voice+text"]
     transcript: str
     total_amount: float | None
     tax_rate: float | None

--- a/backend/app/features/quotes/service.py
+++ b/backend/app/features/quotes/service.py
@@ -241,7 +241,7 @@ class QuoteService:
         user_id: UUID,
         customer_id: UUID | None,
         extraction_result: ExtractionResult,
-        source_type: Literal["text", "voice"],
+        source_type: Literal["text", "voice", "voice+text"],
         commit: bool = True,
     ) -> Document:
         """Delegate extracted-draft persistence to the creation lifecycle slice."""

--- a/backend/app/features/quotes/tests/test_quote_extraction.py
+++ b/backend/app/features/quotes/tests/test_quote_extraction.py
@@ -674,6 +674,34 @@ async def test_extract_combined_enqueues_async_job_when_arq_pool_is_available(
     ]
 
 
+async def test_extract_combined_enqueues_async_job_with_mixed_source(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    csrf_token = await _register_and_login(client, _credentials())
+    pool = _MockArqPool()
+    app.state.arq_pool = pool
+
+    response = await client.post(
+        "/api/quotes/extract",
+        files=[
+            ("clips", ("clip-1.webm", b"clip-a", "audio/webm")),
+            ("notes", (None, "add 10 percent travel surcharge")),
+        ],
+        headers={"X-CSRF-Token": csrf_token},
+    )
+
+    jobs = (await db_session.scalars(select(JobRecord))).all()
+
+    assert response.status_code == 202
+    assert len(jobs) == 1
+    assert pool.calls[0]["kwargs"]["source_type"] == "voice+text"
+    assert pool.calls[0]["kwargs"]["capture_detail"] == "audio+notes"
+    prepared_capture_input = pool.calls[0]["kwargs"]["prepared_capture_input"]
+    assert isinstance(prepared_capture_input, dict)
+    assert prepared_capture_input["source_type"] == "voice+text"
+
+
 async def test_extract_combined_preserves_trusted_ingress_correlation_id_in_queue_payload(
     client: AsyncClient,
     monkeypatch: pytest.MonkeyPatch,
@@ -1035,6 +1063,12 @@ async def test_extract_combined_clips_and_notes_success(client: AsyncClient) -> 
         "transcript from stitched-1\n\nadd 10 percent travel surcharge"
     )
     assert payload["line_items"]
+    quote_response = await client.get(
+        f"/api/quotes/{payload['quote_id']}",
+        headers={"X-CSRF-Token": csrf_token},
+    )
+    assert quote_response.status_code == 200
+    assert quote_response.json()["source_type"] == "voice+text"
 
 
 async def test_extract_combined_requires_clip_or_notes(client: AsyncClient) -> None:

--- a/backend/app/features/quotes/tests/test_quote_to_invoice.py
+++ b/backend/app/features/quotes/tests/test_quote_to_invoice.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta
+from uuid import UUID
 
 import pytest
 from httpx import AsyncClient
@@ -343,6 +344,40 @@ async def test_optional_pricing_persists_on_quotes_public_payloads_and_converted
     assert invoice_payload["discount_value"] == 10
     assert invoice_payload["tax_rate"] == 0.1
     assert invoice_payload["deposit_amount"] == 30
+
+
+async def test_convert_quote_to_invoice_preserves_voice_plus_text_source_type(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    csrf_token = await _register_and_login(client, _credentials())
+    customer_id = await _create_customer(client, csrf_token)
+
+    quote_response = await client.post(
+        "/api/quotes",
+        json={
+            "customer_id": customer_id,
+            "transcript": "voice transcript\n\ntyped notes",
+            "line_items": [{"description": "line item", "details": None, "price": 55}],
+            "total_amount": 55,
+            "notes": "typed notes",
+            "source_type": "voice+text",
+        },
+        headers={"X-CSRF-Token": csrf_token},
+    )
+    assert quote_response.status_code == 201
+    quote_id = quote_response.json()["id"]
+
+    convert_response = await client.post(
+        f"/api/quotes/{quote_id}/convert-to-invoice",
+        headers={"X-CSRF-Token": csrf_token},
+    )
+    assert convert_response.status_code == 201
+    invoice_id = convert_response.json()["id"]
+
+    persisted_invoice = await db_session.get(Document, UUID(invoice_id))
+    assert persisted_invoice is not None
+    assert persisted_invoice.source_type == "voice+text"
 
 
 @pytest.mark.parametrize(

--- a/backend/app/worker/job_registry.py
+++ b/backend/app/worker/job_registry.py
@@ -494,10 +494,10 @@ class _UnusedWorkerStorageService:
         raise RuntimeError("Storage is not available in extraction persistence")
 
 
-def _validate_extraction_source_type(source_type: str) -> Literal["text", "voice"]:
-    if source_type not in {"text", "voice"}:
+def _validate_extraction_source_type(source_type: str) -> Literal["text", "voice", "voice+text"]:
+    if source_type not in {"text", "voice", "voice+text"}:
         raise NonRetryableJobError("Extraction job missing valid source_type")
-    return cast(Literal["text", "voice"], source_type)
+    return cast(Literal["text", "voice", "voice+text"], source_type)
 
 
 def _validate_extraction_mode(extraction_mode: str) -> ExtractionMode:
@@ -516,6 +516,8 @@ def _resolve_worker_capture_detail(*, source_type: str, capture_detail: str | No
     normalized_capture_detail = (capture_detail or "").strip()
     if normalized_capture_detail:
         return normalized_capture_detail
+    if source_type == "voice+text":
+        return "audio+notes"
     if source_type == "voice":
         return "audio"
     return "notes"
@@ -550,7 +552,9 @@ def _resolve_prepared_capture_input(
         raise NonRetryableJobError(
             "Extraction job requires transcript or prepared_capture_input payload"
         )
-    prepared_source_type: Literal["text", "voice"] = "voice" if source_type == "voice" else "text"
+    prepared_source_type: Literal["text", "voice"] = (
+        "voice" if source_type in {"voice", "voice+text"} else "text"
+    )
     return PreparedCaptureInput.from_legacy_transcript(
         transcript=normalized_transcript,
         source_type=prepared_source_type,

--- a/backend/app/worker/tests/test_job_registry.py
+++ b/backend/app/worker/tests/test_job_registry.py
@@ -97,6 +97,43 @@ async def test_extraction_job_accepts_legacy_enqueued_payload_without_source_met
     assert legacy_input.raw_transcript is None  # nosec B101 - pytest assertion
 
 
+async def test_extraction_job_persists_voice_plus_text_source_type(
+    db_session: AsyncSession,
+) -> None:
+    user = await _seed_user(db_session)
+    repository = JobRepository(db_session)
+    record = await repository.create(user_id=user.id, job_type=JobType.EXTRACTION)
+    await db_session.commit()
+
+    mixed_capture_input = PreparedCaptureInput(
+        transcript="voice transcript text\n\ntyped note text",
+        source_type="voice+text",
+        raw_typed_notes="typed note text",
+        raw_transcript="voice transcript text",
+    )
+
+    await extraction_job(
+        _worker_context(
+            db_session,
+            extraction_integration=_SuccessfulExtractionIntegration(),
+        ),
+        str(record.id),
+        prepared_capture_input=mixed_capture_input.model_dump(mode="json"),
+        source_type="voice+text",
+        capture_detail="audio+notes",
+    )
+
+    refreshed = await _load_job_record(db_session, record.id)
+    assert refreshed is not None  # nosec B101 - pytest assertion
+    assert refreshed.status == JobStatus.SUCCESS  # nosec B101 - pytest assertion
+    assert refreshed.document_id is not None  # nosec B101 - pytest assertion
+
+    persisted_quote = await db_session.get(Document, refreshed.document_id)
+    assert persisted_quote is not None  # nosec B101 - pytest assertion
+    assert persisted_quote.source_type == "voice+text"  # nosec B101 - pytest assertion
+    assert persisted_quote.transcript == mixed_capture_input.transcript  # nosec B101 - pytest assertion
+
+
 async def test_extraction_job_rejects_removed_append_mode(
     db_session: AsyncSession,
 ) -> None:

--- a/frontend/src/features/quotes/components/CaptureScreen.tsx
+++ b/frontend/src/features/quotes/components/CaptureScreen.tsx
@@ -244,7 +244,7 @@ export function CaptureScreen(): React.ReactElement {
       if (!isMountedRef.current) {
         return;
       }
-      const sourceType: QuoteSourceType = clips.length > 0 ? "voice" : "text";
+      const sourceType: QuoteSourceType = hasClips ? (hasNotes ? "voice+text" : "voice") : "text";
       if (extraction.type === "sync") {
         await markOutboxJobSucceeded({
           sessionId: extractionSessionId,

--- a/frontend/src/features/quotes/hooks/quoteDraftPersistence.ts
+++ b/frontend/src/features/quotes/hooks/quoteDraftPersistence.ts
@@ -68,7 +68,9 @@ function parseDraftFromValue(value: unknown): QuoteDraft | null {
   }
 
   const parsedSourceType: QuoteSourceType =
-    sourceType === "voice" || sourceType === "text" ? sourceType : "text";
+    sourceType === "voice" || sourceType === "text" || sourceType === "voice+text"
+      ? sourceType
+      : "text";
 
   return {
     customerId,

--- a/frontend/src/features/quotes/tests/CaptureScreen.test.tsx
+++ b/frontend/src/features/quotes/tests/CaptureScreen.test.tsx
@@ -617,6 +617,7 @@ describe("CaptureScreen", () => {
       expect.objectContaining({
         quoteId: "quote-1",
         customerId: "cust-1",
+        sourceType: "voice+text",
       }),
     );
     expect(mockedQuoteService.createQuote).not.toHaveBeenCalled();

--- a/frontend/src/features/quotes/types/quote.types.ts
+++ b/frontend/src/features/quotes/types/quote.types.ts
@@ -99,7 +99,7 @@ export type QuoteStatus =
   | "viewed"
   | "approved"
   | "declined";
-export type QuoteSourceType = "text" | "voice";
+export type QuoteSourceType = "text" | "voice" | "voice+text";
 export type ExtractionTier = "primary" | "degraded";
 
 export interface QuotePricingFields {


### PR DESCRIPTION
## Summary
- preserve mixed capture provenance as "voice+text" through quote persistence and API contracts
- align backend/worker/frontend source_type unions and resolver logic for clips+notes inputs
- add coverage for mixed sync extraction, mixed async queue payloads, mixed worker persistence, and capture draft source typing

## Verification
- cd backend && .venv/bin/pytest app/features/quotes/tests/test_quote_extraction.py -k "clips_and_notes_success or enqueues_async_job_with_mixed_source" -x --tb=short
- cd backend && .venv/bin/pytest app/worker/tests/test_job_registry.py -k "voice_plus_text_source_type" -x --tb=short
- cd frontend && npx vitest run src/features/quotes/tests/CaptureScreen.test.tsx -t "submits extraction with customer context and routes to persisted review id"
- make backend-static-verify
- make backend-verify
- make frontend-verify

Closes #639
