### PR TITLE
Task #655: frontend selection mode shell for quote/invoice list

### DIFF
--- a/frontend/src/features/quotes/components/DocumentRowsSection.tsx
+++ b/frontend/src/features/quotes/components/DocumentRowsSection.tsx
@@ -4,6 +4,7 @@ import type { StatusPillVariant } from "@/ui/StatusPill";
 
 export interface DocumentRow {
   id: string;
+  doc_type: "quote" | "invoice";
   customerLabel: string;
   titleLabel?: string | null;
   docAndDate: string;
@@ -21,12 +22,16 @@ interface DocumentRowsSectionProps {
   label: string;
   rows: DocumentRow[];
   onRowClick: (row: DocumentRow) => void;
+  isSelectionMode?: boolean;
+  isSelected?: (row: DocumentRow) => boolean;
 }
 
 export function DocumentRowsSection({
   label,
   rows,
   onRowClick,
+  isSelectionMode = false,
+  isSelected,
 }: DocumentRowsSectionProps): React.ReactElement {
   return (
     <section aria-label={label}>
@@ -45,6 +50,8 @@ export function DocumentRowsSection({
                 status={row.status}
                 isDraft={row.isDraft}
                 needsCustomerAssignment={row.needsCustomerAssignment}
+                isSelectionMode={isSelectionMode}
+                isSelected={isSelected?.(row)}
                 onClick={() => onRowClick(row)}
               />
             </li>

--- a/frontend/src/features/quotes/components/DocumentSelectionFooter.tsx
+++ b/frontend/src/features/quotes/components/DocumentSelectionFooter.tsx
@@ -1,0 +1,113 @@
+import { useEffect, useRef, useState } from "react";
+
+import { Button } from "@/shared/components/Button";
+import { AppIcon } from "@/ui/Icon";
+
+interface DocumentSelectionFooterProps {
+  selectedCount: number;
+  onCancelSelection: () => void;
+  onArchiveSelection?: () => void;
+  onDeleteSelectionPermanently?: () => void;
+}
+
+export function DocumentSelectionFooter({
+  selectedCount,
+  onCancelSelection,
+  onArchiveSelection,
+  onDeleteSelectionPermanently,
+}: DocumentSelectionFooterProps): React.ReactElement {
+  const [isMoreOpen, setIsMoreOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!isMoreOpen) {
+      return undefined;
+    }
+
+    function closeMenu(): void {
+      setIsMoreOpen(false);
+    }
+
+    function onPointerDown(event: PointerEvent): void {
+      if (!containerRef.current?.contains(event.target as Node)) {
+        closeMenu();
+      }
+    }
+
+    function onKeyDown(event: KeyboardEvent): void {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        closeMenu();
+      }
+    }
+
+    document.addEventListener("pointerdown", onPointerDown);
+    document.addEventListener("keydown", onKeyDown);
+    return () => {
+      document.removeEventListener("pointerdown", onPointerDown);
+      document.removeEventListener("keydown", onKeyDown);
+    };
+  }, [isMoreOpen]);
+
+  return (
+    <footer className="fixed inset-x-0 bottom-[4.5rem] z-40 border-t border-outline-variant/20 glass-surface p-4 backdrop-blur-md">
+      <div className="mx-auto flex w-full max-w-3xl items-center justify-between gap-3">
+        <p className="text-sm font-semibold text-on-surface">{selectedCount} selected</p>
+
+        {selectedCount === 0 ? (
+          <Button type="button" variant="ghost" size="sm" onClick={onCancelSelection}>
+            Cancel
+          </Button>
+        ) : (
+          <div ref={containerRef} className="relative flex items-center gap-2">
+            <Button type="button" variant="secondary" size="sm" onClick={onArchiveSelection}>
+              Archive
+            </Button>
+            <Button
+              type="button"
+              variant="tonal"
+              size="sm"
+              aria-haspopup="menu"
+              aria-expanded={isMoreOpen}
+              onClick={() => setIsMoreOpen((current) => !current)}
+            >
+              More
+            </Button>
+            {isMoreOpen ? (
+              <div
+                role="menu"
+                aria-label="More selection actions"
+                className="absolute bottom-full right-0 mb-2 w-60 rounded-[var(--radius-document)] border border-outline-variant/50 bg-surface-container-low p-1.5 ghost-shadow"
+              >
+                <button
+                  type="button"
+                  role="menuitem"
+                  className="grid w-full cursor-pointer grid-cols-[1.25rem_minmax(0,1fr)] items-center gap-2.5 rounded-[var(--radius-document)] px-2.5 py-2.5 text-left text-sm font-medium text-error transition-colors hover:bg-surface-container-high focus-visible:bg-surface-container-high focus-visible:outline-none"
+                  onClick={() => {
+                    setIsMoreOpen(false);
+                    onDeleteSelectionPermanently?.();
+                  }}
+                >
+                  <AppIcon name="delete" className="block text-[1.125rem] leading-none" />
+                  <span>Delete permanently...</span>
+                </button>
+                <button
+                  type="button"
+                  role="menuitem"
+                  className="grid w-full cursor-pointer grid-cols-[1.25rem_minmax(0,1fr)] items-center gap-2.5 rounded-[var(--radius-document)] px-2.5 py-2.5 text-left text-sm font-medium text-on-surface transition-colors hover:bg-surface-container-high focus-visible:bg-surface-container-high focus-visible:outline-none"
+                  onClick={() => {
+                    setIsMoreOpen(false);
+                    onCancelSelection();
+                  }}
+                >
+                  <AppIcon name="close" className="block text-[1.125rem] leading-none" />
+                  <span>Cancel selection</span>
+                </button>
+              </div>
+            ) : null}
+          </div>
+        )}
+      </div>
+    </footer>
+  );
+}

--- a/frontend/src/features/quotes/components/QuoteList.tsx
+++ b/frontend/src/features/quotes/components/QuoteList.tsx
@@ -17,16 +17,17 @@ import { getJobForSession, updateJobStatus } from "@/features/quotes/offline/out
 import { quoteService } from "@/features/quotes/services/quoteService";
 import type { QuoteListItem } from "@/features/quotes/types/quote.types";
 import { BottomNav } from "@/shared/components/BottomNav";
-import { Button } from "@/shared/components/Button";
 import { DocumentCardSkeleton } from "@/shared/components/DocumentCardSkeleton";
 import { FeedbackMessage } from "@/shared/components/FeedbackMessage";
-import { Input } from "@/shared/components/Input";
 import { ScreenHeader } from "@/shared/components/ScreenHeader";
 import { formatDate } from "@/shared/lib/formatters";
 import { Banner } from "@/ui/Banner";
 import { EmptyState } from "@/ui/EmptyState";
 import { AppIcon } from "@/ui/Icon";
+import { DocumentSelectionFooter } from "./DocumentSelectionFooter";
+import { QuoteListControls } from "./QuoteListControls";
 import { buildInvoiceSubtitle, buildPendingCaptureError, buildQuoteSubtitle, matchesSearch } from "./QuoteList.helpers";
+import { useDocumentSelection } from "../hooks/useDocumentSelection";
 type DocumentMode = "quotes" | "invoices";
 
 export function QuoteList(): React.ReactElement {
@@ -43,6 +44,14 @@ export function QuoteList(): React.ReactElement {
   const [invoiceLoadError, setInvoiceLoadError] = useState<string | null>(null);
   const [pendingCaptureActionError, setPendingCaptureActionError] = useState<string | null>(null);
   const [capturePendingDelete, setCapturePendingDelete] = useState<LocalCaptureSummary | null>(null);
+  const {
+    isSelectionMode,
+    selectedCount,
+    enterSelectionMode,
+    cancelSelection,
+    toggleSelection,
+    isSelected,
+  } = useDocumentSelection({ activeMode: documentMode });
   const {
     captures: recoverableCaptures,
     isLoading: isLoadingRecoverableCaptures,
@@ -166,6 +175,7 @@ export function QuoteList(): React.ReactElement {
   const draftQuoteRows = useMemo<DocumentRow[]>(
     () => draftQuotes.map((quote) => ({
       id: quote.id,
+      doc_type: "quote",
       customerLabel: quote.customer_name ?? "Unassigned",
       titleLabel: quote.title ?? null,
       docAndDate: [quote.doc_number, formatDate(quote.created_at, timezone)].join(" · "),
@@ -181,6 +191,7 @@ export function QuoteList(): React.ReactElement {
   const nonDraftQuoteRows = useMemo<DocumentRow[]>(
     () => nonDraftQuotes.map((quote) => ({
       id: quote.id,
+      doc_type: "quote",
       customerLabel: quote.customer_name ?? "Unassigned",
       titleLabel: quote.title ?? null,
       docAndDate: [quote.doc_number, formatDate(quote.created_at, timezone)].join(" · "),
@@ -193,6 +204,7 @@ export function QuoteList(): React.ReactElement {
   const invoiceRows = useMemo<DocumentRow[]>(
     () => filteredInvoices.map((invoice) => ({
       id: invoice.id,
+      doc_type: "invoice",
       customerLabel: invoice.customer_name,
       titleLabel: invoice.title ?? null,
       docAndDate: [invoice.doc_number, formatDate(invoice.created_at, timezone)].join(" · "),
@@ -258,78 +270,24 @@ export function QuoteList(): React.ReactElement {
     <main className="min-h-screen bg-background pb-24">
       <ScreenHeader title={headerTitle} subtitle={headerSubtitle} layout="top-level" />
       <section className="mx-auto w-full max-w-3xl pb-2 pt-20">
-        <div className="mb-4 px-4">
-          <div className="mb-4 flex items-center justify-between gap-3">
-            <div
-              aria-label="Document type filter"
-              className="inline-flex rounded-full bg-surface-container-low p-1"
-            >
-              <button
-                type="button"
-                aria-pressed={documentMode === "quotes"}
-                className={`cursor-pointer rounded-full px-4 py-2 text-sm font-semibold transition ${
-                  documentMode === "quotes"
-                    ? "ghost-shadow bg-surface-container-lowest text-primary ring-1 ring-selection-ring"
-                    : "text-on-surface-variant"
-                }`}
-                onClick={() => setDocumentMode("quotes")}
-              >
-                Quotes
-              </button>
-              <button
-                type="button"
-                aria-pressed={documentMode === "invoices"}
-                className={`cursor-pointer rounded-full px-4 py-2 text-sm font-semibold transition ${
-                  documentMode === "invoices"
-                    ? "ghost-shadow bg-surface-container-lowest text-primary ring-1 ring-selection-ring"
-                    : "text-on-surface-variant"
-                }`}
-                onClick={() => setDocumentMode("invoices")}
-              >
-                Invoices
-              </button>
-            </div>
-            <Button
-              type="button"
-              variant="iconButton"
-              size="sm"
-              aria-label={isSearchOpen ? "Close search" : "Open search"}
-              className={isSearchOpen
-                ? "border border-primary/70 bg-primary text-on-primary ghost-shadow hover:bg-primary/90"
-                : "border border-outline-variant/30 bg-surface-container-lowest text-on-surface ghost-shadow"}
-              onClick={() => {
-                if (isSearchOpen) {
-                  setSearchQuery("");
-                }
-                setIsSearchOpen((open) => !open);
-              }}
-            >
-              <AppIcon name="search" className="block text-[1.125rem] leading-none" />
-            </Button>
-          </div>
-          {isSearchOpen ? (
-            <Input
-              label={searchLabel}
-              id="document-search"
-              placeholder={searchPlaceholder}
-              hideLabel
-              value={searchQuery}
-              onChange={(event) => setSearchQuery(event.target.value)}
-              endAdornment={(
-                <Button
-                  type="button"
-                  variant="iconButton"
-                  size="xs"
-                  aria-label="Clear search text"
-                  className="text-outline"
-                  onClick={() => setSearchQuery("")}
-                >
-                  <AppIcon name="close" className="block text-base leading-none" />
-                </Button>
-              )}
-            />
-          ) : null}
-        </div>
+        <QuoteListControls
+          documentMode={documentMode}
+          isSelectionMode={isSelectionMode}
+          isSearchOpen={isSearchOpen}
+          searchQuery={searchQuery}
+          searchLabel={searchLabel}
+          searchPlaceholder={searchPlaceholder}
+          onDocumentModeChange={setDocumentMode}
+          onSearchToggle={() => {
+            if (isSearchOpen) {
+              setSearchQuery("");
+            }
+            setIsSearchOpen((open) => !open);
+          }}
+          onSearchChange={setSearchQuery}
+          onSearchClear={() => setSearchQuery("")}
+          onEnterSelectionMode={enterSelectionMode}
+        />
 
         {documentMode === "quotes" ? (
           <>
@@ -389,7 +347,15 @@ export function QuoteList(): React.ReactElement {
                   <DocumentRowsSection
                     label="DRAFTS"
                     rows={draftQuoteRows}
-                    onRowClick={(row) => navigate(row.destination, { state: row.destinationState })}
+                    isSelectionMode={isSelectionMode}
+                    isSelected={(row) => isSelected(row.id)}
+                    onRowClick={(row) => {
+                      if (isSelectionMode) {
+                        toggleSelection(row.id);
+                        return;
+                      }
+                      navigate(row.destination, { state: row.destinationState });
+                    }}
                   />
                 ) : null}
                 {nonDraftQuoteRows.length > 0 ? (
@@ -397,7 +363,15 @@ export function QuoteList(): React.ReactElement {
                     <DocumentRowsSection
                       label="PAST QUOTES"
                       rows={nonDraftQuoteRows}
-                      onRowClick={(row) => navigate(row.destination)}
+                      isSelectionMode={isSelectionMode}
+                      isSelected={(row) => isSelected(row.id)}
+                      onRowClick={(row) => {
+                        if (isSelectionMode) {
+                          toggleSelection(row.id);
+                          return;
+                        }
+                        navigate(row.destination);
+                      }}
                     />
                   </div>
                 ) : null}
@@ -406,21 +380,37 @@ export function QuoteList(): React.ReactElement {
               <DocumentRowsSection
                 label="PAST INVOICES"
                 rows={invoiceRows}
-                onRowClick={(row) => navigate(row.destination)}
+                isSelectionMode={isSelectionMode}
+                isSelected={(row) => isSelected(row.id)}
+                onRowClick={(row) => {
+                  if (isSelectionMode) {
+                    toggleSelection(row.id);
+                    return;
+                  }
+                  navigate(row.destination);
+                }}
               />
             )}
           </>
         ) : null}
       </section>
 
-      <button
-        type="button"
-        aria-label="New quote"
-        className="fixed bottom-20 right-4 z-50 flex h-14 w-14 cursor-pointer items-center justify-center rounded-full forest-gradient text-on-primary ghost-shadow transition-all active:scale-95"
-        onClick={quoteCreateFlow.openCreateEntry}
-      >
-        <AppIcon name="description" />
-      </button>
+      {!isSelectionMode ? (
+        <button
+          type="button"
+          aria-label="New quote"
+          className="fixed bottom-20 right-4 z-50 flex h-14 w-14 cursor-pointer items-center justify-center rounded-full forest-gradient text-on-primary ghost-shadow transition-all active:scale-95"
+          onClick={quoteCreateFlow.openCreateEntry}
+        >
+          <AppIcon name="description" />
+        </button>
+      ) : null}
+      {isSelectionMode ? (
+        <DocumentSelectionFooter
+          selectedCount={selectedCount}
+          onCancelSelection={cancelSelection}
+        />
+      ) : null}
       <PendingCaptureDeleteDialog
         capture={capturePendingDelete}
         onCancel={() => setCapturePendingDelete(null)}

--- a/frontend/src/features/quotes/components/QuoteListControls.tsx
+++ b/frontend/src/features/quotes/components/QuoteListControls.tsx
@@ -1,0 +1,120 @@
+import { Button } from "@/shared/components/Button";
+import { Input } from "@/shared/components/Input";
+import { OverflowMenu } from "@/shared/components/OverflowMenu";
+import { AppIcon } from "@/ui/Icon";
+
+type DocumentMode = "quotes" | "invoices";
+
+interface QuoteListControlsProps {
+  documentMode: DocumentMode;
+  isSelectionMode: boolean;
+  isSearchOpen: boolean;
+  searchQuery: string;
+  searchLabel: string;
+  searchPlaceholder: string;
+  onDocumentModeChange: (mode: DocumentMode) => void;
+  onSearchToggle: () => void;
+  onSearchChange: (nextQuery: string) => void;
+  onSearchClear: () => void;
+  onEnterSelectionMode: () => void;
+}
+
+export function QuoteListControls({
+  documentMode,
+  isSelectionMode,
+  isSearchOpen,
+  searchQuery,
+  searchLabel,
+  searchPlaceholder,
+  onDocumentModeChange,
+  onSearchToggle,
+  onSearchChange,
+  onSearchClear,
+  onEnterSelectionMode,
+}: QuoteListControlsProps): React.ReactElement {
+  return (
+    <div className="mb-4 px-4">
+      <div className="mb-4 flex items-center justify-between gap-3">
+        <div
+          aria-label="Document type filter"
+          className="inline-flex rounded-full bg-surface-container-low p-1"
+        >
+          <button
+            type="button"
+            aria-pressed={documentMode === "quotes"}
+            disabled={isSelectionMode}
+            className={`cursor-pointer rounded-full px-4 py-2 text-sm font-semibold transition ${
+              documentMode === "quotes"
+                ? "ghost-shadow bg-surface-container-lowest text-primary ring-1 ring-selection-ring"
+                : "text-on-surface-variant"
+            } ${isSelectionMode ? "opacity-50" : ""}`}
+            onClick={() => onDocumentModeChange("quotes")}
+          >
+            Quotes
+          </button>
+          <button
+            type="button"
+            aria-pressed={documentMode === "invoices"}
+            disabled={isSelectionMode}
+            className={`cursor-pointer rounded-full px-4 py-2 text-sm font-semibold transition ${
+              documentMode === "invoices"
+                ? "ghost-shadow bg-surface-container-lowest text-primary ring-1 ring-selection-ring"
+                : "text-on-surface-variant"
+            } ${isSelectionMode ? "opacity-50" : ""}`}
+            onClick={() => onDocumentModeChange("invoices")}
+          >
+            Invoices
+          </button>
+        </div>
+        <div className="flex items-center gap-2">
+          <Button
+            type="button"
+            variant="iconButton"
+            size="sm"
+            aria-label={isSearchOpen ? "Close search" : "Open search"}
+            className={isSearchOpen
+              ? "border border-primary/70 bg-primary text-on-primary ghost-shadow hover:bg-primary/90"
+              : "border border-outline-variant/30 bg-surface-container-lowest text-on-surface ghost-shadow"}
+            onClick={onSearchToggle}
+          >
+            <AppIcon name="search" className="block text-[1.125rem] leading-none" />
+          </Button>
+          <OverflowMenu
+            triggerLabel="List actions"
+            items={[
+              {
+                label: "Select",
+                icon: "check",
+                onSelect: onEnterSelectionMode,
+                disabled: isSelectionMode,
+              },
+            ]}
+          />
+        </div>
+      </div>
+
+      {isSearchOpen ? (
+        <Input
+          label={searchLabel}
+          id="document-search"
+          placeholder={searchPlaceholder}
+          hideLabel
+          value={searchQuery}
+          onChange={(event) => onSearchChange(event.target.value)}
+          endAdornment={(
+            <Button
+              type="button"
+              variant="iconButton"
+              size="xs"
+              aria-label="Clear search text"
+              className="text-outline"
+              onClick={onSearchClear}
+            >
+              <AppIcon name="close" className="block text-base leading-none" />
+            </Button>
+          )}
+        />
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/src/features/quotes/hooks/useDocumentSelection.ts
+++ b/frontend/src/features/quotes/hooks/useDocumentSelection.ts
@@ -1,0 +1,61 @@
+import { useMemo, useState } from "react";
+
+export type SelectionDocumentMode = "quotes" | "invoices";
+
+interface UseDocumentSelectionArgs {
+  activeMode: SelectionDocumentMode;
+}
+
+interface UseDocumentSelectionResult {
+  isSelectionMode: boolean;
+  selectedCount: number;
+  enterSelectionMode: () => void;
+  cancelSelection: () => void;
+  toggleSelection: (documentId: string) => void;
+  isSelected: (documentId: string) => boolean;
+}
+
+export function useDocumentSelection({
+  activeMode,
+}: UseDocumentSelectionArgs): UseDocumentSelectionResult {
+  const [selectionModeFor, setSelectionModeFor] = useState<SelectionDocumentMode | null>(null);
+  const [selectedIds, setSelectedIds] = useState<string[]>([]);
+
+  const isSelectionMode = selectionModeFor === activeMode;
+
+  const selectedIdSet = useMemo(() => new Set(selectedIds), [selectedIds]);
+
+  function enterSelectionMode(): void {
+    setSelectionModeFor(activeMode);
+    setSelectedIds([]);
+  }
+
+  function cancelSelection(): void {
+    setSelectionModeFor(null);
+    setSelectedIds([]);
+  }
+
+  function toggleSelection(documentId: string): void {
+    if (!isSelectionMode) {
+      return;
+    }
+    setSelectedIds((current) => (
+      current.includes(documentId)
+        ? current.filter((id) => id !== documentId)
+        : [...current, documentId]
+    ));
+  }
+
+  function isSelected(documentId: string): boolean {
+    return selectedIdSet.has(documentId);
+  }
+
+  return {
+    isSelectionMode,
+    selectedCount: selectedIds.length,
+    enterSelectionMode,
+    cancelSelection,
+    toggleSelection,
+    isSelected,
+  };
+}

--- a/frontend/src/features/quotes/tests/DocumentSelectionFooter.test.tsx
+++ b/frontend/src/features/quotes/tests/DocumentSelectionFooter.test.tsx
@@ -1,0 +1,60 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { DocumentSelectionFooter } from "@/features/quotes/components/DocumentSelectionFooter";
+
+describe("DocumentSelectionFooter", () => {
+  it("shows count and cancel action when nothing is selected", () => {
+    const onCancelSelection = vi.fn();
+
+    render(
+      <DocumentSelectionFooter
+        selectedCount={0}
+        onCancelSelection={onCancelSelection}
+      />,
+    );
+
+    expect(screen.getByText("0 selected")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Archive" })).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(onCancelSelection).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows archive and more actions when one or more are selected", async () => {
+    const onCancelSelection = vi.fn();
+    const onArchiveSelection = vi.fn();
+    const onDeleteSelectionPermanently = vi.fn();
+
+    render(
+      <DocumentSelectionFooter
+        selectedCount={2}
+        onCancelSelection={onCancelSelection}
+        onArchiveSelection={onArchiveSelection}
+        onDeleteSelectionPermanently={onDeleteSelectionPermanently}
+      />,
+    );
+
+    expect(screen.getByText("2 selected")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Archive" }));
+    expect(onArchiveSelection).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByRole("button", { name: "More" }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Delete permanently..." }));
+    expect(onDeleteSelectionPermanently).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByRole("button", { name: "More" }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Cancel selection" }));
+    expect(onCancelSelection).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByRole("button", { name: "More" }));
+    expect(screen.getByRole("menu", { name: "More selection actions" })).toBeInTheDocument();
+    fireEvent.keyDown(document, { key: "Escape" });
+
+    await waitFor(() => {
+      expect(screen.queryByRole("menu", { name: "More selection actions" })).not.toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/features/quotes/tests/QuoteList.test.tsx
+++ b/frontend/src/features/quotes/tests/QuoteList.test.tsx
@@ -261,6 +261,68 @@ describe("QuoteList", () => {
     expect(await screen.findByRole("button", { name: /bob brown/i })).toBeInTheDocument();
   });
 
+  it("enters selection mode from overflow menu and renders row checkboxes", async () => {
+    mockedQuoteService.listQuotes.mockResolvedValueOnce([makeQuoteListItem({ status: "ready" })]);
+
+    renderScreen();
+    await screen.findByText(/Q-001/);
+
+    fireEvent.click(screen.getByRole("button", { name: "List actions" }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Select" }));
+
+    const rowCheckbox = screen.getByRole("checkbox", { name: "Select Alice Johnson" });
+    expect(rowCheckbox).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /alice johnson/i }));
+    expect(rowCheckbox).toHaveAttribute("aria-checked", "true");
+    expect(navigateMock).not.toHaveBeenCalled();
+  });
+
+  it("locks tab switch, preserves search, and clears selection via cancel", async () => {
+    mockedQuoteService.listQuotes.mockResolvedValueOnce([
+      makeQuoteListItem({ id: "quote-1", customer_name: "Alice Johnson", status: "ready" }),
+      makeQuoteListItem({
+        id: "quote-2",
+        customer_id: "cust-2",
+        customer_name: "Bob Brown",
+        doc_number: "Q-002",
+        status: "ready",
+      }),
+    ]);
+
+    renderScreen();
+    await screen.findByText(/Q-001/);
+
+    const searchInput = await openSearch();
+    fireEvent.change(searchInput, { target: { value: "alice" } });
+    expect(searchInput).toHaveValue("alice");
+
+    fireEvent.click(screen.getByRole("button", { name: "List actions" }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Select" }));
+
+    expect(screen.getByLabelText("Search quotes")).toHaveValue("alice");
+    const documentTypeFilter = screen.getByLabelText("Document type filter");
+    expect(within(documentTypeFilter).getByRole("button", { name: "Quotes" })).toBeDisabled();
+    expect(within(documentTypeFilter).getByRole("button", { name: "Invoices" })).toBeDisabled();
+    expect(screen.queryByRole("button", { name: "New quote" })).not.toBeInTheDocument();
+    expect(screen.getByText("0 selected")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /alice johnson/i }));
+    expect(screen.getByText("1 selected")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Archive" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "More" })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "More" }));
+    expect(screen.getByRole("menuitem", { name: "Delete permanently..." })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("menuitem", { name: "Cancel selection" }));
+
+    expect(screen.queryByText("0 selected")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "New quote" })).toBeInTheDocument();
+    expect(within(documentTypeFilter).getByRole("button", { name: "Invoices" })).not.toBeDisabled();
+    expect(screen.queryByRole("checkbox", { name: "Select Alice Johnson" })).not.toBeInTheDocument();
+  });
+
   it("uses token-backed emphasis for the active filter and create button", async () => {
     mockedQuoteService.listQuotes.mockResolvedValueOnce([makeQuoteListItem()]);
 

--- a/frontend/src/ui/QuoteListRow.tsx
+++ b/frontend/src/ui/QuoteListRow.tsx
@@ -10,6 +10,8 @@ interface QuoteListRowProps {
   status: StatusPillVariant;
   isDraft?: boolean;
   needsCustomerAssignment?: boolean;
+  isSelectionMode?: boolean;
+  isSelected?: boolean;
   onClick: () => void;
 }
 
@@ -25,33 +27,56 @@ export function QuoteListRow({
   status,
   isDraft,
   needsCustomerAssignment,
+  isSelectionMode,
+  isSelected,
   onClick,
 }: QuoteListRowProps): React.ReactElement {
+  const selectedClassName = isSelected
+    ? "ring-2 ring-selection-ring bg-selection-bg"
+    : undefined;
+  const layoutClassName = isSelectionMode ? "flex items-start gap-3" : undefined;
+
   return (
     <button
       type="button"
       onClick={onClick}
-      className={isDraft ? draftRowClasses : baseRowClasses}
+      className={[isDraft ? draftRowClasses : baseRowClasses, selectedClassName, layoutClassName].filter(Boolean).join(" ")}
     >
-      <div className="flex items-baseline justify-between gap-3">
-        <p className="font-headline font-bold text-on-surface">{customerLabel}</p>
-        <p className="font-headline font-bold text-on-surface">{formatCurrency(totalAmount)}</p>
-      </div>
-      <div className="mt-1 space-y-1">
-        {titleLabel ? (
-          <p className="text-sm text-on-surface-variant">{titleLabel}</p>
-        ) : null}
-        <div className="flex items-center gap-3">
-          <p className="text-xs text-on-surface-variant">{docAndDate}</p>
-          {needsCustomerAssignment ? (
-            <span className="ml-auto">
-              <StatusPill variant="needs_customer" />
-            </span>
-          ) : (
-            <span className="ml-auto">
-              <StatusPill variant={status} />
-            </span>
-          )}
+      {isSelectionMode ? (
+        <span
+          role="checkbox"
+          aria-checked={isSelected === true}
+          aria-label={`Select ${customerLabel}`}
+          className={`mt-0.5 inline-flex h-5 w-5 shrink-0 items-center justify-center rounded border transition-colors ${
+            isSelected
+              ? "border-primary bg-primary text-on-primary"
+              : "border-outline-variant/60 bg-surface-container-lowest text-transparent"
+          }`}
+        >
+          <span className="text-[0.75rem] leading-none">✓</span>
+        </span>
+      ) : null}
+      <div className="min-w-0 flex-1">
+        <div className="flex items-baseline justify-between gap-3">
+          <p className="font-headline font-bold text-on-surface">{customerLabel}</p>
+          <p className="font-headline font-bold text-on-surface">{formatCurrency(totalAmount)}</p>
+        </div>
+        <div className="mt-1 space-y-1">
+          {titleLabel ? (
+            <p className="text-sm text-on-surface-variant">{titleLabel}</p>
+          ) : null}
+          <div className="flex items-center gap-3">
+            <p className="text-xs text-on-surface-variant">{docAndDate}</p>
+            {needsCustomerAssignment ? (
+              <span className="ml-auto">
+                <StatusPill variant="needs_customer" />
+              </span>
+            ) : (
+              <span className="ml-auto">
+                <StatusPill variant={status} />
+              </span>
+            )}
+          </div>
         </div>
       </div>
     </button>


### PR DESCRIPTION
## Summary
- add home-list selection mode shell via overflow `Select` action with tab-scoped state in `useDocumentSelection`
- render selection checkboxes and selected-row visual state in quote/invoice rows, while preserving existing search/filter state
- add sticky `DocumentSelectionFooter` above bottom nav with `Cancel`, `Archive`, and `More` menu (`Delete permanently...`, `Cancel selection`), with actions stubbed
- hide FAB and disable Quotes/Invoices mode toggle while selection mode is active
- add/update QuoteList tests for selection-mode behavior and add dedicated footer tests

## Verification
- `cd frontend && npx vitest run src/features/quotes/tests/QuoteList.test.tsx --bail=1`
- `cd frontend && npx vitest run src/features/quotes/tests/DocumentSelectionFooter.test.tsx --bail=1`
- `cd frontend && npx eslint src/features/quotes`
- `cd frontend && npx tsc --noEmit`
- `make frontend-verify`

Closes #655