### PR TITLE
Task #656: wire archive/delete selection actions in QuoteList

### DIFF
--- a/frontend/src/features/invoices/services/invoiceService.ts
+++ b/frontend/src/features/invoices/services/invoiceService.ts
@@ -1,4 +1,6 @@
 import type {
+  InvoiceBulkActionRequest,
+  InvoiceBulkActionResponse,
   InvoiceCreateRequest,
   Invoice,
   InvoiceDetail,
@@ -73,6 +75,13 @@ async function sendInvoiceEmail(id: string, idempotencyKey?: string): Promise<Jo
   return response.data;
 }
 
+function bulkAction(payload: InvoiceBulkActionRequest): Promise<InvoiceBulkActionResponse> {
+  return request<InvoiceBulkActionResponse>("/api/invoices/bulk-action", {
+    method: "POST",
+    body: payload,
+  });
+}
+
 export const invoiceService = {
   createInvoice,
   getInvoice,
@@ -84,4 +93,5 @@ export const invoiceService = {
   markInvoicePaid,
   markInvoiceVoid,
   sendInvoiceEmail,
+  bulkAction,
 };

--- a/frontend/src/features/invoices/types/invoice.types.ts
+++ b/frontend/src/features/invoices/types/invoice.types.ts
@@ -1,5 +1,7 @@
 import type { InvoiceStatus } from "@/features/invoices/types/invoice-status";
 import type {
+  BulkActionRequest,
+  BulkActionResponse,
   LineItem,
   LineItemDraft,
   PdfArtifact,
@@ -80,3 +82,6 @@ export interface InvoiceUpdateRequest {
   due_date?: string;
   doc_type?: "quote" | "invoice";
 }
+
+export type InvoiceBulkActionRequest = BulkActionRequest;
+export type InvoiceBulkActionResponse = BulkActionResponse;

--- a/frontend/src/features/quotes/components/QuoteList.tsx
+++ b/frontend/src/features/quotes/components/QuoteList.tsx
@@ -6,14 +6,14 @@ import { invoiceService } from "@/features/invoices/services/invoiceService";
 import type { InvoiceListItem } from "@/features/invoices/types/invoice.types";
 import { PendingCaptureDeleteDialog } from "@/features/quotes/components/PendingCaptureDeleteDialog";
 import { PendingCapturesSection } from "@/features/quotes/components/PendingCapturesSection";
+import { QuoteListSelectionOverlays } from "@/features/quotes/components/QuoteListSelectionOverlays";
+import { useDocumentBulkActions } from "@/features/quotes/hooks/useDocumentBulkActions";
+import { useQuoteListPendingCaptureActions } from "@/features/quotes/hooks/useQuoteListPendingCaptureActions";
 import { useReconnectRefresh } from "@/features/quotes/components/useReconnectRefresh";
 import { useOutboxSuccessQuoteRefresh } from "@/features/quotes/components/useOutboxSuccessQuoteRefresh";
 import { useQuoteCreateFlow } from "@/features/quotes/hooks/useQuoteCreateFlow";
-import { getStorageErrorMessage } from "@/features/quotes/offline/captureDb";
 import type { LocalCaptureSummary } from "@/features/quotes/offline/captureTypes";
 import { useRecoverableCaptures } from "@/features/quotes/offline/useRecoverableCaptures";
-import { runOutboxPass } from "@/features/quotes/offline/outboxEngine";
-import { getJobForSession, updateJobStatus } from "@/features/quotes/offline/outboxRepository";
 import { quoteService } from "@/features/quotes/services/quoteService";
 import type { QuoteListItem } from "@/features/quotes/types/quote.types";
 import { BottomNav } from "@/shared/components/BottomNav";
@@ -24,12 +24,10 @@ import { formatDate } from "@/shared/lib/formatters";
 import { Banner } from "@/ui/Banner";
 import { EmptyState } from "@/ui/EmptyState";
 import { AppIcon } from "@/ui/Icon";
-import { DocumentSelectionFooter } from "./DocumentSelectionFooter";
 import { QuoteListControls } from "./QuoteListControls";
 import { buildInvoiceSubtitle, buildPendingCaptureError, buildQuoteSubtitle, matchesSearch } from "./QuoteList.helpers";
 import { useDocumentSelection } from "../hooks/useDocumentSelection";
 type DocumentMode = "quotes" | "invoices";
-
 export function QuoteList(): React.ReactElement {
   const navigate = useNavigate();
   const { authMode, user } = useAuth();
@@ -42,16 +40,38 @@ export function QuoteList(): React.ReactElement {
   const [isLoadingInvoices, setIsLoadingInvoices] = useState(false);
   const [quoteLoadError, setQuoteLoadError] = useState<string | null>(null);
   const [invoiceLoadError, setInvoiceLoadError] = useState<string | null>(null);
-  const [pendingCaptureActionError, setPendingCaptureActionError] = useState<string | null>(null);
   const [capturePendingDelete, setCapturePendingDelete] = useState<LocalCaptureSummary | null>(null);
+  const [refreshTick, setRefreshTick] = useState(0);
   const {
     isSelectionMode,
+    selectedIds,
     selectedCount,
     enterSelectionMode,
     cancelSelection,
     toggleSelection,
     isSelected,
   } = useDocumentSelection({ activeMode: documentMode });
+  const {
+    bulkActionError,
+    bulkActionFeedback,
+    isBulkActionPending,
+    showArchiveConfirm,
+    showDeleteConfirm,
+    openArchiveConfirm,
+    openDeleteConfirm,
+    closeArchiveConfirm,
+    closeDeleteConfirm,
+    closeSelectionActionDialogs,
+    clearBulkActionFeedback,
+    executeBulkAction,
+  } = useDocumentBulkActions({
+    documentMode,
+    selectedIds,
+    onComplete: () => {
+      cancelSelection();
+      setRefreshTick((current) => current + 1);
+    },
+  });
   const {
     captures: recoverableCaptures,
     isLoading: isLoadingRecoverableCaptures,
@@ -60,6 +80,17 @@ export function QuoteList(): React.ReactElement {
     deleteCapture,
   } = useRecoverableCaptures(user?.id);
   const { isOnline, reconnectTick } = useReconnectRefresh(refreshRecoverableCaptures);
+  const {
+    pendingCaptureActionError,
+    clearPendingCaptureActionError,
+    navigateToLocalCapture,
+    onDeleteCapture,
+    onRetryCapture,
+  } = useQuoteListPendingCaptureActions({
+    userId: user?.id,
+    deleteCapture,
+    refreshRecoverableCaptures,
+  });
   useOutboxSuccessQuoteRefresh({
     userId: user?.id,
     onQuotesLoaded: setQuotes,
@@ -117,12 +148,11 @@ export function QuoteList(): React.ReactElement {
         }
       }
     }
-
     void fetchDocuments();
     return () => {
       isActive = false;
     };
-  }, [authMode, documentMode, reconnectTick]);
+  }, [authMode, documentMode, reconnectTick, refreshTick]);
 
   useEffect(() => {
     if (!isSearchOpen) {
@@ -167,11 +197,9 @@ export function QuoteList(): React.ReactElement {
   const headerSubtitle = documentMode === "quotes" ? quoteSubtitle : invoiceSubtitle;
   const searchLabel = documentMode === "quotes" ? "Search quotes" : "Search invoices";
   const searchPlaceholder = documentMode === "quotes" ? "Search customer, title, or quote ID..." : "Search customer, title, or invoice ID...";
-  const emptyStateMessage = totalRows === 0
-    ? documentMode === "quotes"
-      ? "No quotes yet. Tap New Quote to create your first."
-      : "No invoices yet. Convert a quote to an invoice from Preview."
-    : `No ${documentMode} match your search.`;
+  const emptyStateMessage = totalRows === 0 ? (documentMode === "quotes"
+    ? "No quotes yet. Tap New Quote to create your first."
+    : "No invoices yet. Convert a quote to an invoice from Preview.") : `No ${documentMode} match your search.`;
   const draftQuoteRows = useMemo<DocumentRow[]>(
     () => draftQuotes.map((quote) => ({
       id: quote.id,
@@ -224,48 +252,6 @@ export function QuoteList(): React.ReactElement {
     recoverableCapturesError,
     pendingCaptureActionError,
   });
-  function navigateToLocalCapture(sessionId: string, options?: { autoExtract?: boolean }): void {
-    const nextSearchParams = new URLSearchParams({ localSession: sessionId });
-    if (options?.autoExtract) {
-      nextSearchParams.set("autoExtract", "1");
-    }
-    navigate(`/quotes/capture?${nextSearchParams.toString()}`);
-  }
-
-  async function onDeleteCapture(sessionId: string): Promise<void> {
-    setPendingCaptureActionError(null);
-    try {
-      await deleteCapture(sessionId);
-    } catch (deleteError) {
-      const message = getStorageErrorMessage(deleteError, "Unable to delete pending capture.");
-      setPendingCaptureActionError(message);
-    }
-  }
-
-  async function onRetryCapture(sessionId: string): Promise<void> {
-    if (!user?.id) {
-      return;
-    }
-
-    setPendingCaptureActionError(null);
-    try {
-      const outboxJob = await getJobForSession(sessionId);
-      if (!outboxJob || outboxJob.status === "running") {
-        return;
-      }
-
-      await updateJobStatus(outboxJob.jobId, {
-        status: "queued",
-        nextRetryAt: null,
-      });
-      await runOutboxPass(user.id);
-      await refreshRecoverableCaptures();
-    } catch (retryError) {
-      const message = getStorageErrorMessage(retryError, "Unable to retry pending capture.");
-      setPendingCaptureActionError(message);
-    }
-  }
-
   return (
     <main className="min-h-screen bg-background pb-24">
       <ScreenHeader title={headerTitle} subtitle={headerSubtitle} layout="top-level" />
@@ -289,6 +275,16 @@ export function QuoteList(): React.ReactElement {
           onEnterSelectionMode={enterSelectionMode}
         />
 
+        {bulkActionFeedback ? (
+          <div className="mb-4 px-4">
+            <Banner kind={bulkActionFeedback.kind} title={bulkActionFeedback.title} message={bulkActionFeedback.message} onDismiss={clearBulkActionFeedback} />
+          </div>
+        ) : null}
+        {bulkActionError ? (
+          <div className="mb-4 px-4">
+            <FeedbackMessage variant="error">{bulkActionError}</FeedbackMessage>
+          </div>
+        ) : null}
         {documentMode === "quotes" ? (
           <>
             {authMode === "offline_recovered" ? (
@@ -302,10 +298,20 @@ export function QuoteList(): React.ReactElement {
               isOnline={isOnline}
               timezone={timezone}
               error={pendingCaptureError}
-              onResume={(sessionId) => navigateToLocalCapture(sessionId)}
-              onExtract={(sessionId) => navigateToLocalCapture(sessionId, { autoExtract: true })}
-              onRetry={(sessionId) => { void onRetryCapture(sessionId); }}
+              onResume={(sessionId) => {
+                clearPendingCaptureActionError();
+                navigateToLocalCapture(sessionId);
+              }}
+              onExtract={(sessionId) => {
+                clearPendingCaptureActionError();
+                navigateToLocalCapture(sessionId, { autoExtract: true });
+              }}
+              onRetry={(sessionId) => {
+                clearPendingCaptureActionError();
+                void onRetryCapture(sessionId);
+              }}
               onDelete={(sessionId) => {
+                clearPendingCaptureActionError();
                 const capture = recoverableCaptures.find((item) => item.sessionId === sessionId) ?? null;
                 setCapturePendingDelete(capture);
               }}
@@ -405,12 +411,27 @@ export function QuoteList(): React.ReactElement {
           <AppIcon name="description" />
         </button>
       ) : null}
-      {isSelectionMode ? (
-        <DocumentSelectionFooter
-          selectedCount={selectedCount}
-          onCancelSelection={cancelSelection}
-        />
-      ) : null}
+      <QuoteListSelectionOverlays
+        isSelectionMode={isSelectionMode}
+        selectedCount={selectedCount}
+        isBulkActionPending={isBulkActionPending}
+        showArchiveConfirm={showArchiveConfirm}
+        showDeleteConfirm={showDeleteConfirm}
+        onCancelSelection={() => {
+          closeSelectionActionDialogs();
+          cancelSelection();
+        }}
+        onArchiveSelection={openArchiveConfirm}
+        onDeleteSelectionPermanently={openDeleteConfirm}
+        onArchiveConfirmCancel={closeArchiveConfirm}
+        onDeleteConfirmCancel={closeDeleteConfirm}
+        onArchiveConfirm={() => {
+          void executeBulkAction("archive");
+        }}
+        onDeleteConfirm={() => {
+          void executeBulkAction("delete");
+        }}
+      />
       <PendingCaptureDeleteDialog
         capture={capturePendingDelete}
         onCancel={() => setCapturePendingDelete(null)}

--- a/frontend/src/features/quotes/components/QuoteListSelectionOverlays.tsx
+++ b/frontend/src/features/quotes/components/QuoteListSelectionOverlays.tsx
@@ -1,0 +1,68 @@
+import { ConfirmModal } from "@/shared/components/ConfirmModal";
+import { DocumentSelectionFooter } from "@/features/quotes/components/DocumentSelectionFooter";
+
+interface QuoteListSelectionOverlaysProps {
+  isSelectionMode: boolean;
+  selectedCount: number;
+  isBulkActionPending: boolean;
+  showArchiveConfirm: boolean;
+  showDeleteConfirm: boolean;
+  onCancelSelection: () => void;
+  onArchiveSelection: () => void;
+  onDeleteSelectionPermanently: () => void;
+  onArchiveConfirmCancel: () => void;
+  onDeleteConfirmCancel: () => void;
+  onArchiveConfirm: () => void;
+  onDeleteConfirm: () => void;
+}
+
+export function QuoteListSelectionOverlays({
+  isSelectionMode,
+  selectedCount,
+  isBulkActionPending,
+  showArchiveConfirm,
+  showDeleteConfirm,
+  onCancelSelection,
+  onArchiveSelection,
+  onDeleteSelectionPermanently,
+  onArchiveConfirmCancel,
+  onDeleteConfirmCancel,
+  onArchiveConfirm,
+  onDeleteConfirm,
+}: QuoteListSelectionOverlaysProps): React.ReactElement {
+  return (
+    <>
+      {isSelectionMode ? (
+        <DocumentSelectionFooter
+          selectedCount={selectedCount}
+          onCancelSelection={onCancelSelection}
+          onArchiveSelection={onArchiveSelection}
+          onDeleteSelectionPermanently={onDeleteSelectionPermanently}
+        />
+      ) : null}
+      {showArchiveConfirm ? (
+        <ConfirmModal
+          title={`Archive ${selectedCount} selected ${selectedCount === 1 ? "document" : "documents"}?`}
+          body="Archived documents remain in history and can be restored later."
+          confirmLabel="Archive"
+          cancelLabel="Keep selected"
+          confirmDisabled={isBulkActionPending || selectedCount === 0}
+          onCancel={onArchiveConfirmCancel}
+          onConfirm={onArchiveConfirm}
+        />
+      ) : null}
+      {showDeleteConfirm ? (
+        <ConfirmModal
+          title={`Delete ${selectedCount} selected ${selectedCount === 1 ? "document" : "documents"} permanently?`}
+          body="This action cannot be undone. Documents blocked by policy will stay untouched."
+          confirmLabel="Delete permanently"
+          cancelLabel="Keep selected"
+          variant="destructive"
+          confirmDisabled={isBulkActionPending || selectedCount === 0}
+          onCancel={onDeleteConfirmCancel}
+          onConfirm={onDeleteConfirm}
+        />
+      ) : null}
+    </>
+  );
+}

--- a/frontend/src/features/quotes/components/quoteListBulkActionFeedback.ts
+++ b/frontend/src/features/quotes/components/quoteListBulkActionFeedback.ts
@@ -1,0 +1,66 @@
+import type {
+  BulkActionBlockedItem,
+  BulkActionResponse,
+  BulkActionType,
+} from "@/features/quotes/types/quote.types";
+
+interface BulkActionFeedback {
+  kind: "success" | "warn";
+  title: string;
+  message: string;
+}
+
+function pluralize(noun: string, count: number): string {
+  return `${count} ${noun}${count === 1 ? "" : "s"}`;
+}
+
+function formatBlockedSummary(blocked: BulkActionBlockedItem[]): string {
+  if (blocked.length === 0) {
+    return "";
+  }
+
+  const uniqueMessages = Array.from(new Set(blocked.map((item) => item.message.trim()).filter(Boolean)));
+
+  if (uniqueMessages.length === 0) {
+    return `${pluralize("document", blocked.length)} were blocked.`;
+  }
+
+  if (uniqueMessages.length === 1) {
+    return uniqueMessages[0] ?? "";
+  }
+
+  return uniqueMessages.map((message) => `- ${message}`).join(" ");
+}
+
+function actionPastTense(action: BulkActionType): string {
+  return action === "archive" ? "archived" : "deleted";
+}
+
+export function buildBulkActionFeedback(response: BulkActionResponse): BulkActionFeedback {
+  const actionVerb = actionPastTense(response.action);
+  const appliedCount = response.applied.length;
+  const blockedCount = response.blocked.length;
+  const blockedSummary = formatBlockedSummary(response.blocked);
+
+  if (appliedCount > 0 && blockedCount === 0) {
+    return {
+      kind: "success",
+      title: response.action === "archive" ? "Archive complete" : "Delete complete",
+      message: `${pluralize("document", appliedCount)} ${actionVerb}.`,
+    };
+  }
+
+  if (appliedCount > 0) {
+    return {
+      kind: "warn",
+      title: "Partially complete",
+      message: `${pluralize("document", appliedCount)} ${actionVerb}. ${pluralize("document", blockedCount)} could not be ${actionVerb}. ${blockedSummary}`.trim(),
+    };
+  }
+
+  return {
+    kind: "warn",
+    title: response.action === "archive" ? "No documents archived" : "No documents deleted",
+    message: blockedSummary || `No documents were ${actionVerb}.`,
+  };
+}

--- a/frontend/src/features/quotes/components/quotePreview.helpers.ts
+++ b/frontend/src/features/quotes/components/quotePreview.helpers.ts
@@ -155,13 +155,15 @@ export function buildOverflowItems({
 
   if (actionState === "draft") {
     items = [
-      {
-        label: "Delete Quote",
-        icon: "delete",
-        tone: "destructive",
-        disabled: isBusy,
-        onSelect: onDeleteRequest,
-      },
+      ...(!hasLinkedInvoice
+        ? [{
+          label: "Delete Quote",
+          icon: "delete",
+          tone: "destructive" as const,
+          disabled: isBusy,
+          onSelect: onDeleteRequest,
+        }]
+        : []),
       {
         label: "Mark as Won",
         icon: "check_circle",
@@ -178,13 +180,15 @@ export function buildOverflowItems({
     ];
   } else if (actionState === "ready") {
     items = [
-      {
-        label: "Delete Quote",
-        icon: "delete",
-        tone: "destructive",
-        disabled: isBusy,
-        onSelect: onDeleteRequest,
-      },
+      ...(!hasLinkedInvoice
+        ? [{
+          label: "Delete Quote",
+          icon: "delete",
+          tone: "destructive" as const,
+          disabled: isBusy,
+          onSelect: onDeleteRequest,
+        }]
+        : []),
       {
         label: "Mark as Won",
         icon: "check_circle",

--- a/frontend/src/features/quotes/hooks/useDocumentBulkActions.ts
+++ b/frontend/src/features/quotes/hooks/useDocumentBulkActions.ts
@@ -1,0 +1,113 @@
+import { useState } from "react";
+import { invoiceService } from "@/features/invoices/services/invoiceService";
+import { buildBulkActionFeedback } from "@/features/quotes/components/quoteListBulkActionFeedback";
+import { quoteService } from "@/features/quotes/services/quoteService";
+import type {
+  BulkActionResponse,
+  BulkActionType,
+} from "@/features/quotes/types/quote.types";
+import { isHttpRequestError } from "@/shared/lib/http";
+
+type DocumentMode = "quotes" | "invoices";
+
+export interface BulkActionFeedbackState {
+  kind: "success" | "warn";
+  title: string;
+  message: string;
+}
+
+interface UseDocumentBulkActionsArgs {
+  documentMode: DocumentMode;
+  selectedIds: string[];
+  onComplete: () => void;
+}
+
+interface UseDocumentBulkActionsResult {
+  bulkActionError: string | null;
+  bulkActionFeedback: BulkActionFeedbackState | null;
+  isBulkActionPending: boolean;
+  showArchiveConfirm: boolean;
+  showDeleteConfirm: boolean;
+  openArchiveConfirm: () => void;
+  openDeleteConfirm: () => void;
+  closeArchiveConfirm: () => void;
+  closeDeleteConfirm: () => void;
+  closeSelectionActionDialogs: () => void;
+  clearBulkActionFeedback: () => void;
+  executeBulkAction: (action: BulkActionType) => Promise<void>;
+}
+
+export function useDocumentBulkActions({
+  documentMode,
+  selectedIds,
+  onComplete,
+}: UseDocumentBulkActionsArgs): UseDocumentBulkActionsResult {
+  const [bulkActionError, setBulkActionError] = useState<string | null>(null);
+  const [bulkActionFeedback, setBulkActionFeedback] = useState<BulkActionFeedbackState | null>(null);
+  const [showArchiveConfirm, setShowArchiveConfirm] = useState(false);
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+  const [isBulkActionPending, setIsBulkActionPending] = useState(false);
+
+  function closeSelectionActionDialogs(): void {
+    setShowArchiveConfirm(false);
+    setShowDeleteConfirm(false);
+  }
+
+  function resolveBulkActionErrorMessage(error: unknown): string {
+    if (isHttpRequestError(error)) {
+      if (error.status === 422) {
+        return "Unable to run that bulk action. Please refresh and try again.";
+      }
+      return error.message || "Unable to complete the selected action.";
+    }
+    if (error instanceof Error) {
+      return error.message;
+    }
+    return "Unable to complete the selected action.";
+  }
+
+  async function executeBulkAction(action: BulkActionType): Promise<void> {
+    if (selectedIds.length === 0 || isBulkActionPending) {
+      return;
+    }
+
+    setBulkActionError(null);
+    setBulkActionFeedback(null);
+    setIsBulkActionPending(true);
+
+    try {
+      const response: BulkActionResponse = documentMode === "quotes"
+        ? await quoteService.bulkAction({ action, ids: selectedIds })
+        : await invoiceService.bulkAction({ action, ids: selectedIds });
+
+      setBulkActionFeedback(buildBulkActionFeedback(response));
+      closeSelectionActionDialogs();
+      onComplete();
+    } catch (error) {
+      setBulkActionError(resolveBulkActionErrorMessage(error));
+    } finally {
+      setIsBulkActionPending(false);
+    }
+  }
+
+  return {
+    bulkActionError,
+    bulkActionFeedback,
+    isBulkActionPending,
+    showArchiveConfirm,
+    showDeleteConfirm,
+    openArchiveConfirm: () => {
+      setBulkActionError(null);
+      setShowArchiveConfirm(true);
+    },
+    openDeleteConfirm: () => {
+      setBulkActionError(null);
+      setShowDeleteConfirm(true);
+    },
+    closeArchiveConfirm: () => setShowArchiveConfirm(false),
+    closeDeleteConfirm: () => setShowDeleteConfirm(false),
+    closeSelectionActionDialogs,
+    clearBulkActionFeedback: () => setBulkActionFeedback(null),
+    executeBulkAction,
+  };
+}

--- a/frontend/src/features/quotes/hooks/useDocumentSelection.ts
+++ b/frontend/src/features/quotes/hooks/useDocumentSelection.ts
@@ -8,6 +8,7 @@ interface UseDocumentSelectionArgs {
 
 interface UseDocumentSelectionResult {
   isSelectionMode: boolean;
+  selectedIds: string[];
   selectedCount: number;
   enterSelectionMode: () => void;
   cancelSelection: () => void;
@@ -52,6 +53,7 @@ export function useDocumentSelection({
 
   return {
     isSelectionMode,
+    selectedIds,
     selectedCount: selectedIds.length,
     enterSelectionMode,
     cancelSelection,

--- a/frontend/src/features/quotes/hooks/useQuoteListPendingCaptureActions.ts
+++ b/frontend/src/features/quotes/hooks/useQuoteListPendingCaptureActions.ts
@@ -1,0 +1,82 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { getStorageErrorMessage } from "@/features/quotes/offline/captureDb";
+import { runOutboxPass } from "@/features/quotes/offline/outboxEngine";
+import { getJobForSession, updateJobStatus } from "@/features/quotes/offline/outboxRepository";
+
+interface UseQuoteListPendingCaptureActionsArgs {
+  userId: string | undefined;
+  deleteCapture: (sessionId: string) => Promise<void>;
+  refreshRecoverableCaptures: () => Promise<void>;
+}
+
+interface UseQuoteListPendingCaptureActionsResult {
+  pendingCaptureActionError: string | null;
+  clearPendingCaptureActionError: () => void;
+  navigateToLocalCapture: (sessionId: string, options?: { autoExtract?: boolean }) => void;
+  onDeleteCapture: (sessionId: string) => Promise<void>;
+  onRetryCapture: (sessionId: string) => Promise<void>;
+}
+
+export function useQuoteListPendingCaptureActions({
+  userId,
+  deleteCapture,
+  refreshRecoverableCaptures,
+}: UseQuoteListPendingCaptureActionsArgs): UseQuoteListPendingCaptureActionsResult {
+  const navigate = useNavigate();
+  const [pendingCaptureActionError, setPendingCaptureActionError] = useState<string | null>(null);
+
+  function clearPendingCaptureActionError(): void {
+    setPendingCaptureActionError(null);
+  }
+
+  function navigateToLocalCapture(sessionId: string, options?: { autoExtract?: boolean }): void {
+    const nextSearchParams = new URLSearchParams({ localSession: sessionId });
+    if (options?.autoExtract) {
+      nextSearchParams.set("autoExtract", "1");
+    }
+    navigate(`/quotes/capture?${nextSearchParams.toString()}`);
+  }
+
+  async function onDeleteCapture(sessionId: string): Promise<void> {
+    setPendingCaptureActionError(null);
+    try {
+      await deleteCapture(sessionId);
+    } catch (deleteError) {
+      const message = getStorageErrorMessage(deleteError, "Unable to delete pending capture.");
+      setPendingCaptureActionError(message);
+    }
+  }
+
+  async function onRetryCapture(sessionId: string): Promise<void> {
+    if (!userId) {
+      return;
+    }
+
+    setPendingCaptureActionError(null);
+    try {
+      const outboxJob = await getJobForSession(sessionId);
+      if (!outboxJob || outboxJob.status === "running") {
+        return;
+      }
+
+      await updateJobStatus(outboxJob.jobId, {
+        status: "queued",
+        nextRetryAt: null,
+      });
+      await runOutboxPass(userId);
+      await refreshRecoverableCaptures();
+    } catch (retryError) {
+      const message = getStorageErrorMessage(retryError, "Unable to retry pending capture.");
+      setPendingCaptureActionError(message);
+    }
+  }
+
+  return {
+    pendingCaptureActionError,
+    clearPendingCaptureActionError,
+    navigateToLocalCapture,
+    onDeleteCapture,
+    onRetryCapture,
+  };
+}

--- a/frontend/src/features/quotes/services/quoteService.ts
+++ b/frontend/src/features/quotes/services/quoteService.ts
@@ -1,5 +1,7 @@
 import type { Invoice } from "@/features/invoices/types/invoice.types";
 import type {
+  BulkActionRequest,
+  BulkActionResponse,
   ExtractionResult,
   ExtractionReviewMetadata,
   ExtractionReviewMetadataUpdateRequest,
@@ -239,6 +241,13 @@ function convertToInvoice(id: string): Promise<Invoice> {
   });
 }
 
+function bulkAction(payload: BulkActionRequest): Promise<BulkActionResponse> {
+  return request<BulkActionResponse>("/api/quotes/bulk-action", {
+    method: "POST",
+    body: payload,
+  });
+}
+
 export const quoteService = {
   extract,
   createManualDraft,
@@ -258,4 +267,5 @@ export const quoteService = {
   markQuoteWon,
   markQuoteLost,
   convertToInvoice,
+  bulkAction,
 };

--- a/frontend/src/features/quotes/tests/QuoteList.test.tsx
+++ b/frontend/src/features/quotes/tests/QuoteList.test.tsx
@@ -44,12 +44,14 @@ vi.mock("@/features/quotes/services/quoteService", () => ({
     markQuoteWon: vi.fn(),
     markQuoteLost: vi.fn(),
     convertToInvoice: vi.fn(),
+    bulkAction: vi.fn(),
   },
 }));
 
 vi.mock("@/features/invoices/services/invoiceService", () => ({
   invoiceService: {
     listInvoices: vi.fn(),
+    bulkAction: vi.fn(),
   },
 }));
 
@@ -321,6 +323,103 @@ describe("QuoteList", () => {
     expect(screen.getByRole("button", { name: "New quote" })).toBeInTheDocument();
     expect(within(documentTypeFilter).getByRole("button", { name: "Invoices" })).not.toBeDisabled();
     expect(screen.queryByRole("checkbox", { name: "Select Alice Johnson" })).not.toBeInTheDocument();
+  });
+
+  it("archives selected quotes via bulk endpoint and clears selection after confirmation", async () => {
+    mockedQuoteService.listQuotes
+      .mockResolvedValueOnce([
+        makeQuoteListItem({ id: "quote-1", customer_name: "Alice Johnson", status: "ready" }),
+      ])
+      .mockResolvedValueOnce([
+        makeQuoteListItem({ id: "quote-1", customer_name: "Alice Johnson", status: "ready" }),
+      ]);
+    mockedQuoteService.bulkAction.mockResolvedValueOnce({
+      action: "archive",
+      applied: [{ id: "quote-1" }],
+      blocked: [],
+    });
+
+    renderScreen();
+    await screen.findByText(/Q-001/);
+
+    fireEvent.click(screen.getByRole("button", { name: "List actions" }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Select" }));
+    fireEvent.click(screen.getByRole("button", { name: /alice johnson/i }));
+
+    fireEvent.click(screen.getByRole("button", { name: "Archive" }));
+    const archiveDialog = screen.getByRole("dialog", { name: /archive 1 selected document\?/i });
+    fireEvent.click(within(archiveDialog).getByRole("button", { name: "Archive" }));
+
+    await waitFor(() => {
+      expect(mockedQuoteService.bulkAction).toHaveBeenCalledWith({
+        action: "archive",
+        ids: ["quote-1"],
+      });
+    });
+    expect(mockedInvoiceService.bulkAction).not.toHaveBeenCalled();
+    await waitFor(() => {
+      expect(mockedQuoteService.listQuotes).toHaveBeenCalledTimes(2);
+    });
+    expect(await screen.findByText("1 document archived.")).toBeInTheDocument();
+    expect(screen.queryByText("1 selected")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "New quote" })).toBeInTheDocument();
+  });
+
+  it("routes invoice delete to invoice bulk endpoint and shows blocked feedback", async () => {
+    mockedQuoteService.listQuotes.mockResolvedValueOnce([makeQuoteListItem({ status: "ready" })]);
+    mockedInvoiceService.listInvoices
+      .mockResolvedValueOnce([
+        makeInvoiceListItem({
+          id: "invoice-1",
+          doc_number: "I-001",
+          customer_name: "Alice Johnson",
+          status: "sent",
+        }),
+      ])
+      .mockResolvedValueOnce([
+        makeInvoiceListItem({
+          id: "invoice-1",
+          doc_number: "I-001",
+          customer_name: "Alice Johnson",
+          status: "sent",
+        }),
+      ]);
+    mockedInvoiceService.bulkAction.mockResolvedValueOnce({
+      action: "delete",
+      applied: [],
+      blocked: [
+        {
+          id: "invoice-1",
+          reason: "invoice_delete_not_supported",
+          message: "Invoices cannot be deleted in this version.",
+        },
+      ],
+    });
+
+    renderScreen();
+    await screen.findByText(/Q-001/);
+    fireEvent.click(screen.getByRole("button", { name: "Invoices" }));
+    await screen.findByText(/I-001/);
+
+    fireEvent.click(screen.getByRole("button", { name: "List actions" }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Select" }));
+    fireEvent.click(screen.getByRole("button", { name: /alice johnson/i }));
+    fireEvent.click(screen.getByRole("button", { name: "More" }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Delete permanently..." }));
+
+    const deleteDialog = screen.getByRole("dialog", { name: /delete 1 selected document permanently\?/i });
+    fireEvent.click(within(deleteDialog).getByRole("button", { name: "Delete permanently" }));
+
+    await waitFor(() => {
+      expect(mockedInvoiceService.bulkAction).toHaveBeenCalledWith({
+        action: "delete",
+        ids: ["invoice-1"],
+      });
+    });
+    expect(mockedQuoteService.bulkAction).toHaveBeenCalledTimes(0);
+    expect(await screen.findByText("No documents deleted")).toBeInTheDocument();
+    expect(screen.getByText("Invoices cannot be deleted in this version.")).toBeInTheDocument();
+    expect(screen.queryByText("1 selected")).not.toBeInTheDocument();
   });
 
   it("uses token-backed emphasis for the active filter and create button", async () => {

--- a/frontend/src/features/quotes/tests/QuotePreview.test.tsx
+++ b/frontend/src/features/quotes/tests/QuotePreview.test.tsx
@@ -340,6 +340,7 @@ describe("QuotePreview", () => {
       expect(screen.queryByText("Sent")).not.toBeInTheDocument();
       await openOverflowMenu();
       expect(screen.queryByRole("menuitem", { name: /convert to invoice/i })).not.toBeInTheDocument();
+      expect(screen.queryByRole("menuitem", { name: /delete quote/i })).not.toBeInTheDocument();
     },
   );
 

--- a/frontend/src/features/quotes/types/quote.types.ts
+++ b/frontend/src/features/quotes/types/quote.types.ts
@@ -101,6 +101,36 @@ export type QuoteStatus =
   | "declined";
 export type QuoteSourceType = "text" | "voice" | "voice+text";
 export type ExtractionTier = "primary" | "degraded";
+export type BulkActionType = "archive" | "delete";
+export type BulkBlockedReason =
+  | "not_found"
+  | "already_archived"
+  | "quote_status_not_deletable"
+  | "linked_invoice"
+  | "unsupported_document_type"
+  | "invoice_delete_not_supported";
+
+export interface BulkActionRequest {
+  action: BulkActionType;
+  ids: string[];
+}
+
+export interface BulkActionAppliedItem {
+  id: string;
+}
+
+export interface BulkActionBlockedItem {
+  id: string;
+  reason: BulkBlockedReason;
+  message: string;
+  suggested_action?: BulkActionType | null;
+}
+
+export interface BulkActionResponse {
+  action: BulkActionType;
+  applied: BulkActionAppliedItem[];
+  blocked: BulkActionBlockedItem[];
+}
 
 export interface QuotePricingFields {
   total_amount: number | null;


### PR DESCRIPTION
## Summary
- wire selection mode archive/delete actions to new bulk-action endpoints for quotes and invoices
- add archive and delete confirmation modals, backend-driven blocked feedback banner, list refresh, and selection reset on completion
- hide Quote Preview `Delete Quote` overflow action when quote has `linked_invoice`
- add frontend bulk action request/response types and service methods
- add/extend interaction tests for QuoteList and QuotePreview

## Verification
- cd frontend && npx vitest run src/features/quotes/tests/QuoteList.test.tsx --bail=1
- cd frontend && npx vitest run src/features/quotes/tests/QuotePreview.test.tsx --bail=1
- cd frontend && npx eslint src/features/quotes
- cd frontend && npx tsc --noEmit
- cd frontend && npm run build
- make frontend-verify *(currently flaky in repo; failed on unrelated auth/offline tests in this environment)*

Closes #656