### PR TITLE
Task #651: Polish PDF header contact line density

### DIFF
--- a/backend/app/features/quotes/tests/test_pdf_template.py
+++ b/backend/app/features/quotes/tests/test_pdf_template.py
@@ -525,8 +525,91 @@ def test_render_includes_contractor_contact_details_in_header_only(
     rendered_html = captured_html[0]
     assert "Prepared By" not in rendered_html
     assert 'class="header-contact"' in rendered_html
-    assert "+1-555-111-2222" in rendered_html
-    assert "owner@example.com" in rendered_html
+    assert re.search(
+        r"<p class=\"header-contact\">\s*\+1-555-111-2222 • owner@example\.com\s*</p>",
+        rendered_html,
+        re.DOTALL,
+    )
+
+
+@pytest.mark.parametrize(
+    ("phone_number", "contractor_email", "expected"),
+    [
+        ("+1-555-111-2222", None, "+1-555-111-2222"),
+        (None, "owner@example.com", "owner@example.com"),
+    ],
+)
+def test_render_contractor_contact_header_omits_dangling_separator_when_partial(
+    monkeypatch: pytest.MonkeyPatch,
+    phone_number: str | None,
+    contractor_email: str | None,
+    expected: str,
+) -> None:
+    captured_html: list[str] = []
+
+    class _FakeHTML:
+        def __init__(self, *, string: str, base_url: str) -> None:
+            del base_url
+            captured_html.append(string)
+
+        def write_pdf(self) -> bytes:
+            return b"fake-pdf"
+
+    monkeypatch.setattr("app.integrations.pdf.HTML", _FakeHTML)
+    template_dir = Path(__file__).resolve().parents[3] / "templates"
+    integration = PdfIntegration(template_dir=template_dir)
+
+    result = integration.render(
+        _make_context(
+            updated_at=datetime(2026, 3, 1, 12, 6, tzinfo=UTC),
+            line_item_price=Decimal("120.00"),
+            total=Decimal("120.00"),
+            phone_number=phone_number,
+            contractor_email=contractor_email,
+        )
+    )
+
+    assert result == b"fake-pdf"
+    rendered_html = captured_html[0]
+    assert re.search(
+        rf"<p class=\"header-contact\">\s*{re.escape(expected)}\s*</p>",
+        rendered_html,
+        re.DOTALL,
+    )
+    assert "•" not in rendered_html
+
+
+def test_render_contractor_contact_header_omits_row_when_phone_and_email_absent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured_html: list[str] = []
+
+    class _FakeHTML:
+        def __init__(self, *, string: str, base_url: str) -> None:
+            del base_url
+            captured_html.append(string)
+
+        def write_pdf(self) -> bytes:
+            return b"fake-pdf"
+
+    monkeypatch.setattr("app.integrations.pdf.HTML", _FakeHTML)
+    template_dir = Path(__file__).resolve().parents[3] / "templates"
+    integration = PdfIntegration(template_dir=template_dir)
+
+    result = integration.render(
+        _make_context(
+            updated_at=datetime(2026, 3, 1, 12, 6, tzinfo=UTC),
+            line_item_price=Decimal("120.00"),
+            total=Decimal("120.00"),
+            phone_number=None,
+            contractor_email=None,
+            business_address_lines=[],
+        )
+    )
+
+    assert result == b"fake-pdf"
+    rendered_html = captured_html[0]
+    assert 'class="header-contact"' not in rendered_html
 
 
 def test_render_hides_owner_name_when_both_name_fields_are_null(

--- a/backend/app/templates/quote.html
+++ b/backend/app/templates/quote.html
@@ -95,8 +95,9 @@
       }
 
       .header-contact {
-        margin: 3px 0 0;
+        margin: 2px 0 0;
         font-size: 12px;
+        line-height: 1.35;
         color: #4b5563;
       }
 
@@ -399,6 +400,8 @@
       {% set business_name = (business_name or "").strip() %}
       {% set owner_name = ((first_name or "") ~ " " ~ (last_name or "")).strip() %}
       {% set display_name = business_name or owner_name %}
+      {% set business_phone = (phone_number or "").strip() %}
+      {% set business_email = (contractor_email or "").strip() %}
       <header class="header">
         <table class="header-grid">
           <tbody>
@@ -410,11 +413,16 @@
                 {% if business_name and owner_name %}
                 <p class="owner-name">{{ owner_name }}</p>
                 {% endif %}
-                {% if phone_number %}
-                <p class="header-contact">{{ phone_number }}</p>
-                {% endif %}
-                {% if contractor_email %}
-                <p class="header-contact">{{ contractor_email }}</p>
+                {% if business_phone or business_email %}
+                <p class="header-contact">
+                  {% if business_phone and business_email %}
+                  {{ business_phone }} • {{ business_email }}
+                  {% elif business_phone %}
+                  {{ business_phone }}
+                  {% else %}
+                  {{ business_email }}
+                  {% endif %}
+                </p>
                 {% endif %}
                 {% for line in business_address_lines %}
                 <p class="header-contact">{{ line }}</p>


### PR DESCRIPTION
## Summary
- tighten PDF header contact block vertical rhythm
- render contractor phone + email on one compact line when both exist
- preserve phone-only/email-only behavior with no dangling separator
- strengthen PDF template tests for combined-line markup and sparse variants

## Verification
- cd backend && .venv/bin/pytest app/features/quotes/tests/test_pdf_template.py -q
- make backend-verify

Closes #651
