### PR TITLE
Task #678: Recover Copy Link when Web Share fails

### DIFF
--- a/frontend/src/features/quotes/hooks/useQuoteDocumentActions.ts
+++ b/frontend/src/features/quotes/hooks/useQuoteDocumentActions.ts
@@ -11,6 +11,9 @@ import { usePendingPdfArtifactResume } from "@/shared/hooks/usePendingPdfArtifac
 import { jobService } from "@/shared/lib/jobService";
 import { pollJobUntilSuccess } from "@/shared/lib/jobPolling";
 
+export const SHARE_SHEET_FAILED_USE_MANUAL_LINK =
+  "Couldn't share from this device. Copy the link below.";
+
 interface UseQuoteDocumentActionsArgs {
   quoteId: string | undefined;
   quote: QuoteDetail | null;
@@ -162,7 +165,9 @@ export function useQuoteDocumentActions({
           if (isShareAbortError(error)) {
             return;
           }
-          throw error;
+          setManualCopyUrl(nextSharedUrl);
+          setShareError(SHARE_SHEET_FAILED_USE_MANUAL_LINK);
+          return;
         }
       }
 

--- a/frontend/src/features/quotes/tests/QuotePreview.test.tsx
+++ b/frontend/src/features/quotes/tests/QuotePreview.test.tsx
@@ -3,6 +3,7 @@ import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { QuotePreview } from "@/features/quotes/components/QuotePreview";
+import { SHARE_SHEET_FAILED_USE_MANUAL_LINK } from "@/features/quotes/hooks/useQuoteDocumentActions";
 import { quoteService } from "@/features/quotes/services/quoteService";
 import type { JobStatusResponse, Quote, QuoteDetail } from "@/features/quotes/types/quote.types";
 import { HttpRequestError } from "@/shared/lib/http";
@@ -1202,7 +1203,55 @@ describe("QuotePreview", () => {
       expect(screen.queryByText("Quote link shared.")).not.toBeInTheDocument();
       expect(screen.queryByText("Share link copied to clipboard.")).not.toBeInTheDocument();
       expect(screen.queryByText("Share aborted")).not.toBeInTheDocument();
+      expect(screen.queryByLabelText("Share URL")).not.toBeInTheDocument();
       expect(screen.getByRole("button", { name: /copy link/i })).toBeEnabled();
+    } finally {
+      if (originalDescriptor) {
+        Object.defineProperty(navigator, "share", originalDescriptor);
+      } else {
+        Reflect.deleteProperty(navigator, "share");
+      }
+    }
+  });
+
+  it("recovers with manual-copy guidance when Web Share fails with a non-abort error", async () => {
+    const shareMock = vi.fn().mockRejectedValue(new Error("Web Share exploded"));
+    const originalDescriptor = Object.getOwnPropertyDescriptor(navigator, "share");
+    Object.defineProperty(navigator, "share", {
+      configurable: true,
+      writable: true,
+      value: shareMock,
+    });
+    const writeTextMock = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      writable: true,
+      value: { writeText: writeTextMock },
+    });
+    mockedQuoteService.getQuote.mockResolvedValueOnce(
+      makeQuoteDetail({ status: "ready", customer_email: "customer@example.com" }),
+    );
+
+    try {
+      renderScreen();
+
+      await screen.findByRole("heading", { name: "Quote Preview" });
+      fireEvent.click(screen.getByRole("button", { name: /copy link/i }));
+
+      await waitFor(() => {
+        expect(shareMock).toHaveBeenCalledWith({
+          title: "Quote Q-001",
+          url: "http://localhost:3000/doc/share-token-1",
+        });
+      });
+
+      expect(writeTextMock).not.toHaveBeenCalled();
+      expect(await screen.findByText(SHARE_SHEET_FAILED_USE_MANUAL_LINK)).toBeInTheDocument();
+      expect(await screen.findByLabelText("Share URL")).toHaveValue(
+        "http://localhost:3000/doc/share-token-1",
+      );
+      expect(screen.getByText("Copy this share link manually.")).toBeInTheDocument();
+      expect(screen.queryByText("Web Share exploded")).not.toBeInTheDocument();
     } finally {
       if (originalDescriptor) {
         Object.defineProperty(navigator, "share", originalDescriptor);


### PR DESCRIPTION
## Summary
- preserve manual copy fallback URL when Web Share rejects with non-abort failures
- replace provider/vendor error text with one locked recovery message constant
- add regression tests for abort silent path and non-abort Web Share recovery behavior

## Verification
- cd frontend && rtk vitest run src/features/quotes/tests/QuotePreview.test.tsx
- rtk make frontend-verify

Closes #678