### PR TITLE
Task #676: Archived documents view + unarchive bulk flow

### DIFF
--- a/backend/app/features/invoices/api.py
+++ b/backend/app/features/invoices/api.py
@@ -88,9 +88,15 @@ async def list_invoices(
     user: Annotated[User, Depends(get_current_user)],
     invoice_service: Annotated[InvoiceService, Depends(get_invoice_service)],
     customer_id: Annotated[UUID | None, Query()] = None,
+    archived: Annotated[str | None, Query()] = None,
 ) -> list[InvoiceListItemResponse]:
     """List invoices for the authenticated user."""
-    invoices = await invoice_service.list_invoices(user, customer_id=customer_id)
+    show_archived = (archived or "").lower() == "true"
+    invoices = await invoice_service.list_invoices(
+        user,
+        customer_id=customer_id,
+        archived=show_archived,
+    )
     return [InvoiceListItemResponse.model_validate(invoice) for invoice in invoices]
 
 
@@ -164,7 +170,7 @@ async def bulk_action_invoices(
     user: Annotated[User, Depends(get_current_user)],
     invoice_service: Annotated[InvoiceService, Depends(get_invoice_service)],
 ) -> InvoiceBulkActionResponse:
-    """Execute one invoice-scoped bulk archive/delete action."""
+    """Execute one invoice-scoped bulk archive/unarchive/delete action."""
     return await invoice_service.execute_bulk_action(user, payload)
 
 

--- a/backend/app/features/invoices/repository.py
+++ b/backend/app/features/invoices/repository.py
@@ -156,8 +156,12 @@ class InvoiceRepository:
         self,
         user_id: UUID,
         customer_id: UUID | None = None,
+        archived: bool = False,
     ) -> list[InvoiceListItemSummary]:
         """Return invoice summaries for a user ordered newest-first."""
+        archived_filter = (
+            Document.archived_at.is_not(None) if archived else Document.archived_at.is_(None)
+        )
         statement = (
             select(
                 Document.id,
@@ -175,7 +179,7 @@ class InvoiceRepository:
             .where(
                 Document.user_id == user_id,
                 Document.doc_type == _INVOICE_DOC_TYPE,
-                Document.archived_at.is_(None),
+                archived_filter,
             )
             .order_by(Document.created_at.desc(), Document.doc_sequence.desc())
         )
@@ -654,6 +658,21 @@ class InvoiceRepository:
                 Document.archived_at.is_(None),
             )
             .values(archived_at=func.now())
+            .returning(Document.id)
+        )
+        return row.scalar_one_or_none() is not None
+
+    async def unarchive_by_id(self, *, invoice_id: UUID, user_id: UUID) -> bool:
+        """Unarchive one owned invoice when it is currently archived."""
+        row = await self._session.execute(
+            update(Document)
+            .where(
+                Document.id == invoice_id,
+                Document.user_id == user_id,
+                Document.doc_type == _INVOICE_DOC_TYPE,
+                Document.archived_at.is_not(None),
+            )
+            .values(archived_at=None)
             .returning(Document.id)
         )
         return row.scalar_one_or_none() is not None

--- a/backend/app/features/invoices/service.py
+++ b/backend/app/features/invoices/service.py
@@ -61,6 +61,7 @@ class InvoiceRepositoryProtocol(Protocol):
         self,
         user_id: UUID,
         customer_id: UUID | None = None,
+        archived: bool = False,
     ) -> list[InvoiceListItemSummary]: ...
 
     async def get_by_source_document_id(
@@ -157,6 +158,7 @@ class InvoiceRepositoryProtocol(Protocol):
 
     async def invalidate_pdf_artifact(self, invoice: Document) -> str | None: ...
     async def archive_by_id(self, *, invoice_id: UUID, user_id: UUID) -> bool: ...
+    async def unarchive_by_id(self, *, invoice_id: UUID, user_id: UUID) -> bool: ...
 
     async def mark_ready_if_draft(self, *, invoice_id: UUID, user_id: UUID) -> None: ...
 
@@ -220,11 +222,13 @@ class InvoiceService:
         self,
         user: User,
         customer_id: UUID | None = None,
+        archived: bool = False,
     ) -> list[InvoiceListItemSummary]:
         """List invoices for the authenticated user."""
         return await self._invoice_repository.list_by_user(
             _resolve_user_id(user),
             customer_id=customer_id,
+            archived=archived,
         )
 
     async def convert_quote_to_invoice(self, user: User, quote_id: UUID) -> Document:
@@ -276,7 +280,7 @@ class InvoiceService:
         user: User,
         payload: InvoiceBulkActionRequest,
     ) -> InvoiceBulkActionResponse:
-        """Execute one invoice-scoped bulk archive/delete action."""
+        """Execute one invoice-scoped bulk archive/unarchive/delete action."""
         user_id = _resolve_user_id(user)
         unique_ids = _dedupe_ids(payload.ids)
         applied: list[BulkActionAppliedItem] = []
@@ -313,29 +317,54 @@ class InvoiceService:
                 )
                 continue
 
