### PR TITLE
Task #653: Backend archive visibility model

### DIFF
--- a/backend/alembic/versions/20260502_0029_add_documents_archived_at.py
+++ b/backend/alembic/versions/20260502_0029_add_documents_archived_at.py
@@ -1,0 +1,32 @@
+"""Add archived_at visibility column to documents.
+
+Revision ID: 20260502_0029
+Revises: 20260429_0028
+Create Date: 2026-05-02
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "20260502_0029"
+down_revision: str | None = "20260429_0028"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "documents",
+        sa.Column("archived_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.create_index("ix_documents_archived_at", "documents", ["archived_at"], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index("ix_documents_archived_at", table_name="documents")
+    op.drop_column("documents", "archived_at")

--- a/backend/app/features/invoices/repository.py
+++ b/backend/app/features/invoices/repository.py
@@ -175,6 +175,7 @@ class InvoiceRepository:
             .where(
                 Document.user_id == user_id,
                 Document.doc_type == _INVOICE_DOC_TYPE,
+                Document.archived_at.is_(None),
             )
             .order_by(Document.created_at.desc(), Document.doc_sequence.desc())
         )
@@ -629,6 +630,21 @@ class InvoiceRepository:
         invoice.pdf_artifact_revision += 1
         await self._session.flush()
         return previous_path
+
+    async def archive_by_id(self, *, invoice_id: UUID, user_id: UUID) -> bool:
+        """Archive one owned invoice when it is not already archived."""
+        row = await self._session.execute(
+            update(Document)
+            .where(
+                Document.id == invoice_id,
+                Document.user_id == user_id,
+                Document.doc_type == _INVOICE_DOC_TYPE,
+                Document.archived_at.is_(None),
+            )
+            .values(archived_at=func.now())
+            .returning(Document.id)
+        )
+        return row.scalar_one_or_none() is not None
 
     async def mark_ready_if_draft(self, *, invoice_id: UUID, user_id: UUID) -> None:
         """Transition invoice status to ready when previewing a draft invoice."""

--- a/backend/app/features/invoices/tests/test_archive_visibility.py
+++ b/backend/app/features/invoices/tests/test_archive_visibility.py
@@ -1,0 +1,174 @@
+"""Invoice archive visibility behavior tests."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+import pytest
+from app.features.invoices.repository import InvoiceRepository
+from app.features.quotes.models import Document, QuoteStatus
+from app.features.quotes.repository import QuoteRepository
+from app.features.quotes.tests import test_quotes as quotes_test_module
+from app.features.quotes.tests.support.helpers import (
+    _create_customer,
+    _create_direct_invoice,
+    _create_quote,
+    _credentials,
+    _get_user_by_email,
+    _register_and_login,
+    _set_quote_status,
+)
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+pytestmark = pytest.mark.asyncio
+
+# Reuse existing fixture wiring/helpers from test_quotes to preserve behavior.
+_reset_email_delivery_fallback_cache = quotes_test_module._reset_email_delivery_fallback_cache
+_override_storage_service_dependency = quotes_test_module._override_storage_service_dependency
+_override_quote_service_dependency = quotes_test_module._override_quote_service_dependency
+_override_extraction_service_dependency = quotes_test_module._override_extraction_service_dependency
+_reset_rate_limiter = quotes_test_module._reset_rate_limiter
+
+
+async def test_archived_invoice_hidden_from_default_lists_and_public_share_still_works(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    csrf_token = await _register_and_login(client, _credentials())
+    customer_id = await _create_customer(client, csrf_token, name="Invoice Archive Customer")
+    invoice = await _create_direct_invoice(
+        client,
+        csrf_token,
+        customer_id,
+        title="Archive me",
+        transcript="invoice transcript",
+        total_amount=180,
+    )
+
+    share_response = await client.post(
+        f"/api/invoices/{invoice['id']}/share",
+        headers={"X-CSRF-Token": csrf_token},
+    )
+    assert share_response.status_code == 200
+    share_token = share_response.json()["share_token"]
+    assert isinstance(share_token, str)
+
+    persisted_invoice = await db_session.get(Document, UUID(str(invoice["id"])))
+    assert persisted_invoice is not None
+    original_status = persisted_invoice.status
+
+    repository = InvoiceRepository(db_session)
+    archived = await repository.archive_by_id(
+        invoice_id=persisted_invoice.id,
+        user_id=persisted_invoice.user_id,
+    )
+    assert archived
+    await repository.commit()
+
+    await db_session.refresh(persisted_invoice)
+    assert persisted_invoice.archived_at is not None
+    assert persisted_invoice.status == original_status
+
+    list_response = await client.get("/api/invoices")
+    assert list_response.status_code == 200
+    assert list_response.json() == []
+
+    customer_list_response = await client.get(f"/api/invoices?customer_id={customer_id}")
+    assert customer_list_response.status_code == 200
+    assert customer_list_response.json() == []
+
+    detail_response = await client.get(f"/api/invoices/{invoice['id']}")
+    assert detail_response.status_code == 200
+
+    public_response = await client.get(f"/api/public/doc/{share_token}")
+    assert public_response.status_code == 200
+
+
+async def test_archive_invoice_rejects_other_user_and_rearchive(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    owner_credentials = _credentials()
+    owner_csrf = await _register_and_login(client, owner_credentials)
+    customer_id = await _create_customer(client, owner_csrf)
+    invoice = await _create_direct_invoice(
+        client,
+        owner_csrf,
+        customer_id,
+        title="Owner invoice",
+        transcript="invoice transcript",
+        total_amount=200,
+    )
+
+    persisted_invoice = await db_session.get(Document, UUID(str(invoice["id"])))
+    assert persisted_invoice is not None
+    original_status = persisted_invoice.status
+
+    other_credentials = _credentials()
+    await _register_and_login(client, other_credentials)
+    other_user = await _get_user_by_email(db_session, other_credentials["email"])
+
+    repository = InvoiceRepository(db_session)
+    archived_by_other_user = await repository.archive_by_id(
+        invoice_id=persisted_invoice.id,
+        user_id=other_user.id,
+    )
+    assert archived_by_other_user is False
+
+    archived_by_owner = await repository.archive_by_id(
+        invoice_id=persisted_invoice.id,
+        user_id=persisted_invoice.user_id,
+    )
+    assert archived_by_owner
+    await repository.commit()
+
+    archived_again = await repository.archive_by_id(
+        invoice_id=persisted_invoice.id,
+        user_id=persisted_invoice.user_id,
+    )
+    assert archived_again is False
+
+    await db_session.refresh(persisted_invoice)
+    assert persisted_invoice.archived_at is not None
+    assert persisted_invoice.status == original_status
+
+
+async def test_source_document_relationship_survives_quote_archiving(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    csrf_token = await _register_and_login(client, _credentials())
+    customer_id = await _create_customer(client, csrf_token)
+    quote = await _create_quote(client, csrf_token, customer_id)
+    await _set_quote_status(db_session, quote["id"], QuoteStatus.APPROVED)
+
+    convert_response = await client.post(
+        f"/api/quotes/{quote['id']}/convert-to-invoice",
+        headers={"X-CSRF-Token": csrf_token},
+    )
+    assert convert_response.status_code == 201
+    invoice_payload = convert_response.json()
+
+    persisted_quote = await db_session.get(Document, UUID(quote["id"]))
+    assert persisted_quote is not None
+
+    quote_repository = QuoteRepository(db_session)
+    archived = await quote_repository.archive_by_id(
+        quote_id=persisted_quote.id,
+        user_id=persisted_quote.user_id,
+    )
+    assert archived
+    await quote_repository.commit()
+
+    invoice_repository = InvoiceRepository(db_session)
+    linked_invoice = await invoice_repository.get_by_source_document_id(
+        source_document_id=persisted_quote.id,
+        user_id=persisted_quote.user_id,
+    )
+    assert linked_invoice is not None
+    assert str(linked_invoice.id) == str(invoice_payload["id"])
+
+    invoice_detail_response = await client.get(f"/api/invoices/{invoice_payload['id']}")
+    assert invoice_detail_response.status_code == 200
+    assert invoice_detail_response.json()["source_document_id"] == quote["id"]

--- a/backend/app/features/quotes/models.py
+++ b/backend/app/features/quotes/models.py
@@ -139,6 +139,11 @@ class Document(Base):
         sa.DateTime(timezone=True),
         nullable=True,
     )
+    archived_at: Mapped[datetime | None] = mapped_column(
+        sa.DateTime(timezone=True),
+        nullable=True,
+        index=True,
+    )
     created_at: Mapped[datetime] = mapped_column(
         sa.DateTime(timezone=True),
         nullable=False,

--- a/backend/app/features/quotes/repository.py
+++ b/backend/app/features/quotes/repository.py
@@ -285,6 +285,7 @@ class QuoteRepository:
             .where(
                 Document.user_id == user_id,
                 Document.doc_type == _QUOTE_DOC_TYPE,
+                Document.archived_at.is_(None),
             )
             .order_by(Document.created_at.desc(), Document.doc_sequence.desc())
         )
@@ -339,6 +340,7 @@ class QuoteRepository:
             .where(
                 Document.user_id == user_id,
                 Document.doc_type == _QUOTE_DOC_TYPE,
+                Document.archived_at.is_(None),
             )
             .order_by(Document.created_at.desc(), Document.doc_sequence.desc())
         )
@@ -799,6 +801,21 @@ class QuoteRepository:
     async def delete(self, document_id: UUID) -> None:
         """Hard-delete a quote document; line items are removed by cascade."""
         await self._session.execute(delete(Document).where(Document.id == document_id))
+
+    async def archive_by_id(self, *, quote_id: UUID, user_id: UUID) -> bool:
+        """Archive one owned quote when it is not already archived."""
+        row = await self._session.execute(
+            update(Document)
+            .where(
+                Document.id == quote_id,
+                Document.user_id == user_id,
+                Document.doc_type == _QUOTE_DOC_TYPE,
+                Document.archived_at.is_(None),
+            )
+            .values(archived_at=func.now())
+            .returning(Document.id)
+        )
+        return row.scalar_one_or_none() is not None
 
     async def update(
         self,

--- a/backend/app/features/quotes/tests/test_archive_visibility.py
+++ b/backend/app/features/quotes/tests/test_archive_visibility.py
@@ -1,0 +1,162 @@
+"""Quote archive visibility behavior tests."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.features.invoices.repository import InvoiceRepository
+from app.features.quotes.models import Document, QuoteStatus
+from app.features.quotes.repository import QuoteRepository
+from app.features.quotes.tests import test_quotes as quotes_test_module
+from app.features.quotes.tests.support.helpers import (
+    _create_customer,
+    _create_quote,
+    _credentials,
+    _get_user_by_email,
+    _register_and_login,
+    _set_quote_status,
+)
+
+pytestmark = pytest.mark.asyncio
+
+# Reuse existing fixture wiring/helpers from test_quotes to preserve behavior.
+_reset_email_delivery_fallback_cache = quotes_test_module._reset_email_delivery_fallback_cache
+_override_storage_service_dependency = quotes_test_module._override_storage_service_dependency
+_override_quote_service_dependency = quotes_test_module._override_quote_service_dependency
+_override_extraction_service_dependency = quotes_test_module._override_extraction_service_dependency
+_reset_rate_limiter = quotes_test_module._reset_rate_limiter
+
+
+async def test_archived_quote_hidden_from_default_lists_and_public_share_still_works(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    csrf_token = await _register_and_login(client, _credentials())
+    customer_id = await _create_customer(client, csrf_token, name="Archive Customer")
+    quote = await _create_quote(client, csrf_token, customer_id)
+    await _set_quote_status(db_session, quote["id"], QuoteStatus.SHARED)
+
+    share_response = await client.post(
+        f"/api/quotes/{quote['id']}/share",
+        headers={"X-CSRF-Token": csrf_token},
+    )
+    assert share_response.status_code == 200
+    share_token = share_response.json()["share_token"]
+    assert isinstance(share_token, str)
+
+    persisted_quote = await db_session.get(Document, UUID(quote["id"]))
+    assert persisted_quote is not None
+    original_status = persisted_quote.status
+
+    repository = QuoteRepository(db_session)
+    archived = await repository.archive_by_id(
+        quote_id=persisted_quote.id,
+        user_id=persisted_quote.user_id,
+    )
+    assert archived
+    await repository.commit()
+
+    await db_session.refresh(persisted_quote)
+    assert persisted_quote.archived_at is not None
+    assert persisted_quote.status == original_status
+
+    list_response = await client.get("/api/quotes")
+    assert list_response.status_code == 200
+    assert list_response.json() == []
+
+    customer_list_response = await client.get(f"/api/quotes?customer_id={customer_id}")
+    assert customer_list_response.status_code == 200
+    assert customer_list_response.json() == []
+
+    reuse_response = await client.get("/api/quotes/reuse-candidates")
+    assert reuse_response.status_code == 200
+    assert reuse_response.json() == []
+
+    detail_response = await client.get(f"/api/quotes/{quote['id']}")
+    assert detail_response.status_code == 200
+
+    public_response = await client.get(f"/api/public/doc/{share_token}")
+    assert public_response.status_code == 200
+
+
+async def test_archive_quote_rejects_other_user_and_rearchive(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    owner_credentials = _credentials()
+    owner_csrf = await _register_and_login(client, owner_credentials)
+    customer_id = await _create_customer(client, owner_csrf)
+    quote = await _create_quote(client, owner_csrf, customer_id)
+
+    persisted_quote = await db_session.get(Document, UUID(quote["id"]))
+    assert persisted_quote is not None
+    original_status = persisted_quote.status
+
+    other_credentials = _credentials()
+    await _register_and_login(client, other_credentials)
+    other_user = await _get_user_by_email(db_session, other_credentials["email"])
+
+    repository = QuoteRepository(db_session)
+    archived_by_other_user = await repository.archive_by_id(
+        quote_id=persisted_quote.id,
+        user_id=other_user.id,
+    )
+    assert archived_by_other_user is False
+
+    archived_by_owner = await repository.archive_by_id(
+        quote_id=persisted_quote.id,
+        user_id=persisted_quote.user_id,
+    )
+    assert archived_by_owner
+    await repository.commit()
+
+    archived_again = await repository.archive_by_id(
+        quote_id=persisted_quote.id,
+        user_id=persisted_quote.user_id,
+    )
+    assert archived_again is False
+
+    await db_session.refresh(persisted_quote)
+    assert persisted_quote.archived_at is not None
+    assert persisted_quote.status == original_status
+
+
+async def test_has_linked_invoice_still_true_after_linked_invoice_archived(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    csrf_token = await _register_and_login(client, _credentials())
+    customer_id = await _create_customer(client, csrf_token)
+    quote = await _create_quote(client, csrf_token, customer_id)
+    await _set_quote_status(db_session, quote["id"], QuoteStatus.APPROVED)
+
+    convert_response = await client.post(
+        f"/api/quotes/{quote['id']}/convert-to-invoice",
+        headers={"X-CSRF-Token": csrf_token},
+    )
+    assert convert_response.status_code == 201
+    invoice_id = convert_response.json()["id"]
+
+    persisted_quote = await db_session.get(Document, UUID(quote["id"]))
+    persisted_invoice = await db_session.get(Document, UUID(invoice_id))
+    assert persisted_quote is not None
+    assert persisted_invoice is not None
+
+    invoice_repository = InvoiceRepository(db_session)
+    archived_invoice = await invoice_repository.archive_by_id(
+        invoice_id=persisted_invoice.id,
+        user_id=persisted_invoice.user_id,
+    )
+    assert archived_invoice
+    await invoice_repository.commit()
+
+    quote_repository = QuoteRepository(db_session)
+    has_linked_invoice = await quote_repository.has_linked_invoice(
+        source_document_id=persisted_quote.id,
+        user_id=persisted_quote.user_id,
+    )
+    assert has_linked_invoice


### PR DESCRIPTION
## Summary
- add documents.archived_at model field and Alembic migration with index
- add quote/invoice repository archive mutation methods that set archived_at only for owned, not-yet-archived docs
- hide archived docs from default owner-facing quote/invoice list and quote reuse candidate queries
- add integration coverage for archive ownership/idempotency, visibility filtering, linked-document checks, and public share behavior

## Verification
- cd backend && .venv/bin/pytest app/features/quotes/tests/test_archive_visibility.py -x --tb=short
- cd backend && .venv/bin/pytest app/features/invoices/tests/test_archive_visibility.py -x --tb=short
- make backend-static-verify
- make backend-verify

Closes #653