### PR TITLE
Fix review total currency display to always show two decimals

### DIFF
--- a/frontend/src/features/quotes/components/TotalAmountSection.test.tsx
+++ b/frontend/src/features/quotes/components/TotalAmountSection.test.tsx
@@ -52,7 +52,9 @@ describe("TotalAmountSection", () => {
 
     expect(screen.getByText("Line Item Sum")).toBeInTheDocument();
     expect(screen.getByText("$100.00")).toBeInTheDocument();
-    expect(screen.getByLabelText(/total amount/i)).toHaveAttribute("id", "quote-total");
+    const totalInput = screen.getByLabelText(/total amount/i) as HTMLInputElement;
+    expect(totalInput).toHaveAttribute("id", "quote-total");
+    expect(totalInput.value).toBe("100.00");
   });
 
   it("forwards total amount edits through onTotalChange", () => {
@@ -76,6 +78,30 @@ describe("TotalAmountSection", () => {
 
     fireEvent.change(screen.getByLabelText(/total amount/i), { target: { value: "150" } });
     expect(onTotalChange).toHaveBeenLastCalledWith(150);
+  });
+
+  it("keeps partial total text while typing, then normalizes to two decimals on blur", () => {
+    renderSection();
+
+    const totalInput = screen.getByLabelText(/total amount/i) as HTMLInputElement;
+    fireEvent.focus(totalInput);
+    fireEvent.change(totalInput, { target: { value: "4." } });
+    expect(totalInput.value).toBe("4.");
+
+    fireEvent.blur(totalInput);
+    expect(totalInput.value).toBe("4.00");
+  });
+
+  it("normalizes decimal totals to two places after blur without injecting currency symbol", () => {
+    renderSection();
+
+    const totalInput = screen.getByLabelText(/total amount/i) as HTMLInputElement;
+    fireEvent.focus(totalInput);
+    fireEvent.change(totalInput, { target: { value: "4.5" } });
+    fireEvent.blur(totalInput);
+
+    expect(totalInput.value).toBe("4.50");
+    expect(totalInput.value.includes("$")).toBe(false);
   });
 
   it("keeps optional pricing discoverable while collapsed when nothing is active", () => {

--- a/frontend/src/features/quotes/components/TotalAmountSection.tsx
+++ b/frontend/src/features/quotes/components/TotalAmountSection.tsx
@@ -42,6 +42,7 @@ export function TotalAmountSection({
   const [taxToggleOverride, setTaxToggleOverride] = useState<boolean | null>(null);
   const [depositToggleOverride, setDepositToggleOverride] = useState<boolean | null>(null);
   const [isOptionalPricingOpen, setIsOptionalPricingOpen] = useState(false);
+  const [totalInputDraft, setTotalInputDraft] = useState<string | null>(null);
   const isDiscountEnabled = discountToggleOverride ?? (
     discountType !== null || hasActivePricingValue(discountValue)
   );
@@ -59,6 +60,8 @@ export function TotalAmountSection({
   const hasPricingBreakdown = pricingBreakdown.hasPricingBreakdown;
   const shouldShowOptionalPricingPanel = hasActiveOptionalPricing || isOptionalPricingOpen;
 
+  const totalInputValue = totalInputDraft ?? toTwoDecimalInputValue(total);
+
   return (
     <section className="rounded-[var(--radius-document)] bg-surface-container-low p-4">
       <div className="flex items-center justify-between text-sm text-outline">
@@ -74,8 +77,9 @@ export function TotalAmountSection({
             hideLabel
             step={0.01}
             disabled={disabled}
-            value={total === null ? "" : total.toString()}
+            value={totalInputValue}
             onChange={(rawValue) => {
+              setTotalInputDraft(rawValue);
               const normalizedValue = rawValue.replaceAll(",", "").trim();
               if (normalizedValue.length === 0) {
                 onTotalChange(null);
@@ -84,6 +88,9 @@ export function TotalAmountSection({
 
               const parsedValue = Number(normalizedValue);
               onTotalChange(Number.isFinite(parsedValue) ? parsedValue : null);
+            }}
+            onBlur={() => {
+              setTotalInputDraft(null);
             }}
             showStepControls={false}
             formatOnBlur={false}
@@ -295,4 +302,12 @@ export function TotalAmountSection({
 
 function hasActivePricingValue(value: number | null): boolean {
   return value !== null;
+}
+
+function toTwoDecimalInputValue(value: number | null): string {
+  if (value === null || !Number.isFinite(value)) {
+    return "";
+  }
+
+  return value.toFixed(2);
 }


### PR DESCRIPTION
## Summary
- keep raw typing state for the review total NumericField so partial numeric text is not rewritten while editing
- normalize displayed total to exactly two decimals when not actively editing
- keep currency symbol rendering in the existing adornment (no "$" in input value)
- add component tests covering partial input behavior and two-decimal normalization on blur

## Verification
- cd frontend && npx vitest run src/features/quotes/components/TotalAmountSection.test.tsx
- cd frontend && npx eslint src/features/quotes/components/TotalAmountSection.tsx src/features/quotes/components/TotalAmountSection.test.tsx
- make frontend-verify

Closes #644