### PR TITLE
P1 Spec 4: polish reuse/catalog copy and discoverability

### DIFF
--- a/frontend/src/features/quotes/components/LineItemCatalogTabPanel.tsx
+++ b/frontend/src/features/quotes/components/LineItemCatalogTabPanel.tsx
@@ -53,7 +53,7 @@ export function LineItemCatalogTabPanel({
 
       {loadState === "loaded" && items.length === 0 ? (
         <EmptyState
-          icon="description"
+          icon="folder_off"
           title="No reusable items yet"
           body="Save your first reusable item from the Manual tab or from an existing line item."
         />

--- a/frontend/src/features/quotes/components/LineItemCatalogTabPanel.tsx
+++ b/frontend/src/features/quotes/components/LineItemCatalogTabPanel.tsx
@@ -2,6 +2,7 @@ import type { LineItemCatalogItem } from "@/features/line-item-catalog/types/lin
 import { Button } from "@/shared/components/Button";
 import { FeedbackMessage } from "@/shared/components/FeedbackMessage";
 import { Card } from "@/ui/Card";
+import { EmptyState } from "@/ui/EmptyState";
 import { Eyebrow } from "@/ui/Eyebrow";
 
 interface LineItemCatalogTabPanelProps {
@@ -32,7 +33,7 @@ export function LineItemCatalogTabPanel({
   return (
     <div id="line-item-tabpanel-catalog" role="tabpanel" className={className}>
       {loadState === "loading" ? (
-        <p role="status" className="text-sm text-on-surface-variant">Loading catalog items...</p>
+        <p role="status" className="text-sm text-on-surface-variant">Loading reusable items...</p>
       ) : null}
 
       {loadState === "error" && loadError ? (
@@ -51,11 +52,11 @@ export function LineItemCatalogTabPanel({
       ) : null}
 
       {loadState === "loaded" && items.length === 0 ? (
-        <Card className="bg-surface-container-high">
-          <p className="text-sm text-on-surface-variant">
-            No catalog items yet. Save one from the Manual tab or from another line item.
-          </p>
-        </Card>
+        <EmptyState
+          icon="description"
+          title="No reusable items yet"
+          body="Save your first reusable item from the Manual tab or from an existing line item."
+        />
       ) : null}
 
       {loadState === "loaded" && items.length > 0 ? (

--- a/frontend/src/features/quotes/components/QuoteReuseChooser.tsx
+++ b/frontend/src/features/quotes/components/QuoteReuseChooser.tsx
@@ -5,6 +5,7 @@ import type { QuoteReuseCandidate } from "@/features/quotes/types/quote.types";
 import { Button } from "@/shared/components/Button";
 import { FeedbackMessage } from "@/shared/components/FeedbackMessage";
 import { Input } from "@/shared/components/Input";
+import { EmptyState } from "@/ui/EmptyState";
 import { StatusPill } from "@/ui/StatusPill";
 import { Sheet, SheetBody, SheetCloseButton, SheetDescription, SheetFooter, SheetHeader, SheetTitle } from "@/ui/Sheet";
 import { formatCurrency, formatDate } from "@/shared/lib/formatters";
@@ -27,14 +28,14 @@ function buildLoadErrorMessage(error: unknown): string {
   if (error instanceof Error && error.message.trim().length > 0) {
     return error.message;
   }
-  return "Unable to load quotes";
+  return "Could not load quotes. Try again.";
 }
 
 function buildDuplicateErrorMessage(error: unknown): string {
   if (error instanceof Error && error.message.trim().length > 0) {
     return error.message;
   }
-  return "Unable to duplicate quote";
+  return "Could not duplicate this quote. Try again.";
 }
 
 function resolveVisibleCandidates(candidates: QuoteReuseCandidate[], activeTab: ChooserTab): QuoteReuseCandidate[] {
@@ -50,12 +51,16 @@ function buildEmptyStateMessage(
   hasCustomerScope: boolean,
 ): string {
   if (normalizedSearchQuery) {
-    return "No quotes match your search.";
+    return "No matches yet. Change or clear your search to see more quotes.";
   }
   if (activeTab === "recent") {
-    return hasCustomerScope ? "No recent quotes for this customer." : "No recent quotes yet.";
+    return hasCustomerScope
+      ? "No recent quotes for this customer yet. Try All Quotes or create a new quote."
+      : "No recent quotes yet. Try All Quotes or create a new quote.";
   }
-  return hasCustomerScope ? "No quotes found for this customer." : "No quotes available.";
+  return hasCustomerScope
+    ? "No quotes found for this customer. Clear the customer filter or create a new quote."
+    : "No quotes available yet. Create a new quote to get started.";
 }
 
 export function QuoteReuseChooser({
@@ -176,8 +181,8 @@ export function QuoteReuseChooser({
     >
       <SheetHeader>
         <div>
-          <SheetTitle>Create from existing</SheetTitle>
-          <SheetDescription>Pick a quote to duplicate into a new draft.</SheetDescription>
+          <SheetTitle>Duplicate an existing quote</SheetTitle>
+          <SheetDescription>Choose a quote to copy into a new editable draft.</SheetDescription>
         </div>
         <SheetCloseButton />
       </SheetHeader>
@@ -224,7 +229,7 @@ export function QuoteReuseChooser({
             <div className="mt-4 max-h-[52vh] space-y-3 overflow-y-auto pr-1">
               {isLoading ? (
                 <div role="status" aria-label="Loading quotes" className="rounded-[var(--radius-document)] bg-surface-container-low p-4 text-sm text-on-surface-variant">
-                  Loading quotes...
+                  Loading quotes to duplicate...
                 </div>
               ) : null}
 
@@ -237,9 +242,11 @@ export function QuoteReuseChooser({
               ) : null}
 
               {!isLoading && !loadError && visibleCandidates.length === 0 ? (
-                <section className="rounded-[var(--radius-document)] bg-surface-container-low p-4 text-sm text-on-surface-variant">
-                  {emptyStateMessage}
-                </section>
+                <EmptyState
+                  icon="search"
+                  title="No quotes found"
+                  body={emptyStateMessage}
+                />
               ) : null}
 
               {!isLoading && !loadError ? (

--- a/frontend/src/features/quotes/tests/QuoteReuseChooser.test.tsx
+++ b/frontend/src/features/quotes/tests/QuoteReuseChooser.test.tsx
@@ -50,6 +50,24 @@ afterEach(() => {
 });
 
 describe("QuoteReuseChooser", () => {
+  it("renders duplicate-draft framing copy and actionable empty state guidance", async () => {
+    mockedQuoteService.listReuseCandidates.mockResolvedValueOnce([]);
+
+    render(
+      <QuoteReuseChooser
+        open
+        timezone="UTC"
+        onClose={vi.fn()}
+        onQuoteDuplicated={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Duplicate an existing quote")).toBeInTheDocument();
+    expect(screen.getByText("Choose a quote to copy into a new editable draft.")).toBeInTheDocument();
+    expect(await screen.findByText("No quotes found")).toBeInTheDocument();
+    expect(screen.getByText("No recent quotes yet. Try All Quotes or create a new quote.")).toBeInTheDocument();
+  });
+
   it("renders reuse candidates with preview rows and overflow count", async () => {
     mockedQuoteService.listReuseCandidates.mockResolvedValueOnce([makeReuseCandidate()]);
 

--- a/frontend/src/features/settings/components/SettingsCatalogShortcutCard.tsx
+++ b/frontend/src/features/settings/components/SettingsCatalogShortcutCard.tsx
@@ -11,10 +11,10 @@ export function SettingsCatalogShortcutCard({
 }: SettingsCatalogShortcutCardProps): React.ReactElement {
   return (
     <Card className="bg-surface-container-low p-4">
-      <Eyebrow>Catalog</Eyebrow>
+      <Eyebrow>Reusable Line Items</Eyebrow>
       <div className="mt-3 flex items-center justify-between gap-3">
         <p className="text-sm text-on-surface-variant">
-          Save and manage reusable line item presets.
+          Create and manage reusable line item presets you can insert while editing quotes.
         </p>
         <Button
           type="button"
@@ -23,7 +23,7 @@ export function SettingsCatalogShortcutCard({
           className="shrink-0 whitespace-nowrap px-3 py-2 text-xs"
           onClick={onOpenLineItemCatalog}
         >
-          Manage Items
+          Manage Catalog
         </Button>
       </div>
     </Card>

--- a/frontend/src/features/settings/tests/SettingsScreen.test.tsx
+++ b/frontend/src/features/settings/tests/SettingsScreen.test.tsx
@@ -180,6 +180,11 @@ describe("SettingsScreen", () => {
     expect(screen.queryByRole("button", { name: /back/i })).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: /settings/i })).toHaveClass("text-primary");
     expect(screen.queryByText("Appearance")).not.toBeInTheDocument();
+    expect(screen.getByText("Reusable Line Items")).toBeInTheDocument();
+    expect(
+      screen.getByText("Create and manage reusable line item presets you can insert while editing quotes."),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /manage catalog/i })).toBeInTheDocument();
 
     await openBusinessProfileEditMode();
     expect(screen.getByDisplayValue("Bright Lawn Care")).toBeInTheDocument();


### PR DESCRIPTION
## Summary
- clarify quote reuse framing as duplicate-into-new-draft copy
- migrate quote reuse and catalog empty states to `EmptyState` with actionable guidance
- tighten settings shortcut card language for reusable line-item presets and add assertions

## Verification
- cd frontend && npx vitest run src/features/quotes/tests/QuoteReuseChooser.test.tsx
- cd frontend && npx vitest run src/features/settings/tests/SettingsScreen.test.tsx
- cd frontend && npx vitest run src/features/quotes/tests/LineItemCatalogInsert.test.tsx
- make frontend-verify

Closes #684