### PR TITLE
P1 Spec 9 PR2 — Sensitive logging and telemetry redaction

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -235,10 +235,6 @@ class Settings(BaseSettings):
         default="fallback_default",
         validation_alias="EXTRACTION_FALLBACK_PROMPT_VARIANT",
     )
-    extraction_trace_include_raw_content: bool = Field(
-        default=False,
-        validation_alias="EXTRACTION_TRACE_INCLUDE_RAW_CONTENT",
-    )
     transcription_model: str = Field(
         default="whisper-1",
         validation_alias="TRANSCRIPTION_MODEL",
@@ -481,12 +477,6 @@ class Settings(BaseSettings):
             raise ValueError("ALLOWED_HOSTS must be non-empty when ENVIRONMENT is 'production'")
         if "*" in self.allowed_hosts:
             raise ValueError("ALLOWED_HOSTS must not contain '*' when ENVIRONMENT is 'production'")
-
-        if self.extraction_trace_include_raw_content:
-            raise ValueError(
-                "EXTRACTION_TRACE_INCLUDE_RAW_CONTENT must be false "
-                "when ENVIRONMENT is 'production'"
-            )
         if self.allow_redis_degraded_mode:
             raise ValueError(
                 "ALLOW_REDIS_DEGRADED_MODE must be false when ENVIRONMENT is 'production'"

--- a/backend/app/core/tests/test_config.py
+++ b/backend/app/core/tests/test_config.py
@@ -69,20 +69,6 @@ def test_extraction_job_reaper_settings_use_expected_defaults() -> None:
     assert settings.extraction_job_stale_ttl_seconds == 300
 
 
-def test_extraction_trace_raw_content_logging_defaults_to_disabled() -> None:
-    settings = get_settings()
-
-    assert settings.extraction_trace_include_raw_content is False
-
-
-def test_extraction_trace_raw_content_logging_can_be_enabled(monkeypatch) -> None:
-    monkeypatch.setenv("EXTRACTION_TRACE_INCLUDE_RAW_CONTENT", "true")
-
-    settings = get_settings()
-
-    assert settings.extraction_trace_include_raw_content is True
-
-
 def test_extraction_job_reaper_settings_must_be_positive(monkeypatch) -> None:
     monkeypatch.setenv("EXTRACTION_JOB_REAPER_INTERVAL_SECONDS", "0")
 
@@ -322,17 +308,6 @@ def test_production_rejects_wildcard_allowed_hosts(monkeypatch) -> None:
     monkeypatch.setenv("ALLOWED_HOSTS", "*")
 
     with pytest.raises(ValidationError):
-        get_settings()
-
-
-def test_production_rejects_raw_content_extraction_trace(monkeypatch) -> None:
-    _set_production_safe_defaults(monkeypatch)
-    monkeypatch.setenv("EXTRACTION_TRACE_INCLUDE_RAW_CONTENT", "true")
-
-    with pytest.raises(
-        ValidationError,
-        match="EXTRACTION_TRACE_INCLUDE_RAW_CONTENT must be false",
-    ):
         get_settings()
 
 

--- a/backend/app/features/quotes/tests/test_extraction.py
+++ b/backend/app/features/quotes/tests/test_extraction.py
@@ -869,6 +869,72 @@ async def test_extract_emits_trace_events_for_primary_repair_and_result_stages(
     assert ("result", "succeeded") in {(call["stage"], call["outcome"]) for call in trace_calls}
 
 
+async def test_extract_trace_events_never_include_raw_sensitive_content(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    transcript_sentinel = "TRANSCRIPT_SENTINEL_DO_NOT_LOG"
+    payload_sentinel = "TOOL_PAYLOAD_SENTINEL_DO_NOT_LOG"
+    trace_calls: list[dict[str, object]] = []
+
+    def _capture_trace(
+        event: str,
+        *,
+        stage: str,
+        outcome: str,
+        **fields: object,
+    ) -> None:
+        trace_calls.append(
+            {
+                "event": event,
+                "stage": stage,
+                "outcome": outcome,
+                **fields,
+            }
+        )
+
+    monkeypatch.setattr(extraction_module, "log_extraction_trace", _capture_trace)
+    client = _FakeClient(
+        lambda _: _FakeResponse(
+            content=[
+                {
+                    "type": "tool_use",
+                    "input": {
+                        "transcript": transcript_sentinel,
+                        "line_items": [
+                            {
+                                "description": payload_sentinel,
+                                "details": None,
+                                "price": 125,
+                            }
+                        ],
+                        "pricing_hints": {"explicit_total": 125},
+                    },
+                }
+            ]
+        )
+    )
+    integration = ExtractionIntegration(api_key="test", model="test-model", client=client)
+
+    result = await integration.extract(transcript_sentinel)
+
+    assert result.total == 125
+    serialized_traces = json.dumps(trace_calls, sort_keys=True, default=str)
+    assert transcript_sentinel not in serialized_traces
+    assert payload_sentinel not in serialized_traces
+    provider_response = next(
+        call
+        for call in trace_calls
+        if call["stage"] == "primary" and call["outcome"] == "provider_response"
+    )
+    assert provider_response["transcript_chars"] == len(transcript_sentinel)
+    assert provider_response["line_item_count"] == 1
+    result_trace = next(
+        call for call in trace_calls if call["stage"] == "result" and call["outcome"] == "succeeded"
+    )
+    assert result_trace["line_item_count"] == 1
+    assert result_trace["transcript_chars"] == len(transcript_sentinel)
+
+
 async def test_guard_flags_line_items_with_price_in_description() -> None:
     transcript = TRANSCRIPTS["clean_with_total"]
     client = _FakeClient(

--- a/backend/app/features/quotes/tests/test_pdf.py
+++ b/backend/app/features/quotes/tests/test_pdf.py
@@ -46,6 +46,7 @@ from app.worker.runtime import (
     DEFAULT_MAX_TRIES,
     DEFAULT_RETRY_BASE_SECONDS,
     DEFAULT_RETRY_JITTER_SECONDS,
+    TERMINAL_ERROR_UNEXPECTED,
     NonRetryableJobError,
     WorkerRuntimeSettings,
 )
@@ -994,7 +995,7 @@ async def test_generate_pdf_returns_422_when_render_fails(
     )
 
     job_payload = _assert_async_pdf_job_response(response, document_id=quote["id"])
-    with pytest.raises(NonRetryableJobError, match="Unable to render quote PDF"):
+    with pytest.raises(NonRetryableJobError, match=TERMINAL_ERROR_UNEXPECTED):
         await _run_pdf_job(
             db_session,
             job_id=job_payload["id"],
@@ -1052,7 +1053,7 @@ async def test_generate_pdf_rejects_documents_that_exceed_render_limits(
     )
 
     job_payload = _assert_async_pdf_job_response(response, document_id=quote["id"])
-    with pytest.raises(NonRetryableJobError, match="Document exceeds supported render limits"):
+    with pytest.raises(NonRetryableJobError, match=TERMINAL_ERROR_UNEXPECTED):
         await _run_pdf_job(
             db_session,
             job_id=job_payload["id"],

--- a/backend/app/integrations/extraction.py
+++ b/backend/app/integrations/extraction.py
@@ -460,7 +460,6 @@ class ExtractionIntegration:
                     extraction_model_id=tier.model_id,
                     extraction_prompt_variant=tier.prompt_variant,
                     error_class=type(exc).__name__,
-                    error_message=str(exc),
                 )
                 continue
 
@@ -474,7 +473,6 @@ class ExtractionIntegration:
             extraction_mode=mode,
             reason="all_tiers_failed",
             error_class=type(last_error).__name__,
-            error_message=str(last_error),
         )
         raise last_error
 
@@ -527,7 +525,6 @@ class ExtractionIntegration:
             extraction_model_id=tier.model_id,
             extraction_prompt_variant=tier.prompt_variant,
             transcript_chars=len(prepared_input.transcript),
-            raw_transcript=prepared_input.transcript,
         )
         _set_last_call_metadata(
             model_id=tier.model_id,
@@ -582,8 +579,7 @@ class ExtractionIntegration:
                 )
                 is not None
             ),
-            raw_transcript=prepared_input.transcript,
-            raw_tool_payload=candidate_payload,
+            transcript_chars=len(prepared_input.transcript),
         )
 
         try:
@@ -624,8 +620,7 @@ class ExtractionIntegration:
                 extraction_model_id=response_model_id,
                 extraction_prompt_variant=repair_prompt_variant,
                 validation_error_count=len(validation_errors),
-                raw_transcript=prepared_input.transcript,
-                raw_tool_payload=candidate_payload,
+                transcript_chars=len(prepared_input.transcript),
             )
             try:
                 repair_response = await self._request_with_retry(
@@ -702,8 +697,7 @@ class ExtractionIntegration:
                     reason="repair_invalid",
                     token_input_tokens=_token_usage_value(repair_usage, "input_tokens"),
                     token_output_tokens=_token_usage_value(repair_usage, "output_tokens"),
-                    raw_transcript=prepared_input.transcript,
-                    raw_tool_payload=repair_candidate_payload,
+                    transcript_chars=len(prepared_input.transcript),
                 )
                 degraded_result = _build_validation_repair_failed_result(
                     transcript=prepared_input.transcript
@@ -743,8 +737,7 @@ class ExtractionIntegration:
                     ).get("explicit_total")
                     is not None
                 ),
