### PR TITLE
Task #688: preserve reuse chooser results during search refresh

### DIFF
--- a/frontend/src/features/quotes/components/QuoteReuseChooser.tsx
+++ b/frontend/src/features/quotes/components/QuoteReuseChooser.tsx
@@ -75,6 +75,7 @@ export function QuoteReuseChooser({
   const [debouncedSearchQuery, setDebouncedSearchQuery] = useState("");
   const [candidates, setCandidates] = useState<QuoteReuseCandidate[]>([]);
   const [isLoading, setIsLoading] = useState(false);
+  const [hasLoadedOnce, setHasLoadedOnce] = useState(false);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [duplicateError, setDuplicateError] = useState<string | null>(null);
   const [duplicatingId, setDuplicatingId] = useState<string | null>(null);
@@ -89,6 +90,8 @@ export function QuoteReuseChooser({
     activeTab,
     Boolean(customerId),
   );
+  const showInitialLoading = isLoading && !hasLoadedOnce;
+  const showRefreshIndicator = isLoading && hasLoadedOnce;
 
   useEffect(() => {
     if (!open) {
@@ -124,6 +127,7 @@ export function QuoteReuseChooser({
       .then((nextCandidates) => {
         if (isActive) {
           setCandidates(nextCandidates);
+          setHasLoadedOnce(true);
         }
       })
       .catch((error: unknown) => {
@@ -153,6 +157,7 @@ export function QuoteReuseChooser({
     setDebouncedSearchQuery("");
     setCandidates([]);
     setIsLoading(false);
+    setHasLoadedOnce(false);
     setLoadError(null);
     setDuplicateError(null);
     setDuplicatingId(null);
@@ -227,10 +232,15 @@ export function QuoteReuseChooser({
             </div>
 
             <div className="mt-4 max-h-[52vh] space-y-3 overflow-y-auto pr-1">
-              {isLoading ? (
+              {showInitialLoading ? (
                 <div role="status" aria-label="Loading quotes" className="rounded-[var(--radius-document)] bg-surface-container-low p-4 text-sm text-on-surface-variant">
                   Loading quotes to duplicate...
                 </div>
+              ) : null}
+              {showRefreshIndicator ? (
+                <p role="status" className="text-xs text-on-surface-variant">
+                  Searching quotes...
+                </p>
               ) : null}
 
               {loadError ? (
@@ -241,7 +251,7 @@ export function QuoteReuseChooser({
                 <FeedbackMessage variant="error">{duplicateError}</FeedbackMessage>
               ) : null}
 
-              {!isLoading && !loadError && visibleCandidates.length === 0 ? (
+              {!showInitialLoading && !loadError && visibleCandidates.length === 0 ? (
                 <EmptyState
                   icon="search"
                   title="No quotes found"
@@ -249,7 +259,7 @@ export function QuoteReuseChooser({
                 />
               ) : null}
 
-              {!isLoading && !loadError ? (
+              {!showInitialLoading && !loadError ? (
                 <ul className="space-y-3">
                   {visibleCandidates.map((candidate) => (
                     <li key={candidate.id}>

--- a/frontend/src/features/quotes/tests/QuoteReuseChooser.test.tsx
+++ b/frontend/src/features/quotes/tests/QuoteReuseChooser.test.tsx
@@ -255,6 +255,95 @@ describe("QuoteReuseChooser", () => {
     expect(screen.queryByRole("button", { name: /older quote/i })).not.toBeInTheDocument();
   });
 
+  it("keeps existing results visible while a debounced search refresh is pending", async () => {
+    vi.useFakeTimers();
+    const initial = deferred<ReturnType<typeof makeReuseCandidate>[]>();
+    const refresh = deferred<ReturnType<typeof makeReuseCandidate>[]>();
+
+    mockedQuoteService.listReuseCandidates.mockImplementation((params) => {
+      if (params?.q === "updated") {
+        return refresh.promise;
+      }
+      return initial.promise;
+    });
+
+    render(
+      <QuoteReuseChooser
+        open
+        timezone="UTC"
+        onClose={vi.fn()}
+        onQuoteDuplicated={vi.fn()}
+      />,
+    );
+
+    await act(async () => {
+      initial.resolve([makeReuseCandidate("quote-1", "Original Quote")]);
+      await Promise.resolve();
+    });
+    expect(screen.getByRole("button", { name: /original quote/i })).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText("Search existing quotes"), {
+      target: { value: "updated" },
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(275);
+    });
+
+    expect(screen.getByRole("button", { name: /original quote/i })).toBeInTheDocument();
+    expect(screen.getByRole("status")).toHaveTextContent("Searching quotes...");
+    expect(screen.queryByText("Loading quotes to duplicate...")).not.toBeInTheDocument();
+
+    await act(async () => {
+      refresh.resolve([makeReuseCandidate("quote-2", "Updated Quote")]);
+      await Promise.resolve();
+    });
+    expect(screen.getByRole("button", { name: /updated quote/i })).toBeInTheDocument();
+  });
+
+  it("shows empty search state only after refresh resolves with no matches", async () => {
+    vi.useFakeTimers();
+    const initial = deferred<ReturnType<typeof makeReuseCandidate>[]>();
+    const emptyRefresh = deferred<ReturnType<typeof makeReuseCandidate>[]>();
+
+    mockedQuoteService.listReuseCandidates.mockImplementation((params) => {
+      if (params?.q === "missing") {
+        return emptyRefresh.promise;
+      }
+      return initial.promise;
+    });
+
+    render(
+      <QuoteReuseChooser
+        open
+        timezone="UTC"
+        onClose={vi.fn()}
+        onQuoteDuplicated={vi.fn()}
+      />,
+    );
+
+    await act(async () => {
+      initial.resolve([makeReuseCandidate("quote-1", "Original Quote")]);
+      await Promise.resolve();
+    });
+    expect(screen.getByRole("button", { name: /original quote/i })).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText("Search existing quotes"), {
+      target: { value: "missing" },
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(275);
+    });
+
+    expect(screen.getByRole("button", { name: /original quote/i })).toBeInTheDocument();
+    expect(screen.queryByText("No quotes found")).not.toBeInTheDocument();
+
+    await act(async () => {
+      emptyRefresh.resolve([]);
+      await Promise.resolve();
+    });
+    expect(screen.getByText("No quotes found")).toBeInTheDocument();
+  });
+
   it("ignores late responses after the sheet closes", async () => {
     const pending = deferred<ReturnType<typeof makeReuseCandidate>[]>();
     mockedQuoteService.listReuseCandidates.mockReturnValue(pending.promise);


### PR DESCRIPTION
## Summary
- keep existing quote reuse candidates visible while debounced search refresh requests are in flight
- show an inline accessible refresh status (Searching quotes...) after the first successful load instead of replacing list content with the full loading block
- add chooser tests covering pending refresh visibility and empty-state timing after refresh resolve

## Verification
- cd frontend && npx vitest run src/features/quotes/tests/QuoteReuseChooser.test.tsx
- make frontend-verify

Closes #688