### PR TITLE
P1 Spec 9 PR3 — Production config fail-closed checks

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -11,6 +11,7 @@ from pydantic import Field, field_validator, model_validator
 from pydantic_settings import BaseSettings, NoDecode, SettingsConfigDict
 
 MIN_SECRET_KEY_LENGTH = 32
+MIN_ADMIN_API_KEY_LENGTH = 32
 LOCALHOST_HOSTS = frozenset({"localhost", "127.0.0.1", "0.0.0.0", "::1"})  # nosec B104
 FORBIDDEN_SECRET_KEY_VALUES = frozenset(
     {
@@ -20,6 +21,18 @@ FORBIDDEN_SECRET_KEY_VALUES = frozenset(
         "replace-me",
         "replace-with-strong-random-value",
         "your-secret-key",
+    }
+)
+FORBIDDEN_ADMIN_API_KEY_VALUES = frozenset(
+    {
+        "admin",
+        "changeme",
+        "change-me",
+        "dev",
+        "development",
+        "test",
+        "secret",
+        "password",
     }
 )
 
@@ -443,16 +456,58 @@ class Settings(BaseSettings):
 
         if not self.cookie_secure:
             raise ValueError("COOKIE_SECURE must be true when ENVIRONMENT is 'production'")
+        if not self.cookie_httponly:
+            raise ValueError("COOKIE_HTTPONLY must be true when ENVIRONMENT is 'production'")
+        if not self.allowed_origins:
+            raise ValueError("ALLOWED_ORIGINS must be non-empty when ENVIRONMENT is 'production'")
+        for allowed_origin in self.allowed_origins:
+            if "*" in allowed_origin:
+                raise ValueError(
+                    "ALLOWED_ORIGINS must not contain wildcard values "
+                    "when ENVIRONMENT is 'production'"
+                )
+            parsed_allowed_origin = urlparse(allowed_origin)
+            if parsed_allowed_origin.scheme != "https" or not parsed_allowed_origin.netloc:
+                raise ValueError(
+                    "ALLOWED_ORIGINS entries must be explicit https origins "
+                    "when ENVIRONMENT is 'production'"
+                )
+            if parsed_allowed_origin.hostname in LOCALHOST_HOSTS:
+                raise ValueError(
+                    "ALLOWED_ORIGINS entries must not use localhost "
+                    "when ENVIRONMENT is 'production'"
+                )
         if not self.allowed_hosts:
             raise ValueError("ALLOWED_HOSTS must be non-empty when ENVIRONMENT is 'production'")
         if "*" in self.allowed_hosts:
             raise ValueError("ALLOWED_HOSTS must not contain '*' when ENVIRONMENT is 'production'")
 
+        if self.extraction_trace_include_raw_content:
+            raise ValueError(
+                "EXTRACTION_TRACE_INCLUDE_RAW_CONTENT must be false "
+                "when ENVIRONMENT is 'production'"
+            )
+        if self.allow_redis_degraded_mode:
+            raise ValueError(
+                "ALLOW_REDIS_DEGRADED_MODE must be false when ENVIRONMENT is 'production'"
+            )
         parsed_frontend_url = urlparse(self.frontend_url)
         if parsed_frontend_url.hostname in LOCALHOST_HOSTS:
             raise ValueError("FRONTEND_URL must not use localhost when ENVIRONMENT is 'production'")
-        if self.redis_url is None and not self.allow_redis_degraded_mode:
+        if self.redis_url is None:
             raise ValueError("REDIS_URL must be set when ENVIRONMENT is 'production'")
+        if self.admin_api_key is not None:
+            if self.admin_api_key.lower() in FORBIDDEN_ADMIN_API_KEY_VALUES:
+                raise ValueError(
+                    "ADMIN_API_KEY cannot use placeholder/dev values "
+                    "when ENVIRONMENT is 'production'"
+                )
+            if len(self.admin_api_key) < MIN_ADMIN_API_KEY_LENGTH:
+                raise ValueError(
+                    "ADMIN_API_KEY must be at least "
+                    f"{MIN_ADMIN_API_KEY_LENGTH} characters "
+                    "when ENVIRONMENT is 'production'"
+                )
 
         return self
 

--- a/backend/app/core/tests/test_config.py
+++ b/backend/app/core/tests/test_config.py
@@ -206,40 +206,89 @@ def test_gcs_bucket_name_is_required(monkeypatch) -> None:
         Settings(_env_file=None)  # type: ignore[call-arg]
 
 
-def test_production_requires_secure_cookies(monkeypatch) -> None:
+def _set_production_safe_defaults(monkeypatch) -> None:
     monkeypatch.setenv("ENVIRONMENT", "production")
-    monkeypatch.setenv("COOKIE_SECURE", "false")
+    monkeypatch.setenv("COOKIE_SECURE", "true")
+    monkeypatch.setenv("COOKIE_HTTPONLY", "true")
     monkeypatch.setenv("FRONTEND_URL", "https://app.stima.dev")
+    monkeypatch.setenv("ALLOWED_ORIGINS", "https://app.stima.dev")
     monkeypatch.setenv("ALLOWED_HOSTS", "api.stima.dev")
+    monkeypatch.setenv("REDIS_URL", "redis://localhost:6379/0")
+    monkeypatch.setenv("ALLOW_REDIS_DEGRADED_MODE", "false")
+
+
+@pytest.mark.parametrize("wildcard_origin", ["*", "http://*", "https://*"])
+def test_production_rejects_wildcard_allowed_origins(monkeypatch, wildcard_origin: str) -> None:
+    _set_production_safe_defaults(monkeypatch)
+    monkeypatch.setenv("ALLOWED_ORIGINS", wildcard_origin)
+
+    with pytest.raises(
+        ValidationError,
+        match="ALLOWED_ORIGINS must not contain wildcard values",
+    ):
+        get_settings()
+
+
+def test_production_allows_explicit_https_allowed_origins(monkeypatch) -> None:
+    _set_production_safe_defaults(monkeypatch)
+    monkeypatch.setenv(
+        "ALLOWED_ORIGINS",
+        "https://stima.example.com,https://www.stima.example.com",
+    )
+
+    settings = get_settings()
+
+    assert settings.allowed_origins == [
+        "https://stima.example.com",
+        "https://www.stima.example.com",
+    ]
+
+
+def test_production_rejects_non_https_allowed_origins(monkeypatch) -> None:
+    _set_production_safe_defaults(monkeypatch)
+    monkeypatch.setenv("ALLOWED_ORIGINS", "http://stima.example.com")
+
+    with pytest.raises(
+        ValidationError,
+        match="ALLOWED_ORIGINS entries must be explicit https origins",
+    ):
+        get_settings()
+
+
+def test_production_rejects_cookie_httponly_false(monkeypatch) -> None:
+    _set_production_safe_defaults(monkeypatch)
+    monkeypatch.setenv("COOKIE_HTTPONLY", "false")
+
+    with pytest.raises(ValidationError, match="COOKIE_HTTPONLY must be true"):
+        get_settings()
+
+
+def test_production_requires_secure_cookies(monkeypatch) -> None:
+    _set_production_safe_defaults(monkeypatch)
+    monkeypatch.setenv("COOKIE_SECURE", "false")
 
     with pytest.raises(ValidationError):
         get_settings()
 
 
 def test_production_requires_non_localhost_frontend_url(monkeypatch) -> None:
-    monkeypatch.setenv("ENVIRONMENT", "production")
-    monkeypatch.setenv("COOKIE_SECURE", "true")
+    _set_production_safe_defaults(monkeypatch)
     monkeypatch.setenv("FRONTEND_URL", "http://localhost:5173")
-    monkeypatch.setenv("ALLOWED_HOSTS", "api.stima.dev")
 
     with pytest.raises(ValidationError):
         get_settings()
 
 
 def test_production_rejects_ipv6_loopback_frontend_url(monkeypatch) -> None:
-    monkeypatch.setenv("ENVIRONMENT", "production")
-    monkeypatch.setenv("COOKIE_SECURE", "true")
+    _set_production_safe_defaults(monkeypatch)
     monkeypatch.setenv("FRONTEND_URL", "http://[::1]:5173")
-    monkeypatch.setenv("ALLOWED_HOSTS", "api.stima.dev")
 
     with pytest.raises(ValidationError):
         get_settings()
 
 
 def test_production_requires_allowed_hosts(monkeypatch) -> None:
-    monkeypatch.setenv("ENVIRONMENT", "production")
-    monkeypatch.setenv("COOKIE_SECURE", "true")
-    monkeypatch.setenv("FRONTEND_URL", "https://app.stima.dev")
+    _set_production_safe_defaults(monkeypatch)
     monkeypatch.delenv("ALLOWED_HOSTS", raising=False)
 
     with pytest.raises(ValidationError):
@@ -247,35 +296,82 @@ def test_production_requires_allowed_hosts(monkeypatch) -> None:
 
 
 def test_production_rejects_wildcard_allowed_hosts(monkeypatch) -> None:
-    monkeypatch.setenv("ENVIRONMENT", "production")
-    monkeypatch.setenv("COOKIE_SECURE", "true")
-    monkeypatch.setenv("FRONTEND_URL", "https://app.stima.dev")
+    _set_production_safe_defaults(monkeypatch)
     monkeypatch.setenv("ALLOWED_HOSTS", "*")
 
     with pytest.raises(ValidationError):
         get_settings()
 
 
+def test_production_rejects_raw_content_extraction_trace(monkeypatch) -> None:
+    _set_production_safe_defaults(monkeypatch)
+    monkeypatch.setenv("EXTRACTION_TRACE_INCLUDE_RAW_CONTENT", "true")
+
+    with pytest.raises(
+        ValidationError,
+        match="EXTRACTION_TRACE_INCLUDE_RAW_CONTENT must be false",
+    ):
+        get_settings()
+
+
 def test_production_requires_redis_url(monkeypatch) -> None:
-    monkeypatch.setenv("ENVIRONMENT", "production")
-    monkeypatch.setenv("COOKIE_SECURE", "true")
-    monkeypatch.setenv("FRONTEND_URL", "https://app.stima.dev")
-    monkeypatch.setenv("ALLOWED_HOSTS", "api.stima.dev")
+    _set_production_safe_defaults(monkeypatch)
     monkeypatch.setenv("REDIS_URL", "")
 
     with pytest.raises(ValidationError, match="REDIS_URL must be set"):
         get_settings()
 
 
-def test_production_allows_missing_redis_url_when_degraded_mode_enabled(monkeypatch) -> None:
-    monkeypatch.setenv("ENVIRONMENT", "production")
-    monkeypatch.setenv("COOKIE_SECURE", "true")
-    monkeypatch.setenv("FRONTEND_URL", "https://app.stima.dev")
-    monkeypatch.setenv("ALLOWED_HOSTS", "api.stima.dev")
+def test_production_rejects_redis_degraded_mode(monkeypatch) -> None:
+    _set_production_safe_defaults(monkeypatch)
     monkeypatch.setenv("ALLOW_REDIS_DEGRADED_MODE", "true")
-    monkeypatch.setenv("REDIS_URL", "")
+
+    with pytest.raises(
+        ValidationError,
+        match="ALLOW_REDIS_DEGRADED_MODE must be false",
+    ):
+        get_settings()
+
+
+@pytest.mark.parametrize(
+    "admin_key",
+    [
+        "admin",
+        "changeme",
+        "change-me",
+        "dev",
+        "development",
+        "test",
+        "secret",
+        "password",
+    ],
+)
+def test_production_rejects_placeholder_admin_api_key(monkeypatch, admin_key: str) -> None:
+    _set_production_safe_defaults(monkeypatch)
+    monkeypatch.setenv("ADMIN_API_KEY", admin_key)
+
+    with pytest.raises(
+        ValidationError,
+        match="ADMIN_API_KEY cannot use placeholder/dev values",
+    ):
+        get_settings()
+
+
+def test_production_rejects_short_admin_api_key(monkeypatch) -> None:
+    _set_production_safe_defaults(monkeypatch)
+    monkeypatch.setenv("ADMIN_API_KEY", "a" * 31)
+
+    with pytest.raises(
+        ValidationError,
+        match="ADMIN_API_KEY must be at least 32 characters",
+    ):
+        get_settings()
+
+
+def test_production_allows_strong_admin_api_key(monkeypatch) -> None:
+    _set_production_safe_defaults(monkeypatch)
+    monkeypatch.setenv("ADMIN_API_KEY", "a" * 48)
 
     settings = get_settings()
 
-    assert settings.redis_url is None
-    assert settings.allow_redis_degraded_mode is True
+    assert settings.admin_api_key == "a" * 48

--- a/backend/app/core/tests/test_config.py
+++ b/backend/app/core/tests/test_config.py
@@ -263,6 +263,28 @@ def test_production_rejects_cookie_httponly_false(monkeypatch) -> None:
         get_settings()
 
 
+def test_production_rejects_empty_allowed_origins(monkeypatch) -> None:
+    _set_production_safe_defaults(monkeypatch)
+    monkeypatch.setenv("ALLOWED_ORIGINS", "")
+
+    with pytest.raises(
+        ValidationError,
+        match="ALLOWED_ORIGINS must be non-empty",
+    ):
+        get_settings()
+
+
+def test_production_rejects_localhost_allowed_origins(monkeypatch) -> None:
+    _set_production_safe_defaults(monkeypatch)
+    monkeypatch.setenv("ALLOWED_ORIGINS", "http://localhost:5173")
+
+    with pytest.raises(
+        ValidationError,
+        match="ALLOWED_ORIGINS entries must be explicit https origins",
+    ):
+        get_settings()
+
+
 def test_production_requires_secure_cookies(monkeypatch) -> None:
     _set_production_safe_defaults(monkeypatch)
     monkeypatch.setenv("COOKIE_SECURE", "false")

--- a/backend/app/core/tests/test_main.py
+++ b/backend/app/core/tests/test_main.py
@@ -69,11 +69,21 @@ async def test_trusted_proxy_headers_prevent_https_redirect_loops(
     monkeypatch.setenv("ENVIRONMENT", "production")
     monkeypatch.setenv("COOKIE_SECURE", "true")
     monkeypatch.setenv("FRONTEND_URL", "https://stima.odysian.dev")
+    monkeypatch.setenv("ALLOWED_ORIGINS", "https://stima.odysian.dev")
     monkeypatch.setenv("REDIS_URL", "redis://localhost:6379/0")
-    monkeypatch.setenv("ALLOW_REDIS_DEGRADED_MODE", "true")
+    monkeypatch.setenv("ALLOW_REDIS_DEGRADED_MODE", "false")
     monkeypatch.setenv("ALLOWED_HOSTS", "api.stima.odysian.dev,127.0.0.1")
     monkeypatch.setenv("ENABLE_HTTPS_REDIRECT", "true")
     monkeypatch.setenv("TRUSTED_PROXY_IPS", "127.0.0.1")
+    monkeypatch.setattr(
+        "app.main.resolve_redis_runtime_state",
+        AsyncMock(
+            return_value=RedisRuntimeState(
+                mode="degraded_memory",
+                degraded_reason="redis_probe_failed",
+            )
+        ),
+    )
     get_settings.cache_clear()
 
     app = create_app()

--- a/backend/app/features/auth/tests/test_auth_api.py
+++ b/backend/app/features/auth/tests/test_auth_api.py
@@ -192,6 +192,24 @@ async def test_login_sets_auth_cookies_and_returns_csrf(client: AsyncClient) -> 
     assert "Path=/" in csrf_cookie
 
 
+async def test_login_sets_httponly_only_for_auth_cookies(client: AsyncClient) -> None:
+    credentials = _credentials()
+    register_response = await client.post("/api/auth/register", json=credentials)
+    assert register_response.status_code == 201
+
+    login_response = await client.post("/api/auth/login", json=credentials)
+    assert login_response.status_code == 200
+
+    set_cookie_values = login_response.headers.get_list("set-cookie")
+    access_cookie = _cookie_header(set_cookie_values, ACCESS_COOKIE_NAME)
+    refresh_cookie = _cookie_header(set_cookie_values, REFRESH_COOKIE_NAME)
+    csrf_cookie = _cookie_header(set_cookie_values, CSRF_COOKIE_NAME)
+
+    assert "HttpOnly" in access_cookie
+    assert "HttpOnly" in refresh_cookie
+    assert "HttpOnly" not in csrf_cookie
+
+
 async def test_login_uses_env_configured_prod_cookie_domain(
     client: AsyncClient,
     monkeypatch: pytest.MonkeyPatch,

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -136,7 +136,7 @@ async def _lifespan(app: FastAPI) -> AsyncIterator[None]:
         try:
             arq_pool = await create_pool(build_arq_redis_settings(settings))
         except Exception:
-            if settings.allow_redis_degraded_mode:
+            if settings.allow_redis_degraded_mode and settings.environment.lower() != "production":
                 runtime_state = RedisRuntimeState(
                     mode="degraded_memory",
                     degraded_reason="redis_probe_failed",

--- a/backend/app/shared/rate_limit.py
+++ b/backend/app/shared/rate_limit.py
@@ -413,7 +413,7 @@ def resolve_limiter_backend_for_runtime_mode(
     if settings.redis_url:
         return LimiterBackendConfig(storage_uri=settings.redis_url, mode="redis")
 
-    if settings.environment.lower() == "production" and not settings.allow_redis_degraded_mode:
+    if settings.environment.lower() == "production":
         raise ValueError("REDIS_URL must be set when ENVIRONMENT is 'production'")
 
     fallback_reason = (

--- a/backend/app/shared/redis_runtime.py
+++ b/backend/app/shared/redis_runtime.py
@@ -56,8 +56,6 @@ async def resolve_redis_runtime_state(settings: Settings) -> RedisRuntimeState:
     if settings.redis_url is None:
         if settings.environment.lower() != "production":
             return RedisRuntimeState(mode="degraded_memory", degraded_reason="redis_missing")
-        if settings.allow_redis_degraded_mode:
-            return RedisRuntimeState(mode="degraded_memory", degraded_reason="redis_missing")
         raise RedisRuntimeResolutionError("REDIS_URL is required in production")
 
     is_healthy, reason = await probe_redis(
@@ -67,6 +65,10 @@ async def resolve_redis_runtime_state(settings: Settings) -> RedisRuntimeState:
     if is_healthy:
         return RedisRuntimeState(mode="redis")
     if settings.allow_redis_degraded_mode:
+        if settings.environment.lower() == "production":
+            raise RedisRuntimeResolutionError(
+                "Redis unavailable at startup and production degraded mode is disabled"
+            )
         return RedisRuntimeState(mode="degraded_memory", degraded_reason=reason)
 
     degraded_reason = reason or "redis_probe_failed"

--- a/backend/app/shared/tests/test_rate_limit.py
+++ b/backend/app/shared/tests/test_rate_limit.py
@@ -242,6 +242,7 @@ def test_production_settings_require_redis_url(monkeypatch: pytest.MonkeyPatch) 
     monkeypatch.setenv("ENVIRONMENT", "production")
     monkeypatch.setenv("COOKIE_SECURE", "true")
     monkeypatch.setenv("FRONTEND_URL", "https://app.stima.dev")
+    monkeypatch.setenv("ALLOWED_ORIGINS", "https://app.stima.dev")
     monkeypatch.setenv("ALLOWED_HOSTS", "api.stima.dev")
     monkeypatch.setenv("REDIS_URL", "")
     get_settings.cache_clear()
@@ -257,17 +258,15 @@ def test_resolve_limiter_backend_rejects_production_without_redis_url() -> None:
         resolve_limiter_backend(settings)
 
 
-def test_resolve_limiter_backend_allows_production_memory_when_degraded_enabled() -> None:
+def test_resolve_limiter_backend_rejects_production_memory_when_degraded_enabled() -> None:
     settings = Settings.model_construct(
         environment="production",
         redis_url=None,
         allow_redis_degraded_mode=True,
     )
 
-    backend = resolve_limiter_backend(settings)
-
-    assert backend.mode == "memory"
-    assert backend.storage_uri == "memory://"
+    with pytest.raises(ValueError, match="REDIS_URL must be set"):
+        resolve_limiter_backend(settings)
 
 
 def test_resolve_limiter_backend_for_runtime_mode_forces_memory() -> None:

--- a/backend/app/shared/tests/test_redis_runtime.py
+++ b/backend/app/shared/tests/test_redis_runtime.py
@@ -7,7 +7,7 @@ from collections.abc import Iterator
 from unittest.mock import AsyncMock
 
 import pytest
-from app.core.config import get_settings
+from app.core.config import Settings, get_settings
 from app.shared.redis_runtime import (
     RedisRuntimeResolutionError,
     probe_redis,
@@ -60,20 +60,15 @@ async def test_probe_redis_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 @pytest.mark.asyncio
-async def test_resolve_runtime_state_uses_degraded_memory_when_missing_redis_and_allowed(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.setenv("ENVIRONMENT", "production")
-    monkeypatch.setenv("COOKIE_SECURE", "true")
-    monkeypatch.setenv("FRONTEND_URL", "https://app.stima.dev")
-    monkeypatch.setenv("ALLOWED_HOSTS", "api.stima.dev")
-    monkeypatch.setenv("ALLOW_REDIS_DEGRADED_MODE", "true")
-    monkeypatch.setenv("REDIS_URL", "")
+async def test_resolve_runtime_state_rejects_missing_redis_url_in_production() -> None:
+    settings = Settings.model_construct(
+        environment="production",
+        redis_url=None,
+        allow_redis_degraded_mode=False,
+    )
 
-    runtime_state = await resolve_redis_runtime_state(get_settings())
-
-    assert runtime_state.mode == "degraded_memory"
-    assert runtime_state.degraded_reason == "redis_missing"
+    with pytest.raises(RedisRuntimeResolutionError, match="REDIS_URL is required in production"):
+        await resolve_redis_runtime_state(settings)
 
 
 @pytest.mark.asyncio
@@ -83,6 +78,7 @@ async def test_resolve_runtime_state_rejects_unhealthy_redis_when_degraded_disab
     monkeypatch.setenv("ENVIRONMENT", "production")
     monkeypatch.setenv("COOKIE_SECURE", "true")
     monkeypatch.setenv("FRONTEND_URL", "https://app.stima.dev")
+    monkeypatch.setenv("ALLOWED_ORIGINS", "https://app.stima.dev")
     monkeypatch.setenv("ALLOWED_HOSTS", "api.stima.dev")
     monkeypatch.setenv("ALLOW_REDIS_DEGRADED_MODE", "false")
     monkeypatch.setenv("REDIS_URL", "redis://localhost:6379/0")


### PR DESCRIPTION
## Summary
- fail closed for unsafe production ALLOWED_ORIGINS, COOKIE_HTTPONLY, EXTRACTION_TRACE_INCLUDE_RAW_CONTENT, ALLOW_REDIS_DEGRADED_MODE, and ADMIN_API_KEY values
- harden runtime fallback guards so production cannot degrade to memory mode when Redis is missing/unhealthy
- add focused tests for each production policy lock plus auth-cookie HttpOnly/CSRF split behavior

## Verification
- cd backend && .venv/bin/pytest app/core/tests/test_config.py -x --tb=short
- cd backend && .venv/bin/pytest app/core/tests/test_main.py -x --tb=short
- cd backend && .venv/bin/pytest app/shared/tests/test_redis_runtime.py -x --tb=short
- cd backend && .venv/bin/pytest app/features/auth/tests/test_auth_api.py -x --tb=short
- make backend-static-verify
- make backend-verify

Closes #691
Parent: #616
Source audit: docs/qa/P1_PRODUCTION_SECURITY_LLM_SAFETY_GATE.md