-                raw_transcript=prepared_input.transcript,
-                raw_tool_payload=repair_candidate_payload,
+                transcript_chars=len(prepared_input.transcript),
             )
             if mode == "append":
                 result = _build_extraction_result_from_append_candidate(
@@ -1493,10 +1486,9 @@ def _log_result_trace(
         flagged_line_item_count=sum(1 for item in result.line_items if item.flagged),
         spoken_money_hint_count=spoken_money_hint_count,
         spoken_money_correction_count=spoken_money_correction_count,
+        transcript_chars=len(result.transcript),
         unresolved_segment_count=len(result.unresolved_segments),
         total_present=result.pricing_hints.explicit_total is not None,
-        raw_transcript=result.transcript,
-        raw_tool_payload=result.model_dump(mode="json"),
     )
 
 
@@ -1633,8 +1625,7 @@ def _apply_spoken_money_correction_guard(
                 _TRACE_EVENT_NAME,
                 stage="semantic_guard",
                 outcome="spoken_money_orphan_hint",
-                spoken_money_phrase=hint.phrase,
-                spoken_money_amount=hint.amount,
+                spoken_money_orphan_hint_count=1,
             )
             continue
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -206,9 +206,7 @@ def create_app() -> FastAPI:
     settings = get_settings()
     init_sentry(dsn=settings.sentry_dsn, environment=settings.environment)
     configure_event_logging(session_factory=get_session_maker())
-    configure_extraction_logging(
-        include_raw_content=settings.extraction_trace_include_raw_content,
-    )
+    configure_extraction_logging()
     configure_security_logging()
 
     app = FastAPI(title="Stima API", lifespan=_lifespan)

--- a/backend/app/shared/extraction_logger.py
+++ b/backend/app/shared/extraction_logger.py
@@ -8,19 +8,16 @@ import sys
 from datetime import UTC, datetime
 from typing import Any
 
-from app.shared.observability import current_correlation_id
+from app.shared.observability import current_correlation_id, sanitize_log_fields
 
 EXTRACTION_LOGGER_NAME = "stima.extraction"
 _HANDLER_SENTINEL = "_stima_extraction_handler"
 _EXTRACTION_LOGGER = logging.getLogger(EXTRACTION_LOGGER_NAME)
-_INCLUDE_RAW_CONTENT = False
 
 
 def configure_extraction_logging(*, include_raw_content: bool = False) -> None:
-    """Attach stdout extraction trace logging once and refresh raw-content settings."""
-    global _INCLUDE_RAW_CONTENT
-
-    _INCLUDE_RAW_CONTENT = include_raw_content
+    """Attach stdout extraction trace logging once."""
+    del include_raw_content
     _EXTRACTION_LOGGER.setLevel(logging.INFO)
     _EXTRACTION_LOGGER.propagate = False
     if any(getattr(handler, _HANDLER_SENTINEL, False) for handler in _EXTRACTION_LOGGER.handlers):
@@ -38,8 +35,6 @@ def log_extraction_trace(
     stage: str,
     outcome: str,
     level: int = logging.INFO,
-    raw_transcript: str | None = None,
-    raw_tool_payload: Any = None,
     **fields: Any,
 ) -> None:
     """Emit one structured extraction trace event."""
@@ -52,15 +47,6 @@ def log_extraction_trace(
         "stage": stage,
         "outcome": outcome,
     }
-    for key, value in fields.items():
-        if value is None:
-            continue
-        payload[key] = value
-
-    if _INCLUDE_RAW_CONTENT:
-        if raw_transcript is not None:
-            payload["raw_transcript"] = raw_transcript
-        if raw_tool_payload is not None:
-            payload["raw_tool_payload"] = raw_tool_payload
+    payload.update(sanitize_log_fields(fields))
 
     _EXTRACTION_LOGGER.log(level, json.dumps(payload, default=str, sort_keys=True))

--- a/backend/app/shared/extraction_logger.py
+++ b/backend/app/shared/extraction_logger.py
@@ -15,9 +15,8 @@ _HANDLER_SENTINEL = "_stima_extraction_handler"
 _EXTRACTION_LOGGER = logging.getLogger(EXTRACTION_LOGGER_NAME)
 
 
-def configure_extraction_logging(*, include_raw_content: bool = False) -> None:
+def configure_extraction_logging() -> None:
     """Attach stdout extraction trace logging once."""
-    del include_raw_content
     _EXTRACTION_LOGGER.setLevel(logging.INFO)
     _EXTRACTION_LOGGER.propagate = False
     if any(getattr(handler, _HANDLER_SENTINEL, False) for handler in _EXTRACTION_LOGGER.handlers):

--- a/backend/app/shared/observability.py
+++ b/backend/app/shared/observability.py
@@ -6,6 +6,7 @@ import contextvars
 import hmac
 import json
 import logging
+import re
 import string
 import sys
 import time
@@ -53,12 +54,59 @@ _request_context_var: contextvars.ContextVar[RequestLogContext | None] = context
     default=None,
 )
 _rate_limited_events: dict[str, float] = {}
-_FORBIDDEN_FIELDS = frozenset(
+_SENSITIVE_FIELD_NAMES = frozenset(
     {
+        "access_token",
+        "api_key",
+        "auth_token",
+        "authorization",
         "authorization_header",
+        "connection_string",
+        "cookie",
+        "cookies",
+        "error_message",
+        "message_body",
+        "model_output",
+        "model_response",
+        "notes",
+        "prompt",
+        "prompt_body",
+        "prompt_text",
         "provider_api_key",
         "raw_share_token",
         "raw_token",
+        "raw_tool_payload",
+        "raw_transcript",
+        "raw_typed_notes",
+        "refresh_token",
+        "response",
+        "response_body",
+        "response_text",
+        "secret",
+        "share_token",
+        "spoken_money_amount",
+        "spoken_money_phrase",
+        "token",
+        "tool_payload",
+        "tool_response",
+        "transcript",
+        "typed_notes",
+    }
+)
+_SENSITIVE_FIELD_SUFFIXES = (
+    "_api_key",
+    "_authorization",
+    "_cookie",
+    "_prompt",
+    "_response",
+    "_secret",
+    "_token",
+)
+_SAFE_SUFFIX_EXCEPTIONS = frozenset(
+    {
+        "token_input_tokens",
+        "token_output_tokens",
+        "token_usage",
     }
 )
 
@@ -282,10 +330,7 @@ def log_security_event(
     if token_ref is not None:
         payload["token_ref_hash"] = hash_token_reference(token_ref)
 
-    for key, value in fields.items():
-        if value is None or key in _FORBIDDEN_FIELDS:
-            continue
-        payload[key] = value
+    payload.update(sanitize_log_fields(fields))
 
     _emit_security_payload(payload, level=level)
 
@@ -369,6 +414,28 @@ def hash_client_ip(client_ip: str | None) -> str | None:
     if client_ip is None:
         return None
     return _hmac_reference("client_ip", client_ip)
+
+
+def sanitize_log_fields(fields: dict[str, Any]) -> dict[str, Any]:
+    """Drop obviously sensitive structured log fields by key."""
+    sanitized: dict[str, Any] = {}
+    for key, value in fields.items():
+        if value is None or is_sensitive_log_field(key):
+            continue
+        sanitized[key] = value
+    return sanitized
+
+
+def is_sensitive_log_field(field_name: str) -> bool:
+    """Return True when a structured log field name should never emit raw content."""
+    normalized = re.sub(r"[^a-z0-9]+", "_", field_name.strip().lower()).strip("_")
+    if not normalized:
+        return False
+    if normalized in _SENSITIVE_FIELD_NAMES:
+        return True
+    if normalized in _SAFE_SUFFIX_EXCEPTIONS:
+        return False
+    return normalized.endswith(_SENSITIVE_FIELD_SUFFIXES)
 
 
 def sanitize_route_template(path: str) -> str:

--- a/backend/app/shared/tests/test_extraction_logger.py
+++ b/backend/app/shared/tests/test_extraction_logger.py
@@ -42,6 +42,8 @@ def test_configure_extraction_logging_uses_stdout_and_does_not_duplicate_handler
 def test_log_extraction_trace_excludes_raw_fields_by_default(monkeypatch) -> None:
     captured: list[tuple[int, str]] = []
     monkeypatch.setattr(extraction_logger, "current_correlation_id", lambda: "corr-123")
+    transcript_sentinel = "TRANSCRIPT_SENTINEL_DO_NOT_LOG"
+    payload_sentinel = "TOOL_PAYLOAD_SENTINEL_DO_NOT_LOG"
 
     def _capture(level: int, message: str) -> None:
         captured.append((level, message))
@@ -53,8 +55,9 @@ def test_log_extraction_trace_excludes_raw_fields_by_default(monkeypatch) -> Non
         "extraction.trace",
         stage="primary",
         outcome="started",
-        raw_transcript="operator notes",
-        raw_tool_payload={"line_items": [{"description": "trim"}]},
+        raw_transcript=transcript_sentinel,
+        raw_tool_payload={"line_items": [{"description": payload_sentinel}]},
+        error_message="PROVIDER_SECRET_SENTINEL_DO_NOT_LOG",
         extraction_model_id="test-model",
     )
 
@@ -68,11 +71,17 @@ def test_log_extraction_trace_excludes_raw_fields_by_default(monkeypatch) -> Non
     assert payload["extraction_model_id"] == "test-model"
     assert "raw_transcript" not in payload
     assert "raw_tool_payload" not in payload
+    assert "error_message" not in payload
+    assert transcript_sentinel not in captured[0][1]
+    assert payload_sentinel not in captured[0][1]
+    assert "PROVIDER_SECRET_SENTINEL_DO_NOT_LOG" not in captured[0][1]
 
 
-def test_log_extraction_trace_includes_raw_fields_when_opted_in(monkeypatch) -> None:
+def test_log_extraction_trace_drops_sensitive_fields_when_raw_mode_requested(monkeypatch) -> None:
     captured: list[tuple[int, str]] = []
     monkeypatch.setattr(extraction_logger, "current_correlation_id", lambda: "corr-456")
+    transcript_sentinel = "TRANSCRIPT_SENTINEL_DO_NOT_LOG"
+    payload_sentinel = "TOOL_PAYLOAD_SENTINEL_DO_NOT_LOG"
 
     def _capture(level: int, message: str) -> None:
         captured.append((level, message))
@@ -84,8 +93,9 @@ def test_log_extraction_trace_includes_raw_fields_when_opted_in(monkeypatch) -> 
         "extraction.trace",
         stage="repair",
         outcome="succeeded",
-        raw_transcript="full transcript",
-        raw_tool_payload={"line_items": [{"description": "edging"}]},
+        raw_transcript=transcript_sentinel,
+        raw_tool_payload={"line_items": [{"description": payload_sentinel}]},
+        prompt="PROMPT_SENTINEL_DO_NOT_LOG",
         extraction_model_id="test-model",
     )
 
