### PR TITLE
Task #654: backend safe bulk action endpoints

### DIFF
--- a/backend/alembic/versions/20260502_0030_restrict_source_document_delete.py
+++ b/backend/alembic/versions/20260502_0030_restrict_source_document_delete.py
@@ -1,0 +1,44 @@
+"""Restrict deleting source documents referenced by invoices.
+
+Revision ID: 20260502_0030
+Revises: 20260502_0029
+Create Date: 2026-05-02
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "20260502_0030"
+down_revision: str | None = "20260502_0029"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_SOURCE_DOCUMENT_FK = "fk_documents_source_document_id_documents"
+
+
+def upgrade() -> None:
+    op.drop_constraint(_SOURCE_DOCUMENT_FK, "documents", type_="foreignkey")
+    op.create_foreign_key(
+        _SOURCE_DOCUMENT_FK,
+        "documents",
+        "documents",
+        ["source_document_id"],
+        ["id"],
+        ondelete="RESTRICT",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(_SOURCE_DOCUMENT_FK, "documents", type_="foreignkey")
+    op.create_foreign_key(
+        _SOURCE_DOCUMENT_FK,
+        "documents",
+        "documents",
+        ["source_document_id"],
+        ["id"],
+        ondelete="SET NULL",
+    )

--- a/backend/app/features/customers/tests/test_customers.py
+++ b/backend/app/features/customers/tests/test_customers.py
@@ -6,8 +6,11 @@ from uuid import uuid4
 
 import pytest
 from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.features.auth.service import CSRF_COOKIE_NAME
+from app.features.quotes.models import QuoteStatus
+from app.features.quotes.tests.support.helpers import _set_quote_status
 
 pytestmark = pytest.mark.asyncio
 
@@ -215,6 +218,57 @@ async def test_delete_customer_deletes_owned_customer_and_cascades_documents(
     invoice_response = await client.get(f"/api/invoices/{invoice['id']}")
     assert invoice_response.status_code == 404
     assert invoice_response.json() == {"detail": "Not found"}
+
+
+async def test_delete_customer_with_linked_quote_invoice_cascades_successfully(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    csrf_token = await _register_and_login(client, _credentials())
+    created_customer = await _create_customer(
+        client,
+        csrf_token,
+        {"name": "Linked Pair Customer"},
+    )
+    quote = await _create_quote_for_customer(
+        client,
+        csrf_token,
+        customer_id=str(created_customer["id"]),
+    )
+    quote_id = str(quote["id"])
+    await _set_quote_status(db_session, quote_id, QuoteStatus.APPROVED)
+
+    convert_response = await client.post(
+        f"/api/quotes/{quote_id}/convert-to-invoice",
+        headers={"X-CSRF-Token": csrf_token},
+    )
+    assert convert_response.status_code == 201
+    invoice = convert_response.json()
+
+    archive_invoice_response = await client.post(
+        "/api/invoices/bulk-action",
+        json={"action": "archive", "ids": [invoice["id"]]},
+        headers={"X-CSRF-Token": csrf_token},
+    )
+    assert archive_invoice_response.status_code == 200
+    assert archive_invoice_response.json()["applied"] == [{"id": invoice["id"]}]
+
+    response = await client.delete(
+        f"/api/customers/{created_customer['id']}",
+        headers={"X-CSRF-Token": csrf_token},
+    )
+
+    assert response.status_code == 204
+    assert response.content == b""
+
+    customer_response = await client.get(f"/api/customers/{created_customer['id']}")
+    assert customer_response.status_code == 404
+
+    quote_response = await client.get(f"/api/quotes/{quote_id}")
+    assert quote_response.status_code == 404
+
+    invoice_response = await client.get(f"/api/invoices/{invoice['id']}")
+    assert invoice_response.status_code == 404
 
 
 async def test_delete_customer_returns_404_for_nonexistent_id(client: AsyncClient) -> None:

--- a/backend/app/features/invoices/api.py
+++ b/backend/app/features/invoices/api.py
@@ -16,6 +16,8 @@ from app.core.database import get_db
 from app.features.auth.models import User
 from app.features.invoices.email_delivery_service import InvoiceEmailDeliveryService
 from app.features.invoices.schemas import (
+    InvoiceBulkActionRequest,
+    InvoiceBulkActionResponse,
     InvoiceCreateRequest,
     InvoiceCustomerResponse,
     InvoiceDetailResponse,
@@ -149,6 +151,20 @@ async def get_invoice(
             terminal_error=invoice.pdf_artifact_terminal_error,
         ),
     )
+
+
+@router.post(
+    "/bulk-action",
+    response_model=InvoiceBulkActionResponse,
+    dependencies=[Depends(require_csrf)],
+)
+async def bulk_action_invoices(
+    payload: InvoiceBulkActionRequest,
+    user: Annotated[User, Depends(get_current_user)],
+    invoice_service: Annotated[InvoiceService, Depends(get_invoice_service)],
+) -> InvoiceBulkActionResponse:
+    """Execute one invoice-scoped bulk archive/delete action."""
+    return await invoice_service.execute_bulk_action(user, payload)
 
 
 @router.patch(

--- a/backend/app/features/invoices/api.py
+++ b/backend/app/features/invoices/api.py
@@ -156,6 +156,7 @@ async def get_invoice(
 @router.post(
     "/bulk-action",
     response_model=InvoiceBulkActionResponse,
+    response_model_exclude_none=True,
     dependencies=[Depends(require_csrf)],
 )
 async def bulk_action_invoices(

--- a/backend/app/features/invoices/repository.py
+++ b/backend/app/features/invoices/repository.py
@@ -214,6 +214,18 @@ class InvoiceRepository:
         )
         return result.scalar_one_or_none()
 
+    async def get_owned_document_by_id(self, document_id: UUID, user_id: UUID) -> Document | None:
+        """Return one owned document of any type, including line items."""
+        result = await self._session.execute(
+            select(Document)
+            .where(
+                Document.id == document_id,
+                Document.user_id == user_id,
+            )
+            .options(selectinload(Document.line_items))
+        )
+        return result.scalar_one_or_none()
+
     async def get_by_source_document_id(
         self,
         *,

--- a/backend/app/features/invoices/schemas.py
+++ b/backend/app/features/invoices/schemas.py
@@ -9,6 +9,8 @@ from uuid import UUID
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from app.features.quotes.schemas import (
+    BulkActionRequest,
+    BulkActionResponse,
     DiscountType,
     LineItemDraft,
     LineItemResponse,
@@ -141,3 +143,11 @@ class InvoiceUpdateRequest(BaseModel):
         if "doc_type" in self.model_fields_set and self.doc_type is None:
             raise ValueError("doc_type cannot be null")
         return self
+
+
+class InvoiceBulkActionRequest(BulkActionRequest):
+    """Invoice bulk action request payload."""
+
+
+class InvoiceBulkActionResponse(BulkActionResponse):
+    """Invoice bulk action response payload."""

--- a/backend/app/features/invoices/service.py
+++ b/backend/app/features/invoices/service.py
@@ -27,15 +27,22 @@ from app.features.invoices.repository import (
     InvoicePublicShareRecord,
     InvoiceRepository,
 )
-from app.features.invoices.schemas import InvoiceCreateRequest, InvoiceUpdateRequest
+from app.features.invoices.schemas import (
+    InvoiceBulkActionRequest,
+    InvoiceBulkActionResponse,
+    InvoiceCreateRequest,
+    InvoiceUpdateRequest,
+)
 from app.features.invoices.share import InvoiceShareService
 from app.features.jobs.models import JobRecord
 from app.features.jobs.service import JobService
 from app.features.quotes.models import Document
 from app.features.quotes.repository import QuoteRenderContext
-from app.features.quotes.schemas import LineItemDraft
+from app.features.quotes.schemas import BulkActionAppliedItem, BulkActionBlockedItem, LineItemDraft
 from app.features.quotes.service import QuoteRepositoryProtocol, QuoteServiceError
 from app.integrations.storage import StorageServiceProtocol
+
+_INVOICE_DOC_TYPE = "invoice"
 
 
 class InvoiceRepositoryProtocol(Protocol):
@@ -44,6 +51,11 @@ class InvoiceRepositoryProtocol(Protocol):
     async def customer_exists_for_user(self, *, user_id: UUID, customer_id: UUID) -> bool: ...
 
     async def get_by_id(self, invoice_id: UUID, user_id: UUID) -> Document | None: ...
+    async def get_owned_document_by_id(
+        self,
+        document_id: UUID,
+        user_id: UUID,
+    ) -> Document | None: ...
 
     async def list_by_user(
         self,
@@ -144,6 +156,7 @@ class InvoiceRepositoryProtocol(Protocol):
     ) -> Document: ...
 
     async def invalidate_pdf_artifact(self, invoice: Document) -> str | None: ...
+    async def archive_by_id(self, *, invoice_id: UUID, user_id: UUID) -> bool: ...
 
     async def mark_ready_if_draft(self, *, invoice_id: UUID, user_id: UUID) -> None: ...
 
@@ -258,6 +271,77 @@ class InvoiceService:
             data=data,
         )
 
+    async def execute_bulk_action(
+        self,
+        user: User,
+        payload: InvoiceBulkActionRequest,
+    ) -> InvoiceBulkActionResponse:
+        """Execute one invoice-scoped bulk archive/delete action."""
+        user_id = _resolve_user_id(user)
+        unique_ids = _dedupe_ids(payload.ids)
+        applied: list[BulkActionAppliedItem] = []
+        blocked: list[BulkActionBlockedItem] = []
+
+        for document_id in unique_ids:
+            document = await self._invoice_repository.get_owned_document_by_id(document_id, user_id)
+            if document is None:
+                blocked.append(
+                    BulkActionBlockedItem(
+                        id=document_id,
+                        reason="not_found",
+                        message="Document not found.",
+                    )
+                )
+                continue
+            if document.doc_type != _INVOICE_DOC_TYPE:
+                blocked.append(
+                    BulkActionBlockedItem(
+                        id=document_id,
+                        reason="unsupported_document_type",
+                        message="Only invoices can be changed from this endpoint.",
+                    )
+                )
+                continue
+
+            if payload.action == "delete":
+                blocked.append(
+                    BulkActionBlockedItem(
+                        id=document_id,
+                        reason="invoice_delete_not_supported",
+                        message="Invoices cannot be deleted in this version.",
+                    )
+                )
+                continue
+
+            if document.archived_at is not None:
+                blocked.append(
+                    BulkActionBlockedItem(
+                        id=document_id,
+                        reason="already_archived",
+                        message="Invoice is already archived.",
+                    )
+                )
+                continue
+
+            archived = await self._invoice_repository.archive_by_id(
+                invoice_id=document_id,
+                user_id=user_id,
+            )
+            if not archived:
+                blocked.append(
+                    BulkActionBlockedItem(
+                        id=document_id,
+                        reason="already_archived",
+                        message="Invoice is already archived.",
+                    )
+                )
+                continue
+
+            await self._invoice_repository.commit()
+            applied.append(BulkActionAppliedItem(id=document_id))
+
+        return InvoiceBulkActionResponse(action=payload.action, applied=applied, blocked=blocked)
+
     async def start_pdf_generation(
         self,
         user: User,
@@ -325,3 +409,14 @@ def _resolve_user_id(user: User) -> UUID:
     if identity and identity[0] is not None:
         return cast(UUID, identity[0])
     return user.id
+
+
+def _dedupe_ids(ids: list[UUID]) -> list[UUID]:
+    seen: set[UUID] = set()
+    deduped: list[UUID] = []
+    for document_id in ids:
+        if document_id in seen:
+            continue
+        seen.add(document_id)
+        deduped.append(document_id)
+    return deduped

--- a/backend/app/features/invoices/tests/test_bulk_action.py
+++ b/backend/app/features/invoices/tests/test_bulk_action.py
@@ -65,7 +65,6 @@ async def test_bulk_archive_invoices_deduplicates_ids_and_blocks_rearchive(
                 "id": invoice["id"],
                 "reason": "already_archived",
                 "message": "Invoice is already archived.",
-                "suggested_action": None,
             }
         ],
     }
@@ -102,19 +101,16 @@ async def test_bulk_delete_invoices_reports_blocked_per_document(
                 "id": invoice["id"],
                 "reason": "invoice_delete_not_supported",
                 "message": "Invoices cannot be deleted in this version.",
-                "suggested_action": None,
             },
             {
                 "id": quote["id"],
                 "reason": "unsupported_document_type",
                 "message": "Only invoices can be changed from this endpoint.",
-                "suggested_action": None,
             },
             {
                 "id": missing_id,
                 "reason": "not_found",
                 "message": "Document not found.",
-                "suggested_action": None,
             },
         ],
     }

--- a/backend/app/features/invoices/tests/test_bulk_action.py
+++ b/backend/app/features/invoices/tests/test_bulk_action.py
@@ -1,0 +1,143 @@
+"""Invoice bulk action API behavior tests."""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+from app.features.quotes.tests import test_quotes as quotes_test_module
+from app.features.quotes.tests.support.helpers import (
+    _create_customer,
+    _create_direct_invoice,
+    _create_quote,
+    _credentials,
+    _register_and_login,
+)
+from httpx import AsyncClient
+
+pytestmark = pytest.mark.asyncio
+
+# Reuse existing fixture wiring/helpers from test_quotes to preserve behavior.
+_reset_email_delivery_fallback_cache = quotes_test_module._reset_email_delivery_fallback_cache
+_override_storage_service_dependency = quotes_test_module._override_storage_service_dependency
+_override_quote_service_dependency = quotes_test_module._override_quote_service_dependency
+_override_extraction_service_dependency = quotes_test_module._override_extraction_service_dependency
+_reset_rate_limiter = quotes_test_module._reset_rate_limiter
+
+
+async def test_bulk_archive_invoices_deduplicates_ids_and_blocks_rearchive(
+    client: AsyncClient,
+) -> None:
+    csrf_token = await _register_and_login(client, _credentials())
+    customer_id = await _create_customer(client, csrf_token)
+    invoice = await _create_direct_invoice(
+        client,
+        csrf_token,
+        customer_id,
+        title="Archive me",
+        transcript="invoice transcript",
+        total_amount=100,
+    )
+
+    first_response = await client.post(
+        "/api/invoices/bulk-action",
+        json={"action": "archive", "ids": [invoice["id"], invoice["id"]]},
+        headers={"X-CSRF-Token": csrf_token},
+    )
+    assert first_response.status_code == 200
+    assert first_response.json() == {
+        "action": "archive",
+        "applied": [{"id": invoice["id"]}],
+        "blocked": [],
+    }
+
+    second_response = await client.post(
+        "/api/invoices/bulk-action",
+        json={"action": "archive", "ids": [invoice["id"]]},
+        headers={"X-CSRF-Token": csrf_token},
+    )
+    assert second_response.status_code == 200
+    assert second_response.json() == {
+        "action": "archive",
+        "applied": [],
+        "blocked": [
+            {
+                "id": invoice["id"],
+                "reason": "already_archived",
+                "message": "Invoice is already archived.",
+                "suggested_action": None,
+            }
+        ],
+    }
+
+
+async def test_bulk_delete_invoices_reports_blocked_per_document(
+    client: AsyncClient,
+) -> None:
+    csrf_token = await _register_and_login(client, _credentials())
+    customer_id = await _create_customer(client, csrf_token)
+    invoice = await _create_direct_invoice(
+        client,
+        csrf_token,
+        customer_id,
+        title="Delete blocked",
+        transcript="invoice transcript",
+        total_amount=50,
+    )
+    quote = await _create_quote(client, csrf_token, customer_id)
+    missing_id = str(uuid4())
+
+    response = await client.post(
+        "/api/invoices/bulk-action",
+        json={"action": "delete", "ids": [invoice["id"], quote["id"], missing_id]},
+        headers={"X-CSRF-Token": csrf_token},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "action": "delete",
+        "applied": [],
+        "blocked": [
+            {
+                "id": invoice["id"],
+                "reason": "invoice_delete_not_supported",
+                "message": "Invoices cannot be deleted in this version.",
+                "suggested_action": None,
+            },
+            {
+                "id": quote["id"],
+                "reason": "unsupported_document_type",
+                "message": "Only invoices can be changed from this endpoint.",
+                "suggested_action": None,
+            },
+            {
+                "id": missing_id,
+                "reason": "not_found",
+                "message": "Document not found.",
+                "suggested_action": None,
+            },
+        ],
+    }
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"action": "archive", "ids": []},
+        {"action": "void", "ids": [str(uuid4())]},
+        {"action": "delete", "ids": ["not-a-uuid"]},
+    ],
+)
+async def test_bulk_invoices_request_validation_returns_422(
+    client: AsyncClient,
+    payload: dict[str, object],
+) -> None:
+    csrf_token = await _register_and_login(client, _credentials())
+
+    response = await client.post(
+        "/api/invoices/bulk-action",
+        json=payload,
+        headers={"X-CSRF-Token": csrf_token},
+    )
+
+    assert response.status_code == 422

--- a/backend/app/features/invoices/tests/test_service.py
+++ b/backend/app/features/invoices/tests/test_service.py
@@ -33,6 +33,11 @@ class _RetryingInvoiceRepository:
         del user_id
         return None
 
+    async def get_owned_document_by_id(self, document_id, user_id):  # noqa: ANN001
+        del document_id
+        del user_id
+        return None
+
     async def customer_exists_for_user(self, *, user_id, customer_id):  # noqa: ANN001
         del user_id
         del customer_id
@@ -110,6 +115,11 @@ class _RetryingInvoiceRepository:
         del invoice
         return None
 
+    async def archive_by_id(self, *, invoice_id, user_id):  # noqa: ANN001
+        del invoice_id
+        del user_id
+        return False
+
     async def mark_ready_if_draft(self, *, invoice_id, user_id):  # noqa: ANN001
         del invoice_id
         del user_id
@@ -181,6 +191,11 @@ class _DirectInvoiceCollisionRepository:
         del user_id
         return None
 
+    async def get_owned_document_by_id(self, document_id, user_id):  # noqa: ANN001
+        del document_id
+        del user_id
+        return None
+
     async def get_by_source_document_id(self, *, source_document_id, user_id):  # noqa: ANN001
         del source_document_id
         del user_id
@@ -242,6 +257,11 @@ class _DirectInvoiceCollisionRepository:
     async def invalidate_pdf_artifact(self, invoice):  # noqa: ANN001
         del invoice
         return None
+
+    async def archive_by_id(self, *, invoice_id, user_id):  # noqa: ANN001
+        del invoice_id
+        del user_id
+        return False
 
     async def mark_ready_if_draft(self, *, invoice_id, user_id):  # noqa: ANN001
         del invoice_id
@@ -352,6 +372,11 @@ class _UpdatingInvoiceRepository:
             return self._invoice
         return None
 
+    async def get_owned_document_by_id(self, document_id, user_id):  # noqa: ANN001
+        if document_id == self._invoice.id and user_id == self._invoice.user_id:
+            return self._invoice
+        return None
+
     async def update(self, **kwargs):  # noqa: ANN001
         invoice = kwargs["invoice"]
         if kwargs["update_title"]:
@@ -379,6 +404,11 @@ class _UpdatingInvoiceRepository:
         invoice.pdf_artifact_path = None
         invoice.pdf_artifact_revision += 1
         return "artifacts/invoice.pdf"
+
+    async def archive_by_id(self, *, invoice_id, user_id):  # noqa: ANN001
+        del invoice_id
+        del user_id
+        return False
 
     async def commit(self) -> None:
         self.commit_calls += 1

--- a/backend/app/features/quotes/api.py
+++ b/backend/app/features/quotes/api.py
@@ -578,6 +578,7 @@ async def list_quote_reuse_candidates(
 @router.post(
     "/bulk-action",
     response_model=BulkActionResponse,
+    response_model_exclude_none=True,
     dependencies=[Depends(require_csrf)],
 )
 async def bulk_action_quotes(

--- a/backend/app/features/quotes/api.py
+++ b/backend/app/features/quotes/api.py
@@ -41,6 +41,8 @@ from app.features.quotes.extraction_outcomes import (
 from app.features.quotes.extraction_service import CaptureAudioClip, ExtractionService
 from app.features.quotes.review_metadata import normalize_extraction_review_metadata
 from app.features.quotes.schemas import (
+    BulkActionRequest,
+    BulkActionResponse,
     ConvertNotesRequest,
     DiscountType,
     ExtractionResponse,
@@ -571,6 +573,20 @@ async def list_quote_reuse_candidates(
         q=q,
     )
     return [QuoteReuseCandidateResponse.model_validate(candidate) for candidate in candidates]
+
+
+@router.post(
+    "/bulk-action",
+    response_model=BulkActionResponse,
+    dependencies=[Depends(require_csrf)],
+)
+async def bulk_action_quotes(
+    payload: BulkActionRequest,
+    user: Annotated[User, Depends(get_current_user)],
+    quote_service: Annotated[QuoteService, Depends(get_quote_service)],
+) -> BulkActionResponse:
+    """Execute one quote-scoped bulk archive/delete action."""
+    return await quote_service.execute_bulk_action(user, payload)
 
 
 @router.get("/{quote_id}", response_model=QuoteDetailResponse)

--- a/backend/app/features/quotes/deletion/service.py
+++ b/backend/app/features/quotes/deletion/service.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from typing import Protocol
 from uuid import UUID
 
+from sqlalchemy.exc import IntegrityError
+
 from app.features.quotes.errors import QuoteServiceError
 from app.features.quotes.models import Document, QuoteStatus
 from app.shared.event_logger import log_event
@@ -17,16 +19,31 @@ _NON_DELETABLE_QUOTE_STATUSES = frozenset(
         QuoteStatus.DECLINED,
     }
 )
+_QUOTE_DOC_TYPE = "quote"
+_LINKED_INVOICE_BLOCK_DETAIL = "Quotes with a linked invoice cannot be deleted."
 
 
 class QuoteDeletionRepositoryProtocol(Protocol):
     """Structural protocol for quote-deletion persistence behavior."""
 
-    async def get_by_id(self, quote_id: UUID, user_id: UUID) -> Document | None: ...
+    async def get_owned_document_by_id(
+        self,
+        document_id: UUID,
+        user_id: UUID,
+    ) -> Document | None: ...
+
+    async def has_linked_invoice(
+        self,
+        *,
+        source_document_id: UUID,
+        user_id: UUID,
+    ) -> bool: ...
 
     async def delete(self, document_id: UUID) -> None: ...
 
     async def commit(self) -> None: ...
+
+    async def rollback(self) -> None: ...
 
 
 class QuoteDeletionService:
@@ -37,20 +54,36 @@ class QuoteDeletionService:
 
     async def delete_quote(self, *, user_id: UUID, quote_id: UUID) -> None:
         """Hard-delete an owned quote when its status allows deletion."""
-        quote = await self._repository.get_by_id(quote_id, user_id)
-        if quote is None:
+        document = await self._repository.get_owned_document_by_id(quote_id, user_id)
+        if document is None or document.doc_type != _QUOTE_DOC_TYPE:
             raise QuoteServiceError(detail="Not found", status_code=404)
-        if quote.status in _NON_DELETABLE_QUOTE_STATUSES:
+        if document.status in _NON_DELETABLE_QUOTE_STATUSES:
             raise QuoteServiceError(
                 detail="Shared quotes cannot be deleted",
                 status_code=409,
             )
+        has_linked_invoice = await self._repository.has_linked_invoice(
+            source_document_id=document.id,
+            user_id=user_id,
+        )
+        if has_linked_invoice:
+            raise QuoteServiceError(
+                detail=_LINKED_INVOICE_BLOCK_DETAIL,
+                status_code=409,
+            )
 
-        await self._repository.delete(quote_id)
-        await self._repository.commit()
+        try:
+            await self._repository.delete(quote_id)
+            await self._repository.commit()
+        except IntegrityError as exc:
+            await self._repository.rollback()
+            raise QuoteServiceError(
+                detail=_LINKED_INVOICE_BLOCK_DETAIL,
+                status_code=409,
+            ) from exc
         log_event(
             "quote.deleted",
             user_id=user_id,
-            quote_id=quote.id,
-            customer_id=quote.customer_id,
+            quote_id=document.id,
+            customer_id=document.customer_id,
         )

--- a/backend/app/features/quotes/models.py
+++ b/backend/app/features/quotes/models.py
@@ -68,7 +68,7 @@ class Document(Base):
     doc_number: Mapped[str] = mapped_column(sa.String(20), nullable=False)
     title: Mapped[str | None] = mapped_column(sa.String(120), nullable=True)
     source_document_id: Mapped[UUID | None] = mapped_column(
-        sa.ForeignKey("documents.id", ondelete="SET NULL"),
+        sa.ForeignKey("documents.id", ondelete="RESTRICT"),
         nullable=True,
     )
     status: Mapped[DocumentStatus] = mapped_column(

--- a/backend/app/features/quotes/repository.py
+++ b/backend/app/features/quotes/repository.py
@@ -427,6 +427,18 @@ class QuoteRepository:
         )
         return result.scalar_one_or_none()
 
+    async def get_owned_document_by_id(self, document_id: UUID, user_id: UUID) -> Document | None:
+        """Return one owned document of any type, including line items."""
+        result = await self._session.execute(
+            select(Document)
+            .where(
+                Document.id == document_id,
+                Document.user_id == user_id,
+            )
+            .options(selectinload(Document.line_items))
+        )
+        return result.scalar_one_or_none()
+
     async def get_by_id_for_update(self, quote_id: UUID, user_id: UUID) -> Document | None:
         """Return one quote row with a write lock for serialized mutations."""
         result = await self._session.execute(

--- a/backend/app/features/quotes/schemas.py
+++ b/backend/app/features/quotes/schemas.py
@@ -606,6 +606,47 @@ class QuoteUpdateRequest(BaseModel):
         return self
 
 
+BulkActionType = Literal["archive", "delete"]
+BulkBlockedReason = Literal[
+    "not_found",
+    "already_archived",
+    "quote_status_not_deletable",
+    "linked_invoice",
+    "unsupported_document_type",
+    "invoice_delete_not_supported",
+]
+
+
+class BulkActionRequest(BaseModel):
+    """Request payload for route-scoped quote/invoice bulk actions."""
+
+    action: BulkActionType
+    ids: list[UUID] = Field(min_length=1)
+
+
+class BulkActionAppliedItem(BaseModel):
+    """One document id that was successfully mutated by a bulk action."""
+
+    id: UUID
+
+
+class BulkActionBlockedItem(BaseModel):
+    """One document id blocked by policy or ownership checks."""
+
+    id: UUID
+    reason: BulkBlockedReason
+    message: str
+    suggested_action: BulkActionType | None = None
+
+
+class BulkActionResponse(BaseModel):
+    """Best-effort bulk action result with per-document outcomes."""
+
+    action: BulkActionType
+    applied: list[BulkActionAppliedItem] = Field(default_factory=list)
+    blocked: list[BulkActionBlockedItem] = Field(default_factory=list)
+
+
 class ExtractionReviewStateClearRequest(BaseModel):
     """Request payload for clearing grouped extraction review state flags."""
 

--- a/backend/app/features/quotes/service.py
+++ b/backend/app/features/quotes/service.py
@@ -9,6 +9,7 @@ from uuid import UUID
 
 from arq.connections import ArqRedis
 from sqlalchemy import inspect as sa_inspect
+from sqlalchemy.exc import IntegrityError
 
 from app.features.auth.models import User
 from app.features.jobs.models import JobRecord
@@ -29,6 +30,10 @@ from app.features.quotes.repository import (
     QuoteViewTransition,
 )
 from app.features.quotes.schemas import (
+    BulkActionAppliedItem,
+    BulkActionBlockedItem,
+    BulkActionRequest,
+    BulkActionResponse,
     ExtractionResult,
     ExtractionReviewMetadataUpdateRequest,
     ExtractionReviewMetadataV1,
@@ -42,6 +47,15 @@ from app.integrations.storage import StorageServiceProtocol
 LOGGER = logging.getLogger(__name__)
 _TERMINAL_QUOTE_STATUSES = frozenset({QuoteStatus.APPROVED, QuoteStatus.DECLINED})
 _CUSTOMER_ASSIGNMENT_REQUIRED_DETAIL = "Assign a customer before continuing."
+_QUOTE_DOC_TYPE = "quote"
+_NON_DELETABLE_QUOTE_STATUSES = frozenset(
+    {
+        QuoteStatus.SHARED,
+        QuoteStatus.VIEWED,
+        QuoteStatus.APPROVED,
+        QuoteStatus.DECLINED,
+    }
+)
 
 
 class QuoteRepositoryProtocol(Protocol):
@@ -63,6 +77,11 @@ class QuoteRepositoryProtocol(Protocol):
     ) -> list[QuoteReuseCandidateSummary]: ...
 
     async def get_by_id(self, quote_id: UUID, user_id: UUID) -> Document | None: ...
+    async def get_owned_document_by_id(
+        self,
+        document_id: UUID,
+        user_id: UUID,
+    ) -> Document | None: ...
     async def get_by_id_for_update(self, quote_id: UUID, user_id: UUID) -> Document | None: ...
 
     async def get_detail_by_id(self, quote_id: UUID, user_id: UUID) -> QuoteDetailRow | None: ...
@@ -169,6 +188,7 @@ class QuoteRepositoryProtocol(Protocol):
     ) -> Document: ...
 
     async def delete(self, document_id: UUID) -> None: ...
+    async def archive_by_id(self, *, quote_id: UUID, user_id: UUID) -> bool: ...
 
     async def commit(self) -> None: ...
 
@@ -344,6 +364,107 @@ class QuoteService:
             quote_id=quote_id,
         )
 
+    async def execute_bulk_action(
+        self,
+        user: User,
+        payload: BulkActionRequest,
+    ) -> BulkActionResponse:
+        """Execute one quote-scoped bulk archive/delete action with per-id outcomes."""
+        user_id = _resolve_user_id(user)
+        unique_ids = _dedupe_ids(payload.ids)
+        applied: list[BulkActionAppliedItem] = []
+        blocked: list[BulkActionBlockedItem] = []
+
+        for document_id in unique_ids:
+            document = await self._repository.get_owned_document_by_id(document_id, user_id)
+            if document is None:
+                blocked.append(
+                    BulkActionBlockedItem(
+                        id=document_id,
+                        reason="not_found",
+                        message="Document not found.",
+                    )
+                )
+                continue
+            if document.doc_type != _QUOTE_DOC_TYPE:
+                blocked.append(
+                    BulkActionBlockedItem(
+                        id=document_id,
+                        reason="unsupported_document_type",
+                        message="Only quotes can be changed from this endpoint.",
+                    )
+                )
+                continue
+
+            if payload.action == "archive":
+                if document.archived_at is not None:
+                    blocked.append(
+                        BulkActionBlockedItem(
+                            id=document_id,
+                            reason="already_archived",
+                            message="Quote is already archived.",
+                        )
+                    )
+                    continue
+                archived = await self._repository.archive_by_id(
+                    quote_id=document_id,
+                    user_id=user_id,
+                )
+                if not archived:
+                    blocked.append(
+                        BulkActionBlockedItem(
+                            id=document_id,
+                            reason="already_archived",
+                            message="Quote is already archived.",
+                        )
+                    )
+                    continue
+                await self._repository.commit()
+                applied.append(BulkActionAppliedItem(id=document_id))
+                continue
+
+            if document.status in _NON_DELETABLE_QUOTE_STATUSES:
+                blocked.append(
+                    BulkActionBlockedItem(
+                        id=document_id,
+                        reason="quote_status_not_deletable",
+                        message="Shared, viewed, approved, and declined quotes cannot be deleted.",
+                    )
+                )
+                continue
+            has_linked_invoice = await self._repository.has_linked_invoice(
+                source_document_id=document_id,
+                user_id=user_id,
+            )
+            if has_linked_invoice:
+                blocked.append(
+                    BulkActionBlockedItem(
+                        id=document_id,
+                        reason="linked_invoice",
+                        message="Quotes with a linked invoice cannot be deleted.",
+                        suggested_action="archive",
+                    )
+                )
+                continue
+
+            try:
+                await self._repository.delete(document_id)
+                await self._repository.commit()
+            except IntegrityError:
+                await self._repository.rollback()
+                blocked.append(
+                    BulkActionBlockedItem(
+                        id=document_id,
+                        reason="linked_invoice",
+                        message="Quotes with a linked invoice cannot be deleted.",
+                        suggested_action="archive",
+                    )
+                )
+                continue
+            applied.append(BulkActionAppliedItem(id=document_id))
+
+        return BulkActionResponse(action=payload.action, applied=applied, blocked=blocked)
+
     async def start_pdf_generation(
         self,
         user: User,
@@ -426,6 +547,17 @@ def _resolve_user_id(user: User) -> UUID:
     if identity and identity[0] is not None:
         return cast(UUID, identity[0])
     return user.id
+
+
+def _dedupe_ids(ids: list[UUID]) -> list[UUID]:
+    seen: set[UUID] = set()
+    deduped: list[UUID] = []
+    for document_id in ids:
+        if document_id in seen:
+            continue
+        seen.add(document_id)
+        deduped.append(document_id)
+    return deduped
 
 
 def ensure_quote_customer_assigned(quote: Document) -> None:

--- a/backend/app/features/quotes/tests/test_bulk_action.py
+++ b/backend/app/features/quotes/tests/test_bulk_action.py
@@ -1,0 +1,191 @@
+"""Quote bulk action API behavior tests."""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.features.quotes.models import QuoteStatus
+from app.features.quotes.tests import test_quotes as quotes_test_module
+from app.features.quotes.tests.support.helpers import (
+    _create_customer,
+    _create_direct_invoice,
+    _create_quote,
+    _credentials,
+    _register_and_login,
+    _set_quote_status,
+)
+
+pytestmark = pytest.mark.asyncio
+
+# Reuse existing fixture wiring/helpers from test_quotes to preserve behavior.
+_reset_email_delivery_fallback_cache = quotes_test_module._reset_email_delivery_fallback_cache
+_override_storage_service_dependency = quotes_test_module._override_storage_service_dependency
+_override_quote_service_dependency = quotes_test_module._override_quote_service_dependency
+_override_extraction_service_dependency = quotes_test_module._override_extraction_service_dependency
+_reset_rate_limiter = quotes_test_module._reset_rate_limiter
+
+
+async def test_bulk_delete_quotes_returns_applied_and_blocked_for_linked_invoice(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    csrf_token = await _register_and_login(client, _credentials())
+    customer_id = await _create_customer(client, csrf_token)
+
+    deletable_quote = await _create_quote(client, csrf_token, customer_id)
+    linked_quote = await _create_quote(client, csrf_token, customer_id)
+    await _set_quote_status(db_session, linked_quote["id"], QuoteStatus.APPROVED)
+
+    convert_response = await client.post(
+        f"/api/quotes/{linked_quote['id']}/convert-to-invoice",
+        headers={"X-CSRF-Token": csrf_token},
+    )
+    assert convert_response.status_code == 201
+    invoice_payload = convert_response.json()
+    await _set_quote_status(db_session, linked_quote["id"], QuoteStatus.READY)
+
+    archive_response = await client.post(
+        "/api/invoices/bulk-action",
+        json={"action": "archive", "ids": [invoice_payload["id"]]},
+        headers={"X-CSRF-Token": csrf_token},
+    )
+    assert archive_response.status_code == 200
+
+    response = await client.post(
+        "/api/quotes/bulk-action",
+        json={"action": "delete", "ids": [deletable_quote["id"], linked_quote["id"]]},
+        headers={"X-CSRF-Token": csrf_token},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["action"] == "delete"
+    assert payload["applied"] == [{"id": deletable_quote["id"]}]
+    assert payload["blocked"] == [
+        {
+            "id": linked_quote["id"],
+            "reason": "linked_invoice",
+            "message": "Quotes with a linked invoice cannot be deleted.",
+            "suggested_action": "archive",
+        }
+    ]
+
+
+async def test_bulk_archive_quotes_deduplicates_ids_and_blocks_rearchive(
+    client: AsyncClient,
+) -> None:
+    csrf_token = await _register_and_login(client, _credentials())
+    customer_id = await _create_customer(client, csrf_token)
+    quote = await _create_quote(client, csrf_token, customer_id)
+
+    first_response = await client.post(
+        "/api/quotes/bulk-action",
+        json={"action": "archive", "ids": [quote["id"], quote["id"]]},
+        headers={"X-CSRF-Token": csrf_token},
+    )
+    assert first_response.status_code == 200
+    assert first_response.json() == {
+        "action": "archive",
+        "applied": [{"id": quote["id"]}],
+        "blocked": [],
+    }
+
+    second_response = await client.post(
+        "/api/quotes/bulk-action",
+        json={"action": "archive", "ids": [quote["id"]]},
+        headers={"X-CSRF-Token": csrf_token},
+    )
+    assert second_response.status_code == 200
+    assert second_response.json() == {
+        "action": "archive",
+        "applied": [],
+        "blocked": [
+            {
+                "id": quote["id"],
+                "reason": "already_archived",
+                "message": "Quote is already archived.",
+                "suggested_action": None,
+            }
+        ],
+    }
+
+
+async def test_bulk_delete_quotes_reports_not_found_status_and_doc_type_blocks(
+    client: AsyncClient,
+) -> None:
+    csrf_token = await _register_and_login(client, _credentials())
+    customer_id = await _create_customer(client, csrf_token)
+    shared_quote = await _create_quote(client, csrf_token, customer_id)
+
+    share_response = await client.post(
+        f"/api/quotes/{shared_quote['id']}/share",
+        headers={"X-CSRF-Token": csrf_token},
+    )
+    assert share_response.status_code == 200
+
+    invoice = await _create_direct_invoice(
+        client,
+        csrf_token,
+        customer_id,
+        title="Invoice",
+        transcript="invoice",
+        total_amount=10,
+    )
+
+    missing_id = str(uuid4())
+    response = await client.post(
+        "/api/quotes/bulk-action",
+        json={"action": "delete", "ids": [shared_quote["id"], invoice["id"], missing_id]},
+        headers={"X-CSRF-Token": csrf_token},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["applied"] == []
+    assert payload["blocked"] == [
+        {
+            "id": shared_quote["id"],
+            "reason": "quote_status_not_deletable",
+            "message": "Shared, viewed, approved, and declined quotes cannot be deleted.",
+            "suggested_action": None,
+        },
+        {
+            "id": invoice["id"],
+            "reason": "unsupported_document_type",
+            "message": "Only quotes can be changed from this endpoint.",
+            "suggested_action": None,
+        },
+        {
+            "id": missing_id,
+            "reason": "not_found",
+            "message": "Document not found.",
+            "suggested_action": None,
+        },
+    ]
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"action": "archive", "ids": []},
+        {"action": "void", "ids": [str(uuid4())]},
+        {"action": "delete", "ids": ["not-a-uuid"]},
+    ],
+)
+async def test_bulk_quotes_request_validation_returns_422(
+    client: AsyncClient,
+    payload: dict[str, object],
+) -> None:
+    csrf_token = await _register_and_login(client, _credentials())
+
+    response = await client.post(
+        "/api/quotes/bulk-action",
+        json=payload,
+        headers={"X-CSRF-Token": csrf_token},
+    )
+
+    assert response.status_code == 422

--- a/backend/app/features/quotes/tests/test_bulk_action.py
+++ b/backend/app/features/quotes/tests/test_bulk_action.py
@@ -108,7 +108,6 @@ async def test_bulk_archive_quotes_deduplicates_ids_and_blocks_rearchive(
                 "id": quote["id"],
                 "reason": "already_archived",
                 "message": "Quote is already archived.",
-                "suggested_action": None,
             }
         ],
     }
@@ -151,19 +150,16 @@ async def test_bulk_delete_quotes_reports_not_found_status_and_doc_type_blocks(
             "id": shared_quote["id"],
             "reason": "quote_status_not_deletable",
             "message": "Shared, viewed, approved, and declined quotes cannot be deleted.",
-            "suggested_action": None,
         },
         {
             "id": invoice["id"],
             "reason": "unsupported_document_type",
             "message": "Only quotes can be changed from this endpoint.",
-            "suggested_action": None,
         },
         {
             "id": missing_id,
             "reason": "not_found",
             "message": "Document not found.",
-            "suggested_action": None,
         },
     ]
 

--- a/backend/app/features/quotes/tests/test_quote_auth_csrf.py
+++ b/backend/app/features/quotes/tests/test_quote_auth_csrf.py
@@ -50,6 +50,11 @@ _reset_rate_limiter = quotes_test_module._reset_rate_limiter
             "/api/quotes/00000000-0000-0000-0000-000000000000",
             {"notes": "updated"},
         ),
+        (
+            "post",
+            "/api/quotes/bulk-action",
+            {"action": "archive", "ids": ["00000000-0000-0000-0000-000000000000"]},
+        ),
         ("delete", "/api/quotes/00000000-0000-0000-0000-000000000000", None),
         ("post", "/api/quotes/00000000-0000-0000-0000-000000000000/duplicate", None),
         ("post", "/api/quotes/00000000-0000-0000-0000-000000000000/pdf", None),
@@ -94,6 +99,11 @@ async def test_all_quote_endpoints_require_authentication(
             },
         ),
         ("get", "/api/invoices/00000000-0000-0000-0000-000000000000", None),
+        (
+            "post",
+            "/api/invoices/bulk-action",
+            {"action": "archive", "ids": ["00000000-0000-0000-0000-000000000000"]},
+        ),
         (
             "patch",
             "/api/invoices/00000000-0000-0000-0000-000000000000",
@@ -233,6 +243,18 @@ async def test_delete_quote_requires_csrf(client: AsyncClient) -> None:
     assert response.json() == {"detail": "CSRF token missing"}
 
 
+async def test_quote_bulk_action_requires_csrf(client: AsyncClient) -> None:
+    await _register_and_login(client, _credentials())
+
+    response = await client.post(
+        "/api/quotes/bulk-action",
+        json={"action": "archive", "ids": ["00000000-0000-0000-0000-000000000000"]},
+    )
+
+    assert response.status_code == 403
+    assert response.json() == {"detail": "CSRF token missing"}
+
+
 async def test_duplicate_quote_requires_csrf(client: AsyncClient) -> None:
     csrf_token = await _register_and_login(client, _credentials())
     customer_id = await _create_customer(client, csrf_token)
@@ -335,6 +357,18 @@ async def test_create_invoice_requires_csrf(client: AsyncClient) -> None:
             "notes": None,
             "source_type": "text",
         },
+    )
+
+    assert response.status_code == 403
+    assert response.json() == {"detail": "CSRF token missing"}
+
+
+async def test_invoice_bulk_action_requires_csrf(client: AsyncClient) -> None:
+    await _register_and_login(client, _credentials())
+
+    response = await client.post(
+        "/api/invoices/bulk-action",
+        json={"action": "archive", "ids": ["00000000-0000-0000-0000-000000000000"]},
     )
 
     assert response.status_code == 403

--- a/backend/app/features/quotes/tests/test_quote_crud.py
+++ b/backend/app/features/quotes/tests/test_quote_crud.py
@@ -1699,6 +1699,51 @@ async def test_delete_non_editable_quote_statuses_return_409(
     assert delete_response.json() == {"detail": "Shared quotes cannot be deleted"}
 
 
+async def test_delete_quote_with_linked_invoice_returns_409_even_if_linked_invoice_archived(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    csrf_token = await _register_and_login(client, _credentials())
+    customer_id = await _create_customer(client, csrf_token)
+    quote = await _create_quote(client, csrf_token, customer_id)
+    quote_id = quote["id"]
+
+    await _set_quote_status(db_session, quote_id, QuoteStatus.APPROVED)
+    convert_response = await client.post(
+        f"/api/quotes/{quote_id}/convert-to-invoice",
+        headers={"X-CSRF-Token": csrf_token},
+    )
+    assert convert_response.status_code == 201
+    invoice_id = convert_response.json()["id"]
+    await _set_quote_status(db_session, quote_id, QuoteStatus.READY)
+
+    first_delete_response = await client.delete(
+        f"/api/quotes/{quote_id}",
+        headers={"X-CSRF-Token": csrf_token},
+    )
+    assert first_delete_response.status_code == 409
+    assert first_delete_response.json() == {
+        "detail": "Quotes with a linked invoice cannot be deleted."
+    }
+
+    archive_invoice_response = await client.post(
+        "/api/invoices/bulk-action",
+        json={"action": "archive", "ids": [invoice_id]},
+        headers={"X-CSRF-Token": csrf_token},
+    )
+    assert archive_invoice_response.status_code == 200
+    assert archive_invoice_response.json()["applied"] == [{"id": invoice_id}]
+
+    second_delete_response = await client.delete(
+        f"/api/quotes/{quote_id}",
+        headers={"X-CSRF-Token": csrf_token},
+    )
+    assert second_delete_response.status_code == 409
+    assert second_delete_response.json() == {
+        "detail": "Quotes with a linked invoice cannot be deleted."
+    }
+
+
 async def test_create_quote_persists_voice_source_type(client: AsyncClient) -> None:
     csrf_token = await _register_and_login(client, _credentials())
     customer_id = await _create_customer(client, csrf_token)

--- a/backend/app/features/quotes/tests/test_quote_crud.py
+++ b/backend/app/features/quotes/tests/test_quote_crud.py
@@ -16,6 +16,7 @@ from app.features.quotes.schemas import LineItemDraft
 from app.features.quotes.tests import test_quotes as quotes_test_module
 from app.features.quotes.tests.support.helpers import (
     _create_customer,
+    _create_direct_invoice,
     _create_quote,
     _credentials,
     _get_user_by_email,
@@ -1551,6 +1552,29 @@ async def test_delete_quote_returns_404_for_different_users_quote(
     response = await client.delete(
         f"/api/quotes/{quote_id}",
         headers={"X-CSRF-Token": csrf_token_user_b},
+    )
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Not found"}
+
+
+async def test_delete_quote_returns_404_for_owned_invoice_document(
+    client: AsyncClient,
+) -> None:
+    csrf_token = await _register_and_login(client, _credentials())
+    customer_id = await _create_customer(client, csrf_token)
+    invoice = await _create_direct_invoice(
+        client,
+        csrf_token,
+        customer_id,
+        title="Owned invoice",
+        transcript="invoice transcript",
+        total_amount=55,
+    )
+
+    response = await client.delete(
+        f"/api/quotes/{invoice['id']}",
+        headers={"X-CSRF-Token": csrf_token},
     )
 
     assert response.status_code == 404

--- a/backend/app/features/quotes/tests/test_schema_constraints.py
+++ b/backend/app/features/quotes/tests/test_schema_constraints.py
@@ -9,6 +9,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.features.auth.models import User
+from app.features.customers.models import Customer
 from app.features.quotes.models import Document, QuoteStatus
 
 pytestmark = pytest.mark.asyncio
@@ -65,5 +66,54 @@ async def test_invoice_rows_reject_extraction_outcome_fields(
         )
     )
 
+    with pytest.raises(IntegrityError):
+        await db_session.flush()
+
+
+async def test_source_quote_cannot_be_deleted_while_invoice_reference_exists(
+    db_session: AsyncSession,
+) -> None:
+    user = User(
+        email=f"user-{uuid4().hex[:12]}@example.com",
+        password_hash="hash",  # nosec B106 - test-only stub value
+    )
+    db_session.add(user)
+    await db_session.flush()
+
+    customer = Customer(
+        user_id=user.id,
+        name="Constraint Customer",
+    )
+    db_session.add(customer)
+    await db_session.flush()
+
+    source_quote = Document(
+        user_id=user.id,
+        customer_id=customer.id,
+        doc_type="quote",
+        doc_sequence=1,
+        doc_number="Q-001",
+        status=QuoteStatus.DRAFT,
+        source_type="text",
+        transcript="quote transcript",
+    )
+    db_session.add(source_quote)
+    await db_session.flush()
+
+    linked_invoice = Document(
+        user_id=user.id,
+        customer_id=customer.id,
+        doc_type="invoice",
+        doc_sequence=1,
+        doc_number="I-001",
+        status=QuoteStatus.DRAFT,
+        source_type="text",
+        transcript="invoice transcript",
+        source_document_id=source_quote.id,
+    )
+    db_session.add(linked_invoice)
+    await db_session.flush()
+
+    await db_session.delete(source_quote)
     with pytest.raises(IntegrityError):
         await db_session.flush()


### PR DESCRIPTION
## Summary
- add `POST /api/quotes/bulk-action` with best-effort `applied`/`blocked` results for `archive` and `delete`
- add `POST /api/invoices/bulk-action` with `archive` support and per-id `invoice_delete_not_supported` blocking for `delete`
- harden quote deletion policy to block linked invoices (including archived linked invoices) and enforce DB-level relationship protection via FK `ondelete=RESTRICT`
- add integration tests for bulk-action behavior, CSRF/auth coverage, single-delete linked-invoice guard, and DB constraint behavior

## Verification
- `cd backend && .venv/bin/pytest app/features/quotes/tests/test_bulk_action.py -x --tb=short`
- `cd backend && .venv/bin/pytest app/features/invoices/tests/test_bulk_action.py -x --tb=short`
- `cd backend && .venv/bin/pytest app/features/quotes/tests/test_quote_crud.py -x --tb=short`
- `cd backend && .venv/bin/pytest app/features/quotes/tests/test_quote_auth_csrf.py -x --tb=short`
- `cd backend && .venv/bin/pytest app/features/quotes/tests/test_schema_constraints.py -x --tb=short`
- `make backend-static-verify`
- `make backend-verify`

Closes #654