-            if document.archived_at is not None:
-                blocked.append(
-                    BulkActionBlockedItem(
-                        id=document_id,
-                        reason="already_archived",
-                        message="Invoice is already archived.",
+            if payload.action == "archive":
+                if document.archived_at is not None:
+                    blocked.append(
+                        BulkActionBlockedItem(
+                            id=document_id,
+                            reason="already_archived",
+                            message="Invoice is already archived.",
+                        )
                     )
-                )
-                continue
+                    continue
 
-            archived = await self._invoice_repository.archive_by_id(
-                invoice_id=document_id,
-                user_id=user_id,
-            )
-            if not archived:
-                blocked.append(
-                    BulkActionBlockedItem(
-                        id=document_id,
-                        reason="already_archived",
-                        message="Invoice is already archived.",
-                    )
+                archived = await self._invoice_repository.archive_by_id(
+                    invoice_id=document_id,
+                    user_id=user_id,
                 )
-                continue
+                if not archived:
+                    blocked.append(
+                        BulkActionBlockedItem(
+                            id=document_id,
+                            reason="already_archived",
+                            message="Invoice is already archived.",
+                        )
+                    )
+                    continue
+            else:
+                if document.archived_at is None:
+                    blocked.append(
+                        BulkActionBlockedItem(
+                            id=document_id,
+                            reason="not_archived",
+                            message="Invoice is not archived.",
+                        )
+                    )
+                    continue
+
+                unarchived = await self._invoice_repository.unarchive_by_id(
+                    invoice_id=document_id,
+                    user_id=user_id,
+                )
+                if not unarchived:
+                    blocked.append(
+                        BulkActionBlockedItem(
+                            id=document_id,
+                            reason="not_archived",
+                            message="Invoice is not archived.",
+                        )
+                    )
+                    continue
 
             await self._invoice_repository.commit()
             applied.append(BulkActionAppliedItem(id=document_id))

--- a/backend/app/features/invoices/tests/test_archive_visibility.py
+++ b/backend/app/features/invoices/tests/test_archive_visibility.py
@@ -74,9 +74,19 @@ async def test_archived_invoice_hidden_from_default_lists_and_public_share_still
     assert list_response.status_code == 200
     assert list_response.json() == []
 
+    archived_list_response = await client.get("/api/invoices?archived=true")
+    assert archived_list_response.status_code == 200
+    assert [item["id"] for item in archived_list_response.json()] == [invoice["id"]]
+
     customer_list_response = await client.get(f"/api/invoices?customer_id={customer_id}")
     assert customer_list_response.status_code == 200
     assert customer_list_response.json() == []
+
+    archived_customer_list_response = await client.get(
+        f"/api/invoices?archived=true&customer_id={customer_id}"
+    )
+    assert archived_customer_list_response.status_code == 200
+    assert [item["id"] for item in archived_customer_list_response.json()] == [invoice["id"]]
 
     detail_response = await client.get(f"/api/invoices/{invoice['id']}")
     assert detail_response.status_code == 200
@@ -132,6 +142,57 @@ async def test_archive_invoice_rejects_other_user_and_rearchive(
     await db_session.refresh(persisted_invoice)
     assert persisted_invoice.archived_at is not None
     assert persisted_invoice.status == original_status
+
+
+async def test_archived_invoice_list_filters_by_customer_when_archived_true(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    csrf_token = await _register_and_login(client, _credentials())
+    customer_id = await _create_customer(client, csrf_token, name="Archived Invoice Customer")
+    other_customer_id = await _create_customer(client, csrf_token, name="Active Invoice Customer")
+    archived_invoice = await _create_direct_invoice(
+        client,
+        csrf_token,
+        customer_id,
+        title="Archived invoice",
+        transcript="invoice transcript",
+        total_amount=180,
+    )
+    await _create_direct_invoice(
+        client,
+        csrf_token,
+        other_customer_id,
+        title="Active invoice",
+        transcript="invoice transcript",
+        total_amount=180,
+    )
+
+    repository = InvoiceRepository(db_session)
+    persisted_invoice = await db_session.get(Document, UUID(str(archived_invoice["id"])))
+    assert persisted_invoice is not None
+    archived = await repository.archive_by_id(
+        invoice_id=persisted_invoice.id,
+        user_id=persisted_invoice.user_id,
+    )
+    assert archived
+    await repository.commit()
+
+    archived_response = await client.get("/api/invoices?archived=true")
+    assert archived_response.status_code == 200
+    assert [item["id"] for item in archived_response.json()] == [archived_invoice["id"]]
+
+    archived_customer_response = await client.get(
+        f"/api/invoices?archived=true&customer_id={customer_id}"
+    )
+    assert archived_customer_response.status_code == 200
+    assert [item["id"] for item in archived_customer_response.json()] == [archived_invoice["id"]]
+
+    archived_other_customer_response = await client.get(
+        f"/api/invoices?archived=true&customer_id={other_customer_id}"
+    )
+    assert archived_other_customer_response.status_code == 200
+    assert archived_other_customer_response.json() == []
 
 
 async def test_source_document_relationship_survives_quote_archiving(

--- a/backend/app/features/invoices/tests/test_bulk_action.py
+++ b/backend/app/features/invoices/tests/test_bulk_action.py
@@ -70,6 +70,63 @@ async def test_bulk_archive_invoices_deduplicates_ids_and_blocks_rearchive(
     }
 
 
+async def test_bulk_unarchive_invoices_applies_owned_archived_and_blocks_others(
+    client: AsyncClient,
+) -> None:
+    csrf_token = await _register_and_login(client, _credentials())
+    customer_id = await _create_customer(client, csrf_token)
+    archived_invoice = await _create_direct_invoice(
+        client,
+        csrf_token,
+        customer_id,
+        title="Archived invoice",
+        transcript="invoice transcript",
+        total_amount=100,
+    )
+    active_invoice = await _create_direct_invoice(
+        client,
+        csrf_token,
+        customer_id,
+        title="Active invoice",
+        transcript="invoice transcript",
+        total_amount=120,
+    )
+
+    archive_response = await client.post(
+        "/api/invoices/bulk-action",
+        json={"action": "archive", "ids": [archived_invoice["id"]]},
+        headers={"X-CSRF-Token": csrf_token},
+    )
+    assert archive_response.status_code == 200
+
+    missing_id = str(uuid4())
+    unarchive_response = await client.post(
+        "/api/invoices/bulk-action",
+        json={
+            "action": "unarchive",
+            "ids": [archived_invoice["id"], active_invoice["id"], missing_id],
+        },
+        headers={"X-CSRF-Token": csrf_token},
+    )
+    assert unarchive_response.status_code == 200
+    assert unarchive_response.json() == {
+        "action": "unarchive",
+        "applied": [{"id": archived_invoice["id"]}],
+        "blocked": [
+            {
+                "id": active_invoice["id"],
+                "reason": "not_archived",
+                "message": "Invoice is not archived.",
+            },
+            {
+                "id": missing_id,
+                "reason": "not_found",
+                "message": "Document not found.",
+            },
+        ],
+    }
+
+
 async def test_bulk_delete_invoices_reports_blocked_per_document(
     client: AsyncClient,
 ) -> None:

--- a/backend/app/features/invoices/tests/test_service.py
+++ b/backend/app/features/invoices/tests/test_service.py
@@ -43,9 +43,10 @@ class _RetryingInvoiceRepository:
         del customer_id
         return False
 
-    async def list_by_user(self, user_id, customer_id=None):  # noqa: ANN001
+    async def list_by_user(self, user_id, customer_id=None, archived=False):  # noqa: ANN001
         del user_id
         del customer_id
+        del archived
         return []
 
     async def get_by_source_document_id(self, *, source_document_id, user_id):  # noqa: ANN001
@@ -120,6 +121,11 @@ class _RetryingInvoiceRepository:
         del user_id
         return False
 
+    async def unarchive_by_id(self, *, invoice_id, user_id):  # noqa: ANN001
+        del invoice_id
+        del user_id
+        return False
+
     async def mark_ready_if_draft(self, *, invoice_id, user_id):  # noqa: ANN001
         del invoice_id
         del user_id
@@ -181,9 +187,10 @@ class _DirectInvoiceCollisionRepository:
         del customer_id
         return True
 
-    async def list_by_user(self, user_id, customer_id=None):  # noqa: ANN001
+    async def list_by_user(self, user_id, customer_id=None, archived=False):  # noqa: ANN001
         del user_id
         del customer_id
+        del archived
         return []
 
     async def get_by_id(self, invoice_id, user_id):  # noqa: ANN001
@@ -259,6 +266,11 @@ class _DirectInvoiceCollisionRepository:
         return None
 
     async def archive_by_id(self, *, invoice_id, user_id):  # noqa: ANN001
+        del invoice_id
+        del user_id
+        return False
+
+    async def unarchive_by_id(self, *, invoice_id, user_id):  # noqa: ANN001
         del invoice_id
         del user_id
         return False

--- a/backend/app/features/quotes/api.py
+++ b/backend/app/features/quotes/api.py
@@ -553,9 +553,15 @@ async def list_quotes(
     user: Annotated[User, Depends(get_current_user)],
     quote_service: Annotated[QuoteService, Depends(get_quote_service)],
     customer_id: Annotated[UUID | None, Query()] = None,
+    archived: Annotated[str | None, Query()] = None,
 ) -> list[QuoteListItemResponse]:
     """List quotes for the authenticated user."""
-    quotes = await quote_service.list_quotes(user, customer_id=customer_id)
+    show_archived = (archived or "").lower() == "true"
+    quotes = await quote_service.list_quotes(
+        user,
+        customer_id=customer_id,
+        archived=show_archived,
+    )
     return [QuoteListItemResponse.model_validate(quote) for quote in quotes]
 
 
@@ -586,7 +592,7 @@ async def bulk_action_quotes(
     user: Annotated[User, Depends(get_current_user)],
     quote_service: Annotated[QuoteService, Depends(get_quote_service)],
 ) -> BulkActionResponse:
-    """Execute one quote-scoped bulk archive/delete action."""
+    """Execute one quote-scoped bulk archive/unarchive/delete action."""
     return await quote_service.execute_bulk_action(user, payload)
 
 

--- a/backend/app/features/quotes/repository.py
+++ b/backend/app/features/quotes/repository.py
@@ -250,6 +250,7 @@ class QuoteRepository:
         self,
         user_id: UUID,
         customer_id: UUID | None = None,
+        archived: bool = False,
     ) -> list[QuoteListItemSummary]:
         """Return quote summaries for a user ordered newest-first."""
         linked_invoice = aliased(Document)
@@ -268,6 +269,9 @@ class QuoteRepository:
             )
             .exists()
         )
+        archived_filter = (
+            Document.archived_at.is_not(None) if archived else Document.archived_at.is_(None)
+        )
         statement = (
             select(
                 Document.id,
@@ -285,7 +289,7 @@ class QuoteRepository:
             .where(
                 Document.user_id == user_id,
                 Document.doc_type == _QUOTE_DOC_TYPE,
-                Document.archived_at.is_(None),
+                archived_filter,
             )
             .order_by(Document.created_at.desc(), Document.doc_sequence.desc())
         )
@@ -825,6 +829,21 @@ class QuoteRepository:
                 Document.archived_at.is_(None),
             )
             .values(archived_at=func.now())
+            .returning(Document.id)
+        )
+        return row.scalar_one_or_none() is not None
+
+    async def unarchive_by_id(self, *, quote_id: UUID, user_id: UUID) -> bool:
+        """Unarchive one owned quote when it is currently archived."""
+        row = await self._session.execute(
+            update(Document)
+            .where(
+                Document.id == quote_id,
+                Document.user_id == user_id,
+                Document.doc_type == _QUOTE_DOC_TYPE,
+                Document.archived_at.is_not(None),
+            )
+            .values(archived_at=None)
             .returning(Document.id)
         )
         return row.scalar_one_or_none() is not None

--- a/backend/app/features/quotes/schemas.py
+++ b/backend/app/features/quotes/schemas.py
@@ -606,10 +606,11 @@ class QuoteUpdateRequest(BaseModel):
         return self
 
 
-BulkActionType = Literal["archive", "delete"]
+BulkActionType = Literal["archive", "unarchive", "delete"]
 BulkBlockedReason = Literal[
     "not_found",
     "already_archived",
+    "not_archived",
     "quote_status_not_deletable",
     "linked_invoice",
     "unsupported_document_type",

--- a/backend/app/features/quotes/service.py
+++ b/backend/app/features/quotes/service.py
@@ -67,6 +67,7 @@ class QuoteRepositoryProtocol(Protocol):
         self,
         user_id: UUID,
         customer_id: UUID | None = None,
+        archived: bool = False,
     ) -> list[QuoteListItemSummary]: ...
     async def list_reuse_candidates(
         self,
@@ -189,6 +190,7 @@ class QuoteRepositoryProtocol(Protocol):
 
     async def delete(self, document_id: UUID) -> None: ...
     async def archive_by_id(self, *, quote_id: UUID, user_id: UUID) -> bool: ...
+    async def unarchive_by_id(self, *, quote_id: UUID, user_id: UUID) -> bool: ...
 
     async def commit(self) -> None: ...
 
@@ -296,11 +298,13 @@ class QuoteService:
         self,
         user: User,
         customer_id: UUID | None = None,
+        archived: bool = False,
     ) -> list[QuoteListItemSummary]:
         """List quotes for the authenticated user."""
         return await self._repository.list_by_user(
             _resolve_user_id(user),
             customer_id=customer_id,
+            archived=archived,
         )
 
     async def list_quote_reuse_candidates(
@@ -369,7 +373,7 @@ class QuoteService:
         user: User,
         payload: BulkActionRequest,
     ) -> BulkActionResponse:
-        """Execute one quote-scoped bulk archive/delete action with per-id outcomes."""
+        """Execute one quote-scoped bulk archive/unarchive/delete action with per-id outcomes."""
         user_id = _resolve_user_id(user)
         unique_ids = _dedupe_ids(payload.ids)
         applied: list[BulkActionAppliedItem] = []
@@ -416,6 +420,33 @@ class QuoteService:
                             id=document_id,
                             reason="already_archived",
                             message="Quote is already archived.",
+                        )
+                    )
+                    continue
+                await self._repository.commit()
+                applied.append(BulkActionAppliedItem(id=document_id))
+                continue
+
+            if payload.action == "unarchive":
+                if document.archived_at is None:
+                    blocked.append(
+                        BulkActionBlockedItem(
+                            id=document_id,
+                            reason="not_archived",
+                            message="Quote is not archived.",
+                        )
+                    )
+                    continue
+                unarchived = await self._repository.unarchive_by_id(
+                    quote_id=document_id,
+                    user_id=user_id,
+                )
+                if not unarchived:
+                    blocked.append(
+                        BulkActionBlockedItem(
+                            id=document_id,
+                            reason="not_archived",
+                            message="Quote is not archived.",
                         )
                     )
                     continue