@@ -94,5 +104,10 @@ def test_log_extraction_trace_includes_raw_fields_when_opted_in(monkeypatch) -> 
     assert payload["stage"] == "repair"
     assert payload["outcome"] == "succeeded"
     assert payload["correlation_id"] == "corr-456"
-    assert payload["raw_transcript"] == "full transcript"
-    assert payload["raw_tool_payload"] == {"line_items": [{"description": "edging"}]}
+    assert payload["extraction_model_id"] == "test-model"
+    assert "raw_transcript" not in payload
+    assert "raw_tool_payload" not in payload
+    assert "prompt" not in payload
+    assert transcript_sentinel not in captured[0][1]
+    assert payload_sentinel not in captured[0][1]
+    assert "PROMPT_SENTINEL_DO_NOT_LOG" not in captured[0][1]

--- a/backend/app/shared/tests/test_extraction_logger.py
+++ b/backend/app/shared/tests/test_extraction_logger.py
@@ -49,7 +49,7 @@ def test_log_extraction_trace_excludes_raw_fields_by_default(monkeypatch) -> Non
         captured.append((level, message))
 
     monkeypatch.setattr(extraction_logger._EXTRACTION_LOGGER, "log", _capture)  # noqa: SLF001
-    extraction_logger.configure_extraction_logging(include_raw_content=False)
+    extraction_logger.configure_extraction_logging()
 
     extraction_logger.log_extraction_trace(
         "extraction.trace",
@@ -77,7 +77,7 @@ def test_log_extraction_trace_excludes_raw_fields_by_default(monkeypatch) -> Non
     assert "PROVIDER_SECRET_SENTINEL_DO_NOT_LOG" not in captured[0][1]
 
 
-def test_log_extraction_trace_drops_sensitive_fields_when_raw_mode_requested(monkeypatch) -> None:
+def test_log_extraction_trace_drops_sensitive_fields_by_name(monkeypatch) -> None:
     captured: list[tuple[int, str]] = []
     monkeypatch.setattr(extraction_logger, "current_correlation_id", lambda: "corr-456")
     transcript_sentinel = "TRANSCRIPT_SENTINEL_DO_NOT_LOG"
@@ -87,7 +87,7 @@ def test_log_extraction_trace_drops_sensitive_fields_when_raw_mode_requested(mon
         captured.append((level, message))
 
     monkeypatch.setattr(extraction_logger._EXTRACTION_LOGGER, "log", _capture)  # noqa: SLF001
-    extraction_logger.configure_extraction_logging(include_raw_content=True)
+    extraction_logger.configure_extraction_logging()
 
     extraction_logger.log_extraction_trace(
         "extraction.trace",

--- a/backend/app/shared/tests/test_observability.py
+++ b/backend/app/shared/tests/test_observability.py
@@ -1,0 +1,47 @@
+"""Structured observability logging tests."""
+
+from __future__ import annotations
+
+import logging
+
+from app.shared import observability
+
+
+def test_log_security_event_drops_sensitive_fields_by_name(monkeypatch) -> None:
+    captured: list[dict[str, object]] = []
+
+    def _capture(payload: dict[str, object], *, level: int) -> None:
+        captured.append({**payload, "_level": level})
+
+    monkeypatch.setattr(observability, "_emit_security_payload", _capture)
+    monkeypatch.setattr(observability, "current_correlation_id", lambda: "corr-sec-123")
+
+    observability.log_security_event(
+        "jobs.terminal_failure",
+        outcome="terminal",
+        level=logging.ERROR,
+        reason="unexpected_error",
+        job_id="job-123",
+        error_class="RuntimeError",
+        raw_transcript="TRANSCRIPT_SENTINEL_DO_NOT_LOG",
+        raw_tool_payload={"details": "TOOL_PAYLOAD_SENTINEL_DO_NOT_LOG"},
+        prompt="PROMPT_SENTINEL_DO_NOT_LOG",
+        response="RESPONSE_SENTINEL_DO_NOT_LOG",
+        provider_api_key="SECRET_SENTINEL_DO_NOT_LOG",
+        token_usage={"input_tokens": 12, "output_tokens": 4},
+        transcript_chars=42,
+    )
+
+    assert len(captured) == 1
+    payload = captured[0]
+    assert payload["event"] == "jobs.terminal_failure"
+    assert payload["correlation_id"] == "corr-sec-123"
+    assert payload["job_id"] == "job-123"
+    assert payload["error_class"] == "RuntimeError"
+    assert payload["token_usage"] == {"input_tokens": 12, "output_tokens": 4}
+    assert payload["transcript_chars"] == 42
+    assert "raw_transcript" not in payload
+    assert "raw_tool_payload" not in payload
+    assert "prompt" not in payload
+    assert "response" not in payload
+    assert "provider_api_key" not in payload

--- a/backend/app/worker/job_registry.py
+++ b/backend/app/worker/job_registry.py
@@ -421,7 +421,6 @@ async def _attach_logo_data_uri(ctx: dict[str, Any], context: Any) -> None:
     except Exception:  # noqa: BLE001
         logger.warning(
             "Failed to load document logo for PDF render; omitting logo",
-            exc_info=True,
         )
         context.logo_data_uri = None
         return
@@ -601,9 +600,9 @@ async def _store_extraction_result(
             except QuoteServiceError as exc:
                 await session.rollback()
                 logger.warning(
-                    "Extraction draft persistence failed for job %s",
+                    "Extraction draft persistence failed for job %s error_class=%s",
                     job_id,
-                    exc_info=True,
+                    type(exc).__name__,
                 )
                 log_security_event(
                     "quotes.extract_persist_failed",
@@ -621,9 +620,9 @@ async def _store_extraction_result(
             except Exception as exc:  # noqa: BLE001
                 await session.rollback()
                 logger.warning(
-                    "Extraction draft persistence failed for job %s",
+                    "Extraction draft persistence failed for job %s error_class=%s",
                     job_id,
-                    exc_info=True,
+                    type(exc).__name__,
                 )
                 log_security_event(
                     "quotes.extract_persist_failed",
@@ -704,7 +703,7 @@ async def _store_pdf_artifact(
             try:
                 await asyncio.to_thread(storage_service.delete, artifact_path)
             except Exception:  # noqa: BLE001
-                logger.warning("Failed to delete stale PDF artifact upload", exc_info=True)
+                logger.warning("Failed to delete stale PDF artifact upload")
             raise NonRetryableJobError(
                 "PDF job became stale before persistence completed",
                 terminal_reason=TERMINAL_ERROR_STALE_DOCUMENT_REVISION,
@@ -725,7 +724,7 @@ async def _store_pdf_artifact(
         try:
             await asyncio.to_thread(storage_service.delete, persistence_result.previous_path)
         except Exception:  # noqa: BLE001
-            logger.warning("Failed to delete superseded PDF artifact", exc_info=True)
+            logger.warning("Failed to delete superseded PDF artifact")
 
 
 async def _log_extraction_terminal_failure(

--- a/backend/app/worker/runtime.py
+++ b/backend/app/worker/runtime.py
@@ -61,6 +61,11 @@ class NonRetryableJobError(RuntimeError):
         self.terminal_reason = terminal_reason
 
 
+def _raise_sanitized_terminal_error(*, reason: str) -> None:
+    """Raise an ARQ-facing terminal exception without leaking the original error text."""
+    raise NonRetryableJobError(reason, terminal_reason=reason) from None
+
+
 def build_arq_redis_settings(settings: Settings) -> RedisSettings:
     """Translate the app REDIS_URL into ARQ Redis settings."""
     redis_url = settings.redis_url
@@ -171,7 +176,7 @@ async def process_job[T](
                 job_type=job_type,
                 reason=_terminal_error_code(exc),
             )
-            raise
+            _raise_sanitized_terminal_error(reason=_terminal_error_code(exc))
 
         await _set_failed(runtime, job_id=job_id, job_type=job_type)
         raise Retry(
@@ -206,7 +211,7 @@ async def process_job[T](
             job_type=job_type,
             reason=_terminal_error_code(exc),
         )
-        raise
+        _raise_sanitized_terminal_error(reason=_terminal_error_code(exc))
     except Exception as exc:
         _log_terminal_transition(
             level=logging.ERROR,
@@ -231,7 +236,7 @@ async def process_job[T](
             job_type=job_type,
             reason=_terminal_error_code(exc),
         )
-        raise
+        _raise_sanitized_terminal_error(reason=_terminal_error_code(exc))
     finally:
         reset_request_context(request_context_token)
         reset_correlation(correlation_token)

--- a/backend/app/worker/runtime.py
+++ b/backend/app/worker/runtime.py
@@ -148,10 +148,13 @@ async def process_job[T](
     except RetryableJobError as exc:
         if attempt_number >= runtime.max_tries:
             await _set_failed(runtime, job_id=job_id, job_type=job_type)
-            logger.warning(
-                "Job %s exhausted retry budget and is transitioning to terminal state.",
-                job_id,
-                exc_info=True,
+            _log_terminal_transition(
+                level=logging.WARNING,
+                job_id=job_id,
+                job_name=resolved_job_name,
+                reason=_terminal_error_code(exc),
+                error_class=_error_class_name(exc),
+                message="Job exhausted retry budget and is transitioning to terminal state.",
             )
             log_security_event(
                 "jobs.terminal_failure",
@@ -180,7 +183,14 @@ async def process_job[T](
             )
         ) from exc
     except NonRetryableJobError as exc:
-        logger.warning("Job %s failed with a non-retryable exception: %s", job_id, exc)
+        _log_terminal_transition(
+            level=logging.WARNING,
+            job_id=job_id,
+            job_name=resolved_job_name,
+            reason=_terminal_error_code(exc),
+            error_class=_error_class_name(exc),
+            message="Job failed with a non-retryable exception.",
+        )
         log_security_event(
             "jobs.terminal_failure",
             outcome="terminal",
@@ -198,7 +208,14 @@ async def process_job[T](
         )
         raise
     except Exception as exc:
-        logger.exception("Job %s failed with a terminal exception.", job_id)
+        _log_terminal_transition(
+            level=logging.ERROR,
+            job_id=job_id,
+            job_name=resolved_job_name,
+            reason=_terminal_error_code(exc),
+            error_class=_error_class_name(exc),
+            message="Job failed with a terminal exception.",
+        )
         log_security_event(
             "jobs.terminal_failure",
             outcome="terminal",
@@ -309,3 +326,23 @@ def _terminal_error_code(exc: Exception) -> str:
 def _error_class_name(exc: Exception) -> str:
     cause = exc.__cause__
     return type(cause if isinstance(cause, Exception) else exc).__name__
+
+
+def _log_terminal_transition(
+    *,
+    level: int,
+    job_id: UUID,
+    job_name: str,
+    reason: str,
+    error_class: str,
+    message: str,
+) -> None:
+    logger.log(
+        level,
+        "%s job_id=%s job_name=%s reason=%s error_class=%s",
+        message,
+        job_id,
+        job_name,
+        reason,
+        error_class,
+    )

--- a/backend/app/worker/runtime.py
+++ b/backend/app/worker/runtime.py
@@ -95,9 +95,7 @@ async def on_worker_startup(ctx: dict[str, Any]) -> None:
         raise ValueError("REDIS_URL must be set for worker execution")
 
     configure_security_logging()
-    configure_extraction_logging(
-        include_raw_content=settings.extraction_trace_include_raw_content,
-    )
+    configure_extraction_logging()
     await ping_worker_redis(redis_url)
     ctx["worker_runtime"] = WorkerRuntimeSettings(
         session_maker=get_session_maker(),

--- a/backend/app/worker/tests/test_job_registry.py
+++ b/backend/app/worker/tests/test_job_registry.py
@@ -26,6 +26,7 @@ from app.shared import event_logger, observability
 from app.worker import job_registry as job_registry_module
 from app.worker.job_registry import TERMINAL_ERROR_DRAFT_PERSISTENCE_FAILED, extraction_job
 from app.worker.runtime import (
+    TERMINAL_ERROR_UNEXPECTED,
     NonRetryableJobError,
     WorkerRuntimeSettings,
 )
@@ -145,7 +146,7 @@ async def test_extraction_job_rejects_removed_append_mode(
     record = await repository.create(user_id=user.id, job_type=JobType.EXTRACTION)
     await db_session.commit()
 
-    with pytest.raises(NonRetryableJobError, match="valid extraction_mode"):
+    with pytest.raises(NonRetryableJobError, match=TERMINAL_ERROR_UNEXPECTED):
         await extraction_job(
             _worker_context(
                 db_session,
@@ -421,7 +422,7 @@ async def test_extraction_job_logs_draft_generation_failed_on_terminal_failure(
     record = await repository.create(user_id=user.id, job_type=JobType.EXTRACTION)
     await db_session.commit()
 
-    with pytest.raises(ExtractionError):
+    with pytest.raises(NonRetryableJobError, match=TERMINAL_ERROR_UNEXPECTED):
         await extraction_job(
             _worker_context(
                 db_session,
@@ -458,7 +459,7 @@ async def test_extraction_job_uses_enqueued_correlation_id_and_logs_failure_meta
 
     ingress_correlation_id = "ingress-correlation-id-123"
     transcript = "mulch the front beds"
-    with pytest.raises(ExtractionError, match="Claude request failed: malformed payload"):
+    with pytest.raises(NonRetryableJobError, match=TERMINAL_ERROR_UNEXPECTED):
         await extraction_job(
             _worker_context(
                 db_session,

--- a/backend/app/worker/tests/test_job_registry.py
+++ b/backend/app/worker/tests/test_job_registry.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import json
 from hashlib import sha256
+from types import SimpleNamespace
+from typing import cast
 from uuid import UUID, uuid4
 
 import pytest
@@ -21,6 +23,7 @@ from app.features.quotes.schemas import (
 from app.features.quotes.service import QuoteServiceError
 from app.integrations.extraction import ExtractionCallMetadata, ExtractionError
 from app.shared import event_logger, observability
+from app.worker import job_registry as job_registry_module
 from app.worker.job_registry import TERMINAL_ERROR_DRAFT_PERSISTENCE_FAILED, extraction_job
 from app.worker.runtime import (
     NonRetryableJobError,
@@ -196,6 +199,105 @@ async def test_extraction_job_marks_terminal_when_draft_persistence_fails(
     assert refreshed.terminal_error == TERMINAL_ERROR_DRAFT_PERSISTENCE_FAILED  # nosec B101 - pytest assertion
     assert refreshed.document_id is None  # nosec B101 - pytest assertion
     assert refreshed.result_json is None  # nosec B101 - pytest assertion
+
+
+async def test_extraction_job_persistence_failure_warning_omits_raw_exception_text(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    rendered_warnings: list[str] = []
+    sentinel = "PROVIDER_SECRET_SENTINEL_DO_NOT_LOG"
+    job_id = uuid4()
+    user_id = uuid4()
+
+    class _FakeSession:
+        def __init__(self) -> None:
+            self.rolled_back = False
+            self.committed = False
+
+        async def rollback(self) -> None:
+            self.rolled_back = True
+
+        async def commit(self) -> None:
+            self.committed = True
+
+    class _FakeSessionContext:
+        def __init__(self, session: _FakeSession) -> None:
+            self._session = session
+
+        async def __aenter__(self) -> _FakeSession:
+            return self._session
+
+        async def __aexit__(self, exc_type, exc, tb) -> None:
+            del exc_type, exc, tb
+
+    class _FakeSessionFactory:
+        def __init__(self, session: _FakeSession) -> None:
+            self._session = session
+
+        def __call__(self) -> _FakeSessionContext:
+            return _FakeSessionContext(self._session)
+
+    class _FakeJobRepository:
+        def __init__(self, session: _FakeSession) -> None:
+            self._session = session
+
+        async def get_by_id(self, candidate_job_id: UUID) -> SimpleNamespace | None:
+            del self._session
+            if candidate_job_id != job_id:
+                return None
+            return SimpleNamespace(
+                id=job_id,
+                user_id=user_id,
+                document_id=None,
+            )
+
+        async def set_extraction_success(self, *args, **kwargs) -> None:  # noqa: ANN002, ANN003
+            del args, kwargs
+            raise AssertionError("set_extraction_success should not run on persistence failure")
+
+    class _FailingQuoteService:
+        def __init__(self, *args, **kwargs) -> None:  # noqa: ANN002, ANN003
+            del args, kwargs
+
+        async def create_extracted_draft(self, *args, **kwargs):  # noqa: ANN002, ANN003
+            del args, kwargs
+            raise QuoteServiceError(detail=sentinel, status_code=503)
+
+    def _capture_warning(message: str, *args: object, **kwargs: object) -> None:
+        del kwargs
+        rendered_warnings.append(message % args if args else message)
+
+    fake_session = _FakeSession()
+    runtime = WorkerRuntimeSettings(
+        session_maker=cast(async_sessionmaker[AsyncSession], _FakeSessionFactory(fake_session)),
+        max_tries=3,
+        retry_base_seconds=5.0,
+        retry_jitter_seconds=3.0,
+    )
+
+    monkeypatch.setattr(job_registry_module, "JobRepository", _FakeJobRepository)
+    monkeypatch.setattr(job_registry_module, "QuoteService", _FailingQuoteService)
+    monkeypatch.setattr(job_registry_module.logger, "warning", _capture_warning)
+
+    with pytest.raises(NonRetryableJobError, match=TERMINAL_ERROR_DRAFT_PERSISTENCE_FAILED):
+        await job_registry_module._store_extraction_result(  # noqa: SLF001
+            runtime,
+            job_id=job_id,
+            result=ExtractionResult(
+                transcript="mulch the front beds",
+                line_items=[],
+                pricing_hints=PricingHints(),
+            ),
+            source_type="text",
+            capture_detail="notes",
+            customer_id=None,
+        )
+
+    assert fake_session.rolled_back is True  # nosec B101 - pytest assertion
+    assert fake_session.committed is False  # nosec B101 - pytest assertion
+    assert rendered_warnings  # nosec B101 - pytest assertion
+    assert all(sentinel not in warning for warning in rendered_warnings)  # nosec B101 - pytest assertion
+    assert any("error_class=QuoteServiceError" in warning for warning in rendered_warnings)  # nosec B101 - pytest assertion
 
 
 async def test_extraction_job_retries_provider_429_then_persists_degraded_on_final_attempt(

--- a/backend/app/worker/tests/test_pdf_job_registry.py
+++ b/backend/app/worker/tests/test_pdf_job_registry.py
@@ -22,7 +22,6 @@ from app.worker.runtime import (
     TERMINAL_ERROR_RETRY_EXHAUSTED,
     TERMINAL_ERROR_UNEXPECTED,
     NonRetryableJobError,
-    RetryableJobError,
     WorkerRuntimeSettings,
 )
 from arq.worker import Retry
@@ -93,7 +92,7 @@ async def test_pdf_job_retries_transient_render_failure_then_marks_retry_exhaust
     assert after_first_failure is not None  # nosec B101 - pytest assertion
     assert after_first_failure.status == JobStatus.FAILED  # nosec B101 - pytest assertion
 
-    with pytest.raises(RetryableJobError):
+    with pytest.raises(NonRetryableJobError, match=TERMINAL_ERROR_RETRY_EXHAUSTED):
         await pdf_job(
             _worker_context(
                 db_session,

--- a/backend/app/worker/tests/test_runtime.py
+++ b/backend/app/worker/tests/test_runtime.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import logging
+from typing import cast
 from uuid import UUID, uuid4
 
 import pytest
@@ -9,6 +11,7 @@ from app.core.config import get_settings
 from app.features.auth.models import User
 from app.features.jobs.models import JobRecord, JobStatus, JobType
 from app.features.jobs.repository import JobRepository
+from app.worker import runtime as runtime_module
 from app.worker.runtime import (
     TERMINAL_ERROR_RETRY_EXHAUSTED,
     RetryableJobError,
@@ -143,6 +146,84 @@ async def test_process_job_marks_failed_before_terminal_on_final_retryable_error
         )
 
     assert call_order == ["failed", "terminal"]  # nosec B101 - pytest assertion
+
+
+async def test_process_job_terminal_logs_omit_raw_exception_text(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    rendered_messages: list[str] = []
+    security_events: list[dict[str, object]] = []
+    terminal_reasons: list[str] = []
+    sentinel = "PROVIDER_SECRET_SENTINEL_DO_NOT_LOG"
+    job_id = uuid4()
+
+    def _capture_log(level: int, message: str, *args: object, **kwargs: object) -> None:
+        del kwargs
+        rendered_messages.append(message % args if args else message)
+
+    def _capture_security_event(
+        event: str,
+        *,
+        outcome: str,
+        level: int = logging.INFO,
+        **fields: object,
+    ) -> None:
+        security_events.append(
+            {
+                "event": event,
+                "outcome": outcome,
+                "level": level,
+                **fields,
+            }
+        )
+
+    async def _noop_set_running(*args, **kwargs) -> None:  # noqa: ANN002, ANN003
+        del args, kwargs
+
+    async def _capture_set_terminal(
+        runtime: WorkerRuntimeSettings,
+        *,
+        job_id: UUID,
+        job_type: JobType,
+        reason: str,
+    ) -> None:
+        del runtime, job_id, job_type
+        terminal_reasons.append(reason)
+
+    runtime = WorkerRuntimeSettings(
+        session_maker=cast(async_sessionmaker[AsyncSession], object()),
+        max_tries=3,
+        retry_base_seconds=5.0,
+        retry_jitter_seconds=3.0,
+    )
+
+    monkeypatch.setattr(runtime_module.logger, "log", _capture_log)
+    monkeypatch.setattr(runtime_module, "log_security_event", _capture_security_event)
+    monkeypatch.setattr(runtime_module, "_set_running", _noop_set_running)
+    monkeypatch.setattr(runtime_module, "_set_terminal", _capture_set_terminal)
+
+    async def _terminal_failure_handler() -> None:
+        raise RuntimeError(sentinel)
+
+    with pytest.raises(RuntimeError, match=sentinel):
+        await process_job(
+            {"job_try": 1, "worker_runtime": runtime},
+            job_id=job_id,
+            job_type=JobType.EXTRACTION,
+            job_name="jobs.extraction",
+            handler=_terminal_failure_handler,
+        )
+
+    assert rendered_messages  # nosec B101 - pytest assertion
+    assert all(sentinel not in message for message in rendered_messages)  # nosec B101 - pytest assertion
+    assert terminal_reasons == ["unexpected_error"]  # nosec B101 - pytest assertion
+    terminal_event = security_events[-1]
+    assert terminal_event["event"] == "jobs.terminal_failure"  # nosec B101 - pytest assertion
+    assert terminal_event["reason"] == "unexpected_error"  # nosec B101 - pytest assertion
+    assert terminal_event["job_id"] == str(job_id)  # nosec B101 - pytest assertion
+    assert terminal_event["job_name"] == "jobs.extraction"  # nosec B101 - pytest assertion
+    assert terminal_event["error_class"] == "RuntimeError"  # nosec B101 - pytest assertion
+    assert sentinel not in str(terminal_event)  # nosec B101 - pytest assertion
 
 
 async def test_worker_startup_raises_when_redis_is_unreachable(

--- a/backend/app/worker/tests/test_runtime.py
+++ b/backend/app/worker/tests/test_runtime.py
@@ -14,6 +14,8 @@ from app.features.jobs.repository import JobRepository
 from app.worker import runtime as runtime_module
 from app.worker.runtime import (
     TERMINAL_ERROR_RETRY_EXHAUSTED,
+    TERMINAL_ERROR_UNEXPECTED,
+    NonRetryableJobError,
     RetryableJobError,
     WorkerRuntimeSettings,
     calculate_retry_delay_seconds,
@@ -98,7 +100,7 @@ async def test_process_job_retries_transient_failures_before_terminal(
     assert after_second_failure.attempts == 2  # nosec B101 - pytest assertion
     assert second_retry.value.defer_score == int(expected_second_retry_delay * 1000)  # nosec B101 - pytest assertion
 
-    with pytest.raises(RetryableJobError, match="temporary upstream outage"):
+    with pytest.raises(NonRetryableJobError, match=TERMINAL_ERROR_RETRY_EXHAUSTED):
         await process_job(
             _worker_context(db_session, job_try=3),
             job_id=record.id,
@@ -137,7 +139,7 @@ async def test_process_job_marks_failed_before_terminal_on_final_retryable_error
     monkeypatch.setattr("app.worker.runtime._set_failed", _tracking_set_failed)
     monkeypatch.setattr("app.worker.runtime._set_terminal", _tracking_set_terminal)
 
-    with pytest.raises(RetryableJobError, match="temporary upstream outage"):
+    with pytest.raises(NonRetryableJobError, match=TERMINAL_ERROR_RETRY_EXHAUSTED):
         await process_job(
             _worker_context(db_session, job_try=3),
             job_id=record.id,
@@ -205,7 +207,7 @@ async def test_process_job_terminal_logs_omit_raw_exception_text(
     async def _terminal_failure_handler() -> None:
         raise RuntimeError(sentinel)
 
-    with pytest.raises(RuntimeError, match=sentinel):
+    with pytest.raises(NonRetryableJobError, match=TERMINAL_ERROR_UNEXPECTED) as exc_info:
         await process_job(
             {"job_try": 1, "worker_runtime": runtime},
             job_id=job_id,
@@ -217,6 +219,8 @@ async def test_process_job_terminal_logs_omit_raw_exception_text(
     assert rendered_messages  # nosec B101 - pytest assertion
     assert all(sentinel not in message for message in rendered_messages)  # nosec B101 - pytest assertion
     assert terminal_reasons == ["unexpected_error"]  # nosec B101 - pytest assertion
+    assert str(exc_info.value) == TERMINAL_ERROR_UNEXPECTED  # nosec B101 - pytest assertion
+    assert sentinel not in f"{type(exc_info.value).__name__}: {exc_info.value}"  # nosec B101 - pytest assertion
     terminal_event = security_events[-1]
     assert terminal_event["event"] == "jobs.terminal_failure"  # nosec B101 - pytest assertion
     assert terminal_event["reason"] == "unexpected_error"  # nosec B101 - pytest assertion

--- a/docs/adr/007-human-review-boundary-for-ai-assisted-documents.md
+++ b/docs/adr/007-human-review-boundary-for-ai-assisted-documents.md
@@ -28,7 +28,7 @@ The current codebase reflects that boundary:
 - Public quote responses expose a limited customer-facing contract, not private authenticated quote detail.
 - Extraction schemas validate and normalize model output before persistence.
 - Review metadata and flags surface uncertainty without automatically deciding for the user.
-- Production config and logging defaults are moving toward privacy-safe behavior; extraction raw content logging is gated behind `EXTRACTION_TRACE_INCLUDE_RAW_CONTENT`, default false.
+- Production config and logging defaults are moving toward privacy-safe behavior; extraction tracing is metadata-only.
 
 This ADR documents the product and safety boundary so future AI features do not weaken it.
 

--- a/docs/audit/telemetry-event-vocabulary-audit.md
+++ b/docs/audit/telemetry-event-vocabulary-audit.md
@@ -10,7 +10,7 @@
 - Only **12 events** are in the `_PILOT_EVENT_NAMES` allowlist; of those, **11 are actually persisted** under normal conditions and **1 is intentionally skipped** (`email_sent` uses `persist_async=False`).
 - **8 events** are stdout-only because they are outside the allowlist.
 - **No frontend telemetry** exists; there are zero `log_event`, analytics, or telemetry calls in the frontend codebase.
-- A **confirmed sensitive payload risk** exists in `backend/app/integrations/extraction.py` where `log_extraction_trace` passes `raw_transcript` and `raw_tool_payload` into the logger. These fields are currently stripped by a global `_INCLUDE_RAW_CONTENT = False` toggle, but the surface remains exposed.
+- A **confirmed sensitive payload risk** previously existed in `backend/app/integrations/extraction.py` where `log_extraction_trace` passed `raw_transcript` and `raw_tool_payload` into the logger. That path is now metadata-only.
 - The **existing backend events are sufficient for core P1 pilot visibility** (quote intake → draft → share → view → outcome, plus invoice creation and viewing). **However, `email_sent` for invoices currently omits `invoice_id`**, so invoice email traceability is incomplete until this is fixed. The smallest founder visibility path is a SQL/query doc or tiny report script against the existing `event_logs` table.
 - No client-event endpoint is required for P1.
 
@@ -74,9 +74,9 @@
 - `stage="repair", outcome="succeeded"` (lines 719–740: `raw_transcript` at 738, `raw_tool_payload` at 739)
 - `_log_result_trace` → `stage="result", outcome="succeeded"` (lines 1459–1474: `raw_transcript` at 1472, `raw_tool_payload` at 1473)
 
-**Current mitigation:** `app/shared/extraction_logger.py` defaults `_INCLUDE_RAW_CONTENT = False`, so these fields are stripped from the JSON payload before logging.
+**Current mitigation:** `app/shared/extraction_logger.py` emits metadata-only extraction traces, so raw fields are not included in the JSON payload.
 
-**Risk:** If `configure_extraction_logging(include_raw_content=True)` is ever called (e.g., in a debugging session or misconfigured environment), raw voice transcripts and structured extraction output would be written to stdout/logs. This violates the hard guardrail: *No raw notes, transcripts, audio, LLM prompts/responses, raw tool payloads … in telemetry/log payloads.*
+**Risk:** Future changes that add raw-content fields back into extraction traces would need to preserve the hard guardrail: *No raw notes, transcripts, audio, LLM prompts/responses, raw tool payloads … in telemetry/log payloads.*
 
 **Decision:** Route the fix to **Spec 9** (production security & LLM safety) per project convention. This PR documents the finding only.
 

--- a/docs/qa/P1_PRODUCTION_SECURITY_LLM_SAFETY_GATE.md
+++ b/docs/qa/P1_PRODUCTION_SECURITY_LLM_SAFETY_GATE.md
@@ -1,0 +1,184 @@
+# P1 Production Security & LLM Safety Gate
+
+Date: 2026-05-04  
+Spec: #616 — P1 Spec 9: Production Security & LLM Safety Gate  
+Scope: PR 1 only — inventory, classification, and follow-up task proposal  
+Code reviewed: `4c2b8f5d58a5b670b73ebe6f3690679d5b707e6c` (`2026-05-04 4c2b8f5 P1 Spec 6: add in-app support contact flow (#690)`)  
+Branch: `task-616-security-llm-safety-gate-pr1`
+
+## Summary
+
+Status: not ready to clear the P1 production safety gate yet.
+
+P1 release blockers identified in this audit:
+- Raw extraction transcript/tool payload logging can still be enabled in production.
+- Production config does not fail closed on unsafe CORS origins.
+- Production config does not fail closed on `COOKIE_HTTPONLY=false` for auth cookies.
+- Audio/extraction failure paths still surface provider/internal error text to clients.
+- Adversarial prompt-injection / unsafe-instruction smoke evidence is not yet present.
+
+What already looks materially good:
+- Auth uses cookie sessions with refresh rotation and CSRF double-submit.
+- Repositories and many tests consistently scope authenticated document access by `user_id`.
+- Public share routes are token-gated, revoked/expired links fail with generic `404`, and JSON/PDF responses are `no-store`.
+- Backend and frontend Sentry init default to `send_default_pii=false`.
+
+This PR makes no production code changes. It records the current state and the follow-up work required before pilot release.
+
+## Environment / build reviewed
+
+| Item | Value |
+|---|---|
+| Backend runtime | FastAPI + SQLAlchemy + Redis/ARQ + GCS + WeasyPrint |
+| Frontend runtime | React 19 + Vite 8 |
+| Backend dependency source | `backend/requirements.txt` |
+| Frontend dependency source | `frontend/package.json` |
+| Audit method | code-review-graph + targeted `rg`/`sed` inspection |
+| Runtime verification | None required for this docs-only PR |
+
+## Sensitive data inventory
+
+| Data class | Where observed | Notes |
+|---|---|---|
+| Access/refresh/CSRF tokens | `backend/app/features/auth/api.py`, `backend/app/shared/dependencies.py`, `frontend/src/shared/lib/http.ts` | Access + refresh use cookies; CSRF cookie is intentionally JS-readable for the double-submit pattern. |
+| Raw typed notes and raw transcripts | `backend/app/features/quotes/schemas.py`, `backend/app/features/quotes/extraction_service.py`, `backend/app/integrations/extraction.py` | Treated as product data and passed into extraction; highest logging/telemetry sensitivity surface. |
+| Structured extraction payloads / model output | `backend/app/integrations/extraction.py` | Candidate payloads and final extraction results can include customer-entered scope, pricing, notes, and transcript-derived content. |
+| Customer PII | `backend/app/features/customers/*`, `backend/app/features/quotes/api.py`, `backend/app/features/invoices/api.py` | Names, emails, phones, addresses appear in authenticated document detail and customer records. |
+| Support contact messages | `backend/app/features/support/*` | User-entered sensitive support text; emailed to configured recipient; should not be persisted or logged by default. |
+| Public share tokens | `backend/app/features/quotes/share/service.py`, `backend/app/features/invoices/share/service.py`, `backend/app/features/quotes/api.py` | Token-gated public access for landing pages, PDFs, and logos. |
+| PDF artifacts and logo assets | `backend/app/worker/job_registry.py`, `backend/app/integrations/storage.py`, `backend/app/features/profile/service.py` | Stored in GCS; app proxies access rather than exposing raw storage URLs. |
+| Pilot telemetry rows | `backend/app/shared/event_logger.py`, `backend/app/features/event_logs/models.py` | Persists internal IDs plus small metadata fields; raw notes/transcripts are not intentionally persisted there. |
+
+## Logging and telemetry findings
+
+| Area | Finding | Severity | P1 blocker? | Owner issue/PR | Verification |
+|---|---|---:|---|---|---|
+| Logging and telemetry | Extraction tracing is now metadata-only; raw transcripts, raw tool payloads, prompts, model responses, and exception messages are excluded from structured logs. | High | Yes | `#616 PR2` + `#616 PR3` | `backend/app/shared/extraction_logger.py`; `backend/app/integrations/extraction.py`; `backend/app/shared/observability.py` |
+| Logging and telemetry | Security/event logging is mostly structured and uses hashed token refs / client IPs, but worker paths still emit `exc_info=True` / `logger.exception(...)`, leaving room for traceback-based leakage if upstream/provider exceptions carry request-sensitive text. | Medium | No | `#616 PR2` | `backend/app/shared/observability.py`; `backend/app/worker/runtime.py`; `backend/app/worker/job_registry.py`; `rg -n "exc_info=True|logger.exception|logger.warning" backend/app/worker backend/app/shared` |
+| Logging and telemetry | Support contact flow accepts arbitrary user-entered sensitive text, but the message body is emailed rather than persisted, service logs stay at category + success/failure metadata, and user-facing failures are generic. This should remain a privacy invariant for future changes after Spec 6 / #690. | Low | No | Current state / Spec 6 | `backend/app/features/support/*`; `backend/app/features/support/tests/test_support_api.py` |
+
+## Production config findings
+
+| Area | Finding | Severity | P1 blocker? | Owner issue/PR | Verification |
+|---|---|---:|---|---|---|
+| Production config | Production validation blocks insecure cookies and wildcard `ALLOWED_HOSTS`, but it does not reject wildcard or otherwise unsafe `ALLOWED_ORIGINS`; `CORSMiddleware` still trusts whatever origin list is provided. | High | Yes | `#616 PR3` | `backend/app/core/config.py`; `backend/app/main.py`; `backend/app/core/tests/test_config.py`; `rg -n "allowed_origins|CORSMiddleware" backend/app/core/config.py backend/app/main.py backend/app/core/tests/test_config.py` |
+| Production config | Production can explicitly degrade to in-memory limiter/idempotency/queue-disabled mode with `ALLOW_REDIS_DEGRADED_MODE=true`. This is warned and exposed via `/health`, so it is not silent, but release policy should decide whether that flag is allowed for pilot prod at all. | Medium | No | `#616 PR3` | `backend/app/core/config.py`; `backend/app/shared/redis_runtime.py`; `backend/app/main.py`; `backend/app/core/tests/test_config.py`; `backend/app/core/tests/test_main.py` |
+| Production config | Admin routes are only mounted when `ADMIN_API_KEY` is present, which is good, but there is no minimum-length/placeholder validation if the key is set. | Medium | No | `#616 PR3` | `backend/app/main.py`; `backend/app/core/config.py`; `backend/app/admin/router.py`; `rg -n "admin_api_key|include_router\\(|X-Admin-Key" backend/app/main.py backend/app/core/config.py backend/app/admin/router.py` |
+
+## Auth/session/cookie findings
+
+| Area | Finding | Severity | P1 blocker? | Owner issue/PR | Verification |
+|---|---|---:|---|---|---|
+| Auth/session/cookie | Access and refresh cookies use path scoping, secure-cookie validation, refresh rotation, and CSRF double-submit. This is a solid baseline. | Low | No | Current state | `backend/app/features/auth/api.py`; `backend/app/features/auth/service.py`; `backend/app/shared/dependencies.py`; `docs/adr/001-cookie-auth-csrf-double-submit.md` |
+| Auth/session/cookie | `COOKIE_HTTPONLY` is runtime-configurable and `_set_auth_cookies()` applies it directly, but production validation never forces it to stay `true`. A bad prod env can make access/refresh cookies readable by JavaScript. | High | Yes | `#616 PR3` | `backend/app/core/config.py`; `backend/app/features/auth/api.py`; `rg -n "cookie_httponly|httponly=settings.cookie_httponly" backend/app/core/config.py backend/app/features/auth/api.py` |
+| Auth/session/cookie | The CSRF cookie is intentionally JS-readable because the app uses the double-submit pattern. This is an accepted design tradeoff, not a defect, but it should stay explicitly documented. | Low | No | Accepted risk (ADR-001) | `docs/adr/001-cookie-auth-csrf-double-submit.md`; `frontend/src/shared/lib/http.ts`; `backend/app/shared/dependencies.py` |
+
+## Tenant isolation findings
+
+| Area | Finding | Severity | P1 blocker? | Owner issue/PR | Verification |
+|---|---|---:|---|---|---|
+| Tenant isolation | Core authenticated repositories and services consistently scope reads/mutations by `user_id`, and existing tests already cover many cross-user `404` paths for customers, quotes, invoices, and line-item catalog items. | Low | No | Current state | `backend/app/features/{quotes,invoices,customers,line_item_catalog,profile}/repository.py`; `rg -n "user_id" backend/app/features/{quotes,invoices,customers,line_item_catalog,profile}`; `rg -n "different_users|other_user|returns_404" backend/app/features/{quotes,invoices,customers,line_item_catalog,invoices}/tests` |
+| Tenant isolation | Coverage is not yet a single deliberate sweep for the exact Spec 9 scope: share/revoke/send/convert/PDF/public artifact negative cases should still be consolidated and extended before clearing the full gate. | Medium | No | `#616 PR4` | `backend/app/features/quotes/tests/test_quote_email.py`; `backend/app/features/invoices/tests/test_invoice_api.py`; `backend/app/features/quotes/tests/test_pdf.py`; `backend/app/features/quotes/tests/test_quote_to_invoice.py` |
+
+## Upload/audio processing findings
+
+| Area | Finding | Severity | P1 blocker? | Owner issue/PR | Verification |
+|---|---|---:|---|---|---|
+| Upload/audio processing | Clip count, per-clip byte size, total byte size, empty uploads, MIME/extension inference, and max combined duration are all enforced. Audio normalization stays in-process through `pydub`; there is no shell interpolation path here. | Low | No | Current state | `backend/app/features/quotes/api.py`; `backend/app/integrations/audio.py`; `backend/app/shared/input_limits.py`; `rg -n "MAX_AUDIO|infer_audio_format|normalize_and_stitch|from_file" backend/app/features/quotes/api.py backend/app/integrations/audio.py backend/app/shared/input_limits.py` |
+| Upload/audio processing | Client-facing transcription/extraction errors still include exception text (`"Transcription failed: {exc}"`, `"Extraction failed: {exc}"`), which can leak provider/internal details. | High | Yes | `#616 PR5` + `#616 PR6` | `backend/app/features/quotes/extraction_service.py`; `backend/app/features/quotes/tests/test_quote_extraction.py`; `rg -n "Transcription failed:|Extraction failed:" backend/app/features/quotes/extraction_service.py backend/app/features/quotes/tests/test_quote_extraction.py` |
+
+## LLM extraction safety findings
+
+| Area | Finding | Severity | P1 blocker? | Owner issue/PR | Verification |
+|---|---|---:|---|---|---|
+| LLM extraction safety | Current design keeps a meaningful safety boundary: extraction uses a separate system prompt + structured JSON request, validates tool output against schema, and customer-facing actions remain separate explicit endpoints per ADR-007. | Low | No | Current state | `backend/app/integrations/extraction.py`; `backend/app/features/quotes/schemas.py`; `docs/adr/007-human-review-boundary-for-ai-assisted-documents.md` |
+| LLM extraction safety | There is still no adversarial prompt-injection / unsafe-instruction smoke evidence beyond malformed-payload coverage. Final gate evidence is incomplete for inputs like “ignore previous instructions”, fake system messages, JSON breakers, or “auto-send / skip review” text. | High | Yes | `#616 PR6` | `backend/app/features/quotes/tests/test_extraction.py`; `backend/app/features/quotes/tests/test_extraction_service.py`; `backend/app/features/quotes/tests/test_quote_extraction.py`; `rg -n "ignore previous instructions|prompt injection|system prompt|developer message|auto-send|skip review|malformed" backend/app/features/quotes/tests backend/app/integrations/tests` |
+
+## PDF/public-share findings
+
+| Area | Finding | Severity | P1 blocker? | Owner issue/PR | Verification |
+|---|---|---:|---|---|---|
+| PDF/public-share | Public JSON/PDF routes are token-gated, emit `Cache-Control: no-store` for document payloads/PDFs, add `X-Robots-Tag: noindex`, and log denied tokens by hashed reference rather than raw token. Expired/revoked links return generic `404`. | Low | No | Current state | `backend/app/features/quotes/api.py`; `backend/app/features/quotes/share/service.py`; `backend/app/features/invoices/share/service.py`; `backend/app/features/quotes/tests/test_pdf.py` |
+| PDF/public-share | Share links default to 90-day expiry and public logo bytes are cacheable for 5 minutes. Both appear intentional and revocable, but they should be treated as consciously accepted pilot tradeoffs rather than “free” defaults. | Medium | No | `#616 PR7` or accepted pilot risk | `backend/app/core/config.py`; `backend/app/features/quotes/share/tokens.py`; `backend/app/features/quotes/api.py`; `rg -n "public_share_link_expire_days|max-age=300|Cache-Control" backend/app/core/config.py backend/app/features/quotes/share/tokens.py backend/app/features/quotes/api.py` |
+
+## Dependency/container/secrets findings
+
+| Area | Finding | Severity | P1 blocker? | Owner issue/PR | Verification |
+|---|---|---:|---|---|---|
+| Dependency/container/secrets | Dependency audit is partially wired already (`pip-audit`, `npm audit`), Bandit is in the verify path, env files are gitignored, and bucket privacy expectations are documented. | Low | No | Current state | `.github/workflows/dependency-audit.yml`; `Makefile`; `.gitignore`; `docs/runbooks/gcs-bucket-security.md`; `git ls-files backend/.env backend/backend.prod.env`; `git check-ignore -v backend/.env backend/backend.prod.env frontend/.env.local` |
+| Dependency/container/secrets | The backend Docker image still runs as root, and the repo does not show automated secret scanning or container image scanning. | Medium | No | `#616 PR8` | `backend/Dockerfile`; `.github/workflows/dependency-audit.yml`; `rg -n "gitleaks|trivy|grype|USER " backend/Dockerfile .github/workflows docs` |
+
+## Release-blocking fixes
+
+These are the minimum child-task candidates required to clear the blockers above.
+
+1. `#616 PR2 — Sensitive logging and telemetry redaction`
+   - CURRENTLY IMPLEMENTING
+   - Remove any production path that can emit raw transcripts, raw tool payloads, prompts, or model responses.
+   - Add sentinel log-capture tests for extraction traces, worker failures, and security logs.
+
+2. `#616 PR3 — Production config fail-closed checks`
+   - DONE
+   - Reject `COOKIE_HTTPONLY=false` in production.
+   - Reject wildcard or unsafe `ALLOWED_ORIGINS` in production.
+   - Keep extraction tracing metadata-only in all environments.
+   - Decide whether `ALLOW_REDIS_DEGRADED_MODE=true` is allowed for pilot prod or must remain emergency-only.
+   - Add validation for `ADMIN_API_KEY` strength if the route is enabled.
+
+3. `#616 PR5 — Upload/audio processing hardening`
+   - Replace provider/internal exception passthrough with generic client-safe error text plus internal reason codes.
+   - Reduce traceback leakage from worker/audio/transcription paths or guarantee redacted logging.
+
+4. `#616 PR6 — LLM extraction safety hardening`
+   - Add adversarial fixtures for prompt injection, fake system/developer content, JSON-breaking notes, and “skip review / auto-send” attempts.
+   - Prove extraction cannot trigger share/send/convert or bypass the human-review boundary.
+
+Gate-required evidence before closing #616:
+- `#616 PR4` — dedicated tenant-isolation sweep for share/revoke/send/convert/PDF/public artifact negative cases.
+
+Recommended parallel/non-blocking follow-ups for later remediation PR sequencing:
+- `#616 PR7` — explicit review of share-token TTL, public logo cache policy, and public payload minimization.
+- `#616 PR8` — non-root container, secret scanning, and image-scan checklist.
+
+Suggested remediation order:
+1. `#616 PR3` — production config fail-closed checks
+2. `#616 PR2` — sensitive logging / telemetry redaction
+3. `#616 PR5` — client-safe upload/audio/transcription/extraction errors
+4. `#616 PR6` — LLM extraction safety smoke tests
+5. `#616 PR4` — tenant-isolation evidence sweep
+6. `#616 PR7` / `#616 PR8` — public-share and dependency/container checklist work as needed
+
+## Accepted/deferred risks
+
+| Area | Finding | Severity | P1 blocker? | Owner issue/PR | Verification |
+|---|---|---:|---|---|---|
+| Accepted/deferred risks | Raw notes/transcripts remain stored as product data in quote records because the workflow requires review/edit of captured content. Retention/minimization beyond logging is not solved by this PR and should be revisited before broader than founder-led pilot usage. | Medium | No | Deferred beyond PR1; future policy task | `backend/app/features/quotes/schemas.py`; `backend/app/features/quotes/api.py`; `backend/app/integrations/extraction.py` |
+| Accepted/deferred risks | Public-share defaults (90-day expiry, short logo cache) are acceptable for a limited founder-led pilot only if revocation remains operator-visible and users understand share is explicit. | Medium | No | `#616 PR7` or explicit pilot sign-off | `backend/app/core/config.py`; `backend/app/features/quotes/share/tokens.py`; `backend/app/features/quotes/api.py` |
+| Accepted/deferred risks | Container hardening and automated secret/image scanning are real hygiene gaps, but they are lower priority than the direct data-leak and error-surface blockers above. | Medium | No | `#616 PR8` | `backend/Dockerfile`; `.github/workflows/dependency-audit.yml` |
+
+## Verification results
+
+Docs-only verification performed for this PR:
+- Readback required after file creation.
+- No backend/frontend test targets run because this PR changes docs only.
+
+Audit commands used:
+
+```bash
+rtk git rev-parse HEAD
+rtk git log -1 --format='%cs %h %s'
+rtk rg --files backend/app frontend/src docs | rtk rg 'auth|extraction|public|invoice|quote|customer|catalog|config|security|observability|event_logger|worker|audio|upload|pdf|share|storage|telemetry|sentry|http|profile|logo|Docker|docker|compose|requirements|package|Makefile|env|README'
+rtk rg -n "raw_transcript|raw_tool_payload|log_extraction_trace|logger\\.|logging\\.|captureException|sentry|log_event\\(|log_security_event\\(" backend/app frontend/src
+rtk rg -n "UploadFile|multipart|ffmpeg|subprocess|NamedTemporaryFile|TemporaryDirectory|tempfile|mkstemp|audio|transcript|transcription|mime|content_type|max.*size|MAX_" backend/app frontend/src
+rtk rg -n "share token|share_token|public/doc|/share/|public share|public_.*token|token" backend/app/features frontend/src/features/public docs/analogs
+rtk rg -n "user_id|current_user|owner|tenant|list_by_user|get_by_id\\(|WHERE .*user_id|filter.*user_id" backend/app/features/{quotes,invoices,customers,line_item_catalog,profile}
+rtk rg -n "Dockerfile|FROM |USER |secret|\\.env|npm audit|pip-audit|safety|bandit|trivy|grype|gitleaks|semgrep" -g 'Dockerfile*' -g '*.yml' -g '*.yaml' -g '*.md' -g 'Makefile' .
+rtk git ls-files backend/.env backend/backend.prod.env frontend/.env.local .env .env.local
+rtk git check-ignore -v backend/.env backend/backend.prod.env frontend/.env.local
+```
+
+Readback command for this artifact:
+
+```bash
+sed -n '1,260p' docs/qa/P1_PRODUCTION_SECURITY_LLM_SAFETY_GATE.md
+```


### PR DESCRIPTION
Closes #693
Parent: #616
Source audit: docs/qa/P1_PRODUCTION_SECURITY_LLM_SAFETY_GATE.md

## Summary
- make extraction trace logging fail-safe by dropping sensitive field families and removing raw content from extraction trace call sites
- sanitize worker runtime and job-registry terminal warnings so default logs keep metadata without raw exception text
- add sentinel coverage for extraction traces, shared observability filtering, and worker terminal/persistence failure logging

## Verification
- `cd backend && .venv/bin/pytest app/shared/tests/test_extraction_logger.py -x --tb=short`
- `cd backend && .venv/bin/pytest app/shared/tests/test_observability.py -x --tb=short`
- `cd backend && .venv/bin/pytest app/features/quotes/tests/test_extraction.py -k "never_include_raw_sensitive_content or emits_trace_events_for_primary_repair_and_result_stages" -x --tb=short`
- `cd backend && .venv/bin/pytest app/features/quotes/tests/test_extraction_service.py -k metadata_without_raw_transcript_content -x --tb=short`
- `cd backend && .venv/bin/pytest app/worker/tests/test_runtime.py -k terminal_logs_omit_raw_exception_text -x --tb=short`
- `cd backend && .venv/bin/pytest app/worker/tests/test_job_registry.py -k persistence_failure_warning_omits_raw_exception_text -x --tb=short`
- `make backend-static-verify`

## Blocked
- `make backend-verify` is still blocked locally because PostgreSQL was unreachable at `127.0.0.1:5432` in this session.