### PR TITLE
Hide empty-state body text in Pending Captures section

### DIFF
--- a/frontend/src/features/quotes/components/PendingCapturesSection.tsx
+++ b/frontend/src/features/quotes/components/PendingCapturesSection.tsx
@@ -93,10 +93,12 @@ export function PendingCapturesSection({
   onRetry,
   onDelete,
 }: PendingCapturesSectionProps): React.ReactElement {
+  const hasBodyContent = Boolean(error) || isLoading || captures.length > 0;
+
   return (
     <section aria-label="Pending captures" className="mb-4 px-4">
       <div className="ghost-shadow rounded-[var(--radius-document)] border border-outline-variant/20 bg-surface-container-low p-4">
-        <div className="mb-3 flex items-center justify-between">
+        <div className={`${hasBodyContent ? "mb-3 " : ""}flex items-center justify-between`}>
           <Eyebrow className="text-on-surface">PENDING CAPTURES</Eyebrow>
           <Eyebrow
             as="span"
@@ -112,9 +114,6 @@ export function PendingCapturesSection({
         ) : null}
         {isLoading ? (
           <p className="text-sm text-on-surface-variant">Loading pending captures...</p>
-        ) : null}
-        {!isLoading && captures.length === 0 ? (
-          <p className="text-sm text-on-surface-variant">No pending captures yet.</p>
         ) : null}
         {!isLoading && captures.length > 0 ? (
           <ul className="space-y-3">

--- a/frontend/src/features/quotes/tests/QuoteList.test.tsx
+++ b/frontend/src/features/quotes/tests/QuoteList.test.tsx
@@ -426,6 +426,30 @@ describe("QuoteList", () => {
     });
   });
 
+  it("keeps pending captures header and count, without empty-state body text, when captures are empty", async () => {
+    mockedUseRecoverableCaptures.mockReturnValue({
+      captures: [],
+      isLoading: false,
+      error: null,
+      refresh: vi.fn(async () => undefined),
+      deleteCapture: vi.fn(async () => undefined),
+    });
+    mockedQuoteService.listQuotes.mockResolvedValueOnce([makeQuoteListItem()]);
+
+    renderScreen();
+    await screen.findByText(/Q-001/);
+
+    const pendingCapturesRegion = screen.getByRole("region", { name: "Pending captures" });
+    expect(within(pendingCapturesRegion).getByText("PENDING CAPTURES")).toBeInTheDocument();
+    expect(within(pendingCapturesRegion).getByText("0")).toBeInTheDocument();
+    expect(within(pendingCapturesRegion).queryByText("No pending captures yet.")).not.toBeInTheDocument();
+    expect(within(pendingCapturesRegion).queryByText("Loading pending captures...")).not.toBeInTheDocument();
+
+    const headerContainer = pendingCapturesRegion.querySelector("div > div");
+    expect(headerContainer).not.toBeNull();
+    expect(headerContainer).not.toHaveClass("mb-3");
+  });
+
   it("sanitizes IndexedDB errors from pending-capture delete actions", async () => {
     const deleteCaptureMock = vi.fn(async () => {
       throw new Error("Failed to execute 'transaction' on 'IDBDatabase': The database connection is closing.");


### PR DESCRIPTION
## Summary
- remove the empty-state body text in Pending Captures when there are no captures and loading is false
- keep section header and count badge visible in empty state
- remove leftover header bottom margin in compact empty state
- add targeted QuoteList test coverage for empty-state rendering

## Verification
- cd frontend && npm run test -- src/features/quotes/tests/QuoteList.test.tsx
- cd frontend && npm exec eslint src/features/quotes/components/PendingCapturesSection.tsx
- make frontend-verify

Closes #642