--- a/backend/app/features/quotes/tests/test_archive_visibility.py
+++ b/backend/app/features/quotes/tests/test_archive_visibility.py
@@ -68,9 +68,19 @@ async def test_archived_quote_hidden_from_default_lists_and_public_share_still_w
     assert list_response.status_code == 200
     assert list_response.json() == []
 
+    archived_list_response = await client.get("/api/quotes?archived=true")
+    assert archived_list_response.status_code == 200
+    assert [item["id"] for item in archived_list_response.json()] == [quote["id"]]
+
     customer_list_response = await client.get(f"/api/quotes?customer_id={customer_id}")
     assert customer_list_response.status_code == 200
     assert customer_list_response.json() == []
+
+    archived_customer_list_response = await client.get(
+        f"/api/quotes?archived=true&customer_id={customer_id}"
+    )
+    assert archived_customer_list_response.status_code == 200
+    assert [item["id"] for item in archived_customer_list_response.json()] == [quote["id"]]
 
     reuse_response = await client.get("/api/quotes/reuse-candidates")
     assert reuse_response.status_code == 200
@@ -123,6 +133,43 @@ async def test_archive_quote_rejects_other_user_and_rearchive(
     await db_session.refresh(persisted_quote)
     assert persisted_quote.archived_at is not None
     assert persisted_quote.status == original_status
+
+
+async def test_archived_quote_list_filters_by_customer_when_archived_true(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    csrf_token = await _register_and_login(client, _credentials())
+    customer_id = await _create_customer(client, csrf_token, name="Archived Customer")
+    other_customer_id = await _create_customer(client, csrf_token, name="Active Customer")
+    archived_quote = await _create_quote(client, csrf_token, customer_id)
+    await _create_quote(client, csrf_token, other_customer_id)
+
+    repository = QuoteRepository(db_session)
+    persisted_quote = await db_session.get(Document, UUID(archived_quote["id"]))
+    assert persisted_quote is not None
+    archived = await repository.archive_by_id(
+        quote_id=persisted_quote.id,
+        user_id=persisted_quote.user_id,
+    )
+    assert archived
+    await repository.commit()
+
+    archived_response = await client.get("/api/quotes?archived=true")
+    assert archived_response.status_code == 200
+    assert [item["id"] for item in archived_response.json()] == [archived_quote["id"]]
+
+    archived_customer_response = await client.get(
+        f"/api/quotes?archived=true&customer_id={customer_id}"
+    )
+    assert archived_customer_response.status_code == 200
+    assert [item["id"] for item in archived_customer_response.json()] == [archived_quote["id"]]
+
+    archived_other_customer_response = await client.get(
+        f"/api/quotes?archived=true&customer_id={other_customer_id}"
+    )
+    assert archived_other_customer_response.status_code == 200
+    assert archived_other_customer_response.json() == []
 
 
 async def test_has_linked_invoice_still_true_after_linked_invoice_archived(

--- a/backend/app/features/quotes/tests/test_bulk_action.py
+++ b/backend/app/features/quotes/tests/test_bulk_action.py
@@ -113,6 +113,49 @@ async def test_bulk_archive_quotes_deduplicates_ids_and_blocks_rearchive(
     }
 
 
+async def test_bulk_unarchive_quotes_applies_owned_archived_and_blocks_others(
+    client: AsyncClient,
+) -> None:
+    csrf_token = await _register_and_login(client, _credentials())
+    customer_id = await _create_customer(client, csrf_token)
+    archived_quote = await _create_quote(client, csrf_token, customer_id)
+    active_quote = await _create_quote(client, csrf_token, customer_id)
+
+    archive_response = await client.post(
+        "/api/quotes/bulk-action",
+        json={"action": "archive", "ids": [archived_quote["id"]]},
+        headers={"X-CSRF-Token": csrf_token},
+    )
+    assert archive_response.status_code == 200
+
+    missing_id = str(uuid4())
+    unarchive_response = await client.post(
+        "/api/quotes/bulk-action",
+        json={
+            "action": "unarchive",
+            "ids": [archived_quote["id"], active_quote["id"], missing_id],
+        },
+        headers={"X-CSRF-Token": csrf_token},
+    )
+    assert unarchive_response.status_code == 200
+    assert unarchive_response.json() == {
+        "action": "unarchive",
+        "applied": [{"id": archived_quote["id"]}],
+        "blocked": [
+            {
+                "id": active_quote["id"],
+                "reason": "not_archived",
+                "message": "Quote is not archived.",
+            },
+            {
+                "id": missing_id,
+                "reason": "not_found",
+                "message": "Document not found.",
+            },
+        ],
+    }
+
+
 async def test_bulk_delete_quotes_reports_not_found_status_and_doc_type_blocks(
     client: AsyncClient,
 ) -> None:

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -14,6 +14,7 @@ import { RegisterForm } from "@/features/auth/components/RegisterForm";
 import { ResetPasswordPage } from "@/features/auth/components/ResetPasswordPage";
 import { useAuth } from "@/features/auth/hooks/useAuth";
 import { LandingPage } from "@/features/marketing/components/LandingPage";
+import { ArchiveList } from "@/features/quotes/components/ArchiveList";
 import { QuoteList } from "@/features/quotes/components/QuoteList";
 import { OutboxSyncCoordinator } from "@/features/quotes/offline/OutboxSyncCoordinator";
 import { PwaUpdatePrompt } from "@/shared/components/PwaUpdatePrompt";
@@ -177,6 +178,7 @@ export default function App(): React.ReactElement {
             <Route path="/invoices/:id/edit" element={<InvoiceEditRedirect />} />
             <Route path="/invoices/:id/edit/line-items/:lineItemIndex/edit" element={<InvoiceEditRedirect />} />
             <Route path="/quotes/new" element={<Navigate to="/quotes/capture" replace />} />
+            <Route path="/archived" element={<ArchiveList />} />
             <Route path="/quotes/capture" element={withRouteSuspense(<CaptureScreen />)} />
             <Route path="/quotes/capture/:customerId" element={withRouteSuspense(<CaptureScreen />)} />
             <Route path="/documents/:id/edit" element={withRouteSuspense(<DocumentEditScreen />)} />

--- a/frontend/src/features/invoices/services/invoiceService.ts
+++ b/frontend/src/features/invoices/services/invoiceService.ts
@@ -22,9 +22,16 @@ function getInvoice(id: string): Promise<InvoiceDetail> {
   return request<InvoiceDetail>(`/api/invoices/${id}`);
 }
 
-function listInvoices(params?: { customer_id?: string }): Promise<InvoiceListItem[]> {
-  const query = params?.customer_id ? `?customer_id=${params.customer_id}` : "";
-  return request<InvoiceListItem[]>(`/api/invoices${query}`);
+function listInvoices(params?: { customer_id?: string; archived?: boolean }): Promise<InvoiceListItem[]> {
+  const queryParams = new URLSearchParams();
+  if (params?.customer_id) {
+    queryParams.set("customer_id", params.customer_id);
+  }
+  if (params?.archived === true) {
+    queryParams.set("archived", "true");
+  }
+  const query = queryParams.toString();
+  return request<InvoiceListItem[]>(`/api/invoices${query ? `?${query}` : ""}`);
 }
 
 function updateInvoice(id: string, data: InvoiceUpdateRequest): Promise<Invoice> {

--- a/frontend/src/features/quotes/components/ArchiveList.tsx
+++ b/frontend/src/features/quotes/components/ArchiveList.tsx
@@ -1,0 +1,369 @@
+import { useEffect, useMemo, useState } from "react";
+import { useNavigate } from "react-router-dom";
+
+import { useAuth } from "@/features/auth/hooks/useAuth";
+import { DocumentRowsSection, type DocumentRow } from "@/features/quotes/components/DocumentRowsSection";
+import { DocumentSelectionFooter } from "@/features/quotes/components/DocumentSelectionFooter";
+import { QuoteListControls } from "@/features/quotes/components/QuoteListControls";
+import { useReconnectRefresh } from "@/features/quotes/components/useReconnectRefresh";
+import { useDocumentBulkActions } from "@/features/quotes/hooks/useDocumentBulkActions";
+import { useDocumentSelection } from "@/features/quotes/hooks/useDocumentSelection";
+import { quoteService } from "@/features/quotes/services/quoteService";
+import type { QuoteListItem } from "@/features/quotes/types/quote.types";
+import { matchesSearch } from "@/features/quotes/components/QuoteList.helpers";
+import { invoiceService } from "@/features/invoices/services/invoiceService";
+import type { InvoiceListItem } from "@/features/invoices/types/invoice.types";
+import { BottomNav } from "@/shared/components/BottomNav";
+import { ConfirmModal } from "@/shared/components/ConfirmModal";
+import { DocumentCardSkeleton } from "@/shared/components/DocumentCardSkeleton";
+import { FeedbackMessage } from "@/shared/components/FeedbackMessage";
+import { ScreenHeader } from "@/shared/components/ScreenHeader";
+import { formatDate } from "@/shared/lib/formatters";
+import { Banner } from "@/ui/Banner";
+import { EmptyState } from "@/ui/EmptyState";
+
+type DocumentMode = "quotes" | "invoices";
+
+function buildArchivedSubtitle(params: {
+  mode: DocumentMode;
+  quotes: QuoteListItem[];
+  invoices: InvoiceListItem[];
+  isLoadingQuotes: boolean;
+  isLoadingInvoices: boolean;
+  quoteLoadError: string | null;
+  invoiceLoadError: string | null;
+}): string {
+  if (params.mode === "quotes") {
+    if (params.isLoadingQuotes) {
+      return "Loading archived quotes...";
+    }
+    if (params.quoteLoadError) {
+      return "Unable to load archived quotes.";
+    }
+    if (params.quotes.length === 0 && !params.isLoadingQuotes) {
+      return "No archived quotes yet.";
+    }
+    return `${params.quotes.length} archived quote${params.quotes.length === 1 ? "" : "s"}`;
+  }
+
+  if (params.isLoadingInvoices) {
+    return "Loading archived invoices...";
+  }
+  if (params.invoiceLoadError) {
+    return "Unable to load archived invoices.";
+  }
+  if (params.invoices.length === 0 && !params.isLoadingInvoices) {
+    return "No archived invoices yet.";
+  }
+  return `${params.invoices.length} archived invoice${params.invoices.length === 1 ? "" : "s"}`;
+}
+
+export function ArchiveList(): React.ReactElement {
+  const navigate = useNavigate();
+  const { authMode, user } = useAuth();
+  const [documentMode, setDocumentMode] = useState<DocumentMode>("quotes");
+  const [quotes, setQuotes] = useState<QuoteListItem[]>([]);
+  const [invoices, setInvoices] = useState<InvoiceListItem[]>([]);
+  const [isSearchOpen, setIsSearchOpen] = useState(false);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [isLoadingQuotes, setIsLoadingQuotes] = useState(true);
+  const [isLoadingInvoices, setIsLoadingInvoices] = useState(false);
+  const [quoteLoadError, setQuoteLoadError] = useState<string | null>(null);
+  const [invoiceLoadError, setInvoiceLoadError] = useState<string | null>(null);
+  const [refreshTick, setRefreshTick] = useState(0);
+  const {
+    isSelectionMode,
+    selectedIds,
+    selectedCount,
+    enterSelectionMode,
+    cancelSelection,
+    toggleSelection,
+    isSelected,
+  } = useDocumentSelection({ activeMode: documentMode });
+  const {
+    bulkActionError,
+    bulkActionFeedback,
+    isBulkActionPending,
+    showArchiveConfirm,
+    showDeleteConfirm,
+    openArchiveConfirm,
+    openDeleteConfirm,
+    closeArchiveConfirm,
+    closeDeleteConfirm,
+    closeSelectionActionDialogs,
+    clearBulkActionFeedback,
+    executeBulkAction,
+  } = useDocumentBulkActions({
+    documentMode,
+    selectedIds,
+    onComplete: () => {
+      cancelSelection();
+      setRefreshTick((current) => current + 1);
+    },
+  });
+
+  const { reconnectTick } = useReconnectRefresh(async () => undefined);
+
+  useEffect(() => {
+    let isActive = true;
+
+    async function fetchDocuments(): Promise<void> {
+      if (authMode === "signed_out") {
+        if (isActive) {
+          setQuotes([]);
+          setInvoices([]);
+          setQuoteLoadError(null);
+          setInvoiceLoadError(null);
+          setIsLoadingQuotes(false);
+          setIsLoadingInvoices(false);
+        }
+        return;
+      }
+
+      if (documentMode === "quotes") {
+        setIsLoadingQuotes(true);
+        setQuoteLoadError(null);
+        try {
+          const nextQuotes = await quoteService.listQuotes({ archived: true });
+          if (isActive) {
+            setQuotes(nextQuotes);
+          }
+        } catch (error) {
+          const message = error instanceof Error ? error.message : "Unable to load archived quotes";
+          if (isActive) {
+            setQuoteLoadError(message);
+          }
+        } finally {
+          if (isActive) {
+            setIsLoadingQuotes(false);
+          }
+        }
+        return;
+      }
+
+      setIsLoadingInvoices(true);
+      setInvoiceLoadError(null);
+      try {
+        const nextInvoices = await invoiceService.listInvoices({ archived: true });
+        if (isActive) {
+          setInvoices(nextInvoices);
+        }
+      } catch (error) {
+        const message = error instanceof Error ? error.message : "Unable to load archived invoices";
+        if (isActive) {
+          setInvoiceLoadError(message);
+        }
+      } finally {
+        if (isActive) {
+          setIsLoadingInvoices(false);
+        }
+      }
+    }
+
+    void fetchDocuments();
+    return () => {
+      isActive = false;
+    };
+  }, [authMode, documentMode, reconnectTick, refreshTick]);
+
+  useEffect(() => {
+    if (!isSearchOpen) {
+      return;
+    }
+    const inputElement = document.getElementById("document-search");
+    if (inputElement instanceof HTMLInputElement) {
+      inputElement.focus();
+    }
+  }, [isSearchOpen]);
+
+  const normalizedSearchQuery = searchQuery.trim().toLowerCase();
+  const filteredQuotes = useMemo(
+    () => quotes.filter((quote) => matchesSearch(quote, normalizedSearchQuery)),
+    [normalizedSearchQuery, quotes],
+  );
+  const filteredInvoices = useMemo(
+    () => invoices.filter((invoice) => matchesSearch(invoice, normalizedSearchQuery)),
+    [invoices, normalizedSearchQuery],
+  );
+
+  const timezone = user?.timezone ?? null;
+  const headerSubtitle = buildArchivedSubtitle({
+    mode: documentMode,
+    quotes,
+    invoices,
+    isLoadingQuotes,
+    isLoadingInvoices,
+    quoteLoadError,
+    invoiceLoadError,
+  });
+  const isLoading = documentMode === "quotes" ? isLoadingQuotes : isLoadingInvoices;
+  const loadError = documentMode === "quotes" ? quoteLoadError : invoiceLoadError;
+  const filteredRows = documentMode === "quotes" ? filteredQuotes : filteredInvoices;
+  const totalRows = documentMode === "quotes" ? quotes.length : invoices.length;
+
+  const quoteRows = useMemo<DocumentRow[]>(
+    () => filteredQuotes.map((quote) => ({
+      id: quote.id,
+      doc_type: "quote",
+      customerLabel: quote.customer_name ?? "Unassigned",
+      titleLabel: quote.title ?? null,
+      docAndDate: [quote.doc_number, formatDate(quote.created_at, timezone)].join(" · "),
+      totalAmount: quote.total_amount,
+      status: quote.status,
+      destination: quote.status === "draft" ? `/documents/${quote.id}/edit` : `/quotes/${quote.id}/preview`,
+      destinationState: quote.status === "draft" ? { origin: "list" } : undefined,
+      isDraft: quote.status === "draft",
+      needsCustomerAssignment: quote.requires_customer_assignment === true,
+    })),
+    [filteredQuotes, timezone],
+  );
+  const invoiceRows = useMemo<DocumentRow[]>(
+    () => filteredInvoices.map((invoice) => ({
+      id: invoice.id,
+      doc_type: "invoice",
+      customerLabel: invoice.customer_name,
+      titleLabel: invoice.title ?? null,
+      docAndDate: [invoice.doc_number, formatDate(invoice.created_at, timezone)].join(" · "),
+      totalAmount: invoice.total_amount,
+      status: invoice.status,
+      destination: `/invoices/${invoice.id}`,
+    })),
+    [filteredInvoices, timezone],
+  );
+
+  const rows = documentMode === "quotes" ? quoteRows : invoiceRows;
+  const sectionLabel = documentMode === "quotes" ? "ARCHIVED QUOTES" : "ARCHIVED INVOICES";
+  const emptyStateTitle = totalRows === 0
+    ? "No archived documents yet."
+    : `No archived ${documentMode} match your search.`;
+  const searchLabel = documentMode === "quotes" ? "Search archived quotes" : "Search archived invoices";
+  const searchPlaceholder = documentMode === "quotes"
+    ? "Search customer, title, or quote ID..."
+    : "Search customer, title, or invoice ID...";
+
+  return (
+    <main className="min-h-screen bg-background pb-24">
+      <ScreenHeader title="Archived" subtitle={headerSubtitle} onBack={() => navigate("/")} />
+
+      <section className="mx-auto w-full max-w-3xl pb-4 pt-20">
+        <QuoteListControls
+          documentMode={documentMode}
+          isSelectionMode={isSelectionMode}
+          isSearchOpen={isSearchOpen}
+          searchQuery={searchQuery}
+          searchLabel={searchLabel}
+          searchPlaceholder={searchPlaceholder}
+          onDocumentModeChange={setDocumentMode}
+          onSearchToggle={() => {
+            if (isSearchOpen) {
+              setSearchQuery("");
+            }
+            setIsSearchOpen((open) => !open);
+          }}
+          onSearchChange={setSearchQuery}
+          onSearchClear={() => setSearchQuery("")}
+          onEnterSelectionMode={enterSelectionMode}
+        />
+
+        {bulkActionFeedback ? (
+          <div className="mb-4 px-4">
+            <Banner
+              kind={bulkActionFeedback.kind}
+              title={bulkActionFeedback.title}
+              message={bulkActionFeedback.message}
+              onDismiss={clearBulkActionFeedback}
+            />
+          </div>
+        ) : null}
+
+        {bulkActionError ? (
+          <div className="mb-4 px-4">
+            <FeedbackMessage variant="error">{bulkActionError}</FeedbackMessage>
+          </div>
+        ) : null}
+
+        {isLoading ? (
+          <div
+            role="status"
+            aria-label={documentMode === "quotes" ? "Loading archived quotes" : "Loading archived invoices"}
+            className="space-y-3 px-4"
+          >
+            {Array.from({ length: 4 }).map((_, index) => (
+              <DocumentCardSkeleton key={`${documentMode}-archived-skeleton-${index}`} />
+            ))}
+          </div>
+        ) : null}
+
+        {loadError ? (
+          <div className="mx-4">
+            <FeedbackMessage variant="error">{loadError}</FeedbackMessage>
+          </div>
+        ) : null}
+
+        {!isLoading && !loadError && filteredRows.length === 0 ? (
+          <EmptyState className="mx-4 mt-8 p-8" icon="inventory_2" title={emptyStateTitle} />
+        ) : null}
+
+        {!isLoading && !loadError && filteredRows.length > 0 ? (
+          <DocumentRowsSection
+            label={sectionLabel}
+            rows={rows}
+            isSelectionMode={isSelectionMode}
+            isSelected={(row) => isSelected(row.id)}
+            onRowClick={(row) => {
+              if (isSelectionMode) {
+                toggleSelection(row.id);
+                return;
+              }
+              navigate(row.destination, row.destinationState ? { state: row.destinationState } : undefined);
+            }}
+          />
+        ) : null}
+      </section>
+
+      {isSelectionMode ? (
+        <DocumentSelectionFooter
+          selectedCount={selectedCount}
+          archiveLabel="Unarchive"
+          onCancelSelection={() => {
+            closeSelectionActionDialogs();
+            cancelSelection();
+          }}
+          onArchiveSelection={openArchiveConfirm}
+          onDeleteSelectionPermanently={openDeleteConfirm}
+        />
+      ) : null}
+
+      {showArchiveConfirm ? (
+        <ConfirmModal
+          title={`Unarchive ${selectedCount} selected ${selectedCount === 1 ? "document" : "documents"}?`}
+          body="Unarchived documents return to active lists."
+          confirmLabel="Unarchive"
+          cancelLabel="Keep selected"
+          confirmDisabled={isBulkActionPending || selectedCount === 0}
+          onCancel={closeArchiveConfirm}
+          onConfirm={() => {
+            void executeBulkAction("unarchive");
+          }}
+        />
+      ) : null}
+
+      {showDeleteConfirm ? (
+        <ConfirmModal
+          title={`Delete ${selectedCount} selected ${selectedCount === 1 ? "document" : "documents"} permanently?`}
+          body="This action cannot be undone. Documents blocked by policy will stay untouched."
+          confirmLabel="Delete permanently"
+          cancelLabel="Keep selected"
+          variant="destructive"
+          confirmDisabled={isBulkActionPending || selectedCount === 0}
+          onCancel={closeDeleteConfirm}
+          onConfirm={() => {
+            void executeBulkAction("delete");
+          }}
+        />
+      ) : null}
+
+      <BottomNav active="quotes" />
+    </main>
+  );
+}

--- a/frontend/src/features/quotes/components/DocumentSelectionFooter.tsx
+++ b/frontend/src/features/quotes/components/DocumentSelectionFooter.tsx
@@ -8,6 +8,7 @@ interface DocumentSelectionFooterProps {
   onCancelSelection: () => void;
   onArchiveSelection?: () => void;
   onDeleteSelectionPermanently?: () => void;
+  archiveLabel?: string;
 }
 
 export function DocumentSelectionFooter({
@@ -15,6 +16,7 @@ export function DocumentSelectionFooter({
   onCancelSelection,
   onArchiveSelection,
   onDeleteSelectionPermanently,
+  archiveLabel = "Archive",
 }: DocumentSelectionFooterProps): React.ReactElement {
   const [isMoreOpen, setIsMoreOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -61,7 +63,7 @@ export function DocumentSelectionFooter({
         ) : (
           <div ref={containerRef} className="relative flex items-center gap-2">
             <Button type="button" variant="secondary" size="sm" onClick={onArchiveSelection}>
-              Archive
+              {archiveLabel}
             </Button>
             <Button
               type="button"

--- a/frontend/src/features/quotes/components/QuoteList.tsx
+++ b/frontend/src/features/quotes/components/QuoteList.tsx
@@ -273,6 +273,7 @@ export function QuoteList(): React.ReactElement {
           onSearchChange={setSearchQuery}
           onSearchClear={() => setSearchQuery("")}
           onEnterSelectionMode={enterSelectionMode}
+          onViewArchived={() => navigate("/archived")}
         />
 
         {bulkActionFeedback ? (

--- a/frontend/src/features/quotes/components/QuoteListControls.tsx
+++ b/frontend/src/features/quotes/components/QuoteListControls.tsx
@@ -17,6 +17,7 @@ interface QuoteListControlsProps {
   onSearchChange: (nextQuery: string) => void;
   onSearchClear: () => void;
   onEnterSelectionMode: () => void;
+  onViewArchived?: () => void;
 }
 
 export function QuoteListControls({
@@ -31,7 +32,26 @@ export function QuoteListControls({
   onSearchChange,
   onSearchClear,
   onEnterSelectionMode,
+  onViewArchived,
 }: QuoteListControlsProps): React.ReactElement {
+  const menuItems = [
+    {
+      label: "Select",
+      icon: "check",
+      onSelect: onEnterSelectionMode,
+      disabled: isSelectionMode,
+    },
+  ];
+
+  if (onViewArchived) {
+    menuItems.push({
+      label: "View archived",
+      icon: "inventory_2",
+      onSelect: onViewArchived,
+      disabled: isSelectionMode,
+    });
+  }
+
   return (
     <div className="mb-4 px-4">
       <div className="mb-4 flex items-center justify-between gap-3">
@@ -81,14 +101,7 @@ export function QuoteListControls({
           </Button>
           <OverflowMenu
             triggerLabel="List actions"
-            items={[
-              {
-                label: "Select",
-                icon: "check",
-                onSelect: onEnterSelectionMode,
-                disabled: isSelectionMode,
-              },
-            ]}
+            items={menuItems}
           />
         </div>
       </div>

--- a/frontend/src/features/quotes/components/quoteListBulkActionFeedback.ts
+++ b/frontend/src/features/quotes/components/quoteListBulkActionFeedback.ts
@@ -33,7 +33,33 @@ function formatBlockedSummary(blocked: BulkActionBlockedItem[]): string {
 }
 
 function actionPastTense(action: BulkActionType): string {
-  return action === "archive" ? "archived" : "deleted";
+  if (action === "archive") {
+    return "archived";
+  }
+  if (action === "unarchive") {
+    return "unarchived";
+  }
+  return "deleted";
+}
+
+function actionCompletionTitle(action: BulkActionType): string {
+  if (action === "archive") {
+    return "Archive complete";
+  }
+  if (action === "unarchive") {
+    return "Unarchive complete";
+  }
+  return "Delete complete";
+}
+
+function actionNoopTitle(action: BulkActionType): string {
+  if (action === "archive") {
+    return "No documents archived";
+  }
+  if (action === "unarchive") {
+    return "No documents unarchived";
+  }
+  return "No documents deleted";
 }
 
 export function buildBulkActionFeedback(response: BulkActionResponse): BulkActionFeedback {
@@ -45,7 +71,7 @@ export function buildBulkActionFeedback(response: BulkActionResponse): BulkActio
   if (appliedCount > 0 && blockedCount === 0) {
     return {
       kind: "success",
-      title: response.action === "archive" ? "Archive complete" : "Delete complete",
+      title: actionCompletionTitle(response.action),
       message: `${pluralize("document", appliedCount)} ${actionVerb}.`,
     };
   }
@@ -60,7 +86,7 @@ export function buildBulkActionFeedback(response: BulkActionResponse): BulkActio
 
   return {
     kind: "warn",
-    title: response.action === "archive" ? "No documents archived" : "No documents deleted",
+    title: actionNoopTitle(response.action),
     message: blockedSummary || `No documents were ${actionVerb}.`,
   };
 }

--- a/frontend/src/features/quotes/services/quoteService.ts
+++ b/frontend/src/features/quotes/services/quoteService.ts
@@ -140,9 +140,16 @@ function createQuote(data: QuoteCreateRequest): Promise<Quote> {
   });
 }
 
-function listQuotes(params?: { customer_id?: string }): Promise<QuoteListItem[]> {
-  const query = params?.customer_id ? `?customer_id=${params.customer_id}` : "";
-  return request<QuoteListItem[]>(`/api/quotes${query}`);
+function listQuotes(params?: { customer_id?: string; archived?: boolean }): Promise<QuoteListItem[]> {
+  const queryParams = new URLSearchParams();
+  if (params?.customer_id) {
+    queryParams.set("customer_id", params.customer_id);
+  }
+  if (params?.archived === true) {
+    queryParams.set("archived", "true");
+  }
+  const query = queryParams.toString();
+  return request<QuoteListItem[]>(`/api/quotes${query ? `?${query}` : ""}`);
 }
 
 function listReuseCandidates(params?: { customer_id?: string; q?: string }): Promise<QuoteReuseCandidate[]> {

--- a/frontend/src/features/quotes/tests/ArchiveList.test.tsx
+++ b/frontend/src/features/quotes/tests/ArchiveList.test.tsx
@@ -1,0 +1,168 @@
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useAuth } from "@/features/auth/hooks/useAuth";
+import { invoiceService } from "@/features/invoices/services/invoiceService";
+import type { InvoiceListItem } from "@/features/invoices/types/invoice.types";
+import { ArchiveList } from "@/features/quotes/components/ArchiveList";
+import { quoteService } from "@/features/quotes/services/quoteService";
+import type { QuoteListItem } from "@/features/quotes/types/quote.types";
+
+const navigateMock = vi.fn();
+
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual<typeof import("react-router-dom")>("react-router-dom");
+  return {
+    ...actual,
+    useNavigate: () => navigateMock,
+  };
+});
+
+vi.mock("@/features/quotes/services/quoteService", () => ({
+  quoteService: {
+    listQuotes: vi.fn(),
+    bulkAction: vi.fn(),
+  },
+}));
+
+vi.mock("@/features/invoices/services/invoiceService", () => ({
+  invoiceService: {
+    listInvoices: vi.fn(),
+    bulkAction: vi.fn(),
+  },
+}));
+
+vi.mock("@/features/auth/hooks/useAuth", () => ({
+  useAuth: vi.fn(),
+}));
+
+const mockedQuoteService = vi.mocked(quoteService);
+const mockedInvoiceService = vi.mocked(invoiceService);
+const mockedUseAuth = vi.mocked(useAuth);
+
+function makeQuoteListItem(overrides: Partial<QuoteListItem> = {}): QuoteListItem {
+  return {
+    id: "quote-1",
+    customer_id: "cust-1",
+    customer_name: "Alice Johnson",
+    doc_number: "Q-001",
+    title: "Archived quote",
+    status: "ready",
+    total_amount: 120,
+    item_count: 1,
+    created_at: "2026-03-20T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function makeInvoiceListItem(overrides: Partial<InvoiceListItem> = {}): InvoiceListItem {
+  return {
+    id: "invoice-1",
+    customer_id: "cust-1",
+    customer_name: "Alice Johnson",
+    doc_number: "I-001",
+    title: "Archived invoice",
+    status: "sent",
+    total_amount: 120,
+    due_date: "2026-04-19",
+    created_at: "2026-03-20T00:00:00.000Z",
+    source_document_id: null,
+    ...overrides,
+  };
+}
+
+function mockProfile(): void {
+  mockedUseAuth.mockReturnValue({
+    authMode: "verified",
+    isLoading: false,
+    isOnboarded: true,
+    login: vi.fn(async () => undefined),
+    logout: vi.fn(async () => undefined),
+    refreshUser: vi.fn(async () => undefined),
+    register: vi.fn(async () => undefined),
+    user: {
+      id: "user-1",
+      email: "test@example.com",
+      is_active: true,
+      is_onboarded: true,
+      timezone: "UTC",
+    },
+  });
+}
+
+function renderScreen(): void {
+  render(
+    <MemoryRouter>
+      <ArchiveList />
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  mockProfile();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("ArchiveList", () => {
+  it("loads archived quotes by default", async () => {
+    mockedQuoteService.listQuotes.mockResolvedValueOnce([makeQuoteListItem()]);
+
+    renderScreen();
+
+    expect(await screen.findByRole("heading", { name: "Archived" })).toBeInTheDocument();
+    expect(await screen.findByRole("button", { name: /alice johnson/i })).toBeInTheDocument();
+    expect(mockedQuoteService.listQuotes).toHaveBeenCalledWith({ archived: true });
+    expect(mockedInvoiceService.listInvoices).not.toHaveBeenCalled();
+  });
+
+  it("toggles to archived invoices tab and fetches invoices", async () => {
+    mockedQuoteService.listQuotes.mockResolvedValueOnce([makeQuoteListItem()]);
+    mockedInvoiceService.listInvoices.mockResolvedValueOnce([makeInvoiceListItem()]);
+
+    renderScreen();
+    await screen.findByRole("button", { name: /alice johnson/i });
+
+    fireEvent.click(screen.getByRole("button", { name: "Invoices" }));
+
+    expect(await screen.findByRole("button", { name: /i-001/i })).toBeInTheDocument();
+    expect(mockedInvoiceService.listInvoices).toHaveBeenCalledWith({ archived: true });
+  });
+
+  it("unarchives selected archived quotes and clears selection", async () => {
+    mockedQuoteService.listQuotes
+      .mockResolvedValueOnce([makeQuoteListItem()])
+      .mockResolvedValueOnce([]);
+    mockedQuoteService.bulkAction.mockResolvedValueOnce({
+      action: "unarchive",
+      applied: [{ id: "quote-1" }],
+      blocked: [],
+    });
+
+    renderScreen();
+    await screen.findByRole("button", { name: /alice johnson/i });
+
+    fireEvent.click(screen.getByRole("button", { name: "List actions" }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Select" }));
+    fireEvent.click(screen.getByRole("button", { name: /alice johnson/i }));
+
+    fireEvent.click(screen.getByRole("button", { name: "Unarchive" }));
+    const dialog = screen.getByRole("dialog", { name: /unarchive 1 selected document\?/i });
+    fireEvent.click(within(dialog).getByRole("button", { name: "Unarchive" }));
+
+    await waitFor(() => {
+      expect(mockedQuoteService.bulkAction).toHaveBeenCalledWith({
+        action: "unarchive",
+        ids: ["quote-1"],
+      });
+    });
+    await waitFor(() => {
+      expect(mockedQuoteService.listQuotes).toHaveBeenCalledTimes(2);
+    });
+    expect(await screen.findByText("1 document unarchived.")).toBeInTheDocument();
+    expect(screen.queryByText("1 selected")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/features/quotes/tests/QuoteList.test.tsx
+++ b/frontend/src/features/quotes/tests/QuoteList.test.tsx
@@ -280,6 +280,18 @@ describe("QuoteList", () => {
     expect(navigateMock).not.toHaveBeenCalled();
   });
 
+  it("navigates to archived view from list actions overflow", async () => {
+    mockedQuoteService.listQuotes.mockResolvedValueOnce([makeQuoteListItem({ status: "ready" })]);
+
+    renderScreen();
+    await screen.findByText(/Q-001/);
+
+    fireEvent.click(screen.getByRole("button", { name: "List actions" }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "View archived" }));
+
+    expect(navigateMock).toHaveBeenCalledWith("/archived");
+  });
+
   it("locks tab switch, preserves search, and clears selection via cancel", async () => {
     mockedQuoteService.listQuotes.mockResolvedValueOnce([
       makeQuoteListItem({ id: "quote-1", customer_name: "Alice Johnson", status: "ready" }),

--- a/frontend/src/features/quotes/types/quote.types.ts
+++ b/frontend/src/features/quotes/types/quote.types.ts
@@ -101,10 +101,11 @@ export type QuoteStatus =
   | "declined";
 export type QuoteSourceType = "text" | "voice" | "voice+text";
 export type ExtractionTier = "primary" | "degraded";
-export type BulkActionType = "archive" | "delete";
+export type BulkActionType = "archive" | "unarchive" | "delete";
 export type BulkBlockedReason =
   | "not_found"
   | "already_archived"
+  | "not_archived"
   | "quote_status_not_deletable"
   | "linked_invoice"
   | "unsupported_document_type"


### PR DESCRIPTION
## Summary
- add `/archived` route and new `ArchiveList` screen with quotes/invoices pill toggle, search, selection mode, and unarchive/delete actions
- add `View archived` overflow action in `QuoteListControls`
- extend quote/invoice list APIs to support `?archived=true` on existing endpoints (with `customer_id` composition)
- add `unarchive` bulk action support plus `not_archived` blocked reason for quotes and invoices
- update frontend bulk action/service/type wiring for `unarchive`
- add backend and frontend tests covering archived filtering, customer filter composition, archive-view navigation, tab toggle, and unarchive confirmation

## Verification
- `cd backend && .venv/bin/pytest app/features/quotes/tests/test_archive_visibility.py app/features/quotes/tests/test_bulk_action.py app/features/invoices/tests/test_archive_visibility.py app/features/invoices/tests/test_bulk_action.py -x --tb=short`
- `cd backend && .venv/bin/pytest app/features/quotes/tests/ -k "archived" -x --tb=short`
- `rtk make backend-static-verify`
- `cd frontend && rtk proxy npx vitest run src/features/quotes/tests/ArchiveList.test.tsx --bail=1`
- `cd frontend && rtk proxy npx vitest run src/features/quotes/tests/QuoteList.test.tsx --bail=1`
- `cd frontend && rtk proxy npx eslint src/features/quotes`
- `cd frontend && rtk proxy npx tsc --noEmit`
- `cd frontend && rtk proxy npm run build`
- `rtk make frontend-verify`
- `rtk make backend-verify`

Closes #676